### PR TITLE
3.x: Widen functional interface throws, replace Callable with Supplier

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -350,7 +350,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable defer(final Callable<? extends CompletableSource> completableSupplier) {
+    public static Completable defer(final Supplier<? extends CompletableSource> completableSupplier) {
         ObjectHelper.requireNonNull(completableSupplier, "completableSupplier");
         return RxJavaPlugins.onAssembly(new CompletableDefer(completableSupplier));
     }
@@ -374,7 +374,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable error(final Callable<? extends Throwable> errorSupplier) {
+    public static Completable error(final Supplier<? extends Throwable> errorSupplier) {
         ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new CompletableErrorSupplier(errorSupplier));
     }
@@ -971,7 +971,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <R> Completable using(Callable<R> resourceSupplier,
+    public static <R> Completable using(Supplier<R> resourceSupplier,
             Function<? super R, ? extends CompletableSource> completableFunction,
             Consumer<? super R> disposer) {
         return using(resourceSupplier, completableFunction, disposer, true);
@@ -1003,7 +1003,7 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <R> Completable using(
-            final Callable<R> resourceSupplier,
+            final Supplier<R> resourceSupplier,
             final Function<? super R, ? extends CompletableSource> completableFunction,
             final Consumer<? super R> disposer,
             final boolean eager) {
@@ -2688,7 +2688,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Single<T> toSingle(final Callable<? extends T> completionValueSupplier) {
+    public final <T> Single<T> toSingle(final Supplier<? extends T> completionValueSupplier) {
         ObjectHelper.requireNonNull(completionValueSupplier, "completionValueSupplier is null");
         return RxJavaPlugins.onAssembly(new CompletableToSingle<T>(this, completionValueSupplier, null));
     }

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -89,7 +89,7 @@ import io.reactivex.subscribers.*;
  * </code></pre>
  * <p>
  * The Reactive Streams specification is relatively strict when defining interactions between {@code Publisher}s and {@code Subscriber}s, so much so
- * that there is a significant performance penalty due certain timing requirements and the need to prepare for invalid 
+ * that there is a significant performance penalty due certain timing requirements and the need to prepare for invalid
  * request amounts via {@link Subscription#request(long)}.
  * Therefore, RxJava has introduced the {@link FlowableSubscriber} interface that indicates the consumer can be driven with relaxed rules.
  * All RxJava operators are implemented with these relaxed rules in mind.
@@ -112,7 +112,7 @@ import io.reactivex.subscribers.*;
  *
  *         // could be some blocking operation
  *         Thread.sleep(1000);
- *         
+ *
  *         // the consumer might have cancelled the flow
  *         if (emitter.isCancelled() {
  *             return;
@@ -138,7 +138,7 @@ import io.reactivex.subscribers.*;
  * RxJava reactive sources, such as {@code Flowable}, are generally synchronous and sequential in nature. In the ReactiveX design, the location (thread)
  * where operators run is <i>orthogonal</i> to when the operators can work with data. This means that asynchrony and parallelism
  * has to be explicitly expressed via operators such as {@link #subscribeOn(Scheduler)}, {@link #observeOn(Scheduler)} and {@link #parallel()}. In general,
- * operators featuring a {@link Scheduler} parameter are introducing this type of asynchrony into the flow. 
+ * operators featuring a {@link Scheduler} parameter are introducing this type of asynchrony into the flow.
  * <p>
  * For more information see the <a href="http://reactivex.io/documentation/Publisher.html">ReactiveX
  * documentation</a>.

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -1935,7 +1935,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> defer(Callable<? extends Publisher<? extends T>> supplier) {
+    public static <T> Flowable<T> defer(Supplier<? extends Publisher<? extends T>> supplier) {
         ObjectHelper.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new FlowableDefer<T>(supplier));
     }
@@ -1979,7 +1979,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      *
      * @param supplier
-     *            a Callable factory to return a Throwable for each individual Subscriber
+     *            a Supplier factory to return a Throwable for each individual Subscriber
      * @param <T>
      *            the type of the items (ostensibly) emitted by the Publisher
      * @return a Flowable that invokes the {@link Subscriber}'s {@link Subscriber#onError onError} method when
@@ -1990,7 +1990,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> error(Callable<? extends Throwable> supplier) {
+    public static <T> Flowable<T> error(Supplier<? extends Throwable> supplier) {
         ObjectHelper.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new FlowableError<T>(supplier));
     }
@@ -2021,7 +2021,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> error(final Throwable throwable) {
         ObjectHelper.requireNonNull(throwable, "throwable is null");
-        return error(Functions.justCallable(throwable));
+        return error(Functions.justSupplier(throwable));
     }
 
     /**
@@ -2086,7 +2086,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <T>
      *         the type of the item emitted by the Publisher
      * @return a Flowable whose {@link Subscriber}s' subscriptions trigger an invocation of the given function
-     * @see #defer(Callable)
+     * @see #defer(Supplier)
      * @since 2.0
      */
     @CheckReturnValue
@@ -2379,7 +2379,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <S> the type of the per-Subscriber state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Subscriber
+     * @param initialState the Supplier to generate the initial state for each Subscriber
      * @param generator the Consumer called with the current state whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event. Signaling multiple {@code onNext}
@@ -2390,7 +2390,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Callable<S> initialState, final BiConsumer<S, Emitter<T>> generator) {
+    public static <T, S> Flowable<T> generate(Supplier<S> initialState, final BiConsumer<S, Emitter<T>> generator) {
         ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator),
                 Functions.emptyConsumer());
@@ -2412,7 +2412,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <S> the type of the per-Subscriber state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Subscriber
+     * @param initialState the Supplier to generate the initial state for each Subscriber
      * @param generator the Consumer called with the current state whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event. Signaling multiple {@code onNext}
@@ -2425,7 +2425,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Callable<S> initialState, final BiConsumer<S, Emitter<T>> generator,
+    public static <T, S> Flowable<T> generate(Supplier<S> initialState, final BiConsumer<S, Emitter<T>> generator,
             Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator), disposeState);
@@ -2447,7 +2447,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <S> the type of the per-Subscriber state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Subscriber
+     * @param initialState the Supplier to generate the initial state for each Subscriber
      * @param generator the Function called with the current state whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event and should return a (new) state for
@@ -2458,7 +2458,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator) {
+    public static <T, S> Flowable<T> generate(Supplier<S> initialState, BiFunction<S, Emitter<T>, S> generator) {
         return generate(initialState, generator, Functions.emptyConsumer());
     }
 
@@ -2478,7 +2478,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <S> the type of the per-Subscriber state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Subscriber
+     * @param initialState the Supplier to generate the initial state for each Subscriber
      * @param generator the Function called with the current state whenever a particular downstream Subscriber has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event and should return a (new) state for
@@ -2492,7 +2492,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator, Consumer<? super S> disposeState) {
+    public static <T, S> Flowable<T> generate(Supplier<S> initialState, BiFunction<S, Emitter<T>, S> generator, Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(initialState, "initialState is null");
         ObjectHelper.requireNonNull(generator, "generator is null");
         ObjectHelper.requireNonNull(disposeState, "disposeState is null");
@@ -4531,7 +4531,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Flowable<T> using(Callable<? extends D> resourceSupplier,
+    public static <T, D> Flowable<T> using(Supplier<? extends D> resourceSupplier,
             Function<? super D, ? extends Publisher<? extends T>> sourceSupplier, Consumer<? super D> resourceDisposer) {
         return using(resourceSupplier, sourceSupplier, resourceDisposer, true);
     }
@@ -4571,7 +4571,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Flowable<T> using(Callable<? extends D> resourceSupplier,
+    public static <T, D> Flowable<T> using(Supplier<? extends D> resourceSupplier,
             Function<? super D, ? extends Publisher<? extends T>> sourceSupplier,
                     Consumer<? super D> resourceDisposer, boolean eager) {
         ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
@@ -6334,7 +6334,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<List<T>> buffer(int count, int skip) {
-        return buffer(count, skip, ArrayListSupplier.<T>asCallable());
+        return buffer(count, skip, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6372,7 +6372,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Flowable<U> buffer(int count, int skip, Callable<U> bufferSupplier) {
+    public final <U extends Collection<? super T>> Flowable<U> buffer(int count, int skip, Supplier<U> bufferSupplier) {
         ObjectHelper.verifyPositive(count, "count");
         ObjectHelper.verifyPositive(skip, "skip");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -6409,7 +6409,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Flowable<U> buffer(int count, Callable<U> bufferSupplier) {
+    public final <U extends Collection<? super T>> Flowable<U> buffer(int count, Supplier<U> bufferSupplier) {
         return buffer(count, count, bufferSupplier);
     }
 
@@ -6444,7 +6444,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Flowable<List<T>> buffer(long timespan, long timeskip, TimeUnit unit) {
-        return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.<T>asCallable());
+        return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6481,7 +6481,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<List<T>> buffer(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler) {
-        return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.<T>asCallable());
+        return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6523,7 +6523,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <U extends Collection<? super T>> Flowable<U> buffer(long timespan, long timeskip, TimeUnit unit,
-            Scheduler scheduler, Callable<U> bufferSupplier) {
+            Scheduler scheduler, Supplier<U> bufferSupplier) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -6635,7 +6635,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler, int count) {
-        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asCallable(), false);
+        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asSupplier(), false);
     }
 
     /**
@@ -6682,7 +6682,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <U extends Collection<? super T>> Flowable<U> buffer(
             long timespan, TimeUnit unit,
             Scheduler scheduler, int count,
-            Callable<U> bufferSupplier,
+            Supplier<U> bufferSupplier,
             boolean restartTimerOnMaxSize) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
@@ -6723,7 +6723,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler) {
-        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asCallable(), false);
+        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asSupplier(), false);
     }
 
     /**
@@ -6759,7 +6759,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <TOpening, TClosing> Flowable<List<T>> buffer(
             Flowable<? extends TOpening> openingIndicator,
             Function<? super TOpening, ? extends Publisher<? extends TClosing>> closingIndicator) {
-        return buffer(openingIndicator, closingIndicator, ArrayListSupplier.<T>asCallable());
+        return buffer(openingIndicator, closingIndicator, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6799,7 +6799,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <TOpening, TClosing, U extends Collection<? super T>> Flowable<U> buffer(
             Flowable<? extends TOpening> openingIndicator,
             Function<? super TOpening, ? extends Publisher<? extends TClosing>> closingIndicator,
-            Callable<U> bufferSupplier) {
+            Supplier<U> bufferSupplier) {
         ObjectHelper.requireNonNull(openingIndicator, "openingIndicator is null");
         ObjectHelper.requireNonNull(closingIndicator, "closingIndicator is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -6837,7 +6837,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Flowable<List<T>> buffer(Publisher<B> boundaryIndicator) {
-        return buffer(boundaryIndicator, ArrayListSupplier.<T>asCallable());
+        return buffer(boundaryIndicator, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6911,7 +6911,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B, U extends Collection<? super T>> Flowable<U> buffer(Publisher<B> boundaryIndicator, Callable<U> bufferSupplier) {
+    public final <B, U extends Collection<? super T>> Flowable<U> buffer(Publisher<B> boundaryIndicator, Supplier<U> bufferSupplier) {
         ObjectHelper.requireNonNull(boundaryIndicator, "boundaryIndicator is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return RxJavaPlugins.onAssembly(new FlowableBufferExactBoundary<T, U, B>(this, boundaryIndicator, bufferSupplier));
@@ -6936,7 +6936,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <B> the value type of the boundary-providing Publisher
      * @param boundaryIndicatorSupplier
-     *            a {@link Callable} that produces a Publisher that governs the boundary between buffers.
+     *            a {@link Supplier} that produces a Publisher that governs the boundary between buffers.
      *            Whenever the supplied {@code Publisher} emits an item, {@code buffer} emits the current buffer and
      *            begins to fill a new one
      * @return a Flowable that emits a connected, non-overlapping buffer of items from the source Publisher
@@ -6946,8 +6946,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Flowable<List<T>> buffer(Callable<? extends Publisher<B>> boundaryIndicatorSupplier) {
-        return buffer(boundaryIndicatorSupplier, ArrayListSupplier.<T>asCallable());
+    public final <B> Flowable<List<T>> buffer(Supplier<? extends Publisher<B>> boundaryIndicatorSupplier) {
+        return buffer(boundaryIndicatorSupplier, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6983,8 +6983,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B, U extends Collection<? super T>> Flowable<U> buffer(Callable<? extends Publisher<B>> boundaryIndicatorSupplier,
-            Callable<U> bufferSupplier) {
+    public final <B, U extends Collection<? super T>> Flowable<U> buffer(Supplier<? extends Publisher<B>> boundaryIndicatorSupplier,
+            Supplier<U> bufferSupplier) {
         ObjectHelper.requireNonNull(boundaryIndicatorSupplier, "boundaryIndicatorSupplier is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return RxJavaPlugins.onAssembly(new FlowableBufferBoundarySupplier<T, U, B>(this, boundaryIndicatorSupplier, bufferSupplier));
@@ -7174,7 +7174,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<U> collect(Callable<? extends U> initialItemSupplier, BiConsumer<? super U, ? super T> collector) {
+    public final <U> Single<U> collect(Supplier<? extends U> initialItemSupplier, BiConsumer<? super U, ? super T> collector) {
         ObjectHelper.requireNonNull(initialItemSupplier, "initialItemSupplier is null");
         ObjectHelper.requireNonNull(collector, "collector is null");
         return RxJavaPlugins.onAssembly(new FlowableCollectSingle<T, U>(this, initialItemSupplier, collector));
@@ -7215,7 +7215,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Single<U> collectInto(final U initialItem, BiConsumer<? super U, ? super T> collector) {
         ObjectHelper.requireNonNull(initialItem, "initialItem is null");
-        return collect(Functions.justCallable(initialItem), collector);
+        return collect(Functions.justSupplier(initialItem), collector);
     }
 
     /**
@@ -7314,9 +7314,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> concatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -7551,9 +7551,9 @@ public abstract class Flowable<T> implements Publisher<T> {
             int prefetch, boolean tillTheEnd) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -8836,7 +8836,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * to {@code OutOfMemoryError}.
      * <p>
      * Customizing the retention policy can happen only by providing a custom {@link java.util.Collection} implementation
-     * to the {@link #distinct(Function, Callable)} overload.
+     * to the {@link #distinct(Function, Supplier)} overload.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s
@@ -8849,7 +8849,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         each other
      * @see <a href="http://reactivex.io/documentation/operators/distinct.html">ReactiveX operators documentation: Distinct</a>
      * @see #distinct(Function)
-     * @see #distinct(Function, Callable)
+     * @see #distinct(Function, Supplier)
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
@@ -8878,7 +8878,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * to {@code OutOfMemoryError}.
      * <p>
      * Customizing the retention policy can happen only by providing a custom {@link java.util.Collection} implementation
-     * to the {@link #distinct(Function, Callable)} overload.
+     * to the {@link #distinct(Function, Supplier)} overload.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s
@@ -8893,7 +8893,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            is distinct from another one or not
      * @return a Flowable that emits those items emitted by the source Publisher that have distinct keys
      * @see <a href="http://reactivex.io/documentation/operators/distinct.html">ReactiveX operators documentation: Distinct</a>
-     * @see #distinct(Function, Callable)
+     * @see #distinct(Function, Supplier)
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
@@ -8933,7 +8933,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<T> distinct(Function<? super T, K> keySelector,
-            Callable<? extends Collection<? super K>> collectionSupplier) {
+            Supplier<? extends Collection<? super K>> collectionSupplier) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return RxJavaPlugins.onAssembly(new FlowableDistinct<T, K>(this, keySelector, collectionSupplier));
@@ -9856,9 +9856,9 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -9903,7 +9903,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> flatMap(
             Function<? super T, ? extends Publisher<? extends R>> onNextMapper,
             Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper,
-            Callable<? extends Publisher<? extends R>> onCompleteSupplier) {
+            Supplier<? extends Publisher<? extends R>> onCompleteSupplier) {
         ObjectHelper.requireNonNull(onNextMapper, "onNextMapper is null");
         ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
         ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
@@ -9950,7 +9950,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> flatMap(
             Function<? super T, ? extends Publisher<? extends R>> onNextMapper,
             Function<Throwable, ? extends Publisher<? extends R>> onErrorMapper,
-            Callable<? extends Publisher<? extends R>> onCompleteSupplier,
+            Supplier<? extends Publisher<? extends R>> onCompleteSupplier,
             int maxConcurrency) {
         ObjectHelper.requireNonNull(onNextMapper, "onNextMapper is null");
         ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
@@ -12594,7 +12594,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * Note that the {@code seed} is shared among all subscribers to the resulting Publisher
      * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
-     * the application of this operator via {@link #defer(Callable)}:
+     * the application of this operator via {@link #defer(Supplier)}:
      * <pre><code>
      * Publisher&lt;T&gt; source = ...
      * Single.defer(() -&gt; source.reduce(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
@@ -12631,7 +12631,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         items emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/reduce.html">ReactiveX operators documentation: Reduce</a>
      * @see <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Wikipedia: Fold (higher-order function)</a>
-     * @see #reduceWith(Callable, BiFunction)
+     * @see #reduceWith(Supplier, BiFunction)
      */
     @CheckReturnValue
     @NonNull
@@ -12669,7 +12669,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the accumulator and output value type
      * @param seedSupplier
-     *            the Callable that provides the initial (seed) accumulator value for each individual Subscriber
+     *            the Supplier that provides the initial (seed) accumulator value for each individual Subscriber
      * @param reducer
      *            an accumulator function to be invoked on each item emitted by the source Publisher, the
      *            result of which will be used in the next accumulator call
@@ -12682,7 +12682,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> reduceWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
+    public final <R> Single<R> reduceWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
         ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
         ObjectHelper.requireNonNull(reducer, "reducer is null");
         return RxJavaPlugins.onAssembly(new FlowableReduceWithSingle<T, R>(this, seedSupplier, reducer));
@@ -12862,7 +12862,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector) {
         ObjectHelper.requireNonNull(selector, "selector is null");
-        return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this), selector);
+        return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this), selector);
     }
 
     /**
@@ -12902,7 +12902,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize) {
         ObjectHelper.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this, bufferSize), selector);
+        return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this, bufferSize), selector);
     }
 
     /**
@@ -12996,7 +12996,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.multicastSelector(
-                FlowableInternalHelper.replayCallable(this, bufferSize, time, unit, scheduler), selector);
+                FlowableInternalHelper.replaySupplier(this, bufferSize, time, unit, scheduler), selector);
     }
 
     /**
@@ -13039,7 +13039,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(selector, "selector is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this, bufferSize),
+        return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this, bufferSize),
                 FlowableInternalHelper.replayFunction(selector, scheduler)
         );
     }
@@ -13119,7 +13119,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(selector, "selector is null");
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this, time, unit, scheduler), selector);
+        return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this, time, unit, scheduler), selector);
     }
 
     /**
@@ -13155,7 +13155,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <R> Flowable<R> replay(final Function<? super Flowable<T>, ? extends Publisher<R>> selector, final Scheduler scheduler) {
         ObjectHelper.requireNonNull(selector, "selector is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return FlowableReplay.multicastSelector(FlowableInternalHelper.replayCallable(this),
+        return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this),
                 FlowableInternalHelper.replayFunction(selector, scheduler));
     }
 
@@ -13938,7 +13938,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * Note that the {@code initialValue} is shared among all subscribers to the resulting Publisher
      * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
-     * the application of this operator via {@link #defer(Callable)}:
+     * the application of this operator via {@link #defer(Supplier)}:
      * <pre><code>
      * Publisher&lt;T&gt; source = ...
      * Flowable.defer(() -&gt; source.scan(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
@@ -13974,7 +13974,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> scan(final R initialValue, BiFunction<R, ? super T, R> accumulator) {
         ObjectHelper.requireNonNull(initialValue, "initialValue is null");
-        return scanWith(Functions.justCallable(initialValue), accumulator);
+        return scanWith(Functions.justSupplier(initialValue), accumulator);
     }
 
     /**
@@ -13999,7 +13999,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <R> the initial, accumulator and result type
      * @param seedSupplier
-     *            a Callable that returns the initial (seed) accumulator item for each individual Subscriber
+     *            a Supplier that returns the initial (seed) accumulator item for each individual Subscriber
      * @param accumulator
      *            an accumulator function to be invoked on each item emitted by the source Publisher, whose
      *            result will be emitted to {@link Subscriber}s via {@link Subscriber#onNext onNext} and used in the
@@ -14012,7 +14012,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> scanWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
+    public final <R> Flowable<R> scanWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
         ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
         ObjectHelper.requireNonNull(accumulator, "accumulator is null");
         return RxJavaPlugins.onAssembly(new FlowableScanSeed<T, R>(this, seedSupplier, accumulator));
@@ -15314,9 +15314,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     <R> Flowable<R> switchMap0(Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize, boolean delayError) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -16990,7 +16990,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <U> the subclass of a collection of Ts
      * @param collectionSupplier
-     *               the Callable returning the collection (for each individual Subscriber) to be filled in
+     *               the Supplier returning the collection (for each individual Subscriber) to be filled in
      * @return a Single that emits a single item: a List containing all of the items emitted by the source
      *         Publisher
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
@@ -16998,7 +16998,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Single<U> toList(Callable<U> collectionSupplier) {
+    public final <U extends Collection<? super T>> Single<U> toList(Supplier<U> collectionSupplier) {
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return RxJavaPlugins.onAssembly(new FlowableToListSingle<T, U>(this, collectionSupplier));
     }
@@ -17035,7 +17035,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Single<Map<K, T>> toMap(final Function<? super T, ? extends K> keySelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
-        return collect(HashMapSupplier.<K, T>asCallable(), Functions.toMapKeySelector(keySelector));
+        return collect(HashMapSupplier.<K, T>asSupplier(), Functions.toMapKeySelector(keySelector));
     }
 
     /**
@@ -17075,7 +17075,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <K, V> Single<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
-        return collect(HashMapSupplier.<K, V>asCallable(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
+        return collect(HashMapSupplier.<K, V>asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
     }
 
     /**
@@ -17113,7 +17113,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Single<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector,
             final Function<? super T, ? extends V> valueSelector,
-            final Callable<? extends Map<K, V>> mapSupplier) {
+            final Supplier<? extends Map<K, V>> mapSupplier) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         return collect(mapSupplier, Functions.toMapKeyValueSelector(keySelector, valueSelector));
@@ -17147,7 +17147,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Single<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
         Function<T, T> valueSelector = Functions.identity();
-        Callable<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asCallable();
+        Supplier<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<T>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
     }
@@ -17184,7 +17184,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Single<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
-        Callable<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asCallable();
+        Supplier<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<V>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
     }
@@ -17228,7 +17228,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
             final Function<? super T, ? extends K> keySelector,
             final Function<? super T, ? extends V> valueSelector,
-            final Callable<? extends Map<K, Collection<V>>> mapSupplier,
+            final Supplier<? extends Map<K, Collection<V>>> mapSupplier,
             final Function<? super K, ? extends Collection<? super V>> collectionFactory) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
@@ -17273,7 +17273,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
             Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector,
-            Callable<Map<K, Collection<V>>> mapSupplier
+            Supplier<Map<K, Collection<V>>> mapSupplier
             ) {
         return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.<V, K>asFunction());
     }
@@ -18119,7 +18119,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <B> the element type of the boundary Publisher
      * @param boundaryIndicatorSupplier
-     *            a {@link Callable} that returns a {@code Publisher} that governs the boundary between windows.
+     *            a {@link Supplier} that returns a {@code Publisher} that governs the boundary between windows.
      *            When the source {@code Publisher} emits an item, {@code window} emits the current window and begins
      *            a new one.
      * @return a Flowable that emits connected, non-overlapping windows of items from the source Publisher
@@ -18129,7 +18129,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Flowable<Flowable<T>> window(Callable<? extends Publisher<B>> boundaryIndicatorSupplier) {
+    public final <B> Flowable<Flowable<T>> window(Supplier<? extends Publisher<B>> boundaryIndicatorSupplier) {
         return window(boundaryIndicatorSupplier, bufferSize());
     }
 
@@ -18152,7 +18152,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * @param <B> the element type of the boundary Publisher
      * @param boundaryIndicatorSupplier
-     *            a {@link Callable} that returns a {@code Publisher} that governs the boundary between windows.
+     *            a {@link Supplier} that returns a {@code Publisher} that governs the boundary between windows.
      *            When the source {@code Publisher} emits an item, {@code window} emits the current window and begins
      *            a new one.
      * @param bufferSize
@@ -18165,7 +18165,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Flowable<Flowable<T>> window(Callable<? extends Publisher<B>> boundaryIndicatorSupplier, int bufferSize) {
+    public final <B> Flowable<Flowable<T>> window(Supplier<? extends Publisher<B>> boundaryIndicatorSupplier, int bufferSize) {
         ObjectHelper.requireNonNull(boundaryIndicatorSupplier, "boundaryIndicatorSupplier is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return RxJavaPlugins.onAssembly(new FlowableWindowBoundarySupplier<T, B>(this, boundaryIndicatorSupplier, bufferSize));

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -573,21 +573,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls a Callable for each individual MaybeObserver to return the actual MaybeSource source to
+     * Calls a Supplier for each individual MaybeObserver to return the actual MaybeSource source to
      * be subscribed to.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param maybeSupplier the Callable that is called for each individual MaybeObserver and
+     * @param maybeSupplier the Supplier that is called for each individual MaybeObserver and
      * returns a MaybeSource instance to subscribe to
      * @return the new Maybe instance
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> defer(final Callable<? extends MaybeSource<? extends T>> maybeSupplier) {
+    public static <T> Maybe<T> defer(final Supplier<? extends MaybeSource<? extends T>> maybeSupplier) {
         ObjectHelper.requireNonNull(maybeSupplier, "maybeSupplier is null");
         return RxJavaPlugins.onAssembly(new MaybeDefer<T>(maybeSupplier));
     }
@@ -648,7 +648,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param supplier
-     *            a Callable factory to return a Throwable for each individual MaybeObserver
+     *            a Supplier factory to return a Throwable for each individual MaybeObserver
      * @param <T>
      *            the type of the items (ostensibly) emitted by the Maybe
      * @return a Maybe that invokes the {@link MaybeObserver}'s {@link MaybeObserver#onError onError} method when
@@ -658,7 +658,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> error(Callable<? extends Throwable> supplier) {
+    public static <T> Maybe<T> error(Supplier<? extends Throwable> supplier) {
         ObjectHelper.requireNonNull(supplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new MaybeErrorCallable<T>(supplier));
     }
@@ -1689,7 +1689,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Maybe<T> using(Callable<? extends D> resourceSupplier,
+    public static <T, D> Maybe<T> using(Supplier<? extends D> resourceSupplier,
             Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
                     Consumer<? super D> resourceDisposer) {
         return using(resourceSupplier, sourceSupplier, resourceDisposer, true);
@@ -1725,7 +1725,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Maybe<T> using(Callable<? extends D> resourceSupplier,
+    public static <T, D> Maybe<T> using(Supplier<? extends D> resourceSupplier,
             Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
                     Consumer<? super D> resourceDisposer, boolean eager) {
         ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
@@ -3022,7 +3022,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     public final <R> Maybe<R> flatMap(
             Function<? super T, ? extends MaybeSource<? extends R>> onSuccessMapper,
             Function<? super Throwable, ? extends MaybeSource<? extends R>> onErrorMapper,
-            Callable<? extends MaybeSource<? extends R>> onCompleteSupplier) {
+            Supplier<? extends MaybeSource<? extends R>> onCompleteSupplier) {
         ObjectHelper.requireNonNull(onSuccessMapper, "onSuccessMapper is null");
         ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
         ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -23,7 +23,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 import io.reactivex.internal.observers.*;
 import io.reactivex.internal.operators.flowable.*;
 import io.reactivex.internal.operators.mixed.*;
@@ -1662,7 +1662,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> defer(Callable<? extends ObservableSource<? extends T>> supplier) {
+    public static <T> Observable<T> defer(Supplier<? extends ObservableSource<? extends T>> supplier) {
         ObjectHelper.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new ObservableDefer<T>(supplier));
     }
@@ -1701,7 +1701,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      *
      * @param errorSupplier
-     *            a Callable factory to return a Throwable for each individual Observer
+     *            a Supplier factory to return a Throwable for each individual Observer
      * @param <T>
      *            the type of the items (ostensibly) emitted by the ObservableSource
      * @return an Observable that invokes the {@link Observer}'s {@link Observer#onError onError} method when
@@ -1711,7 +1711,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> error(Callable<? extends Throwable> errorSupplier) {
+    public static <T> Observable<T> error(Supplier<? extends Throwable> errorSupplier) {
         ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableError<T>(errorSupplier));
     }
@@ -1739,7 +1739,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> error(final Throwable exception) {
         ObjectHelper.requireNonNull(exception, "exception is null");
-        return error(Functions.justCallable(exception));
+        return error(Functions.justSupplier(exception));
     }
 
     /**
@@ -1797,7 +1797,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <T>
      *         the type of the item emitted by the ObservableSource
      * @return an Observable whose {@link Observer}s' subscriptions trigger an invocation of the given function
-     * @see #defer(Callable)
+     * @see #defer(Supplier)
      * @since 2.0
      */
     @CheckReturnValue
@@ -2048,7 +2048,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> generate(final Consumer<Emitter<T>> generator) {
         ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(Functions.<Object>nullSupplier(),
-        ObservableInternalHelper.simpleGenerator(generator), Functions.<Object>emptyConsumer());
+                ObservableInternalHelper.simpleGenerator(generator), Functions.<Object>emptyConsumer());
     }
 
     /**
@@ -2067,7 +2067,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <S> the type of the per-Observer state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Observer
+     * @param initialState the Supplier to generate the initial state for each Observer
      * @param generator the Consumer called with the current state whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
@@ -2077,7 +2077,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Callable<S> initialState, final BiConsumer<S, Emitter<T>> generator) {
+    public static <T, S> Observable<T> generate(Supplier<S> initialState, final BiConsumer<S, Emitter<T>> generator) {
         ObjectHelper.requireNonNull(generator, "generator is null");
         return generate(initialState, ObservableInternalHelper.simpleBiGenerator(generator), Functions.emptyConsumer());
     }
@@ -2098,7 +2098,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <S> the type of the per-Observer state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Observer
+     * @param initialState the Supplier to generate the initial state for each Observer
      * @param generator the Consumer called with the current state whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event. Signalling multiple {@code onNext}
@@ -2111,7 +2111,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Observable<T> generate(
-            final Callable<S> initialState,
+            final Supplier<S> initialState,
             final BiConsumer<S, Emitter<T>> generator,
             Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(generator, "generator is null");
@@ -2134,7 +2134,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <S> the type of the per-Observer state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Observer
+     * @param initialState the Supplier to generate the initial state for each Observer
      * @param generator the Function called with the current state whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event and should return a (new) state for
@@ -2144,7 +2144,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator) {
+    public static <T, S> Observable<T> generate(Supplier<S> initialState, BiFunction<S, Emitter<T>, S> generator) {
         return generate(initialState, generator, Functions.emptyConsumer());
     }
 
@@ -2164,7 +2164,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <S> the type of the per-Observer state
      * @param <T> the generated value type
-     * @param initialState the Callable to generate the initial state for each Observer
+     * @param initialState the Supplier to generate the initial state for each Observer
      * @param generator the Function called with the current state whenever a particular downstream Observer has
      * requested a value. The callback then should call {@code onNext}, {@code onError} or
      * {@code onComplete} to signal a value or a terminal event and should return a (new) state for
@@ -2177,7 +2177,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Callable<S> initialState, BiFunction<S, Emitter<T>, S> generator,
+    public static <T, S> Observable<T> generate(Supplier<S> initialState, BiFunction<S, Emitter<T>, S> generator,
             Consumer<? super S> disposeState) {
         ObjectHelper.requireNonNull(initialState, "initialState is null");
         ObjectHelper.requireNonNull(generator, "generator is null");
@@ -4025,7 +4025,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Observable<T> using(Callable<? extends D> resourceSupplier, Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier, Consumer<? super D> disposer) {
+    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier, Consumer<? super D> disposer) {
         return using(resourceSupplier, sourceSupplier, disposer, true);
     }
 
@@ -4059,7 +4059,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Observable<T> using(Callable<? extends D> resourceSupplier, Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
+    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
         ObjectHelper.requireNonNull(resourceSupplier, "resourceSupplier is null");
         ObjectHelper.requireNonNull(sourceSupplier, "sourceSupplier is null");
         ObjectHelper.requireNonNull(disposer, "disposer is null");
@@ -5603,7 +5603,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<List<T>> buffer(int count, int skip) {
-        return buffer(count, skip, ArrayListSupplier.<T>asCallable());
+        return buffer(count, skip, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -5635,7 +5635,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Observable<U> buffer(int count, int skip, Callable<U> bufferSupplier) {
+    public final <U extends Collection<? super T>> Observable<U> buffer(int count, int skip, Supplier<U> bufferSupplier) {
         ObjectHelper.verifyPositive(count, "count");
         ObjectHelper.verifyPositive(skip, "skip");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -5667,7 +5667,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Observable<U> buffer(int count, Callable<U> bufferSupplier) {
+    public final <U extends Collection<? super T>> Observable<U> buffer(int count, Supplier<U> bufferSupplier) {
         return buffer(count, count, bufferSupplier);
     }
 
@@ -5698,7 +5698,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Observable<List<T>> buffer(long timespan, long timeskip, TimeUnit unit) {
-        return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.<T>asCallable());
+        return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -5731,7 +5731,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<List<T>> buffer(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler) {
-        return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.<T>asCallable());
+        return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -5767,7 +5767,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <U extends Collection<? super T>> Observable<U> buffer(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, Callable<U> bufferSupplier) {
+    public final <U extends Collection<? super T>> Observable<U> buffer(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, Supplier<U> bufferSupplier) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -5868,7 +5868,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler, int count) {
-        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asCallable(), false);
+        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asSupplier(), false);
     }
 
     /**
@@ -5911,7 +5911,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <U extends Collection<? super T>> Observable<U> buffer(
             long timespan, TimeUnit unit,
             Scheduler scheduler, int count,
-            Callable<U> bufferSupplier,
+            Supplier<U> bufferSupplier,
             boolean restartTimerOnMaxSize) {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
@@ -5948,7 +5948,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler) {
-        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asCallable(), false);
+        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asSupplier(), false);
     }
 
     /**
@@ -5980,7 +5980,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <TOpening, TClosing> Observable<List<T>> buffer(
             ObservableSource<? extends TOpening> openingIndicator,
             Function<? super TOpening, ? extends ObservableSource<? extends TClosing>> closingIndicator) {
-        return buffer(openingIndicator, closingIndicator, ArrayListSupplier.<T>asCallable());
+        return buffer(openingIndicator, closingIndicator, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6016,7 +6016,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <TOpening, TClosing, U extends Collection<? super T>> Observable<U> buffer(
             ObservableSource<? extends TOpening> openingIndicator,
             Function<? super TOpening, ? extends ObservableSource<? extends TClosing>> closingIndicator,
-            Callable<U> bufferSupplier) {
+            Supplier<U> bufferSupplier) {
         ObjectHelper.requireNonNull(openingIndicator, "openingIndicator is null");
         ObjectHelper.requireNonNull(closingIndicator, "closingIndicator is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -6050,7 +6050,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <B> Observable<List<T>> buffer(ObservableSource<B> boundary) {
-        return buffer(boundary, ArrayListSupplier.<T>asCallable());
+        return buffer(boundary, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6116,7 +6116,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B, U extends Collection<? super T>> Observable<U> buffer(ObservableSource<B> boundary, Callable<U> bufferSupplier) {
+    public final <B, U extends Collection<? super T>> Observable<U> buffer(ObservableSource<B> boundary, Supplier<U> bufferSupplier) {
         ObjectHelper.requireNonNull(boundary, "boundary is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier));
@@ -6138,7 +6138,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <B> the value type of the boundary-providing ObservableSource
      * @param boundarySupplier
-     *            a {@link Callable} that produces an ObservableSource that governs the boundary between buffers.
+     *            a {@link Supplier} that produces an ObservableSource that governs the boundary between buffers.
      *            Whenever the supplied {@code ObservableSource} emits an item, {@code buffer} emits the current buffer and
      *            begins to fill a new one
      * @return an Observable that emits a connected, non-overlapping buffer of items from the source ObservableSource
@@ -6147,8 +6147,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Observable<List<T>> buffer(Callable<? extends ObservableSource<B>> boundarySupplier) {
-        return buffer(boundarySupplier, ArrayListSupplier.<T>asCallable());
+    public final <B> Observable<List<T>> buffer(Supplier<? extends ObservableSource<B>> boundarySupplier) {
+        return buffer(boundarySupplier, ArrayListSupplier.<T>asSupplier());
     }
 
     /**
@@ -6168,7 +6168,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <U> the collection subclass type to buffer into
      * @param <B> the value type of the boundary-providing ObservableSource
      * @param boundarySupplier
-     *            a {@link Callable} that produces an ObservableSource that governs the boundary between buffers.
+     *            a {@link Supplier} that produces an ObservableSource that governs the boundary between buffers.
      *            Whenever the supplied {@code ObservableSource} emits an item, {@code buffer} emits the current buffer and
      *            begins to fill a new one
      * @param bufferSupplier
@@ -6180,7 +6180,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B, U extends Collection<? super T>> Observable<U> buffer(Callable<? extends ObservableSource<B>> boundarySupplier, Callable<U> bufferSupplier) {
+    public final <B, U extends Collection<? super T>> Observable<U> buffer(Supplier<? extends ObservableSource<B>> boundarySupplier, Supplier<U> bufferSupplier) {
         ObjectHelper.requireNonNull(boundarySupplier, "boundarySupplier is null");
         ObjectHelper.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableBufferBoundarySupplier<T, U, B>(this, boundarySupplier, bufferSupplier));
@@ -6352,7 +6352,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<U> collect(Callable<? extends U> initialValueSupplier, BiConsumer<? super U, ? super T> collector) {
+    public final <U> Single<U> collect(Supplier<? extends U> initialValueSupplier, BiConsumer<? super U, ? super T> collector) {
         ObjectHelper.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
         ObjectHelper.requireNonNull(collector, "collector is null");
         return RxJavaPlugins.onAssembly(new ObservableCollectSingle<T, U>(this, initialValueSupplier, collector));
@@ -6388,7 +6388,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Single<U> collectInto(final U initialValue, BiConsumer<? super U, ? super T> collector) {
         ObjectHelper.requireNonNull(initialValue, "initialValue is null");
-        return collect(Functions.justCallable(initialValue), collector);
+        return collect(Functions.justSupplier(initialValue), collector);
     }
 
     /**
@@ -6468,9 +6468,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> concatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -6528,9 +6528,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
             int prefetch, boolean tillTheEnd) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -7789,7 +7789,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * to {@code OutOfMemoryError}.
      * <p>
      * Customizing the retention policy can happen only by providing a custom {@link java.util.Collection} implementation
-     * to the {@link #distinct(Function, Callable)} overload.
+     * to the {@link #distinct(Function, Supplier)} overload.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code distinct} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -7799,7 +7799,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         each other
      * @see <a href="http://reactivex.io/documentation/operators/distinct.html">ReactiveX operators documentation: Distinct</a>
      * @see #distinct(Function)
-     * @see #distinct(Function, Callable)
+     * @see #distinct(Function, Supplier)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -7827,7 +7827,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * to {@code OutOfMemoryError}.
      * <p>
      * Customizing the retention policy can happen only by providing a custom {@link java.util.Collection} implementation
-     * to the {@link #distinct(Function, Callable)} overload.
+     * to the {@link #distinct(Function, Supplier)} overload.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code distinct} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -7839,7 +7839,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            is distinct from another one or not
      * @return an Observable that emits those items emitted by the source ObservableSource that have distinct keys
      * @see <a href="http://reactivex.io/documentation/operators/distinct.html">ReactiveX operators documentation: Distinct</a>
-     * @see #distinct(Function, Callable)
+     * @see #distinct(Function, Supplier)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -7874,7 +7874,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Observable<T> distinct(Function<? super T, K> keySelector, Callable<? extends Collection<? super K>> collectionSupplier) {
+    public final <K> Observable<T> distinct(Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableDistinct<T, K>(this, keySelector, collectionSupplier));
@@ -8605,9 +8605,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -8645,7 +8645,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> flatMap(
             Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
             Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
-            Callable<? extends ObservableSource<? extends R>> onCompleteSupplier) {
+            Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier) {
         ObjectHelper.requireNonNull(onNextMapper, "onNextMapper is null");
         ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
         ObjectHelper.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
@@ -8685,7 +8685,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> flatMap(
             Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
             Function<Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
-            Callable<? extends ObservableSource<? extends R>> onCompleteSupplier,
+            Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier,
             int maxConcurrency) {
         ObjectHelper.requireNonNull(onNextMapper, "onNextMapper is null");
         ObjectHelper.requireNonNull(onErrorMapper, "onErrorMapper is null");
@@ -10306,7 +10306,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * Note that the {@code seed} is shared among all subscribers to the resulting ObservableSource
      * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
-     * the application of this operator via {@link #defer(Callable)}:
+     * the application of this operator via {@link #defer(Supplier)}:
      * <pre><code>
      * ObservableSource&lt;T&gt; source = ...
      * Single.defer(() -&gt; source.reduce(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
@@ -10340,7 +10340,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         items emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/reduce.html">ReactiveX operators documentation: Reduce</a>
      * @see <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Wikipedia: Fold (higher-order function)</a>
-     * @see #reduceWith(Callable, BiFunction)
+     * @see #reduceWith(Supplier, BiFunction)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -10373,7 +10373,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <R> the accumulator and output value type
      * @param seedSupplier
-     *            the Callable that provides the initial (seed) accumulator value for each individual Observer
+     *            the Supplier that provides the initial (seed) accumulator value for each individual Observer
      * @param reducer
      *            an accumulator function to be invoked on each item emitted by the source ObservableSource, the
      *            result of which will be used in the next accumulator call
@@ -10384,7 +10384,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> reduceWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
+    public final <R> Single<R> reduceWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
         ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
         ObjectHelper.requireNonNull(reducer, "reducer is null");
         return RxJavaPlugins.onAssembly(new ObservableReduceWithSingle<T, R>(this, seedSupplier, reducer));
@@ -10536,7 +10536,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
         ObjectHelper.requireNonNull(selector, "selector is null");
-        return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this), selector);
+        return ObservableReplay.multicastSelector(ObservableInternalHelper.replaySupplier(this), selector);
     }
 
     /**
@@ -10570,7 +10570,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final int bufferSize) {
         ObjectHelper.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this, bufferSize), selector);
+        return ObservableReplay.multicastSelector(ObservableInternalHelper.replaySupplier(this, bufferSize), selector);
     }
 
     /**
@@ -10653,7 +10653,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         return ObservableReplay.multicastSelector(
-                ObservableInternalHelper.replayCallable(this, bufferSize, time, unit, scheduler), selector);
+                ObservableInternalHelper.replaySupplier(this, bufferSize, time, unit, scheduler), selector);
     }
 
     /**
@@ -10690,7 +10690,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(selector, "selector is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this, bufferSize),
+        return ObservableReplay.multicastSelector(ObservableInternalHelper.replaySupplier(this, bufferSize),
                 ObservableInternalHelper.replayFunction(selector, scheduler));
     }
 
@@ -10758,7 +10758,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(selector, "selector is null");
         ObjectHelper.requireNonNull(unit, "unit is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this, time, unit, scheduler), selector);
+        return ObservableReplay.multicastSelector(ObservableInternalHelper.replaySupplier(this, time, unit, scheduler), selector);
     }
 
     /**
@@ -10788,7 +10788,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final Scheduler scheduler) {
         ObjectHelper.requireNonNull(selector, "selector is null");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return ObservableReplay.multicastSelector(ObservableInternalHelper.replayCallable(this),
+        return ObservableReplay.multicastSelector(ObservableInternalHelper.replaySupplier(this),
                 ObservableInternalHelper.replayFunction(selector, scheduler));
     }
 
@@ -11468,7 +11468,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * Note that the {@code initialValue} is shared among all subscribers to the resulting ObservableSource
      * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
-     * the application of this operator via {@link #defer(Callable)}:
+     * the application of this operator via {@link #defer(Supplier)}:
      * <pre><code>
      * ObservableSource&lt;T&gt; source = ...
      * Observable.defer(() -&gt; source.scan(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
@@ -11499,7 +11499,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> scan(final R initialValue, BiFunction<R, ? super T, R> accumulator) {
         ObjectHelper.requireNonNull(initialValue, "initialValue is null");
-        return scanWith(Functions.justCallable(initialValue), accumulator);
+        return scanWith(Functions.justSupplier(initialValue), accumulator);
     }
 
     /**
@@ -11521,7 +11521,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <R> the initial, accumulator and result type
      * @param seedSupplier
-     *            a Callable that returns the initial (seed) accumulator item for each individual Observer
+     *            a Supplier that returns the initial (seed) accumulator item for each individual Observer
      * @param accumulator
      *            an accumulator function to be invoked on each item emitted by the source ObservableSource, whose
      *            result will be emitted to {@link Observer}s via {@link Observer#onNext onNext} and used in the
@@ -11532,7 +11532,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> scanWith(Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
+    public final <R> Observable<R> scanWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
         ObjectHelper.requireNonNull(seedSupplier, "seedSupplier is null");
         ObjectHelper.requireNonNull(accumulator, "accumulator is null");
         return RxJavaPlugins.onAssembly(new ObservableScanSeed<T, R>(this, seedSupplier, accumulator));
@@ -12422,9 +12422,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> switchMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -12698,9 +12698,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> switchMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        if (this instanceof ScalarCallable) {
+        if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
-            T v = ((ScalarCallable<T>)this).call();
+            T v = ((ScalarSupplier<T>)this).get();
             if (v == null) {
                 return empty();
             }
@@ -14013,14 +14013,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <U> the subclass of a collection of Ts
      * @param collectionSupplier
-     *               the Callable returning the collection (for each individual Observer) to be filled in
+     *               the Supplier returning the collection (for each individual Observer) to be filled in
      * @return a Single that emits a single item: a List containing all of the items emitted by the source
      *         ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX operators documentation: To</a>
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Single<U> toList(Callable<U> collectionSupplier) {
+    public final <U extends Collection<? super T>> Single<U> toList(Supplier<U> collectionSupplier) {
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableToListSingle<T, U>(this, collectionSupplier));
     }
@@ -14053,7 +14053,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Single<Map<K, T>> toMap(final Function<? super T, ? extends K> keySelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
-        return collect(HashMapSupplier.<K, T>asCallable(), Functions.toMapKeySelector(keySelector));
+        return collect(HashMapSupplier.<K, T>asSupplier(), Functions.toMapKeySelector(keySelector));
     }
 
     /**
@@ -14090,7 +14090,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             final Function<? super T, ? extends V> valueSelector) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
-        return collect(HashMapSupplier.<K, V>asCallable(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
+        return collect(HashMapSupplier.<K, V>asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
     }
 
     /**
@@ -14124,7 +14124,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <K, V> Single<Map<K, V>> toMap(
             final Function<? super T, ? extends K> keySelector,
             final Function<? super T, ? extends V> valueSelector,
-            Callable<? extends Map<K, V>> mapSupplier) {
+            Supplier<? extends Map<K, V>> mapSupplier) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
         ObjectHelper.requireNonNull(mapSupplier, "mapSupplier is null");
@@ -14157,7 +14157,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <K> Single<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
         @SuppressWarnings({ "rawtypes", "unchecked" })
         Function<? super T, ? extends T> valueSelector = (Function)Functions.identity();
-        Callable<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asCallable();
+        Supplier<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<T>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
     }
@@ -14190,7 +14190,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Single<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
-        Callable<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asCallable();
+        Supplier<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<V>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
     }
@@ -14225,7 +14225,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
             final Function<? super T, ? extends K> keySelector,
             final Function<? super T, ? extends V> valueSelector,
-            final Callable<? extends Map<K, Collection<V>>> mapSupplier,
+            final Supplier<? extends Map<K, Collection<V>>> mapSupplier,
             final Function<? super K, ? extends Collection<? super V>> collectionFactory) {
         ObjectHelper.requireNonNull(keySelector, "keySelector is null");
         ObjectHelper.requireNonNull(valueSelector, "valueSelector is null");
@@ -14266,7 +14266,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
             Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector,
-            Callable<Map<K, Collection<V>>> mapSupplier
+            Supplier<Map<K, Collection<V>>> mapSupplier
             ) {
         return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.<V, K>asFunction());
     }
@@ -15022,7 +15022,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <B> the element type of the boundary ObservableSource
      * @param boundary
-     *            a {@link Callable} that returns an {@code ObservableSource} that governs the boundary between windows.
+     *            a {@link Supplier} that returns an {@code ObservableSource} that governs the boundary between windows.
      *            When the source {@code ObservableSource} emits an item, {@code window} emits the current window and begins
      *            a new one.
      * @return an Observable that emits connected, non-overlapping windows of items from the source ObservableSource
@@ -15031,7 +15031,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Observable<Observable<T>> window(Callable<? extends ObservableSource<B>> boundary) {
+    public final <B> Observable<Observable<T>> window(Supplier<? extends ObservableSource<B>> boundary) {
         return window(boundary, bufferSize());
     }
 
@@ -15048,7 +15048,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <B> the element type of the boundary ObservableSource
      * @param boundary
-     *            a {@link Callable} that returns an {@code ObservableSource} that governs the boundary between windows.
+     *            a {@link Supplier} that returns an {@code ObservableSource} that governs the boundary between windows.
      *            When the source {@code ObservableSource} emits an item, {@code window} emits the current window and begins
      *            a new one.
      * @param bufferSize
@@ -15059,7 +15059,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Observable<Observable<T>> window(Callable<? extends ObservableSource<B>> boundary, int bufferSize) {
+    public final <B> Observable<Observable<T>> window(Supplier<? extends ObservableSource<B>> boundary, int bufferSize) {
         ObjectHelper.requireNonNull(boundary, "boundary is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return RxJavaPlugins.onAssembly(new ObservableWindowBoundarySupplier<T, B>(this, boundary, bufferSize));

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -520,7 +520,7 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Calls a {@link Callable} for each individual {@link SingleObserver} to return the actual {@link SingleSource} to
+     * Calls a {@link Supplier} for each individual {@link SingleObserver} to return the actual {@link SingleSource} to
      * be subscribed to.
      * <p>
      * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.defer.png" alt="">
@@ -529,14 +529,14 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param singleSupplier the {@code Callable} that is called for each individual {@code SingleObserver} and
+     * @param singleSupplier the {@code Supplier} that is called for each individual {@code SingleObserver} and
      * returns a SingleSource instance to subscribe to
      * @return the new Single instance
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> defer(final Callable<? extends SingleSource<? extends T>> singleSupplier) {
+    public static <T> Single<T> defer(final Supplier<? extends SingleSource<? extends T>> singleSupplier) {
         ObjectHelper.requireNonNull(singleSupplier, "singleSupplier is null");
         return RxJavaPlugins.onAssembly(new SingleDefer<T>(singleSupplier));
     }
@@ -550,14 +550,14 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param errorSupplier the callable that is called for each individual SingleObserver and
+     * @param errorSupplier the Supplier that is called for each individual SingleObserver and
      * returns a Throwable instance to be emitted.
      * @return the new Single instance
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> error(final Callable<? extends Throwable> errorSupplier) {
+    public static <T> Single<T> error(final Supplier<? extends Throwable> errorSupplier) {
         ObjectHelper.requireNonNull(errorSupplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new SingleError<T>(errorSupplier));
     }
@@ -585,7 +585,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> error(final Throwable exception) {
         ObjectHelper.requireNonNull(exception, "exception is null");
-        return error(Functions.justCallable(exception));
+        return error(Functions.justSupplier(exception));
     }
 
     /**
@@ -1402,7 +1402,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * </dl>
      * @param <T> the value type of the SingleSource generated
      * @param <U> the resource type
-     * @param resourceSupplier the Callable called for each SingleObserver to generate a resource Object
+     * @param resourceSupplier the Supplier called for each SingleObserver to generate a resource Object
      * @param singleFunction the function called with the returned resource
      *                  Object from {@code resourceSupplier} and should return a SingleSource instance
      *                  to be run by the operator
@@ -1414,7 +1414,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, U> Single<T> using(Callable<U> resourceSupplier,
+    public static <T, U> Single<T> using(Supplier<U> resourceSupplier,
                                          Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
                                          Consumer<? super U> disposer) {
         return using(resourceSupplier, singleFunction, disposer, true);
@@ -1429,7 +1429,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * </dl>
      * @param <T> the value type of the SingleSource generated
      * @param <U> the resource type
-     * @param resourceSupplier the Callable called for each SingleObserver to generate a resource Object
+     * @param resourceSupplier the Supplier called for each SingleObserver to generate a resource Object
      * @param singleFunction the function called with the returned resource
      *                  Object from {@code resourceSupplier} and should return a SingleSource instance
      *                  to be run by the operator
@@ -1446,7 +1446,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, U> Single<T> using(
-            final Callable<U> resourceSupplier,
+            final Supplier<U> resourceSupplier,
             final Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
             final Consumer<? super U> disposer,
             final boolean eager) {

--- a/src/main/java/io/reactivex/functions/Action.java
+++ b/src/main/java/io/reactivex/functions/Action.java
@@ -19,7 +19,7 @@ package io.reactivex.functions;
 public interface Action {
     /**
      * Runs the action and optionally throws a checked exception.
-     * @throws Exception if the implementation wishes to throw a checked exception
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    void run() throws Exception;
+    void run() throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/BiConsumer.java
+++ b/src/main/java/io/reactivex/functions/BiConsumer.java
@@ -24,7 +24,7 @@ public interface BiConsumer<T1, T2> {
      * Performs an operation on the given values.
      * @param t1 the first value
      * @param t2 the second value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    void accept(T1 t1, T2 t2) throws Exception;
+    void accept(T1 t1, T2 t2) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/BiFunction.java
+++ b/src/main/java/io/reactivex/functions/BiFunction.java
@@ -28,8 +28,8 @@ public interface BiFunction<T1, T2, R> {
      * @param t1 the first value
      * @param t2 the second value
      * @return the result value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2) throws Exception;
+    R apply(@NonNull T1 t1, @NonNull T2 t2) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/BiPredicate.java
+++ b/src/main/java/io/reactivex/functions/BiPredicate.java
@@ -27,7 +27,7 @@ public interface BiPredicate<T1, T2> {
      * @param t1 the first value
      * @param t2 the second value
      * @return the boolean result
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    boolean test(@NonNull T1 t1, @NonNull T2 t2) throws Exception;
+    boolean test(@NonNull T1 t1, @NonNull T2 t2) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/BooleanSupplier.java
+++ b/src/main/java/io/reactivex/functions/BooleanSupplier.java
@@ -20,7 +20,7 @@ public interface BooleanSupplier {
     /**
      * Returns a boolean value.
      * @return a boolean value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    boolean getAsBoolean() throws Exception; // NOPMD
+    boolean getAsBoolean() throws Throwable; // NOPMD
 }

--- a/src/main/java/io/reactivex/functions/Cancellable.java
+++ b/src/main/java/io/reactivex/functions/Cancellable.java
@@ -21,7 +21,7 @@ public interface Cancellable {
 
     /**
      * Cancel the action or free a resource.
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    void cancel() throws Exception;
+    void cancel() throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Consumer.java
+++ b/src/main/java/io/reactivex/functions/Consumer.java
@@ -21,7 +21,7 @@ public interface Consumer<T> {
     /**
      * Consume the given value.
      * @param t the value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    void accept(T t) throws Exception;
+    void accept(T t) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Function.java
+++ b/src/main/java/io/reactivex/functions/Function.java
@@ -27,7 +27,7 @@ public interface Function<T, R> {
      * Apply some calculation to the input value and return some other value.
      * @param t the input value
      * @return the output value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    R apply(@NonNull T t) throws Exception;
+    R apply(@NonNull T t) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Function3.java
+++ b/src/main/java/io/reactivex/functions/Function3.java
@@ -29,8 +29,8 @@ public interface Function3<T1, T2, T3, R> {
      * @param t2 the second value
      * @param t3 the third value
      * @return the result value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3) throws Exception;
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Function4.java
+++ b/src/main/java/io/reactivex/functions/Function4.java
@@ -31,8 +31,8 @@ public interface Function4<T1, T2, T3, T4, R> {
      * @param t3 the third value
      * @param t4 the fourth value
      * @return the result value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4) throws Exception;
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Function5.java
+++ b/src/main/java/io/reactivex/functions/Function5.java
@@ -33,8 +33,8 @@ public interface Function5<T1, T2, T3, T4, T5, R> {
      * @param t4 the fourth value
      * @param t5 the fifth value
      * @return the result value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5) throws Exception;
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Function6.java
+++ b/src/main/java/io/reactivex/functions/Function6.java
@@ -35,8 +35,8 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> {
      * @param t5 the fifth value
      * @param t6 the sixth value
      * @return the result value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6) throws Exception;
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Function7.java
+++ b/src/main/java/io/reactivex/functions/Function7.java
@@ -37,8 +37,8 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> {
      * @param t6 the sixth value
      * @param t7 the seventh value
      * @return the result value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7) throws Exception;
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Function8.java
+++ b/src/main/java/io/reactivex/functions/Function8.java
@@ -39,8 +39,8 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
      * @param t7 the seventh value
      * @param t8 the eighth value
      * @return the result value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7, @NonNull T8 t8) throws Exception;
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7, @NonNull T8 t8) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Function9.java
+++ b/src/main/java/io/reactivex/functions/Function9.java
@@ -41,8 +41,8 @@ public interface Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> {
      * @param t8 the eighth value
      * @param t9 the ninth value
      * @return the result value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
     @NonNull
-    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7, @NonNull T8 t8, @NonNull T9 t9) throws Exception;
+    R apply(@NonNull T1 t1, @NonNull T2 t2, @NonNull T3 t3, @NonNull T4 t4, @NonNull T5 t5, @NonNull T6 t6, @NonNull T7 t7, @NonNull T8 t8, @NonNull T9 t9) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/LongConsumer.java
+++ b/src/main/java/io/reactivex/functions/LongConsumer.java
@@ -19,7 +19,7 @@ public interface LongConsumer {
     /**
      * Consume a primitive long input.
      * @param t the primitive long value
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    void accept(long t) throws Exception;
+    void accept(long t) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Predicate.java
+++ b/src/main/java/io/reactivex/functions/Predicate.java
@@ -24,7 +24,7 @@ public interface Predicate<T> {
      * Test the given input value and return a boolean.
      * @param t the value
      * @return the boolean result
-     * @throws Exception on error
+     * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    boolean test(@NonNull T t) throws Exception;
+    boolean test(@NonNull T t) throws Throwable;
 }

--- a/src/main/java/io/reactivex/functions/Supplier.java
+++ b/src/main/java/io/reactivex/functions/Supplier.java
@@ -17,8 +17,8 @@ package io.reactivex.functions;
  * A functional interface (callback) that provides a single value or
  * throws an exception.
  * <p>
- * Thins interface was added to allow throwing any subclass of {@link Throwable}s,
- * which is not directly possible with the Java standard {@link java.util.Callable} interface. 
+ * This interface was added to allow throwing any subclass of {@link Throwable}s,
+ * which is not directly possible with the Java standard {@link java.util.concurrent.Callable} interface.
  * @param <T> the value type returned
  * @since 3.0.0
  */

--- a/src/main/java/io/reactivex/functions/Supplier.java
+++ b/src/main/java/io/reactivex/functions/Supplier.java
@@ -10,21 +10,24 @@
  * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
  * the License for the specific language governing permissions and limitations under the License.
  */
+
 package io.reactivex.functions;
 
-import io.reactivex.annotations.NonNull;
-
 /**
- * A functional interface (callback) that takes a primitive value and return value of type T.
- * @param <T> the returned value type
+ * A functional interface (callback) that provides a single value or
+ * throws an exception.
+ * <p>
+ * Thins interface was added to allow throwing any subclass of {@link Throwable}s,
+ * which is not directly possible with the Java standard {@link java.util.Callable} interface. 
+ * @param <T> the value type returned
+ * @since 3.0.0
  */
-public interface IntFunction<T> {
+public interface Supplier<T> {
+
     /**
-     * Calculates a value based on a primitive integer input.
-     * @param i the input value
-     * @return the result Object
+     * Produces a value or throws an exception.
+     * @return the value produced
      * @throws Throwable if the implementation wishes to throw any type of exception
      */
-    @NonNull
-    T apply(int i) throws Throwable;
+    T get() throws Throwable;
 }

--- a/src/main/java/io/reactivex/internal/disposables/CancellableDisposable.java
+++ b/src/main/java/io/reactivex/internal/disposables/CancellableDisposable.java
@@ -46,7 +46,7 @@ implements Disposable {
             if (c != null) {
                 try {
                     c.cancel();
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     RxJavaPlugins.onError(ex);
                 }

--- a/src/main/java/io/reactivex/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/internal/functions/Functions.java
@@ -187,7 +187,7 @@ public final class Functions {
         public U apply(T t) throws Exception {
             return value;
         }
-        
+
         @Override
         public U get() throws Throwable {
             return value;
@@ -749,7 +749,7 @@ public final class Functions {
         public Object call() {
             return null;
         }
-        
+
         @Override
         public Object get() throws Throwable {
             return null;

--- a/src/main/java/io/reactivex/internal/fuseable/ScalarSupplier.java
+++ b/src/main/java/io/reactivex/internal/fuseable/ScalarSupplier.java
@@ -12,7 +12,7 @@
  */
 package io.reactivex.internal.fuseable;
 
-import java.util.concurrent.Callable;
+import io.reactivex.functions.Supplier;
 
 /**
  * A marker interface indicating that a scalar, constant value
@@ -22,16 +22,16 @@ import java.util.concurrent.Callable;
  * <p>
  * Implementors of {@link #call()} should not throw any exception.
  * <p>
- * Design note: the interface extends {@link Callable} because if a scalar
+ * Design note: the interface extends {@link Supplier} because if a scalar
  * is safe to extract during assembly time, it is also safe to extract at
  * subscription time or later. This allows optimizations to deal with such
  * single-element sources uniformly.
  * <p>
  * @param <T> the scalar value type held by the implementing reactive type
  */
-public interface ScalarCallable<T> extends Callable<T> {
+public interface ScalarSupplier<T> extends Supplier<T> {
 
-    // overridden to remove the throws Exception
+    // overridden to remove the throws Throwable
     @Override
-    T call();
+    T get();
 }

--- a/src/main/java/io/reactivex/internal/fuseable/ScalarSupplier.java
+++ b/src/main/java/io/reactivex/internal/fuseable/ScalarSupplier.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Supplier;
  * safely extracted during assembly time can be used for
  * optimization.
  * <p>
- * Implementors of {@link #call()} should not throw any exception.
+ * Implementors of {@link #get()} should not throw any exception.
  * <p>
  * Design note: the interface extends {@link Supplier} because if a scalar
  * is safe to extract during assembly time, it is also safe to extract at

--- a/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
+++ b/src/main/java/io/reactivex/internal/fuseable/SimpleQueue.java
@@ -48,11 +48,11 @@ public interface SimpleQueue<T> {
      * item, the second poll() is guaranteed to return a non-null item
      * as well.
      * @return the item or null to indicate an empty queue
-     * @throws Exception if some pre-processing of the dequeued
+     * @throws Throwable if some pre-processing of the dequeued
      * item (usually through fused functions) throws.
      */
     @Nullable
-    T poll() throws Exception;
+    T poll() throws Throwable;
 
     /**
      * Returns true if the queue is empty.

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableDefer.java
@@ -13,18 +13,17 @@
 
 package io.reactivex.internal.operators.completable;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 
 public final class CompletableDefer extends Completable {
 
-    final Callable<? extends CompletableSource> completableSupplier;
+    final Supplier<? extends CompletableSource> completableSupplier;
 
-    public CompletableDefer(Callable<? extends CompletableSource> completableSupplier) {
+    public CompletableDefer(Supplier<? extends CompletableSource> completableSupplier) {
         this.completableSupplier = completableSupplier;
     }
 
@@ -33,7 +32,7 @@ public final class CompletableDefer extends Completable {
         CompletableSource c;
 
         try {
-            c = ObjectHelper.requireNonNull(completableSupplier.call(), "The completableSupplier returned a null CompletableSource");
+            c = ObjectHelper.requireNonNull(completableSupplier.get(), "The completableSupplier returned a null CompletableSource");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, observer);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableErrorSupplier.java
@@ -13,18 +13,17 @@
 
 package io.reactivex.internal.operators.completable;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class CompletableErrorSupplier extends Completable {
 
-    final Callable<? extends Throwable> errorSupplier;
+    final Supplier<? extends Throwable> errorSupplier;
 
-    public CompletableErrorSupplier(Callable<? extends Throwable> errorSupplier) {
+    public CompletableErrorSupplier(Supplier<? extends Throwable> errorSupplier) {
         this.errorSupplier = errorSupplier;
     }
 
@@ -33,7 +32,7 @@ public final class CompletableErrorSupplier extends Completable {
         Throwable error;
 
         try {
-            error = ObjectHelper.requireNonNull(errorSupplier.call(), "The error returned is null");
+            error = ObjectHelper.requireNonNull(errorSupplier.get(), "The error returned is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             error = e;

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableToSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableToSingle.java
@@ -13,21 +13,20 @@
 
 package io.reactivex.internal.operators.completable;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 
 public final class CompletableToSingle<T> extends Single<T> {
     final CompletableSource source;
 
-    final Callable<? extends T> completionValueSupplier;
+    final Supplier<? extends T> completionValueSupplier;
 
     final T completionValue;
 
     public CompletableToSingle(CompletableSource source,
-            Callable<? extends T> completionValueSupplier, T completionValue) {
+            Supplier<? extends T> completionValueSupplier, T completionValue) {
         this.source = source;
         this.completionValue = completionValue;
         this.completionValueSupplier = completionValueSupplier;
@@ -52,7 +51,7 @@ public final class CompletableToSingle<T> extends Single<T> {
 
             if (completionValueSupplier != null) {
                 try {
-                    v = completionValueSupplier.call();
+                    v = completionValueSupplier.get();
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     observer.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableUsing.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.completable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
@@ -26,12 +25,12 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CompletableUsing<R> extends Completable {
 
-    final Callable<R> resourceSupplier;
+    final Supplier<R> resourceSupplier;
     final Function<? super R, ? extends CompletableSource> completableFunction;
     final Consumer<? super R> disposer;
     final boolean eager;
 
-    public CompletableUsing(Callable<R> resourceSupplier,
+    public CompletableUsing(Supplier<R> resourceSupplier,
                             Function<? super R, ? extends CompletableSource> completableFunction, Consumer<? super R> disposer,
                             boolean eager) {
         this.resourceSupplier = resourceSupplier;
@@ -45,7 +44,7 @@ public final class CompletableUsing<R> extends Completable {
         R resource;
 
         try {
-            resource = resourceSupplier.call();
+            resource = resourceSupplier.get();
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBuffer.java
@@ -14,14 +14,13 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.*;
@@ -32,9 +31,9 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
     final int skip;
 
-    final Callable<C> bufferSupplier;
+    final Supplier<C> bufferSupplier;
 
-    public FlowableBuffer(Flowable<T> source, int size, int skip, Callable<C> bufferSupplier) {
+    public FlowableBuffer(Flowable<T> source, int size, int skip, Supplier<C> bufferSupplier) {
         super(source);
         this.size = size;
         this.skip = skip;
@@ -57,7 +56,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
         final Subscriber<? super C> downstream;
 
-        final Callable<C> bufferSupplier;
+        final Supplier<C> bufferSupplier;
 
         final int size;
 
@@ -69,7 +68,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
         int index;
 
-        PublisherBufferExactSubscriber(Subscriber<? super C> actual, int size, Callable<C> bufferSupplier) {
+        PublisherBufferExactSubscriber(Subscriber<? super C> actual, int size, Supplier<C> bufferSupplier) {
             this.downstream = actual;
             this.size = size;
             this.bufferSupplier = bufferSupplier;
@@ -106,7 +105,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
             if (b == null) {
 
                 try {
-                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
+                    b = ObjectHelper.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null buffer");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancel();
@@ -163,7 +162,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
         final Subscriber<? super C> downstream;
 
-        final Callable<C> bufferSupplier;
+        final Supplier<C> bufferSupplier;
 
         final int size;
 
@@ -178,7 +177,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
         int index;
 
         PublisherBufferSkipSubscriber(Subscriber<? super C> actual, int size, int skip,
-                Callable<C> bufferSupplier) {
+                Supplier<C> bufferSupplier) {
             this.downstream = actual;
             this.size = size;
             this.skip = skip;
@@ -228,7 +227,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
             if (i++ == 0) {
                 try {
-                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
+                    b = ObjectHelper.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null buffer");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancel();
@@ -293,7 +292,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
 
         final Subscriber<? super C> downstream;
 
-        final Callable<C> bufferSupplier;
+        final Supplier<C> bufferSupplier;
 
         final int size;
 
@@ -314,7 +313,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
         long produced;
 
         PublisherBufferOverlappingSubscriber(Subscriber<? super C> actual, int size, int skip,
-                Callable<C> bufferSupplier) {
+                Supplier<C> bufferSupplier) {
             this.downstream = actual;
             this.size = size;
             this.skip = skip;
@@ -379,7 +378,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
                 C b;
 
                 try {
-                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null buffer");
+                    b = ObjectHelper.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null buffer");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancel();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
@@ -22,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -31,12 +30,12 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableBufferBoundary<T, U extends Collection<? super T>, Open, Close>
 extends AbstractFlowableWithUpstream<T, U> {
-    final Callable<U> bufferSupplier;
+    final Supplier<U> bufferSupplier;
     final Publisher<? extends Open> bufferOpen;
     final Function<? super Open, ? extends Publisher<? extends Close>> bufferClose;
 
     public FlowableBufferBoundary(Flowable<T> source, Publisher<? extends Open> bufferOpen,
-            Function<? super Open, ? extends Publisher<? extends Close>> bufferClose, Callable<U> bufferSupplier) {
+            Function<? super Open, ? extends Publisher<? extends Close>> bufferClose, Supplier<U> bufferSupplier) {
         super(source);
         this.bufferOpen = bufferOpen;
         this.bufferClose = bufferClose;
@@ -60,7 +59,7 @@ extends AbstractFlowableWithUpstream<T, U> {
 
         final Subscriber<? super C> downstream;
 
-        final Callable<C> bufferSupplier;
+        final Supplier<C> bufferSupplier;
 
         final Publisher<? extends Open> bufferOpen;
 
@@ -89,7 +88,7 @@ extends AbstractFlowableWithUpstream<T, U> {
         BufferBoundarySubscriber(Subscriber<? super C> actual,
                 Publisher<? extends Open> bufferOpen,
                 Function<? super Open, ? extends Publisher<? extends Close>> bufferClose,
-                Callable<C> bufferSupplier
+                Supplier<C> bufferSupplier
         ) {
             this.downstream = actual;
             this.bufferSupplier = bufferSupplier;
@@ -184,7 +183,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             Publisher<? extends Close> p;
             C buf;
             try {
-                buf = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null Collection");
+                buf = ObjectHelper.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null Collection");
                 p = ObjectHelper.requireNonNull(bufferClose.apply(token), "The bufferClose returned a null Publisher");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferExactBoundary.java
@@ -14,13 +14,13 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscribers.QueueDrainSubscriber;
@@ -31,9 +31,9 @@ import io.reactivex.subscribers.*;
 public final class FlowableBufferExactBoundary<T, U extends Collection<? super T>, B>
 extends AbstractFlowableWithUpstream<T, U> {
     final Publisher<B> boundary;
-    final Callable<U> bufferSupplier;
+    final Supplier<U> bufferSupplier;
 
-    public FlowableBufferExactBoundary(Flowable<T> source, Publisher<B> boundary, Callable<U> bufferSupplier) {
+    public FlowableBufferExactBoundary(Flowable<T> source, Publisher<B> boundary, Supplier<U> bufferSupplier) {
         super(source);
         this.boundary = boundary;
         this.bufferSupplier = bufferSupplier;
@@ -47,7 +47,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     static final class BufferExactBoundarySubscriber<T, U extends Collection<? super T>, B>
     extends QueueDrainSubscriber<T, U, U> implements FlowableSubscriber<T>, Subscription, Disposable {
 
-        final Callable<U> bufferSupplier;
+        final Supplier<U> bufferSupplier;
         final Publisher<B> boundary;
 
         Subscription upstream;
@@ -56,7 +56,7 @@ extends AbstractFlowableWithUpstream<T, U> {
 
         U buffer;
 
-        BufferExactBoundarySubscriber(Subscriber<? super U> actual, Callable<U> bufferSupplier,
+        BufferExactBoundarySubscriber(Subscriber<? super U> actual, Supplier<U> bufferSupplier,
                                              Publisher<B> boundary) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferSupplier = bufferSupplier;
@@ -73,7 +73,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             U b;
 
             try {
-                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
+                b = ObjectHelper.requireNonNull(bufferSupplier.get(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancelled = true;
@@ -153,7 +153,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             U next;
 
             try {
-                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
+                next = ObjectHelper.requireNonNull(bufferSupplier.get(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 cancel();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollect.java
@@ -12,23 +12,21 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiConsumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T, U> {
 
-    final Callable<? extends U> initialSupplier;
+    final Supplier<? extends U> initialSupplier;
     final BiConsumer<? super U, ? super T> collector;
 
-    public FlowableCollect(Flowable<T> source, Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
+    public FlowableCollect(Flowable<T> source, Supplier<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
         super(source);
         this.initialSupplier = initialSupplier;
         this.collector = collector;
@@ -38,7 +36,7 @@ public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T,
     protected void subscribeActual(Subscriber<? super U> s) {
         U u;
         try {
-            u = ObjectHelper.requireNonNull(initialSupplier.call(), "The initial value supplied is null");
+            u = ObjectHelper.requireNonNull(initialSupplier.get(), "The initial value supplied is null");
         } catch (Throwable e) {
             EmptySubscription.error(e, s);
             return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollectSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCollectSingle.java
@@ -12,14 +12,12 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
-
-import org.reactivestreams.*;
+import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiConsumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.FuseToFlowable;
@@ -30,10 +28,10 @@ public final class FlowableCollectSingle<T, U> extends Single<U> implements Fuse
 
     final Flowable<T> source;
 
-    final Callable<? extends U> initialSupplier;
+    final Supplier<? extends U> initialSupplier;
     final BiConsumer<? super U, ? super T> collector;
 
-    public FlowableCollectSingle(Flowable<T> source, Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
+    public FlowableCollectSingle(Flowable<T> source, Supplier<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
         this.source = source;
         this.initialSupplier = initialSupplier;
         this.collector = collector;
@@ -43,7 +41,7 @@ public final class FlowableCollectSingle<T, U> extends Single<U> implements Fuse
     protected void subscribeActual(SingleObserver<? super U> observer) {
         U u;
         try {
-            u = ObjectHelper.requireNonNull(initialSupplier.call(), "The initialSupplier returned a null value");
+            u = ObjectHelper.requireNonNull(initialSupplier.get(), "The initialSupplier returned a null value");
         } catch (Throwable e) {
             EmptyDisposable.error(e, observer);
             return;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -466,7 +466,7 @@ extends Flowable<R> {
         @Nullable
         @SuppressWarnings("unchecked")
         @Override
-        public R poll() throws Exception {
+        public R poll() throws Throwable {
             Object e = queue.poll();
             if (e == null) {
                 return null;
@@ -550,7 +550,7 @@ extends Flowable<R> {
 
     final class SingletonArrayFunc implements Function<T, R> {
         @Override
-        public R apply(T t) throws Exception {
+        public R apply(T t) throws Throwable {
             return combiner.apply(new Object[] { t });
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -12,14 +12,13 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
@@ -301,14 +300,14 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                 }
                             }
 
-                            if (p instanceof Callable) {
+                            if (p instanceof Supplier) {
                                 @SuppressWarnings("unchecked")
-                                Callable<R> callable = (Callable<R>) p;
+                                Supplier<R> supplier = (Supplier<R>) p;
 
                                 R vr;
 
                                 try {
-                                    vr = callable.call();
+                                    vr = supplier.get();
                                 } catch (Throwable e) {
                                     Exceptions.throwIfFatal(e);
                                     upstream.cancel();
@@ -510,14 +509,14 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                 }
                             }
 
-                            if (p instanceof Callable) {
+                            if (p instanceof Supplier) {
                                 @SuppressWarnings("unchecked")
-                                Callable<R> supplier = (Callable<R>) p;
+                                Supplier<R> supplier = (Supplier<R>) p;
 
                                 R vr;
 
                                 try {
-                                    vr = supplier.call();
+                                    vr = supplier.get();
                                 } catch (Throwable e) {
                                     Exceptions.throwIfFatal(e);
                                     upstream.cancel();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDefer.java
@@ -13,18 +13,17 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 
 public final class FlowableDefer<T> extends Flowable<T> {
-    final Callable<? extends Publisher<? extends T>> supplier;
-    public FlowableDefer(Callable<? extends Publisher<? extends T>> supplier) {
+    final Supplier<? extends Publisher<? extends T>> supplier;
+    public FlowableDefer(Supplier<? extends Publisher<? extends T>> supplier) {
         this.supplier = supplier;
     }
 
@@ -32,7 +31,7 @@ public final class FlowableDefer<T> extends Flowable<T> {
     public void subscribeActual(Subscriber<? super T> s) {
         Publisher<? extends T> pub;
         try {
-            pub = ObjectHelper.requireNonNull(supplier.call(), "The publisher supplied is null");
+            pub = ObjectHelper.requireNonNull(supplier.get(), "The publisher supplied is null");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             EmptySubscription.error(t, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinct.java
@@ -14,14 +14,13 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.internal.subscribers.BasicFuseableSubscriber;
@@ -32,9 +31,9 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
 
     final Function<? super T, K> keySelector;
 
-    final Callable<? extends Collection<? super K>> collectionSupplier;
+    final Supplier<? extends Collection<? super K>> collectionSupplier;
 
-    public FlowableDistinct(Flowable<T> source, Function<? super T, K> keySelector, Callable<? extends Collection<? super K>> collectionSupplier) {
+    public FlowableDistinct(Flowable<T> source, Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
         super(source);
         this.keySelector = keySelector;
         this.collectionSupplier = collectionSupplier;
@@ -45,7 +44,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
         Collection<? super K> collection;
 
         try {
-            collection = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            collection = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptySubscription.error(ex, subscriber);
@@ -121,7 +120,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             for (;;) {
                 T v = qs.poll();
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -109,7 +109,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             for (;;) {
                 T v = qs.poll();
                 if (v == null) {
@@ -199,7 +199,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             for (;;) {
                 T v = qs.poll();
                 if (v == null) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNext.java
@@ -77,7 +77,7 @@ public final class FlowableDoAfterNext<T> extends AbstractFlowableWithUpstream<T
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v = qs.poll();
             if (v != null) {
                 onAfterNext.accept(v);
@@ -126,7 +126,7 @@ public final class FlowableDoAfterNext<T> extends AbstractFlowableWithUpstream<T
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v = qs.poll();
             if (v != null) {
                 onAfterNext.accept(v);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoFinally.java
@@ -132,7 +132,7 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v = qs.poll();
             if (v == null && syncFused) {
                 runFinally();
@@ -242,7 +242,7 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v = qs.poll();
             if (v == null && syncFused) {
                 runFinally();

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDoOnEach.java
@@ -149,7 +149,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v;
 
             try {
@@ -304,7 +304,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v;
 
             try {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableEmpty.java
@@ -16,13 +16,13 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 
 /**
  * A source Flowable that signals an onSubscribe() + onComplete() only.
  */
-public final class FlowableEmpty extends Flowable<Object> implements ScalarCallable<Object> {
+public final class FlowableEmpty extends Flowable<Object> implements ScalarSupplier<Object> {
 
     public static final Flowable<Object> INSTANCE = new FlowableEmpty();
 
@@ -35,7 +35,7 @@ public final class FlowableEmpty extends Flowable<Object> implements ScalarCalla
     }
 
     @Override
-    public Object call() {
+    public Object get() {
         return null; // null scalar is interpreted as being empty
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableError.java
@@ -13,18 +13,17 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 
 public final class FlowableError<T> extends Flowable<T> {
-    final Callable<? extends Throwable> errorSupplier;
-    public FlowableError(Callable<? extends Throwable> errorSupplier) {
+    final Supplier<? extends Throwable> errorSupplier;
+    public FlowableError(Supplier<? extends Throwable> errorSupplier) {
         this.errorSupplier = errorSupplier;
     }
 
@@ -32,7 +31,7 @@ public final class FlowableError<T> extends Flowable<T> {
     public void subscribeActual(Subscriber<? super T> s) {
         Throwable error;
         try {
-            error = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
+            error = ObjectHelper.requireNonNull(errorSupplier.get(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             error = t;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFilter.java
@@ -83,7 +83,7 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             QueueSubscription<T> qs = this.qs;
             Predicate<? super T> f = filter;
 
@@ -146,7 +146,7 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             QueueSubscription<T> qs = this.qs;
             Predicate<? super T> f = filter;
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
@@ -21,7 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.*;
@@ -136,11 +135,11 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                 onError(e);
                 return;
             }
-            if (p instanceof Callable) {
+            if (p instanceof Supplier) {
                 U u;
 
                 try {
-                    u  = ((Callable<U>)p).call();
+                    u  = ((Supplier<U>)p).get();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     errs.addThrowable(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterable.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Iterator;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
@@ -22,7 +21,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscArrayQueue;
@@ -46,11 +45,11 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
     @SuppressWarnings("unchecked")
     @Override
     public void subscribeActual(Subscriber<? super R> s) {
-        if (source instanceof Callable) {
+        if (source instanceof Supplier) {
             T v;
 
             try {
-                v = ((Callable<T>)source).call();
+                v = ((Supplier<T>)source).get();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 EmptySubscription.error(ex, s);
@@ -415,7 +414,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
 
         @Nullable
         @Override
-        public R poll() throws Exception {
+        public R poll() throws Throwable {
             Iterator<? extends R> it = current;
             for (;;) {
                 if (it == null) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGenerate.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.*;
@@ -26,11 +25,11 @@ import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableGenerate<T, S> extends Flowable<T> {
-    final Callable<S> stateSupplier;
+    final Supplier<S> stateSupplier;
     final BiFunction<S, Emitter<T>, S> generator;
     final Consumer<? super S> disposeState;
 
-    public FlowableGenerate(Callable<S> stateSupplier, BiFunction<S, Emitter<T>, S> generator,
+    public FlowableGenerate(Supplier<S> stateSupplier, BiFunction<S, Emitter<T>, S> generator,
             Consumer<? super S> disposeState) {
         this.stateSupplier = stateSupplier;
         this.generator = generator;
@@ -42,7 +41,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
         S state;
 
         try {
-            state = stateSupplier.call();
+            state = stateSupplier.get();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -67,7 +67,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                 Consumer<Object> evictionAction = (Consumer) new EvictionAction<K, V>(evictedGroups);
                 groups = (Map) mapFactory.apply(evictionAction);
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             s.onSubscribe(EmptyComponent.INSTANCE);
             s.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableJust.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableJust.java
@@ -16,14 +16,14 @@ package io.reactivex.internal.operators.flowable;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 import io.reactivex.internal.subscriptions.ScalarSubscription;
 
 /**
  * Represents a constant scalar value.
  * @param <T> the value type
  */
-public final class FlowableJust<T> extends Flowable<T> implements ScalarCallable<T> {
+public final class FlowableJust<T> extends Flowable<T> implements ScalarSupplier<T> {
     private final T value;
     public FlowableJust(final T value) {
         this.value = value;
@@ -35,7 +35,7 @@ public final class FlowableJust<T> extends Flowable<T> implements ScalarCallable
     }
 
     @Override
-    public T call() {
+    public T get() {
         return value;
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMap.java
@@ -75,7 +75,7 @@ public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> 
 
         @Nullable
         @Override
-        public U poll() throws Exception {
+        public U poll() throws Throwable {
             T t = qs.poll();
             return t != null ? ObjectHelper.<U>requireNonNull(mapper.apply(t), "The mapper function returned a null value.") : null;
         }
@@ -135,7 +135,7 @@ public final class FlowableMap<T, U> extends AbstractFlowableWithUpstream<T, U> 
 
         @Nullable
         @Override
-        public U poll() throws Exception {
+        public U poll() throws Throwable {
             T t = qs.poll();
             return t != null ? ObjectHelper.<U>requireNonNull(mapper.apply(t), "The mapper function returned a null value.") : null;
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMapNotification.java
@@ -13,13 +13,11 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscribers.SinglePostCompleteSubscriber;
 
@@ -27,13 +25,13 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
 
     final Function<? super T, ? extends R> onNextMapper;
     final Function<? super Throwable, ? extends R> onErrorMapper;
-    final Callable<? extends R> onCompleteSupplier;
+    final Supplier<? extends R> onCompleteSupplier;
 
     public FlowableMapNotification(
             Flowable<T> source,
             Function<? super T, ? extends R> onNextMapper,
             Function<? super Throwable, ? extends R> onErrorMapper,
-            Callable<? extends R> onCompleteSupplier) {
+            Supplier<? extends R> onCompleteSupplier) {
         super(source);
         this.onNextMapper = onNextMapper;
         this.onErrorMapper = onErrorMapper;
@@ -51,12 +49,12 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
         private static final long serialVersionUID = 2757120512858778108L;
         final Function<? super T, ? extends R> onNextMapper;
         final Function<? super Throwable, ? extends R> onErrorMapper;
-        final Callable<? extends R> onCompleteSupplier;
+        final Supplier<? extends R> onCompleteSupplier;
 
         MapNotificationSubscriber(Subscriber<? super R> actual,
                 Function<? super T, ? extends R> onNextMapper,
                 Function<? super Throwable, ? extends R> onErrorMapper,
-                Callable<? extends R> onCompleteSupplier) {
+                Supplier<? extends R> onCompleteSupplier) {
             super(actual);
             this.onNextMapper = onNextMapper;
             this.onErrorMapper = onErrorMapper;
@@ -99,7 +97,7 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
             R p;
 
             try {
-                p = ObjectHelper.requireNonNull(onCompleteSupplier.call(), "The onComplete publisher returned is null");
+                p = ObjectHelper.requireNonNull(onCompleteSupplier.get(), "The onComplete publisher returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 downstream.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableObserveOn.java
@@ -468,7 +468,7 @@ final Scheduler scheduler;
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v = queue.poll();
             if (v != null && sourceMode != SYNC) {
                 long p = produced + 1;
@@ -712,7 +712,7 @@ final Scheduler scheduler;
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v = queue.poll();
             if (v != null && sourceMode != SYNC) {
                 long p = consumed + 1;

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingle.java
@@ -13,13 +13,11 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.Publisher;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.operators.flowable.FlowableReduceSeedSingle.ReduceSeedObserver;
@@ -35,11 +33,11 @@ public final class FlowableReduceWithSingle<T, R> extends Single<R> {
 
     final Publisher<T> source;
 
-    final Callable<R> seedSupplier;
+    final Supplier<R> seedSupplier;
 
     final BiFunction<R, ? super T, R> reducer;
 
-    public FlowableReduceWithSingle(Publisher<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
+    public FlowableReduceWithSingle(Publisher<T> source, Supplier<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
         this.source = source;
         this.seedSupplier = seedSupplier;
         this.reducer = reducer;
@@ -50,7 +48,7 @@ public final class FlowableReduceWithSingle<T, R> extends Single<R> {
         R seed;
 
         try {
-            seed = ObjectHelper.requireNonNull(seedSupplier.call(), "The seedSupplier returned a null value");
+            seed = ObjectHelper.requireNonNull(seedSupplier.get(), "The seedSupplier returned a null value");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScalarXMap.java
@@ -13,13 +13,11 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -35,7 +33,7 @@ public final class FlowableScalarXMap {
     }
 
     /**
-     * Tries to subscribe to a possibly Callable source's mapped Publisher.
+     * Tries to subscribe to a possibly Supplier source's mapped Publisher.
      * @param <T> the input value type
      * @param <R> the output value type
      * @param source the source Publisher
@@ -47,11 +45,11 @@ public final class FlowableScalarXMap {
     public static <T, R> boolean tryScalarXMapSubscribe(Publisher<T> source,
             Subscriber<? super R> subscriber,
             Function<? super T, ? extends Publisher<? extends R>> mapper) {
-        if (source instanceof Callable) {
+        if (source instanceof Supplier) {
             T t;
 
             try {
-                t = ((Callable<T>)source).call();
+                t = ((Supplier<T>)source).get();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 EmptySubscription.error(ex, subscriber);
@@ -73,11 +71,11 @@ public final class FlowableScalarXMap {
                 return true;
             }
 
-            if (r instanceof Callable) {
+            if (r instanceof Supplier) {
                 R u;
 
                 try {
-                    u = ((Callable<R>)r).call();
+                    u = ((Supplier<R>)r).get();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     EmptySubscription.error(ex, subscriber);
@@ -140,11 +138,11 @@ public final class FlowableScalarXMap {
                 EmptySubscription.error(e, s);
                 return;
             }
-            if (other instanceof Callable) {
+            if (other instanceof Supplier) {
                 R u;
 
                 try {
-                    u = ((Callable<R>)other).call();
+                    u = ((Supplier<R>)other).get();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     EmptySubscription.error(ex, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableScanSeed.java
@@ -12,14 +12,13 @@
  */
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.SimplePlainQueue;
 import io.reactivex.internal.queue.SpscArrayQueue;
@@ -29,9 +28,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T, R> {
     final BiFunction<R, ? super T, R> accumulator;
-    final Callable<R> seedSupplier;
+    final Supplier<R> seedSupplier;
 
-    public FlowableScanSeed(Flowable<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
+    public FlowableScanSeed(Flowable<T> source, Supplier<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
         super(source);
         this.accumulator = accumulator;
         this.seedSupplier = seedSupplier;
@@ -42,7 +41,7 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
         R r;
 
         try {
-            r = ObjectHelper.requireNonNull(seedSupplier.call(), "The seed supplied is null");
+            r = ObjectHelper.requireNonNull(seedSupplier.get(), "The seed supplied is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableToList.java
@@ -14,19 +14,19 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscriptions.*;
 
 public final class FlowableToList<T, U extends Collection<? super T>> extends AbstractFlowableWithUpstream<T, U> {
-    final Callable<U> collectionSupplier;
+    final Supplier<U> collectionSupplier;
 
-    public FlowableToList(Flowable<T> source, Callable<U> collectionSupplier) {
+    public FlowableToList(Flowable<T> source, Supplier<U> collectionSupplier) {
         super(source);
         this.collectionSupplier = collectionSupplier;
     }
@@ -35,7 +35,7 @@ public final class FlowableToList<T, U extends Collection<? super T>> extends Ab
     protected void subscribeActual(Subscriber<? super U> s) {
         U coll;
         try {
-            coll = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            coll = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableToListSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableToListSingle.java
@@ -14,13 +14,13 @@
 package io.reactivex.internal.operators.flowable;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 import org.reactivestreams.Subscription;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.FuseToFlowable;
@@ -32,14 +32,14 @@ public final class FlowableToListSingle<T, U extends Collection<? super T>> exte
 
     final Flowable<T> source;
 
-    final Callable<U> collectionSupplier;
+    final Supplier<U> collectionSupplier;
 
     @SuppressWarnings("unchecked")
     public FlowableToListSingle(Flowable<T> source) {
-        this(source, (Callable<U>)ArrayListSupplier.asCallable());
+        this(source, (Supplier<U>)ArrayListSupplier.asSupplier());
     }
 
-    public FlowableToListSingle(Flowable<T> source, Callable<U> collectionSupplier) {
+    public FlowableToListSingle(Flowable<T> source, Supplier<U> collectionSupplier) {
         this.source = source;
         this.collectionSupplier = collectionSupplier;
     }
@@ -48,7 +48,7 @@ public final class FlowableToListSingle<T, U extends Collection<? super T>> exte
     protected void subscribeActual(SingleObserver<? super U> observer) {
         U coll;
         try {
-            coll = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            coll = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, observer);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableUsing.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.reactivestreams.*;
@@ -26,12 +25,12 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class FlowableUsing<T, D> extends Flowable<T> {
-    final Callable<? extends D> resourceSupplier;
+    final Supplier<? extends D> resourceSupplier;
     final Function<? super D, ? extends Publisher<? extends T>> sourceSupplier;
     final Consumer<? super D> disposer;
     final boolean eager;
 
-    public FlowableUsing(Callable<? extends D> resourceSupplier,
+    public FlowableUsing(Supplier<? extends D> resourceSupplier,
             Function<? super D, ? extends Publisher<? extends T>> sourceSupplier,
             Consumer<? super D> disposer,
             boolean eager) {
@@ -46,7 +45,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
         D resource;
 
         try {
-            resource = resourceSupplier.call();
+            resource = resourceSupplier.get();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWindowBoundarySupplier.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
@@ -21,6 +20,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
@@ -30,11 +30,11 @@ import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.DisposableSubscriber;
 
 public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowableWithUpstream<T, Flowable<T>> {
-    final Callable<? extends Publisher<B>> other;
+    final Supplier<? extends Publisher<B>> other;
     final int capacityHint;
 
     public FlowableWindowBoundarySupplier(Flowable<T> source,
-            Callable<? extends Publisher<B>> other, int capacityHint) {
+            Supplier<? extends Publisher<B>> other, int capacityHint) {
         super(source);
         this.other = other;
         this.capacityHint = capacityHint;
@@ -69,7 +69,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
 
         final AtomicBoolean stopWindows;
 
-        final Callable<? extends Publisher<B>> other;
+        final Supplier<? extends Publisher<B>> other;
 
         static final Object NEXT_WINDOW = new Object();
 
@@ -83,7 +83,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
 
         long emitted;
 
-        WindowBoundaryMainSubscriber(Subscriber<? super Flowable<T>> downstream, int capacityHint, Callable<? extends Publisher<B>> other) {
+        WindowBoundaryMainSubscriber(Subscriber<? super Flowable<T>> downstream, int capacityHint, Supplier<? extends Publisher<B>> other) {
             this.downstream = downstream;
             this.capacityHint = capacityHint;
             this.boundarySubscriber = new AtomicReference<WindowBoundaryInnerSubscriber<T, B>>();
@@ -263,7 +263,7 @@ public final class FlowableWindowBoundarySupplier<T, B> extends AbstractFlowable
                             Publisher<B> otherSource;
 
                             try {
-                                otherSource = ObjectHelper.requireNonNull(other.call(), "The other Callable returned a null Publisher");
+                                otherSource = ObjectHelper.requireNonNull(other.get(), "The other Supplier returned a null Publisher");
                             } catch (Throwable ex) {
                                 Exceptions.throwIfFatal(ex);
                                 errors.addThrowable(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -296,7 +296,7 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
 
     final class SingletonArrayFunc implements Function<T, R> {
         @Override
-        public R apply(T t) throws Exception {
+        public R apply(T t) throws Throwable {
             return ObjectHelper.requireNonNull(combiner.apply(new Object[] { t }), "The combiner returned a null value");
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeDefer.java
@@ -13,10 +13,9 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 
@@ -27,9 +26,9 @@ import io.reactivex.internal.functions.ObjectHelper;
  */
 public final class MaybeDefer<T> extends Maybe<T> {
 
-    final Callable<? extends MaybeSource<? extends T>> maybeSupplier;
+    final Supplier<? extends MaybeSource<? extends T>> maybeSupplier;
 
-    public MaybeDefer(Callable<? extends MaybeSource<? extends T>> maybeSupplier) {
+    public MaybeDefer(Supplier<? extends MaybeSource<? extends T>> maybeSupplier) {
         this.maybeSupplier = maybeSupplier;
     }
 
@@ -38,7 +37,7 @@ public final class MaybeDefer<T> extends Maybe<T> {
         MaybeSource<? extends T> source;
 
         try {
-            source = ObjectHelper.requireNonNull(maybeSupplier.call(), "The maybeSupplier returned a null MaybeSource");
+            source = ObjectHelper.requireNonNull(maybeSupplier.get(), "The maybeSupplier returned a null MaybeSource");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeEmpty.java
@@ -15,12 +15,12 @@ package io.reactivex.internal.operators.maybe;
 
 import io.reactivex.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 
 /**
  * Signals an onComplete.
  */
-public final class MaybeEmpty extends Maybe<Object> implements ScalarCallable<Object> {
+public final class MaybeEmpty extends Maybe<Object> implements ScalarSupplier<Object> {
 
     public static final MaybeEmpty INSTANCE = new MaybeEmpty();
 
@@ -30,7 +30,7 @@ public final class MaybeEmpty extends Maybe<Object> implements ScalarCallable<Ob
     }
 
     @Override
-    public Object call() {
+    public Object get() {
         return null; // nulls of ScalarCallable are considered empty sources
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeErrorCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeErrorCallable.java
@@ -13,23 +13,22 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
+import io.reactivex.internal.functions.ObjectHelper;
 
 /**
- * Signals a Throwable returned by a Callable.
+ * Signals a Throwable returned by a Supplier.
  *
  * @param <T> the value type
  */
 public final class MaybeErrorCallable<T> extends Maybe<T> {
 
-    final Callable<? extends Throwable> errorSupplier;
+    final Supplier<? extends Throwable> errorSupplier;
 
-    public MaybeErrorCallable(Callable<? extends Throwable> errorSupplier) {
+    public MaybeErrorCallable(Supplier<? extends Throwable> errorSupplier) {
         this.errorSupplier = errorSupplier;
     }
 
@@ -39,7 +38,7 @@ public final class MaybeErrorCallable<T> extends Maybe<T> {
         Throwable ex;
 
         try {
-            ex = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
+            ex = ObjectHelper.requireNonNull(errorSupplier.get(), "Supplier returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable ex1) {
             Exceptions.throwIfFatal(ex1);
             ex = ex1;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatMapNotification.java
@@ -13,13 +13,12 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 
@@ -35,12 +34,12 @@ public final class MaybeFlatMapNotification<T, R> extends AbstractMaybeWithUpstr
 
     final Function<? super Throwable, ? extends MaybeSource<? extends R>> onErrorMapper;
 
-    final Callable<? extends MaybeSource<? extends R>> onCompleteSupplier;
+    final Supplier<? extends MaybeSource<? extends R>> onCompleteSupplier;
 
     public MaybeFlatMapNotification(MaybeSource<T> source,
             Function<? super T, ? extends MaybeSource<? extends R>> onSuccessMapper,
             Function<? super Throwable, ? extends MaybeSource<? extends R>> onErrorMapper,
-            Callable<? extends MaybeSource<? extends R>> onCompleteSupplier) {
+            Supplier<? extends MaybeSource<? extends R>> onCompleteSupplier) {
         super(source);
         this.onSuccessMapper = onSuccessMapper;
         this.onErrorMapper = onErrorMapper;
@@ -64,14 +63,14 @@ public final class MaybeFlatMapNotification<T, R> extends AbstractMaybeWithUpstr
 
         final Function<? super Throwable, ? extends MaybeSource<? extends R>> onErrorMapper;
 
-        final Callable<? extends MaybeSource<? extends R>> onCompleteSupplier;
+        final Supplier<? extends MaybeSource<? extends R>> onCompleteSupplier;
 
         Disposable upstream;
 
         FlatMapMaybeObserver(MaybeObserver<? super R> actual,
                 Function<? super T, ? extends MaybeSource<? extends R>> onSuccessMapper,
                 Function<? super Throwable, ? extends MaybeSource<? extends R>> onErrorMapper,
-                Callable<? extends MaybeSource<? extends R>> onCompleteSupplier) {
+                Supplier<? extends MaybeSource<? extends R>> onCompleteSupplier) {
             this.downstream = actual;
             this.onSuccessMapper = onSuccessMapper;
             this.onErrorMapper = onErrorMapper;
@@ -104,7 +103,7 @@ public final class MaybeFlatMapNotification<T, R> extends AbstractMaybeWithUpstr
 
             try {
                 source = ObjectHelper.requireNonNull(onSuccessMapper.apply(value), "The onSuccessMapper returned a null MaybeSource");
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 downstream.onError(ex);
                 return;
@@ -119,7 +118,7 @@ public final class MaybeFlatMapNotification<T, R> extends AbstractMaybeWithUpstr
 
             try {
                 source = ObjectHelper.requireNonNull(onErrorMapper.apply(e), "The onErrorMapper returned a null MaybeSource");
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 downstream.onError(new CompositeException(e, ex));
                 return;
@@ -133,8 +132,8 @@ public final class MaybeFlatMapNotification<T, R> extends AbstractMaybeWithUpstr
             MaybeSource<? extends R> source;
 
             try {
-                source = ObjectHelper.requireNonNull(onCompleteSupplier.call(), "The onCompleteSupplier returned a null MaybeSource");
-            } catch (Exception ex) {
+                source = ObjectHelper.requireNonNull(onCompleteSupplier.get(), "The onCompleteSupplier returned a null MaybeSource");
+            } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 downstream.onError(ex);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatten.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFlatten.java
@@ -86,7 +86,7 @@ public final class MaybeFlatten<T, R> extends AbstractMaybeWithUpstream<T, R> {
 
             try {
                 source = ObjectHelper.requireNonNull(mapper.apply(value), "The mapper returned a null MaybeSource");
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 downstream.onError(ex);
                 return;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromAction.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromAction.java
@@ -13,12 +13,10 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Action;
+import io.reactivex.functions.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -26,7 +24,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class MaybeFromAction<T> extends Maybe<T> implements Callable<T> {
+public final class MaybeFromAction<T> extends Maybe<T> implements Supplier<T> {
 
     final Action action;
 
@@ -60,7 +58,7 @@ public final class MaybeFromAction<T> extends Maybe<T> implements Callable<T> {
     }
 
     @Override
-    public T call() throws Exception {
+    public T get() throws Throwable {
         action.run();
         return null; // considered as onComplete()
     }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromCallable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromCallable.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -25,7 +26,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class MaybeFromCallable<T> extends Maybe<T> implements Callable<T> {
+public final class MaybeFromCallable<T> extends Maybe<T> implements Supplier<T> {
 
     final Callable<? extends T> callable;
 
@@ -65,7 +66,7 @@ public final class MaybeFromCallable<T> extends Maybe<T> implements Callable<T> 
     }
 
     @Override
-    public T call() throws Exception {
+    public T get() throws Exception {
         return callable.call();
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromRunnable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeFromRunnable.java
@@ -13,11 +13,10 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -25,7 +24,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * @param <T> the value type
  */
-public final class MaybeFromRunnable<T> extends Maybe<T> implements Callable<T> {
+public final class MaybeFromRunnable<T> extends Maybe<T> implements Supplier<T> {
 
     final Runnable runnable;
 
@@ -59,7 +58,7 @@ public final class MaybeFromRunnable<T> extends Maybe<T> implements Callable<T> 
     }
 
     @Override
-    public T call() throws Exception {
+    public T get() throws Throwable {
         runnable.run();
         return null;
     }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeJust.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeJust.java
@@ -15,14 +15,14 @@ package io.reactivex.internal.operators.maybe;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 
 /**
  * Signals a constant value.
  *
  * @param <T> the value type
  */
-public final class MaybeJust<T> extends Maybe<T> implements ScalarCallable<T> {
+public final class MaybeJust<T> extends Maybe<T> implements ScalarSupplier<T> {
 
     final T value;
 
@@ -37,7 +37,7 @@ public final class MaybeJust<T> extends Maybe<T> implements ScalarCallable<T> {
     }
 
     @Override
-    public T call() {
+    public T get() {
         return value;
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeUsing.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
@@ -33,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  */
 public final class MaybeUsing<T, D> extends Maybe<T> {
 
-    final Callable<? extends D> resourceSupplier;
+    final Supplier<? extends D> resourceSupplier;
 
     final Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier;
 
@@ -41,7 +40,7 @@ public final class MaybeUsing<T, D> extends Maybe<T> {
 
     final boolean eager;
 
-    public MaybeUsing(Callable<? extends D> resourceSupplier,
+    public MaybeUsing(Supplier<? extends D> resourceSupplier,
             Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
             Consumer<? super D> resourceDisposer,
             boolean eager) {
@@ -56,7 +55,7 @@ public final class MaybeUsing<T, D> extends Maybe<T> {
         D resource;
 
         try {
-            resource = resourceSupplier.call();
+            resource = resourceSupplier.get();
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeZipArray.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeZipArray.java
@@ -189,7 +189,7 @@ public final class MaybeZipArray<T, R> extends Maybe<R> {
 
     final class SingletonArrayFunc implements Function<T, R> {
         @Override
-        public R apply(T t) throws Exception {
+        public R apply(T t) throws Throwable {
             return ObjectHelper.requireNonNull(zipper.apply(new Object[] { t }), "The zipper returned a null value");
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeZipIterable.java
@@ -81,7 +81,7 @@ public final class MaybeZipIterable<T, R> extends Maybe<R> {
 
     final class SingletonArrayFunc implements Function<T, R> {
         @Override
-        public R apply(T t) throws Exception {
+        public R apply(T t) throws Throwable {
             return ObjectHelper.requireNonNull(zipper.apply(new Object[] { t }), "The zipper returned a null value");
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/mixed/ScalarXMapZHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ScalarXMapZHelper.java
@@ -13,11 +13,9 @@
 
 package io.reactivex.internal.operators.mixed;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.operators.maybe.MaybeToObservable;
@@ -38,10 +36,10 @@ final class ScalarXMapZHelper {
 
     /**
      * Try subscribing to a {@link CompletableSource} mapped from
-     * a scalar source (which implements {@link Callable}).
+     * a scalar source (which implements {@link Supplier}).
      * @param <T> the upstream value type
      * @param source the source reactive type ({@code Flowable} or {@code Observable})
-     *               possibly implementing {@link Callable}.
+     *               possibly implementing {@link Supplier}.
      * @param mapper the function that turns the scalar upstream value into a
      *              {@link CompletableSource}
      * @param observer the consumer to subscribe to the mapped {@link CompletableSource}
@@ -50,12 +48,12 @@ final class ScalarXMapZHelper {
     static <T> boolean tryAsCompletable(Object source,
             Function<? super T, ? extends CompletableSource> mapper,
             CompletableObserver observer) {
-        if (source instanceof Callable) {
+        if (source instanceof Supplier) {
             @SuppressWarnings("unchecked")
-            Callable<T> call = (Callable<T>) source;
+            Supplier<T> supplier = (Supplier<T>) source;
             CompletableSource cs = null;
             try {
-                T item = call.call();
+                T item = supplier.get();
                 if (item != null) {
                     cs = ObjectHelper.requireNonNull(mapper.apply(item), "The mapper returned a null CompletableSource");
                 }
@@ -77,10 +75,10 @@ final class ScalarXMapZHelper {
 
     /**
      * Try subscribing to a {@link MaybeSource} mapped from
-     * a scalar source (which implements {@link Callable}).
+     * a scalar source (which implements {@link Supplier}).
      * @param <T> the upstream value type
      * @param source the source reactive type ({@code Flowable} or {@code Observable})
-     *               possibly implementing {@link Callable}.
+     *               possibly implementing {@link Supplier}.
      * @param mapper the function that turns the scalar upstream value into a
      *              {@link MaybeSource}
      * @param observer the consumer to subscribe to the mapped {@link MaybeSource}
@@ -89,12 +87,12 @@ final class ScalarXMapZHelper {
     static <T, R> boolean tryAsMaybe(Object source,
             Function<? super T, ? extends MaybeSource<? extends R>> mapper,
             Observer<? super R> observer) {
-        if (source instanceof Callable) {
+        if (source instanceof Supplier) {
             @SuppressWarnings("unchecked")
-            Callable<T> call = (Callable<T>) source;
+            Supplier<T> supplier = (Supplier<T>) source;
             MaybeSource<? extends R> cs = null;
             try {
-                T item = call.call();
+                T item = supplier.get();
                 if (item != null) {
                     cs = ObjectHelper.requireNonNull(mapper.apply(item), "The mapper returned a null MaybeSource");
                 }
@@ -116,10 +114,10 @@ final class ScalarXMapZHelper {
 
     /**
      * Try subscribing to a {@link SingleSource} mapped from
-     * a scalar source (which implements {@link Callable}).
+     * a scalar source (which implements {@link Supplier}).
      * @param <T> the upstream value type
      * @param source the source reactive type ({@code Flowable} or {@code Observable})
-     *               possibly implementing {@link Callable}.
+     *               possibly implementing {@link Supplier}.
      * @param mapper the function that turns the scalar upstream value into a
      *              {@link SingleSource}
      * @param observer the consumer to subscribe to the mapped {@link SingleSource}
@@ -128,12 +126,12 @@ final class ScalarXMapZHelper {
     static <T, R> boolean tryAsSingle(Object source,
             Function<? super T, ? extends SingleSource<? extends R>> mapper,
             Observer<? super R> observer) {
-        if (source instanceof Callable) {
+        if (source instanceof Supplier) {
             @SuppressWarnings("unchecked")
-            Callable<T> call = (Callable<T>) source;
+            Supplier<T> supplier = (Supplier<T>) source;
             SingleSource<? extends R> cs = null;
             try {
-                T item = call.call();
+                T item = supplier.get();
                 if (item != null) {
                     cs = ObjectHelper.requireNonNull(mapper.apply(item), "The mapper returned a null SingleSource");
                 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBuffer.java
@@ -13,23 +13,23 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class ObservableBuffer<T, U extends Collection<? super T>> extends AbstractObservableWithUpstream<T, U> {
     final int count;
     final int skip;
-    final Callable<U> bufferSupplier;
+    final Supplier<U> bufferSupplier;
 
-    public ObservableBuffer(ObservableSource<T> source, int count, int skip, Callable<U> bufferSupplier) {
+    public ObservableBuffer(ObservableSource<T> source, int count, int skip, Supplier<U> bufferSupplier) {
         super(source);
         this.count = count;
         this.skip = skip;
@@ -51,14 +51,14 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
     static final class BufferExactObserver<T, U extends Collection<? super T>> implements Observer<T>, Disposable {
         final Observer<? super U> downstream;
         final int count;
-        final Callable<U> bufferSupplier;
+        final Supplier<U> bufferSupplier;
         U buffer;
 
         int size;
 
         Disposable upstream;
 
-        BufferExactObserver(Observer<? super U> actual, int count, Callable<U> bufferSupplier) {
+        BufferExactObserver(Observer<? super U> actual, int count, Supplier<U> bufferSupplier) {
             this.downstream = actual;
             this.count = count;
             this.bufferSupplier = bufferSupplier;
@@ -67,7 +67,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
         boolean createBuffer() {
             U b;
             try {
-                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "Empty buffer supplied");
+                b = ObjectHelper.requireNonNull(bufferSupplier.get(), "Empty buffer supplied");
             } catch (Throwable t) {
                 Exceptions.throwIfFatal(t);
                 buffer = null;
@@ -144,7 +144,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
         final Observer<? super U> downstream;
         final int count;
         final int skip;
-        final Callable<U> bufferSupplier;
+        final Supplier<U> bufferSupplier;
 
         Disposable upstream;
 
@@ -152,7 +152,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
 
         long index;
 
-        BufferSkipObserver(Observer<? super U> actual, int count, int skip, Callable<U> bufferSupplier) {
+        BufferSkipObserver(Observer<? super U> actual, int count, int skip, Supplier<U> bufferSupplier) {
             this.downstream = actual;
             this.count = count;
             this.skip = skip;
@@ -184,7 +184,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
                 U b;
 
                 try {
-                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+                    b = ObjectHelper.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
                 } catch (Throwable e) {
                     buffers.clear();
                     upstream.dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundary.java
@@ -14,14 +14,13 @@
 package io.reactivex.internal.operators.observable;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
@@ -30,12 +29,12 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableBufferBoundary<T, U extends Collection<? super T>, Open, Close>
 extends AbstractObservableWithUpstream<T, U> {
-    final Callable<U> bufferSupplier;
+    final Supplier<U> bufferSupplier;
     final ObservableSource<? extends Open> bufferOpen;
     final Function<? super Open, ? extends ObservableSource<? extends Close>> bufferClose;
 
     public ObservableBufferBoundary(ObservableSource<T> source, ObservableSource<? extends Open> bufferOpen,
-                                    Function<? super Open, ? extends ObservableSource<? extends Close>> bufferClose, Callable<U> bufferSupplier) {
+                                    Function<? super Open, ? extends ObservableSource<? extends Close>> bufferClose, Supplier<U> bufferSupplier) {
         super(source);
         this.bufferOpen = bufferOpen;
         this.bufferClose = bufferClose;
@@ -59,7 +58,7 @@ extends AbstractObservableWithUpstream<T, U> {
 
         final Observer<? super C> downstream;
 
-        final Callable<C> bufferSupplier;
+        final Supplier<C> bufferSupplier;
 
         final ObservableSource<? extends Open> bufferOpen;
 
@@ -84,7 +83,7 @@ extends AbstractObservableWithUpstream<T, U> {
         BufferBoundaryObserver(Observer<? super C> actual,
                 ObservableSource<? extends Open> bufferOpen,
                 Function<? super Open, ? extends ObservableSource<? extends Close>> bufferClose,
-                Callable<C> bufferSupplier
+                Supplier<C> bufferSupplier
         ) {
             this.downstream = actual;
             this.bufferSupplier = bufferSupplier;
@@ -175,7 +174,7 @@ extends AbstractObservableWithUpstream<T, U> {
             ObservableSource<? extends Close> p;
             C buf;
             try {
-                buf = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null Collection");
+                buf = ObjectHelper.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null Collection");
                 p = ObjectHelper.requireNonNull(bufferClose.apply(token), "The bufferClose returned a null ObservableSource");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferBoundarySupplier.java
@@ -13,15 +13,15 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.QueueDrainObserver;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.util.QueueDrainHelper;
@@ -30,10 +30,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableBufferBoundarySupplier<T, U extends Collection<? super T>, B>
 extends AbstractObservableWithUpstream<T, U> {
-    final Callable<? extends ObservableSource<B>> boundarySupplier;
-    final Callable<U> bufferSupplier;
+    final Supplier<? extends ObservableSource<B>> boundarySupplier;
+    final Supplier<U> bufferSupplier;
 
-    public ObservableBufferBoundarySupplier(ObservableSource<T> source, Callable<? extends ObservableSource<B>> boundarySupplier, Callable<U> bufferSupplier) {
+    public ObservableBufferBoundarySupplier(ObservableSource<T> source, Supplier<? extends ObservableSource<B>> boundarySupplier, Supplier<U> bufferSupplier) {
         super(source);
         this.boundarySupplier = boundarySupplier;
         this.bufferSupplier = bufferSupplier;
@@ -47,8 +47,8 @@ extends AbstractObservableWithUpstream<T, U> {
     static final class BufferBoundarySupplierObserver<T, U extends Collection<? super T>, B>
     extends QueueDrainObserver<T, U, U> implements Observer<T>, Disposable {
 
-        final Callable<U> bufferSupplier;
-        final Callable<? extends ObservableSource<B>> boundarySupplier;
+        final Supplier<U> bufferSupplier;
+        final Supplier<? extends ObservableSource<B>> boundarySupplier;
 
         Disposable upstream;
 
@@ -56,8 +56,8 @@ extends AbstractObservableWithUpstream<T, U> {
 
         U buffer;
 
-        BufferBoundarySupplierObserver(Observer<? super U> actual, Callable<U> bufferSupplier,
-                                                Callable<? extends ObservableSource<B>> boundarySupplier) {
+        BufferBoundarySupplierObserver(Observer<? super U> actual, Supplier<U> bufferSupplier,
+                Supplier<? extends ObservableSource<B>> boundarySupplier) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferSupplier = bufferSupplier;
             this.boundarySupplier = boundarySupplier;
@@ -73,7 +73,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 U b;
 
                 try {
-                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
+                    b = ObjectHelper.requireNonNull(bufferSupplier.get(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancelled = true;
@@ -87,7 +87,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 ObservableSource<B> boundary;
 
                 try {
-                    boundary = ObjectHelper.requireNonNull(boundarySupplier.call(), "The boundary ObservableSource supplied is null");
+                    boundary = ObjectHelper.requireNonNull(boundarySupplier.get(), "The boundary ObservableSource supplied is null");
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     cancelled = true;
@@ -168,7 +168,7 @@ extends AbstractObservableWithUpstream<T, U> {
             U next;
 
             try {
-                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
+                next = ObjectHelper.requireNonNull(bufferSupplier.get(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();
@@ -179,7 +179,7 @@ extends AbstractObservableWithUpstream<T, U> {
             ObservableSource<B> boundary;
 
             try {
-                boundary = ObjectHelper.requireNonNull(boundarySupplier.call(), "The boundary ObservableSource supplied is null");
+                boundary = ObjectHelper.requireNonNull(boundarySupplier.get(), "The boundary ObservableSource supplied is null");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 cancelled = true;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBufferExactBoundary.java
@@ -13,14 +13,14 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.QueueDrainObserver;
 import io.reactivex.internal.queue.MpscLinkedQueue;
 import io.reactivex.internal.util.QueueDrainHelper;
@@ -29,9 +29,9 @@ import io.reactivex.observers.*;
 public final class ObservableBufferExactBoundary<T, U extends Collection<? super T>, B>
 extends AbstractObservableWithUpstream<T, U> {
     final ObservableSource<B> boundary;
-    final Callable<U> bufferSupplier;
+    final Supplier<U> bufferSupplier;
 
-    public ObservableBufferExactBoundary(ObservableSource<T> source, ObservableSource<B> boundary, Callable<U> bufferSupplier) {
+    public ObservableBufferExactBoundary(ObservableSource<T> source, ObservableSource<B> boundary, Supplier<U> bufferSupplier) {
         super(source);
         this.boundary = boundary;
         this.bufferSupplier = bufferSupplier;
@@ -45,7 +45,7 @@ extends AbstractObservableWithUpstream<T, U> {
     static final class BufferExactBoundaryObserver<T, U extends Collection<? super T>, B>
     extends QueueDrainObserver<T, U, U> implements Observer<T>, Disposable {
 
-        final Callable<U> bufferSupplier;
+        final Supplier<U> bufferSupplier;
         final ObservableSource<B> boundary;
 
         Disposable upstream;
@@ -54,7 +54,7 @@ extends AbstractObservableWithUpstream<T, U> {
 
         U buffer;
 
-        BufferExactBoundaryObserver(Observer<? super U> actual, Callable<U> bufferSupplier,
+        BufferExactBoundaryObserver(Observer<? super U> actual, Supplier<U> bufferSupplier,
                                              ObservableSource<B> boundary) {
             super(actual, new MpscLinkedQueue<U>());
             this.bufferSupplier = bufferSupplier;
@@ -69,7 +69,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 U b;
 
                 try {
-                    b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
+                    b = ObjectHelper.requireNonNull(bufferSupplier.get(), "The buffer supplied is null");
                 } catch (Throwable e) {
                     Exceptions.throwIfFatal(e);
                     cancelled = true;
@@ -148,7 +148,7 @@ extends AbstractObservableWithUpstream<T, U> {
             U next;
 
             try {
-                next = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
+                next = ObjectHelper.requireNonNull(bufferSupplier.get(), "The buffer supplied is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 dispose();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCollect.java
@@ -12,21 +12,19 @@
  */
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.BiConsumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableCollect<T, U> extends AbstractObservableWithUpstream<T, U> {
-    final Callable<? extends U> initialSupplier;
+    final Supplier<? extends U> initialSupplier;
     final BiConsumer<? super U, ? super T> collector;
 
     public ObservableCollect(ObservableSource<T> source,
-            Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
+            Supplier<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
         super(source);
         this.initialSupplier = initialSupplier;
         this.collector = collector;
@@ -36,7 +34,7 @@ public final class ObservableCollect<T, U> extends AbstractObservableWithUpstrea
     protected void subscribeActual(Observer<? super U> t) {
         U u;
         try {
-            u = ObjectHelper.requireNonNull(initialSupplier.call(), "The initialSupplier returned a null value");
+            u = ObjectHelper.requireNonNull(initialSupplier.get(), "The initialSupplier returned a null value");
         } catch (Throwable e) {
             EmptyDisposable.error(e, t);
             return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableCollectSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableCollectSingle.java
@@ -12,11 +12,9 @@
  */
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.BiConsumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.FuseToObservable;
@@ -26,11 +24,11 @@ public final class ObservableCollectSingle<T, U> extends Single<U> implements Fu
 
     final ObservableSource<T> source;
 
-    final Callable<? extends U> initialSupplier;
+    final Supplier<? extends U> initialSupplier;
     final BiConsumer<? super U, ? super T> collector;
 
     public ObservableCollectSingle(ObservableSource<T> source,
-            Callable<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
+            Supplier<? extends U> initialSupplier, BiConsumer<? super U, ? super T> collector) {
         this.source = source;
         this.initialSupplier = initialSupplier;
         this.collector = collector;
@@ -40,7 +38,7 @@ public final class ObservableCollectSingle<T, U> extends Single<U> implements Fu
     protected void subscribeActual(SingleObserver<? super U> t) {
         U u;
         try {
-            u = ObjectHelper.requireNonNull(initialSupplier.call(), "The initialSupplier returned a null value");
+            u = ObjectHelper.requireNonNull(initialSupplier.get(), "The initialSupplier returned a null value");
         } catch (Throwable e) {
             EmptyDisposable.error(e, t);
             return;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMap.java
@@ -12,14 +12,13 @@
  */
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
-import io.reactivex.internal.disposables.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.queue.SpscLinkedArrayQueue;
@@ -455,11 +454,11 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
                             return;
                         }
 
-                        if (o instanceof Callable) {
+                        if (o instanceof Supplier) {
                             R w;
 
                             try {
-                                w = ((Callable<R>)o).call();
+                                w = ((Supplier<R>)o).get();
                             } catch (Throwable ex) {
                                 Exceptions.throwIfFatal(ex);
                                 error.addThrowable(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDefer.java
@@ -13,16 +13,15 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class ObservableDefer<T> extends Observable<T> {
-    final Callable<? extends ObservableSource<? extends T>> supplier;
-    public ObservableDefer(Callable<? extends ObservableSource<? extends T>> supplier) {
+    final Supplier<? extends ObservableSource<? extends T>> supplier;
+    public ObservableDefer(Supplier<? extends ObservableSource<? extends T>> supplier) {
         this.supplier = supplier;
     }
 
@@ -30,7 +29,7 @@ public final class ObservableDefer<T> extends Observable<T> {
     public void subscribeActual(Observer<? super T> observer) {
         ObservableSource<? extends T> pub;
         try {
-            pub = ObjectHelper.requireNonNull(supplier.call(), "null ObservableSource supplied");
+            pub = ObjectHelper.requireNonNull(supplier.get(), "The supplier returned a null ObservableSource");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             EmptyDisposable.error(t, observer);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinct.java
@@ -14,12 +14,11 @@
 package io.reactivex.internal.operators.observable;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.BasicFuseableObserver;
@@ -29,9 +28,9 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
 
     final Function<? super T, K> keySelector;
 
-    final Callable<? extends Collection<? super K>> collectionSupplier;
+    final Supplier<? extends Collection<? super K>> collectionSupplier;
 
-    public ObservableDistinct(ObservableSource<T> source, Function<? super T, K> keySelector, Callable<? extends Collection<? super K>> collectionSupplier) {
+    public ObservableDistinct(ObservableSource<T> source, Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
         super(source);
         this.keySelector = keySelector;
         this.collectionSupplier = collectionSupplier;
@@ -42,7 +41,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
         Collection<? super K> collection;
 
         try {
-            collection = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            collection = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);
@@ -116,7 +115,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             for (;;) {
                 T v = qd.poll();
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -92,7 +92,7 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             for (;;) {
                 T v = qd.poll();
                 if (v == null) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoAfterNext.java
@@ -67,7 +67,7 @@ public final class ObservableDoAfterNext<T> extends AbstractObservableWithUpstre
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v = qd.poll();
             if (v != null) {
                 onAfterNext.accept(v);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDoFinally.java
@@ -128,7 +128,7 @@ public final class ObservableDoFinally<T> extends AbstractObservableWithUpstream
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             T v = qd.poll();
             if (v == null && syncFused) {
                 runFinally();

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableEmpty.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableEmpty.java
@@ -15,9 +15,9 @@ package io.reactivex.internal.operators.observable;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.internal.disposables.EmptyDisposable;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 
-public final class ObservableEmpty extends Observable<Object> implements ScalarCallable<Object> {
+public final class ObservableEmpty extends Observable<Object> implements ScalarSupplier<Object> {
     public static final Observable<Object> INSTANCE = new ObservableEmpty();
 
     private ObservableEmpty() {
@@ -29,7 +29,7 @@ public final class ObservableEmpty extends Observable<Object> implements ScalarC
     }
 
     @Override
-    public Object call() {
+    public Object get() {
         return null; // null scalar is interpreted as being empty
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableError.java
@@ -13,16 +13,15 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class ObservableError<T> extends Observable<T> {
-    final Callable<? extends Throwable> errorSupplier;
-    public ObservableError(Callable<? extends Throwable> errorSupplier) {
+    final Supplier<? extends Throwable> errorSupplier;
+    public ObservableError(Supplier<? extends Throwable> errorSupplier) {
         this.errorSupplier = errorSupplier;
     }
 
@@ -30,7 +29,7 @@ public final class ObservableError<T> extends Observable<T> {
     public void subscribeActual(Observer<? super T> observer) {
         Throwable error;
         try {
-            error = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
+            error = ObjectHelper.requireNonNull(errorSupplier.get(), "Supplier returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             error = t;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFilter.java
@@ -63,7 +63,7 @@ public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T,
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             for (;;) {
                 T v = qd.poll();
                 if (v == null || filter.test(v)) {

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -14,14 +14,13 @@
 package io.reactivex.internal.operators.observable;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.*;
@@ -142,8 +141,8 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
         @SuppressWarnings("unchecked")
         void subscribeInner(ObservableSource<? extends U> p) {
             for (;;) {
-                if (p instanceof Callable) {
-                    if (tryEmitScalar(((Callable<? extends U>)p)) && maxConcurrency != Integer.MAX_VALUE) {
+                if (p instanceof Supplier) {
+                    if (tryEmitScalar(((Supplier<? extends U>)p)) && maxConcurrency != Integer.MAX_VALUE) {
                         boolean empty = false;
                         synchronized (this) {
                             p = sources.poll();
@@ -217,10 +216,10 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             }
         }
 
-        boolean tryEmitScalar(Callable<? extends U> value) {
+        boolean tryEmitScalar(Supplier<? extends U> value) {
             U u;
             try {
-                u = value.call();
+                u = value.get();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 errors.addThrowable(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableGenerate.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
@@ -23,11 +21,11 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableGenerate<T, S> extends Observable<T> {
-    final Callable<S> stateSupplier;
+    final Supplier<S> stateSupplier;
     final BiFunction<S, Emitter<T>, S> generator;
     final Consumer<? super S> disposeState;
 
-    public ObservableGenerate(Callable<S> stateSupplier, BiFunction<S, Emitter<T>, S> generator,
+    public ObservableGenerate(Supplier<S> stateSupplier, BiFunction<S, Emitter<T>, S> generator,
             Consumer<? super S> disposeState) {
         this.stateSupplier = stateSupplier;
         this.generator = generator;
@@ -39,7 +37,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
         S state;
 
         try {
-            state = stateSupplier.call();
+            state = stateSupplier.get();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, observer);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableJust.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableJust.java
@@ -14,14 +14,14 @@
 package io.reactivex.internal.operators.observable;
 
 import io.reactivex.*;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 import io.reactivex.internal.operators.observable.ObservableScalarXMap.ScalarDisposable;
 
 /**
  * Represents a constant scalar value.
  * @param <T> the value type
  */
-public final class ObservableJust<T> extends Observable<T> implements ScalarCallable<T> {
+public final class ObservableJust<T> extends Observable<T> implements ScalarSupplier<T> {
 
     private final T value;
     public ObservableJust(final T value) {
@@ -36,7 +36,7 @@ public final class ObservableJust<T> extends Observable<T> implements ScalarCall
     }
 
     @Override
-    public T call() {
+    public T get() {
         return value;
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMap.java
@@ -69,7 +69,7 @@ public final class ObservableMap<T, U> extends AbstractObservableWithUpstream<T,
 
         @Nullable
         @Override
-        public U poll() throws Exception {
+        public U poll() throws Throwable {
             T t = qd.poll();
             return t != null ? ObjectHelper.<U>requireNonNull(mapper.apply(t), "The mapper function returned a null value.") : null;
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMapNotification.java
@@ -13,12 +13,10 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 
@@ -26,13 +24,13 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
 
     final Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper;
     final Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper;
-    final Callable<? extends ObservableSource<? extends R>> onCompleteSupplier;
+    final Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier;
 
     public ObservableMapNotification(
             ObservableSource<T> source,
             Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
             Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
-                    Callable<? extends ObservableSource<? extends R>> onCompleteSupplier) {
+            Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier) {
         super(source);
         this.onNextMapper = onNextMapper;
         this.onErrorMapper = onErrorMapper;
@@ -49,14 +47,14 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
         final Observer<? super ObservableSource<? extends R>> downstream;
         final Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper;
         final Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper;
-        final Callable<? extends ObservableSource<? extends R>> onCompleteSupplier;
+        final Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier;
 
         Disposable upstream;
 
         MapNotificationObserver(Observer<? super ObservableSource<? extends R>> actual,
                 Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
                 Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
-                        Callable<? extends ObservableSource<? extends R>> onCompleteSupplier) {
+                Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier) {
             this.downstream = actual;
             this.onNextMapper = onNextMapper;
             this.onErrorMapper = onErrorMapper;
@@ -117,7 +115,7 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
             ObservableSource<? extends R> p;
 
             try {
-                p = ObjectHelper.requireNonNull(onCompleteSupplier.call(), "The onComplete ObservableSource returned is null");
+                p = ObjectHelper.requireNonNull(onCompleteSupplier.get(), "The onComplete ObservableSource returned is null");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 downstream.onError(e);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableObserveOn.java
@@ -304,7 +304,7 @@ public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() throws Throwable {
             return queue.poll();
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReduceWithSingle.java
@@ -13,11 +13,9 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.operators.observable.ObservableReduceSeedSingle.ReduceSeedObserver;
@@ -33,11 +31,11 @@ public final class ObservableReduceWithSingle<T, R> extends Single<R> {
 
     final ObservableSource<T> source;
 
-    final Callable<R> seedSupplier;
+    final Supplier<R> seedSupplier;
 
     final BiFunction<R, ? super T, R> reducer;
 
-    public ObservableReduceWithSingle(ObservableSource<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
+    public ObservableReduceWithSingle(ObservableSource<T> source, Supplier<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
         this.source = source;
         this.seedSupplier = seedSupplier;
         this.reducer = reducer;
@@ -48,7 +46,7 @@ public final class ObservableReduceWithSingle<T, R> extends Single<R> {
         R seed;
 
         try {
-            seed = ObjectHelper.requireNonNull(seedSupplier.call(), "The seedSupplier returned a null value");
+            seed = ObjectHelper.requireNonNull(seedSupplier.get(), "The seedSupplier returned a null value");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -14,7 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
@@ -58,7 +58,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      * @return the new Observable instance
      */
     public static <U, R> Observable<R> multicastSelector(
-            final Callable<? extends ConnectableObservable<U>> connectableFactory,
+            final Supplier<? extends ConnectableObservable<U>> connectableFactory,
             final Function<? super Observable<U>, ? extends ObservableSource<R>> selector) {
         return RxJavaPlugins.onAssembly(new MulticastReplay<R, U>(connectableFactory, selector));
     }
@@ -1026,10 +1026,10 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
     }
 
     static final class MulticastReplay<R, U> extends Observable<R> {
-        private final Callable<? extends ConnectableObservable<U>> connectableFactory;
+        private final Supplier<? extends ConnectableObservable<U>> connectableFactory;
         private final Function<? super Observable<U>, ? extends ObservableSource<R>> selector;
 
-        MulticastReplay(Callable<? extends ConnectableObservable<U>> connectableFactory, Function<? super Observable<U>, ? extends ObservableSource<R>> selector) {
+        MulticastReplay(Supplier<? extends ConnectableObservable<U>> connectableFactory, Function<? super Observable<U>, ? extends ObservableSource<R>> selector) {
             this.connectableFactory = connectableFactory;
             this.selector = selector;
         }
@@ -1039,7 +1039,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
             ConnectableObservable<U> co;
             ObservableSource<R> observable;
             try {
-                co = ObjectHelper.requireNonNull(connectableFactory.call(), "The connectableFactory returned a null ConnectableObservable");
+                co = ObjectHelper.requireNonNull(connectableFactory.get(), "The connectableFactory returned a null ConnectableObservable");
                 observable = ObjectHelper.requireNonNull(selector.apply(co), "The selector returned a null ObservableSource");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScalarXMap.java
@@ -13,13 +13,12 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.fuseable.QueueDisposable;
@@ -36,7 +35,7 @@ public final class ObservableScalarXMap {
     }
 
     /**
-     * Tries to subscribe to a possibly Callable source's mapped ObservableSource.
+     * Tries to subscribe to a possibly Supplier source's mapped ObservableSource.
      * @param <T> the input value type
      * @param <R> the output value type
      * @param source the source ObservableSource
@@ -48,11 +47,11 @@ public final class ObservableScalarXMap {
     public static <T, R> boolean tryScalarXMapSubscribe(ObservableSource<T> source,
             Observer<? super R> observer,
             Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        if (source instanceof Callable) {
+        if (source instanceof Supplier) {
             T t;
 
             try {
-                t = ((Callable<T>)source).call();
+                t = ((Supplier<T>)source).get();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 EmptyDisposable.error(ex, observer);
@@ -74,11 +73,11 @@ public final class ObservableScalarXMap {
                 return true;
             }
 
-            if (r instanceof Callable) {
+            if (r instanceof Supplier) {
                 R u;
 
                 try {
-                    u = ((Callable<R>)r).call();
+                    u = ((Supplier<R>)r).get();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     EmptyDisposable.error(ex, observer);
@@ -144,11 +143,11 @@ public final class ObservableScalarXMap {
                 EmptyDisposable.error(e, observer);
                 return;
             }
-            if (other instanceof Callable) {
+            if (other instanceof Supplier) {
                 R u;
 
                 try {
-                    u = ((Callable<R>)other).call();
+                    u = ((Supplier<R>)other).get();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     EmptyDisposable.error(ex, observer);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableScanSeed.java
@@ -12,21 +12,19 @@
  */
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstream<T, R> {
     final BiFunction<R, ? super T, R> accumulator;
-    final Callable<R> seedSupplier;
+    final Supplier<R> seedSupplier;
 
-    public ObservableScanSeed(ObservableSource<T> source, Callable<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
+    public ObservableScanSeed(ObservableSource<T> source, Supplier<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
         super(source);
         this.accumulator = accumulator;
         this.seedSupplier = seedSupplier;
@@ -37,7 +35,7 @@ public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstre
         R r;
 
         try {
-            r = ObjectHelper.requireNonNull(seedSupplier.call(), "The seed supplied is null");
+            r = ObjectHelper.requireNonNull(seedSupplier.get(), "The seed supplied is null");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToList.java
@@ -14,26 +14,26 @@
 package io.reactivex.internal.operators.observable;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.*;
 import io.reactivex.internal.functions.*;
 
 public final class ObservableToList<T, U extends Collection<? super T>>
 extends AbstractObservableWithUpstream<T, U> {
 
-    final Callable<U> collectionSupplier;
+    final Supplier<U> collectionSupplier;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public ObservableToList(ObservableSource<T> source, final int defaultCapacityHint) {
         super(source);
-        this.collectionSupplier = (Callable)Functions.createArrayList(defaultCapacityHint);
+        this.collectionSupplier = (Supplier)Functions.createArrayList(defaultCapacityHint);
     }
 
-    public ObservableToList(ObservableSource<T> source, Callable<U> collectionSupplier) {
+    public ObservableToList(ObservableSource<T> source, Supplier<U> collectionSupplier) {
         super(source);
         this.collectionSupplier = collectionSupplier;
     }
@@ -42,7 +42,7 @@ extends AbstractObservableWithUpstream<T, U> {
     public void subscribeActual(Observer<? super U> t) {
         U coll;
         try {
-            coll = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            coll = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableToListSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableToListSingle.java
@@ -13,17 +13,14 @@
 
 package io.reactivex.internal.operators.observable;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.*;
-import java.util.concurrent.Callable;
+import java.util.Collection;
 
 import io.reactivex.*;
-import io.reactivex.Observable;
-import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.*;
-import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.functions.*;
 import io.reactivex.internal.fuseable.FuseToObservable;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -32,15 +29,15 @@ extends Single<U> implements FuseToObservable<U> {
 
     final ObservableSource<T> source;
 
-    final Callable<U> collectionSupplier;
+    final Supplier<U> collectionSupplier;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public ObservableToListSingle(ObservableSource<T> source, final int defaultCapacityHint) {
         this.source = source;
-        this.collectionSupplier = (Callable)Functions.createArrayList(defaultCapacityHint);
+        this.collectionSupplier = (Supplier)Functions.createArrayList(defaultCapacityHint);
     }
 
-    public ObservableToListSingle(ObservableSource<T> source, Callable<U> collectionSupplier) {
+    public ObservableToListSingle(ObservableSource<T> source, Supplier<U> collectionSupplier) {
         this.source = source;
         this.collectionSupplier = collectionSupplier;
     }
@@ -49,7 +46,7 @@ extends Single<U> implements FuseToObservable<U> {
     public void subscribeActual(SingleObserver<? super U> t) {
         U coll;
         try {
-            coll = ObjectHelper.requireNonNull(collectionSupplier.call(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            coll = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableUsing.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.reactivex.*;
@@ -25,12 +24,12 @@ import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ObservableUsing<T, D> extends Observable<T> {
-    final Callable<? extends D> resourceSupplier;
+    final Supplier<? extends D> resourceSupplier;
     final Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier;
     final Consumer<? super D> disposer;
     final boolean eager;
 
-    public ObservableUsing(Callable<? extends D> resourceSupplier,
+    public ObservableUsing(Supplier<? extends D> resourceSupplier,
             Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier,
             Consumer<? super D> disposer,
             boolean eager) {
@@ -45,7 +44,7 @@ public final class ObservableUsing<T, D> extends Observable<T> {
         D resource;
 
         try {
-            resource = resourceSupplier.call();
+            resource = resourceSupplier.get();
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, observer);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWindowBoundarySupplier.java
@@ -13,12 +13,12 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.DisposableHelper;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.queue.MpscLinkedQueue;
@@ -28,12 +28,12 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.UnicastSubject;
 
 public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObservableWithUpstream<T, Observable<T>> {
-    final Callable<? extends ObservableSource<B>> other;
+    final Supplier<? extends ObservableSource<B>> other;
     final int capacityHint;
 
     public ObservableWindowBoundarySupplier(
             ObservableSource<T> source,
-            Callable<? extends ObservableSource<B>> other, int capacityHint) {
+            Supplier<? extends ObservableSource<B>> other, int capacityHint) {
         super(source);
         this.other = other;
         this.capacityHint = capacityHint;
@@ -68,7 +68,7 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
 
         final AtomicBoolean stopWindows;
 
-        final Callable<? extends ObservableSource<B>> other;
+        final Supplier<? extends ObservableSource<B>> other;
 
         static final Object NEXT_WINDOW = new Object();
 
@@ -78,7 +78,7 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
 
         UnicastSubject<T> window;
 
-        WindowBoundaryMainObserver(Observer<? super Observable<T>> downstream, int capacityHint, Callable<? extends ObservableSource<B>> other) {
+        WindowBoundaryMainObserver(Observer<? super Observable<T>> downstream, int capacityHint, Supplier<? extends ObservableSource<B>> other) {
             this.downstream = downstream;
             this.capacityHint = capacityHint;
             this.boundaryObserver = new AtomicReference<WindowBoundaryInnerObserver<T, B>>();
@@ -254,7 +254,7 @@ public final class ObservableWindowBoundarySupplier<T, B> extends AbstractObserv
                         ObservableSource<B> otherSource;
 
                         try {
-                            otherSource = ObjectHelper.requireNonNull(other.call(), "The other Callable returned a null ObservableSource");
+                            otherSource = ObjectHelper.requireNonNull(other.get(), "The other Supplier returned a null ObservableSource");
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             errors.addThrowable(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -285,7 +285,7 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
 
     final class SingletonArrayFunc implements Function<T, R> {
         @Override
-        public R apply(T t) throws Exception {
+        public R apply(T t) throws Throwable {
             return ObjectHelper.requireNonNull(combiner.apply(new Object[] { t }), "The combiner returned a null value");
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelCollect.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelCollect.java
@@ -13,12 +13,10 @@
 
 package io.reactivex.internal.operators.parallel;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiConsumer;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscribers.DeferredScalarSubscriber;
 import io.reactivex.internal.subscriptions.*;
@@ -35,12 +33,12 @@ public final class ParallelCollect<T, C> extends ParallelFlowable<C> {
 
     final ParallelFlowable<? extends T> source;
 
-    final Callable<? extends C> initialCollection;
+    final Supplier<? extends C> initialCollection;
 
     final BiConsumer<? super C, ? super T> collector;
 
     public ParallelCollect(ParallelFlowable<? extends T> source,
-            Callable<? extends C> initialCollection, BiConsumer<? super C, ? super T> collector) {
+            Supplier<? extends C> initialCollection, BiConsumer<? super C, ? super T> collector) {
         this.source = source;
         this.initialCollection = initialCollection;
         this.collector = collector;
@@ -61,7 +59,7 @@ public final class ParallelCollect<T, C> extends ParallelFlowable<C> {
             C initialValue;
 
             try {
-                initialValue = ObjectHelper.requireNonNull(initialCollection.call(), "The initialSupplier returned a null value");
+                initialValue = ObjectHelper.requireNonNull(initialCollection.get(), "The initialSupplier returned a null value");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 reportError(subscribers, ex);

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduce.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelReduce.java
@@ -13,12 +13,10 @@
 
 package io.reactivex.internal.operators.parallel;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.*;
 
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiFunction;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.subscribers.DeferredScalarSubscriber;
 import io.reactivex.internal.subscriptions.*;
@@ -35,11 +33,11 @@ public final class ParallelReduce<T, R> extends ParallelFlowable<R> {
 
     final ParallelFlowable<? extends T> source;
 
-    final Callable<R> initialSupplier;
+    final Supplier<R> initialSupplier;
 
     final BiFunction<R, ? super T, R> reducer;
 
-    public ParallelReduce(ParallelFlowable<? extends T> source, Callable<R> initialSupplier, BiFunction<R, ? super T, R> reducer) {
+    public ParallelReduce(ParallelFlowable<? extends T> source, Supplier<R> initialSupplier, BiFunction<R, ? super T, R> reducer) {
         this.source = source;
         this.initialSupplier = initialSupplier;
         this.reducer = reducer;
@@ -60,7 +58,7 @@ public final class ParallelReduce<T, R> extends ParallelFlowable<R> {
             R initialValue;
 
             try {
-                initialValue = ObjectHelper.requireNonNull(initialSupplier.call(), "The initialSupplier returned a null value");
+                initialValue = ObjectHelper.requireNonNull(initialSupplier.get(), "The initialSupplier returned a null value");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 reportError(subscribers, ex);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDefer.java
@@ -13,18 +13,17 @@
 
 package io.reactivex.internal.operators.single;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.functions.ObjectHelper;
 
 public final class SingleDefer<T> extends Single<T> {
 
-    final Callable<? extends SingleSource<? extends T>> singleSupplier;
+    final Supplier<? extends SingleSource<? extends T>> singleSupplier;
 
-    public SingleDefer(Callable<? extends SingleSource<? extends T>> singleSupplier) {
+    public SingleDefer(Supplier<? extends SingleSource<? extends T>> singleSupplier) {
         this.singleSupplier = singleSupplier;
     }
 
@@ -33,7 +32,7 @@ public final class SingleDefer<T> extends Single<T> {
         SingleSource<? extends T> next;
 
         try {
-            next = ObjectHelper.requireNonNull(singleSupplier.call(), "The singleSupplier returned a null SingleSource");
+            next = ObjectHelper.requireNonNull(singleSupplier.get(), "The singleSupplier returned a null SingleSource");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, observer);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleError.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleError.java
@@ -13,18 +13,17 @@
 
 package io.reactivex.internal.operators.single;
 
-import io.reactivex.internal.functions.ObjectHelper;
-import java.util.concurrent.Callable;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.disposables.EmptyDisposable;
+import io.reactivex.internal.functions.ObjectHelper;
 
 public final class SingleError<T> extends Single<T> {
 
-    final Callable<? extends Throwable> errorSupplier;
+    final Supplier<? extends Throwable> errorSupplier;
 
-    public SingleError(Callable<? extends Throwable> errorSupplier) {
+    public SingleError(Supplier<? extends Throwable> errorSupplier) {
         this.errorSupplier = errorSupplier;
     }
 
@@ -33,7 +32,7 @@ public final class SingleError<T> extends Single<T> {
         Throwable error;
 
         try {
-            error = ObjectHelper.requireNonNull(errorSupplier.call(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
+            error = ObjectHelper.requireNonNull(errorSupplier.get(), "Supplier returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             error = e;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
@@ -39,7 +39,7 @@ public final class SingleInternalHelper {
         public NoSuchElementException call() throws Exception {
             return new NoSuchElementException();
         }
-        
+
         @Override
         public NoSuchElementException get() throws Throwable {
             return new NoSuchElementException();

--- a/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleInternalHelper.java
@@ -20,7 +20,7 @@ import org.reactivestreams.Publisher;
 
 import io.reactivex.*;
 import io.reactivex.Observable;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 
 /**
  * Helper utility class to support Single with inner classes.
@@ -32,16 +32,21 @@ public final class SingleInternalHelper {
         throw new IllegalStateException("No instances!");
     }
 
-    enum NoSuchElementCallable implements Callable<NoSuchElementException> {
+    enum NoSuchElementCallable implements Supplier<NoSuchElementException>, Callable<NoSuchElementException> {
         INSTANCE;
 
         @Override
         public NoSuchElementException call() throws Exception {
             return new NoSuchElementException();
         }
+        
+        @Override
+        public NoSuchElementException get() throws Throwable {
+            return new NoSuchElementException();
+        }
     }
 
-    public static <T> Callable<NoSuchElementException> emptyThrower() {
+    public static <T> Supplier<NoSuchElementException> emptyThrower() {
         return NoSuchElementCallable.INSTANCE;
     }
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.internal.operators.single;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.*;
@@ -26,12 +25,12 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public final class SingleUsing<T, U> extends Single<T> {
 
-    final Callable<U> resourceSupplier;
+    final Supplier<U> resourceSupplier;
     final Function<? super U, ? extends SingleSource<? extends T>> singleFunction;
     final Consumer<? super U> disposer;
     final boolean eager;
 
-    public SingleUsing(Callable<U> resourceSupplier,
+    public SingleUsing(Supplier<U> resourceSupplier,
                        Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
                        Consumer<? super U> disposer,
                        boolean eager) {
@@ -47,7 +46,7 @@ public final class SingleUsing<T, U> extends Single<T> {
         final U resource; // NOPMD
 
         try {
-            resource = resourceSupplier.call();
+            resource = resourceSupplier.get();
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);

--- a/src/main/java/io/reactivex/internal/operators/single/SingleZipArray.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleZipArray.java
@@ -178,7 +178,7 @@ public final class SingleZipArray<T, R> extends Single<R> {
 
     final class SingletonArrayFunc implements Function<T, R> {
         @Override
-        public R apply(T t) throws Exception {
+        public R apply(T t) throws Throwable {
             return ObjectHelper.requireNonNull(zipper.apply(new Object[] { t }), "The zipper returned a null value");
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleZipIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleZipIterable.java
@@ -81,7 +81,7 @@ public final class SingleZipIterable<T, R> extends Single<R> {
 
     final class SingletonArrayFunc implements Function<T, R> {
         @Override
-        public R apply(T t) throws Exception {
+        public R apply(T t) throws Throwable {
             return ObjectHelper.requireNonNull(zipper.apply(new Object[] { t }), "The zipper returned a null value");
         }
     }

--- a/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
+++ b/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
@@ -158,7 +158,7 @@ public class AppendOnlyLinkedArrayList<T> {
      * @param <S> the extra state type
      * @param state the extra state passed into the consumer
      * @param consumer the consumer of values that returns true if the forEach should terminate
-     * @throws Exception if the predicate throws
+     * @throws Throwable if the predicate throws
      */
     @SuppressWarnings("unchecked")
     public <S> void forEachWhile(S state, BiPredicate<? super S, ? super T> consumer) throws Throwable {

--- a/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
+++ b/src/main/java/io/reactivex/internal/util/AppendOnlyLinkedArrayList.java
@@ -161,7 +161,7 @@ public class AppendOnlyLinkedArrayList<T> {
      * @throws Exception if the predicate throws
      */
     @SuppressWarnings("unchecked")
-    public <S> void forEachWhile(S state, BiPredicate<? super S, ? super T> consumer) throws Exception {
+    public <S> void forEachWhile(S state, BiPredicate<? super S, ? super T> consumer) throws Throwable {
         Object[] a = head;
         final int c = capacity;
         for (;;) {

--- a/src/main/java/io/reactivex/internal/util/ArrayListSupplier.java
+++ b/src/main/java/io/reactivex/internal/util/ArrayListSupplier.java
@@ -14,16 +14,15 @@
 package io.reactivex.internal.util;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 
-public enum ArrayListSupplier implements Callable<List<Object>>, Function<Object, List<Object>> {
+public enum ArrayListSupplier implements Supplier<List<Object>>, Function<Object, List<Object>> {
     INSTANCE;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Callable<List<T>> asCallable() {
-        return (Callable)INSTANCE;
+    public static <T> Supplier<List<T>> asSupplier() {
+        return (Supplier)INSTANCE;
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -32,11 +31,11 @@ public enum ArrayListSupplier implements Callable<List<Object>>, Function<Object
     }
 
     @Override
-    public List<Object> call() throws Exception {
+    public List<Object> get() {
         return new ArrayList<Object>();
     }
 
-    @Override public List<Object> apply(Object o) throws Exception {
+    @Override public List<Object> apply(Object o) {
         return new ArrayList<Object>();
     }
 }

--- a/src/main/java/io/reactivex/internal/util/HashMapSupplier.java
+++ b/src/main/java/io/reactivex/internal/util/HashMapSupplier.java
@@ -13,19 +13,19 @@
 
 package io.reactivex.internal.util;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.*;
 
-public enum HashMapSupplier implements Callable<Map<Object, Object>> {
+import io.reactivex.functions.Supplier;
+
+public enum HashMapSupplier implements Supplier<Map<Object, Object>> {
     INSTANCE;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <K, V> Callable<Map<K, V>> asCallable() {
-        return (Callable)INSTANCE;
+    public static <K, V> Supplier<Map<K, V>> asSupplier() {
+        return (Supplier)INSTANCE;
     }
 
-    @Override public Map<Object, Object> call() throws Exception {
+    @Override public Map<Object, Object> get() {
         return new HashMap<Object, Object>();
     }
 }

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -326,7 +326,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
                     found = true;
                     break;
                 }
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 throw ExceptionHelper.wrapOrThrow(ex);
             }
         }
@@ -421,7 +421,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
                 if (valuePredicate.test(v)) {
                     throw fail("Value at position " + i + " matches predicate " + valuePredicate.toString() + ", which was not expected.");
                 }
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 throw ExceptionHelper.wrapOrThrow(ex);
             }
         }
@@ -481,7 +481,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
             if (valuePredicate.test(values.get(index))) {
                 found = true;
             }
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
 

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -14,7 +14,6 @@
 package io.reactivex.parallel;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import io.reactivex.*;
 import io.reactivex.annotations.*;
@@ -330,7 +329,7 @@ public abstract class ParallelFlowable<T> {
      */
     @CheckReturnValue
     @NonNull
-    public final <R> ParallelFlowable<R> reduce(@NonNull Callable<R> initialSupplier, @NonNull BiFunction<R, ? super T, R> reducer) {
+    public final <R> ParallelFlowable<R> reduce(@NonNull Supplier<R> initialSupplier, @NonNull BiFunction<R, ? super T, R> reducer) {
         ObjectHelper.requireNonNull(initialSupplier, "initialSupplier");
         ObjectHelper.requireNonNull(reducer, "reducer");
         return RxJavaPlugins.onAssembly(new ParallelReduce<T, R>(this, initialSupplier, reducer));
@@ -738,7 +737,7 @@ public abstract class ParallelFlowable<T> {
      */
     @CheckReturnValue
     @NonNull
-    public final <C> ParallelFlowable<C> collect(@NonNull Callable<? extends C> collectionSupplier, @NonNull BiConsumer<? super C, ? super T> collector) {
+    public final <C> ParallelFlowable<C> collect(@NonNull Supplier<? extends C> collectionSupplier, @NonNull BiConsumer<? super C, ? super T> collector) {
         ObjectHelper.requireNonNull(collectionSupplier, "collectionSupplier is null");
         ObjectHelper.requireNonNull(collector, "collector is null");
         return RxJavaPlugins.onAssembly(new ParallelCollect<T, C>(this, collectionSupplier, collector));

--- a/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/plugins/RxJavaPlugins.java
@@ -39,16 +39,16 @@ public final class RxJavaPlugins {
     static volatile Function<? super Runnable, ? extends Runnable> onScheduleHandler;
 
     @Nullable
-    static volatile Function<? super Callable<Scheduler>, ? extends Scheduler> onInitComputationHandler;
+    static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitComputationHandler;
 
     @Nullable
-    static volatile Function<? super Callable<Scheduler>, ? extends Scheduler> onInitSingleHandler;
+    static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitSingleHandler;
 
     @Nullable
-    static volatile Function<? super Callable<Scheduler>, ? extends Scheduler> onInitIoHandler;
+    static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitIoHandler;
 
     @Nullable
-    static volatile Function<? super Callable<Scheduler>, ? extends Scheduler> onInitNewThreadHandler;
+    static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitNewThreadHandler;
 
     @Nullable
     static volatile Function<? super Scheduler, ? extends Scheduler> onComputationHandler;
@@ -191,7 +191,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<? super Callable<Scheduler>, ? extends Scheduler> getInitComputationSchedulerHandler() {
+    public static Function<? super Supplier<Scheduler>, ? extends Scheduler> getInitComputationSchedulerHandler() {
         return onInitComputationHandler;
     }
 
@@ -200,7 +200,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<? super Callable<Scheduler>, ? extends Scheduler> getInitIoSchedulerHandler() {
+    public static Function<? super Supplier<Scheduler>, ? extends Scheduler> getInitIoSchedulerHandler() {
         return onInitIoHandler;
     }
 
@@ -209,7 +209,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<? super Callable<Scheduler>, ? extends Scheduler> getInitNewThreadSchedulerHandler() {
+    public static Function<? super Supplier<Scheduler>, ? extends Scheduler> getInitNewThreadSchedulerHandler() {
         return onInitNewThreadHandler;
     }
 
@@ -218,7 +218,7 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<? super Callable<Scheduler>, ? extends Scheduler> getInitSingleSchedulerHandler() {
+    public static Function<? super Supplier<Scheduler>, ? extends Scheduler> getInitSingleSchedulerHandler() {
         return onInitSingleHandler;
     }
 
@@ -260,14 +260,14 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * @param defaultScheduler a {@link Callable} which returns the hook's input value
+     * @param defaultScheduler a {@link Supplier} which returns the hook's input value
      * @return the value returned by the hook, not null
-     * @throws NullPointerException if the callable parameter or its result are null
+     * @throws NullPointerException if the supplier parameter or its result are null
      */
     @NonNull
-    public static Scheduler initComputationScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
-        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitComputationHandler;
+    public static Scheduler initComputationScheduler(@NonNull Supplier<Scheduler> defaultScheduler) {
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Supplier can't be null");
+        Function<? super Supplier<Scheduler>, ? extends Scheduler> f = onInitComputationHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -276,14 +276,14 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * @param defaultScheduler a {@link Callable} which returns the hook's input value
+     * @param defaultScheduler a {@link Supplier} which returns the hook's input value
      * @return the value returned by the hook, not null
-     * @throws NullPointerException if the callable parameter or its result are null
+     * @throws NullPointerException if the supplier parameter or its result are null
      */
     @NonNull
-    public static Scheduler initIoScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
-        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitIoHandler;
+    public static Scheduler initIoScheduler(@NonNull Supplier<Scheduler> defaultScheduler) {
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Supplier can't be null");
+        Function<? super Supplier<Scheduler>, ? extends Scheduler> f = onInitIoHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -292,14 +292,14 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * @param defaultScheduler a {@link Callable} which returns the hook's input value
+     * @param defaultScheduler a {@link Supplier} which returns the hook's input value
      * @return the value returned by the hook, not null
-     * @throws NullPointerException if the callable parameter or its result are null
+     * @throws NullPointerException if the supplier parameter or its result are null
      */
     @NonNull
-    public static Scheduler initNewThreadScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
-        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitNewThreadHandler;
+    public static Scheduler initNewThreadScheduler(@NonNull Supplier<Scheduler> defaultScheduler) {
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Supplier can't be null");
+        Function<? super Supplier<Scheduler>, ? extends Scheduler> f = onInitNewThreadHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -308,14 +308,14 @@ public final class RxJavaPlugins {
 
     /**
      * Calls the associated hook function.
-     * @param defaultScheduler a {@link Callable} which returns the hook's input value
+     * @param defaultScheduler a {@link Supplier} which returns the hook's input value
      * @return the value returned by the hook, not null
-     * @throws NullPointerException if the callable parameter or its result are null
+     * @throws NullPointerException if the supplier parameter or its result are null
      */
     @NonNull
-    public static Scheduler initSingleScheduler(@NonNull Callable<Scheduler> defaultScheduler) {
-        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Callable can't be null");
-        Function<? super Callable<Scheduler>, ? extends Scheduler> f = onInitSingleHandler;
+    public static Scheduler initSingleScheduler(@NonNull Supplier<Scheduler> defaultScheduler) {
+        ObjectHelper.requireNonNull(defaultScheduler, "Scheduler Supplier can't be null");
+        Function<? super Supplier<Scheduler>, ? extends Scheduler> f = onInitSingleHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -556,7 +556,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitComputationSchedulerHandler(@Nullable Function<? super Callable<Scheduler>, ? extends Scheduler> handler) {
+    public static void setInitComputationSchedulerHandler(@Nullable Function<? super Supplier<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -567,7 +567,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitIoSchedulerHandler(@Nullable Function<? super Callable<Scheduler>, ? extends Scheduler> handler) {
+    public static void setInitIoSchedulerHandler(@Nullable Function<? super Supplier<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -578,7 +578,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitNewThreadSchedulerHandler(@Nullable Function<? super Callable<Scheduler>, ? extends Scheduler> handler) {
+    public static void setInitNewThreadSchedulerHandler(@Nullable Function<? super Supplier<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -589,7 +589,7 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitSingleSchedulerHandler(@Nullable Function<? super Callable<Scheduler>, ? extends Scheduler> handler) {
+    public static void setInitSingleSchedulerHandler(@Nullable Function<? super Supplier<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
@@ -1292,16 +1292,16 @@ public final class RxJavaPlugins {
     }
 
     /**
-     * Wraps the call to the Scheduler creation callable in try-catch and propagates thrown
+     * Wraps the call to the Scheduler creation supplier in try-catch and propagates thrown
      * checked exceptions as RuntimeException and enforces that result is not null.
-     * @param s the {@link Callable} which returns a {@link Scheduler}, not null (not verified). Cannot return null
-     * @return the result of the callable call, not null
-     * @throws NullPointerException if the callable parameter returns null
+     * @param s the {@link Supplier} which returns a {@link Scheduler}, not null (not verified). Cannot return null
+     * @return the result of the supplier call, not null
+     * @throws NullPointerException if the supplier parameter returns null
      */
     @NonNull
-    static Scheduler callRequireNonNull(@NonNull Callable<Scheduler> s) {
+    static Scheduler callRequireNonNull(@NonNull Supplier<Scheduler> s) {
         try {
-            return ObjectHelper.requireNonNull(s.call(), "Scheduler Callable result can't be null");
+            return ObjectHelper.requireNonNull(s.get(), "Scheduler Supplier result can't be null");
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
@@ -1316,8 +1316,8 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the function parameter returns null
      */
     @NonNull
-    static Scheduler applyRequireNonNull(@NonNull Function<? super Callable<Scheduler>, ? extends Scheduler> f, Callable<Scheduler> s) {
-        return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Callable result can't be null");
+    static Scheduler applyRequireNonNull(@NonNull Function<? super Supplier<Scheduler>, ? extends Scheduler> f, Supplier<Scheduler> s) {
+        return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Supplier result can't be null");
     }
 
     /** Helper class, no instances. */

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -17,6 +17,7 @@ import java.util.concurrent.*;
 
 import io.reactivex.Scheduler;
 import io.reactivex.annotations.*;
+import io.reactivex.functions.Supplier;
 import io.reactivex.internal.schedulers.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
@@ -432,30 +433,30 @@ public final class Schedulers {
         SchedulerPoolFactory.start();
     }
 
-    static final class IOTask implements Callable<Scheduler> {
+    static final class IOTask implements Supplier<Scheduler> {
         @Override
-        public Scheduler call() throws Exception {
+        public Scheduler get() throws Exception {
             return IoHolder.DEFAULT;
         }
     }
 
-    static final class NewThreadTask implements Callable<Scheduler> {
+    static final class NewThreadTask implements Supplier<Scheduler> {
         @Override
-        public Scheduler call() throws Exception {
+        public Scheduler get() throws Exception {
             return NewThreadHolder.DEFAULT;
         }
     }
 
-    static final class SingleTask implements Callable<Scheduler> {
+    static final class SingleTask implements Supplier<Scheduler> {
         @Override
-        public Scheduler call() throws Exception {
+        public Scheduler get() throws Exception {
             return SingleHolder.DEFAULT;
         }
     }
 
-    static final class ComputationTask implements Callable<Scheduler> {
+    static final class ComputationTask implements Supplier<Scheduler> {
         @Override
-        public Scheduler call() throws Exception {
+        public Scheduler get() throws Exception {
             return ComputationHolder.DEFAULT;
         }
     }

--- a/src/test/java/io/reactivex/TestHelper.java
+++ b/src/test/java/io/reactivex/TestHelper.java
@@ -2998,7 +2998,7 @@ public enum TestHelper {
             }
 
             @Override
-            public T poll() throws Exception {
+            public T poll() throws Throwable {
                 return qs.poll();
             }
 
@@ -3103,7 +3103,7 @@ public enum TestHelper {
             }
 
             @Override
-            public T poll() throws Exception {
+            public T poll() throws Throwable {
                 return qd.poll();
             }
 

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -64,8 +64,6 @@ public class CompletableTest {
 
                 @Override
                 public void remove() {
-                    // TODO Auto-generated method stub
-
                 }
             };
         }
@@ -90,8 +88,6 @@ public class CompletableTest {
 
                 @Override
                 public void remove() {
-                    // TODO Auto-generated method stub
-
                 }
             };
         }
@@ -308,9 +304,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void concatObservableError() {
-        Completable c = Completable.concat(Flowable.<Completable>error(new Callable<Throwable>() {
+        Completable c = Completable.concat(Flowable.<Completable>error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new TestException();
             }
         }));
@@ -413,9 +409,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000)
     public void defer() {
-        Completable c = Completable.defer(new Callable<Completable>() {
+        Completable c = Completable.defer(new Supplier<Completable>() {
             @Override
-            public Completable call() {
+            public Completable get() {
                 return normal.completable;
             }
         });
@@ -434,9 +430,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = NullPointerException.class)
     public void deferReturnsNull() {
-        Completable c = Completable.defer(new Callable<Completable>() {
+        Completable c = Completable.defer(new Supplier<Completable>() {
             @Override
-            public Completable call() {
+            public Completable get() {
                 return null;
             }
         });
@@ -446,9 +442,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void deferFunctionThrows() {
-        Completable c = Completable.defer(new Callable<Completable>() {
+        Completable c = Completable.defer(new Supplier<Completable>() {
             @Override
-            public Completable call() { throw new TestException(); }
+            public Completable get() { throw new TestException(); }
         });
 
         c.blockingAwait();
@@ -456,9 +452,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void deferErrorSource() {
-        Completable c = Completable.defer(new Callable<Completable>() {
+        Completable c = Completable.defer(new Supplier<Completable>() {
             @Override
-            public Completable call() {
+            public Completable get() {
                 return error.completable;
             }
         });
@@ -468,14 +464,14 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void errorSupplierNull() {
-        Completable.error((Callable<Throwable>)null);
+        Completable.error((Supplier<Throwable>)null);
     }
 
     @Test(timeout = 5000, expected = TestException.class)
     public void errorSupplierNormal() {
-        Completable c = Completable.error(new Callable<Throwable>() {
+        Completable c = Completable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new TestException();
             }
         });
@@ -485,9 +481,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = NullPointerException.class)
     public void errorSupplierReturnsNull() {
-        Completable c = Completable.error(new Callable<Throwable>() {
+        Completable c = Completable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return null;
             }
         });
@@ -497,9 +493,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void errorSupplierThrows() {
-        Completable c = Completable.error(new Callable<Throwable>() {
+        Completable c = Completable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() { throw new TestException(); }
+            public Throwable get() { throw new TestException(); }
         });
 
         c.blockingAwait();
@@ -571,9 +567,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void fromFlowableError() {
-        Completable c = Completable.fromPublisher(Flowable.error(new Callable<Throwable>() {
+        Completable c = Completable.fromPublisher(Flowable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new TestException();
             }
         }));
@@ -604,9 +600,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void fromObservableError() {
-        Completable c = Completable.fromObservable(Observable.error(new Callable<Throwable>() {
+        Completable c = Completable.fromObservable(Observable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new TestException();
             }
         }));
@@ -659,9 +655,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void fromSingleThrows() {
-        Completable c = Completable.fromSingle(Single.error(new Callable<Throwable>() {
+        Completable c = Completable.fromSingle(Single.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new TestException();
             }
         }));
@@ -818,9 +814,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void mergeObservableError() {
-        Completable c = Completable.merge(Flowable.<Completable>error(new Callable<Throwable>() {
+        Completable c = Completable.merge(Flowable.<Completable>error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new TestException();
             }
         }));
@@ -1038,9 +1034,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void mergeDelayErrorObservableError() {
-        Completable c = Completable.mergeDelayError(Flowable.<Completable>error(new Callable<Throwable>() {
+        Completable c = Completable.mergeDelayError(Flowable.<Completable>error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new TestException();
             }
         }));
@@ -1221,9 +1217,9 @@ public class CompletableTest {
     public void usingNormalEager() {
         final AtomicInteger dispose = new AtomicInteger();
 
-        Completable c = Completable.using(new Callable<Integer>() {
+        Completable c = Completable.using(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         }, new Function<Object, Completable>() {
@@ -1267,9 +1263,9 @@ public class CompletableTest {
     public void usingNormalLazy() {
         final AtomicInteger dispose = new AtomicInteger();
 
-        Completable c = Completable.using(new Callable<Integer>() {
+        Completable c = Completable.using(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         }, new Function<Integer, Completable>() {
@@ -1313,9 +1309,9 @@ public class CompletableTest {
     public void usingErrorEager() {
         final AtomicInteger dispose = new AtomicInteger();
 
-        Completable c = Completable.using(new Callable<Integer>() {
+        Completable c = Completable.using(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         }, new Function<Integer, Completable>() {
@@ -1359,9 +1355,9 @@ public class CompletableTest {
     public void usingErrorLazy() {
         final AtomicInteger dispose = new AtomicInteger();
 
-        Completable c = Completable.using(new Callable<Integer>() {
+        Completable c = Completable.using(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         }, new Function<Integer, Completable>() {
@@ -1416,9 +1412,9 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void usingMapperNull() {
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, null, new Consumer<Object>() {
@@ -1429,9 +1425,9 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void usingMapperReturnsNull() {
-        Completable c = Completable.using(new Callable<Object>() {
+        Completable c = Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new Function<Object, Completable>() {
@@ -1449,9 +1445,9 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void usingDisposeNull() {
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new Function<Object, Completable>() {
@@ -1464,9 +1460,9 @@ public class CompletableTest {
 
     @Test(expected = TestException.class)
     public void usingResourceThrows() {
-        Completable c = Completable.using(new Callable<Object>() {
+        Completable c = Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() { throw new TestException(); }
+            public Object get() { throw new TestException(); }
         },
                 new Function<Object, Completable>() {
                     @Override
@@ -1483,9 +1479,9 @@ public class CompletableTest {
 
     @Test(expected = TestException.class)
     public void usingMapperThrows() {
-        Completable c = Completable.using(new Callable<Object>() {
+        Completable c = Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         },
@@ -1502,9 +1498,9 @@ public class CompletableTest {
 
     @Test(expected = TestException.class)
     public void usingDisposerThrows() {
-        Completable c = Completable.using(new Callable<Object>() {
+        Completable c = Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         },
@@ -2886,9 +2882,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000)
     public void toSingleSupplierNormal() {
-        Assert.assertEquals(1, normal.completable.toSingle(new Callable<Object>() {
+        Assert.assertEquals(1, normal.completable.toSingle(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }).blockingGet());
@@ -2896,9 +2892,9 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = TestException.class)
     public void toSingleSupplierError() {
-        error.completable.toSingle(new Callable<Object>() {
+        error.completable.toSingle(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }).blockingGet();
@@ -2911,9 +2907,9 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void toSingleSupplierReturnsNull() {
-        normal.completable.toSingle(new Callable<Object>() {
+        normal.completable.toSingle(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }).blockingGet();
@@ -2921,9 +2917,9 @@ public class CompletableTest {
 
     @Test(expected = TestException.class)
     public void toSingleSupplierThrows() {
-        normal.completable.toSingle(new Callable<Object>() {
+        normal.completable.toSingle(new Supplier<Object>() {
             @Override
-            public Object call() { throw new TestException(); }
+            public Object get() { throw new TestException(); }
         }).blockingGet();
     }
 
@@ -3586,9 +3582,9 @@ public class CompletableTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        Completable.using(new Callable<Integer>() {
+        Completable.using(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         },
@@ -3827,7 +3823,7 @@ public class CompletableTest {
     }
 
     @Test
-    public void testHookCreate() throws Exception {
+    public void testHookCreate() throws Throwable {
         CompletableSource subscriber = mock(CompletableSource.class);
         Completable create = Completable.unsafeCreate(subscriber);
 
@@ -4062,15 +4058,15 @@ public class CompletableTest {
     }
 
     @Test
-    public void usingFactoryThrows() throws Exception {
+    public void usingFactoryThrows() throws Throwable {
         @SuppressWarnings("unchecked")
         Consumer<Integer> onDispose = mock(Consumer.class);
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        Completable.using(new Callable<Integer>() {
+        Completable.using(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         },
@@ -4099,9 +4095,9 @@ public class CompletableTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        Completable.using(new Callable<Integer>() {
+        Completable.using(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         },
@@ -4127,15 +4123,15 @@ public class CompletableTest {
     }
 
     @Test
-    public void usingFactoryReturnsNull() throws Exception {
+    public void usingFactoryReturnsNull() throws Throwable {
         @SuppressWarnings("unchecked")
         Consumer<Integer> onDispose = mock(Consumer.class);
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        Completable.using(new Callable<Integer>() {
+        Completable.using(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         },
@@ -4241,7 +4237,7 @@ public class CompletableTest {
     }
 
     @Test
-    public void testHookSubscribeStart() throws Exception {
+    public void testHookSubscribeStart() throws Throwable {
         TestSubscriber<String> ts = new TestSubscriber<String>();
 
         Completable completable = Completable.unsafeCreate(new CompletableSource() {

--- a/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCollectTest.java
@@ -32,9 +32,9 @@ public final class FlowableCollectTest {
     @Test
     public void testCollectToListFlowable() {
         Flowable<List<Integer>> f = Flowable.just(1, 2, 3)
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() {
+            public List<Integer> get() {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -64,9 +64,9 @@ public final class FlowableCollectTest {
     public void testCollectToStringFlowable() {
         String value = Flowable.just(1, 2, 3)
             .collect(
-                new Callable<StringBuilder>() {
+                new Supplier<StringBuilder>() {
                     @Override
-                    public StringBuilder call() {
+                    public StringBuilder get() {
                         return new StringBuilder();
                     }
                 },
@@ -86,10 +86,10 @@ public final class FlowableCollectTest {
     @Test
     public void testFactoryFailureResultsInErrorEmissionFlowable() {
         final RuntimeException e = new RuntimeException();
-        Flowable.just(1).collect(new Callable<List<Integer>>() {
+        Flowable.just(1).collect(new Supplier<List<Integer>>() {
 
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 throw e;
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -114,7 +114,7 @@ public final class FlowableCollectTest {
             final RuntimeException e2 = new RuntimeException();
 
             Burst.items(1).error(e2) //
-                    .collect(callableListCreator(), biConsumerThrows(e1))
+                    .collect(supplierListCreator(), biConsumerThrows(e1))
                     .toFlowable()
                     .test() //
                     .assertError(e1) //
@@ -131,7 +131,7 @@ public final class FlowableCollectTest {
     public void testCollectorFailureDoesNotResultInErrorAndCompletedEmissionsFlowable() {
         final RuntimeException e = new RuntimeException();
         Burst.item(1).create() //
-                .collect(callableListCreator(), biConsumerThrows(e)) //
+                .collect(supplierListCreator(), biConsumerThrows(e)) //
                 .toFlowable()
                 .test() //
                 .assertError(e) //
@@ -157,7 +157,7 @@ public final class FlowableCollectTest {
             }
         };
         Burst.items(1, 2).create() //
-                .collect(callableListCreator(), throwOnFirstOnly)//
+                .collect(supplierListCreator(), throwOnFirstOnly)//
                 .toFlowable()
                 .test() //
                 .assertError(e) //
@@ -184,9 +184,9 @@ public final class FlowableCollectTest {
     @Test
     public void testCollectToList() {
         Single<List<Integer>> o = Flowable.just(1, 2, 3)
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() {
+            public List<Integer> get() {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -216,9 +216,9 @@ public final class FlowableCollectTest {
     public void testCollectToString() {
         String value = Flowable.just(1, 2, 3)
             .collect(
-                new Callable<StringBuilder>() {
+                new Supplier<StringBuilder>() {
                     @Override
-                    public StringBuilder call() {
+                    public StringBuilder get() {
                         return new StringBuilder();
                     }
                 },
@@ -238,10 +238,10 @@ public final class FlowableCollectTest {
     @Test
     public void testFactoryFailureResultsInErrorEmission() {
         final RuntimeException e = new RuntimeException();
-        Flowable.just(1).collect(new Callable<List<Integer>>() {
+        Flowable.just(1).collect(new Supplier<List<Integer>>() {
 
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 throw e;
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -266,7 +266,7 @@ public final class FlowableCollectTest {
             final RuntimeException e2 = new RuntimeException();
 
             Burst.items(1).error(e2) //
-                    .collect(callableListCreator(), biConsumerThrows(e1)) //
+                    .collect(supplierListCreator(), biConsumerThrows(e1)) //
                     .test() //
                     .assertError(e1) //
                     .assertNotComplete();
@@ -282,7 +282,7 @@ public final class FlowableCollectTest {
     public void testCollectorFailureDoesNotResultInErrorAndCompletedEmissions() {
         final RuntimeException e = new RuntimeException();
         Burst.item(1).create() //
-                .collect(callableListCreator(), biConsumerThrows(e)) //
+                .collect(supplierListCreator(), biConsumerThrows(e)) //
                 .test() //
                 .assertError(e) //
                 .assertNotComplete();
@@ -307,7 +307,7 @@ public final class FlowableCollectTest {
             }
         };
         Burst.items(1, 2).create() //
-                .collect(callableListCreator(), throwOnFirstOnly)//
+                .collect(supplierListCreator(), throwOnFirstOnly)//
                 .test() //
                 .assertError(e) //
                 .assertNoValues() //
@@ -332,7 +332,7 @@ public final class FlowableCollectTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1, 2)
-            .collect(Functions.justCallable(new ArrayList<Integer>()), new BiConsumer<ArrayList<Integer>, Integer>() {
+            .collect(Functions.justSupplier(new ArrayList<Integer>()), new BiConsumer<ArrayList<Integer>, Integer>() {
                 @Override
                 public void accept(ArrayList<Integer> a, Integer b) throws Exception {
                     a.add(b);
@@ -340,7 +340,7 @@ public final class FlowableCollectTest {
             }));
 
         TestHelper.checkDisposed(Flowable.just(1, 2)
-                .collect(Functions.justCallable(new ArrayList<Integer>()), new BiConsumer<ArrayList<Integer>, Integer>() {
+                .collect(Functions.justSupplier(new ArrayList<Integer>()), new BiConsumer<ArrayList<Integer>, Integer>() {
                     @Override
                     public void accept(ArrayList<Integer> a, Integer b) throws Exception {
                         a.add(b);
@@ -353,7 +353,7 @@ public final class FlowableCollectTest {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Integer>, Flowable<ArrayList<Integer>>>() {
             @Override
             public Flowable<ArrayList<Integer>> apply(Flowable<Integer> f) throws Exception {
-                return f.collect(Functions.justCallable(new ArrayList<Integer>()),
+                return f.collect(Functions.justSupplier(new ArrayList<Integer>()),
                         new BiConsumer<ArrayList<Integer>, Integer>() {
                             @Override
                             public void accept(ArrayList<Integer> a, Integer b) throws Exception {
@@ -365,7 +365,7 @@ public final class FlowableCollectTest {
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Integer>, Single<ArrayList<Integer>>>() {
             @Override
             public Single<ArrayList<Integer>> apply(Flowable<Integer> f) throws Exception {
-                return f.collect(Functions.justCallable(new ArrayList<Integer>()),
+                return f.collect(Functions.justSupplier(new ArrayList<Integer>()),
                         new BiConsumer<ArrayList<Integer>, Integer>() {
                             @Override
                             public void accept(ArrayList<Integer> a, Integer b) throws Exception {

--- a/src/test/java/io/reactivex/flowable/FlowableMergeTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableMergeTests.java
@@ -16,13 +16,13 @@ package io.reactivex.flowable;
 import static org.junit.Assert.*;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 import io.reactivex.flowable.FlowableCovarianceTest.*;
+import io.reactivex.functions.Supplier;
 
 public class FlowableMergeTests {
 
@@ -76,9 +76,9 @@ public class FlowableMergeTests {
     @Test
     public void testMergeCovariance4() {
 
-        Flowable<Movie> f1 = Flowable.defer(new Callable<Publisher<Movie>>() {
+        Flowable<Movie> f1 = Flowable.defer(new Supplier<Publisher<Movie>>() {
             @Override
-            public Publisher<Movie> call() {
+            public Publisher<Movie> get() {
                 return Flowable.just(
                         new HorrorMovie(),
                         new Movie()

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -13,11 +13,12 @@
 
 package io.reactivex.flowable;
 
+import static org.junit.Assert.*;
+
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.*;
 
-import static org.junit.Assert.*;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -215,9 +216,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void deferFunctionReturnsNull() {
-        Flowable.defer(new Callable<Publisher<Object>>() {
+        Flowable.defer(new Supplier<Publisher<Object>>() {
             @Override
-            public Publisher<Object> call() {
+            public Publisher<Object> get() {
                 return null;
             }
         }).blockingLast();
@@ -225,14 +226,14 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void errorFunctionNull() {
-        Flowable.error((Callable<Throwable>)null);
+        Flowable.error((Supplier<Throwable>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void errorFunctionReturnsNull() {
-        Flowable.error(new Callable<Throwable>() {
+        Flowable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -375,9 +376,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void generateStateConsumerNull() {
-        Flowable.generate(new Callable<Integer>() {
+        Flowable.generate(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         }, (BiConsumer<Integer, Emitter<Object>>)null);
@@ -391,9 +392,9 @@ public class FlowableNullTests {
                 o.onComplete();
             }
         };
-        Flowable.generate(new Callable<Integer>() {
+        Flowable.generate(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return null;
             }
         }, generator).blockingSubscribe();
@@ -401,9 +402,9 @@ public class FlowableNullTests {
 
     @Test
     public void generateFunctionStateNullAllowed() {
-        Flowable.generate(new Callable<Object>() {
+        Flowable.generate(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }, new BiFunction<Object, Emitter<Object>, Object>() {
@@ -422,9 +423,9 @@ public class FlowableNullTests {
                 o.onNext(1);
             }
         };
-        Flowable.generate(new Callable<Integer>() {
+        Flowable.generate(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         }, generator, null);
@@ -432,9 +433,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void generateFunctionDisposeNull() {
-        Flowable.generate(new Callable<Object>() {
+        Flowable.generate(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new BiFunction<Object, Emitter<Object>, Object>() {
@@ -607,9 +608,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingFlowableSupplierNull() {
-        Flowable.using(new Callable<Object>() {
+        Flowable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, null, Functions.emptyConsumer());
@@ -617,9 +618,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingFlowableSupplierReturnsNull() {
-        Flowable.using(new Callable<Object>() {
+        Flowable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new Function<Object, Publisher<Object>>() {
@@ -632,9 +633,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingDisposeNull() {
-        Flowable.using(new Callable<Object>() {
+        Flowable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new Function<Object, Publisher<Integer>>() {
@@ -775,14 +776,14 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferSupplierNull() {
-        just1.buffer(1, 1, (Callable<List<Integer>>)null);
+        just1.buffer(1, 1, (Supplier<List<Integer>>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferSupplierReturnsNull() {
-        just1.buffer(1, 1, new Callable<Collection<Integer>>() {
+        just1.buffer(1, 1, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -805,9 +806,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferTimedSupplierReturnsNull() {
-        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), new Callable<Collection<Integer>>() {
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -845,14 +846,14 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplierNull() {
-        just1.buffer(just1, (Callable<List<Integer>>)null);
+        just1.buffer(just1, (Supplier<List<Integer>>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplierReturnsNull() {
-        just1.buffer(just1, new Callable<Collection<Integer>>() {
+        just1.buffer(just1, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -860,14 +861,14 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplier2Null() {
-        just1.buffer((Callable<Publisher<Integer>>)null);
+        just1.buffer((Supplier<Publisher<Integer>>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplier2ReturnsNull() {
-        just1.buffer(new Callable<Publisher<Object>>() {
+        just1.buffer(new Supplier<Publisher<Object>>() {
             @Override
-            public Publisher<Object> call() {
+            public Publisher<Object> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -875,9 +876,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplier2SupplierNull() {
-        just1.buffer(new Callable<Flowable<Integer>>() {
+        just1.buffer(new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 return just1;
             }
         }, null);
@@ -885,14 +886,14 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplier2SupplierReturnsNull() {
-        just1.buffer(new Callable<Flowable<Integer>>() {
+        just1.buffer(new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 return just1;
             }
-        }, new Callable<Collection<Integer>>() {
+        }, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -905,7 +906,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void collectInitialSupplierNull() {
-        just1.collect((Callable<Integer>)null, new BiConsumer<Integer, Integer>() {
+        just1.collect((Supplier<Integer>)null, new BiConsumer<Integer, Integer>() {
             @Override
             public void accept(Integer a, Integer b) { }
         });
@@ -913,9 +914,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void collectInitialSupplierReturnsNull() {
-        just1.collect(new Callable<Object>() {
+        just1.collect(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }, new BiConsumer<Object, Integer>() {
@@ -926,9 +927,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void collectInitialCollectorNull() {
-        just1.collect(new Callable<Object>() {
+        just1.collect(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, null);
@@ -1139,9 +1140,9 @@ public class FlowableNullTests {
             public Object apply(Integer v) {
                 return v;
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() {
+            public Collection<Object> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -1297,9 +1298,9 @@ public class FlowableNullTests {
             public Publisher<Integer> apply(Throwable e) {
                 return just1;
             }
-        }, new Callable<Publisher<Integer>>() {
+        }, new Supplier<Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> call() {
+            public Publisher<Integer> get() {
                 return just1;
             }
         });
@@ -1317,9 +1318,9 @@ public class FlowableNullTests {
             public Publisher<Integer> apply(Throwable e) {
                 return just1;
             }
-        }, new Callable<Publisher<Integer>>() {
+        }, new Supplier<Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> call() {
+            public Publisher<Integer> get() {
                 return just1;
             }
         }).blockingSubscribe();
@@ -1332,9 +1333,9 @@ public class FlowableNullTests {
             public Publisher<Integer> apply(Integer v) {
                 return just1;
             }
-        }, null, new Callable<Publisher<Integer>>() {
+        }, null, new Supplier<Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> call() {
+            public Publisher<Integer> get() {
                 return just1;
             }
         });
@@ -1353,9 +1354,9 @@ public class FlowableNullTests {
             public Publisher<Integer> apply(Throwable e) {
                 return null;
             }
-        }, new Callable<Publisher<Integer>>() {
+        }, new Supplier<Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> call() {
+            public Publisher<Integer> get() {
                 return just1;
             }
         }).blockingSubscribe();
@@ -1388,9 +1389,9 @@ public class FlowableNullTests {
             public Publisher<Integer> apply(Throwable e) {
                 return just1;
             }
-        }, new Callable<Publisher<Integer>>() {
+        }, new Supplier<Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> call() {
+            public Publisher<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -1771,9 +1772,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void reduceWithSeedReturnsNull() {
-        just1.reduceWith(new Callable<Object>() {
+        just1.reduceWith(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }, new BiFunction<Object, Integer, Object>() {
@@ -2026,9 +2027,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void scanSeedSupplierReturnsNull() {
-        just1.scanWith(new Callable<Object>() {
+        just1.scanWith(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }, new BiFunction<Object, Integer, Object>() {
@@ -2041,9 +2042,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void scanSeedSupplierFunctionNull() {
-        just1.scanWith(new Callable<Object>() {
+        just1.scanWith(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, null);
@@ -2051,9 +2052,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void scanSeedSupplierFunctionReturnsNull() {
-        just1.scanWith(new Callable<Object>() {
+        just1.scanWith(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new BiFunction<Object, Integer, Object>() {
@@ -2371,9 +2372,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void toListSupplierReturnsNull() {
-        just1.toList(new Callable<Collection<Integer>>() {
+        just1.toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).toFlowable().blockingSubscribe();
@@ -2381,9 +2382,9 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void toListSupplierReturnsNullSingle() {
-        just1.toList(new Callable<Collection<Integer>>() {
+        just1.toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingGet();
@@ -2451,9 +2452,9 @@ public class FlowableNullTests {
             public Object apply(Integer v) {
                 return v;
             }
-        }, new Callable<Map<Object, Object>>() {
+        }, new Supplier<Map<Object, Object>>() {
             @Override
-            public Map<Object, Object> call() {
+            public Map<Object, Object> get() {
                 return null;
             }
         }).blockingGet();
@@ -2516,9 +2517,9 @@ public class FlowableNullTests {
             public Object apply(Integer v) {
                 return v;
             }
-        }, new Callable<Map<Object, Collection<Object>>>() {
+        }, new Supplier<Map<Object, Collection<Object>>>() {
             @Override
-            public Map<Object, Collection<Object>> call() {
+            public Map<Object, Collection<Object>> get() {
                 return null;
             }
         }).blockingGet();
@@ -2536,9 +2537,9 @@ public class FlowableNullTests {
             public Integer apply(Integer v) {
                 return v;
             }
-        }, new Callable<Map<Integer, Collection<Integer>>>() {
+        }, new Supplier<Map<Integer, Collection<Integer>>>() {
             @Override
-            public Map<Integer, Collection<Integer>> call() {
+            public Map<Integer, Collection<Integer>> get() {
                 return new HashMap<Integer, Collection<Integer>>();
             }
         }, null);
@@ -2556,9 +2557,9 @@ public class FlowableNullTests {
             public Integer apply(Integer v) {
                 return v;
             }
-        }, new Callable<Map<Integer, Collection<Integer>>>() {
+        }, new Supplier<Map<Integer, Collection<Integer>>>() {
             @Override
-            public Map<Integer, Collection<Integer>> call() {
+            public Map<Integer, Collection<Integer>> get() {
                 return new HashMap<Integer, Collection<Integer>>();
             }
         }, new Function<Integer, Collection<Integer>>() {
@@ -2626,14 +2627,14 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void windowBoundarySupplierNull() {
-        just1.window((Callable<Publisher<Integer>>)null);
+        just1.window((Supplier<Publisher<Integer>>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void windowBoundarySupplierReturnsNull() {
-        just1.window(new Callable<Publisher<Object>>() {
+        just1.window(new Supplier<Publisher<Object>>() {
             @Override
-            public Publisher<Object> call() {
+            public Publisher<Object> get() {
                 return null;
             }
         }).blockingSubscribe();

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -137,9 +137,9 @@ public class FlowableTests {
 
     @Test
     public void testCountErrorFlowable() {
-        Flowable<String> f = Flowable.error(new Callable<Throwable>() {
+        Flowable<String> f = Flowable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new RuntimeException();
             }
         });
@@ -172,9 +172,9 @@ public class FlowableTests {
 
     @Test
     public void testCountError() {
-        Flowable<String> f = Flowable.error(new Callable<Throwable>() {
+        Flowable<String> f = Flowable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new RuntimeException();
             }
         });
@@ -459,9 +459,9 @@ public class FlowableTests {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         // FIXME custom built???
-        Flowable.just("1", "2").concatWith(Flowable.<String>error(new Callable<Throwable>() {
+        Flowable.just("1", "2").concatWith(Flowable.<String>error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new NumberFormatException();
             }
         }))

--- a/src/test/java/io/reactivex/internal/functions/FunctionsTest.java
+++ b/src/test/java/io/reactivex/internal/functions/FunctionsTest.java
@@ -72,7 +72,7 @@ public class FunctionsTest {
     }
 
     @Test
-    public void booleanSupplierPredicateReverse() throws Exception {
+    public void booleanSupplierPredicateReverse() throws Throwable {
         BooleanSupplier s = new BooleanSupplier() {
             @Override
             public boolean getAsBoolean() throws Exception {
@@ -93,7 +93,7 @@ public class FunctionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void toFunction2() throws Exception {
+    public void toFunction2() throws Throwable {
         Functions.toFunction(new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2) throws Exception {
@@ -103,7 +103,7 @@ public class FunctionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void toFunction3() throws Exception {
+    public void toFunction3() throws Throwable {
         Functions.toFunction(new Function3<Integer, Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2, Integer t3) throws Exception {
@@ -113,7 +113,7 @@ public class FunctionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void toFunction4() throws Exception {
+    public void toFunction4() throws Throwable {
         Functions.toFunction(new Function4<Integer, Integer, Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4) throws Exception {
@@ -123,7 +123,7 @@ public class FunctionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void toFunction5() throws Exception {
+    public void toFunction5() throws Throwable {
         Functions.toFunction(new Function5<Integer, Integer, Integer, Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5) throws Exception {
@@ -133,7 +133,7 @@ public class FunctionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void toFunction6() throws Exception {
+    public void toFunction6() throws Throwable {
         Functions.toFunction(new Function6<Integer, Integer, Integer, Integer, Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6) throws Exception {
@@ -143,7 +143,7 @@ public class FunctionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void toFunction7() throws Exception {
+    public void toFunction7() throws Throwable {
         Functions.toFunction(new Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7) throws Exception {
@@ -153,7 +153,7 @@ public class FunctionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void toFunction8() throws Exception {
+    public void toFunction8() throws Throwable {
         Functions.toFunction(new Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7, Integer t8) throws Exception {
@@ -163,7 +163,7 @@ public class FunctionsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void toFunction9() throws Exception {
+    public void toFunction9() throws Throwable {
         Functions.toFunction(new Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7, Integer t8, Integer t9) throws Exception {
@@ -249,7 +249,7 @@ public class FunctionsTest {
     }
 
     @Test
-    public void errorConsumerEmpty() throws Exception {
+    public void errorConsumerEmpty() throws Throwable {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Functions.ERROR_CONSUMER.accept(new TestException());

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableUsingTest.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.completable;
 import static org.junit.Assert.*;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
@@ -34,9 +33,9 @@ public class CompletableUsingTest {
     @Test
     public void resourceSupplierThrows() {
 
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 throw new TestException();
             }
         }, new Function<Object, CompletableSource>() {
@@ -57,9 +56,9 @@ public class CompletableUsingTest {
     @Test
     public void errorEager() {
 
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -80,9 +79,9 @@ public class CompletableUsingTest {
     @Test
     public void emptyEager() {
 
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -103,9 +102,9 @@ public class CompletableUsingTest {
     @Test
     public void errorNonEager() {
 
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -126,9 +125,9 @@ public class CompletableUsingTest {
     @Test
     public void emptyNonEager() {
 
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -149,9 +148,9 @@ public class CompletableUsingTest {
     @Test
     public void supplierCrashEager() {
 
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -172,9 +171,9 @@ public class CompletableUsingTest {
     @Test
     public void supplierCrashNonEager() {
 
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -194,9 +193,9 @@ public class CompletableUsingTest {
 
     @Test
     public void supplierAndDisposerCrashEager() {
-        TestObserver<Void> to = Completable.using(new Callable<Object>() {
+        TestObserver<Void> to = Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -223,9 +222,9 @@ public class CompletableUsingTest {
     public void supplierAndDisposerCrashNonEager() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Completable.using(new Callable<Object>() {
+            Completable.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, CompletableSource>() {
@@ -252,9 +251,9 @@ public class CompletableUsingTest {
     public void dispose() {
         final int[] call = {0 };
 
-        TestObserver<Void> to = Completable.using(new Callable<Object>() {
+        TestObserver<Void> to = Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -279,9 +278,9 @@ public class CompletableUsingTest {
     public void disposeCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Void> to = Completable.using(new Callable<Object>() {
+            TestObserver<Void> to = Completable.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, CompletableSource>() {
@@ -307,9 +306,9 @@ public class CompletableUsingTest {
 
     @Test
     public void isDisposed() {
-        TestHelper.checkDisposed(Completable.using(new Callable<Object>() {
+        TestHelper.checkDisposed(Completable.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, CompletableSource>() {
@@ -327,9 +326,9 @@ public class CompletableUsingTest {
 
     @Test
     public void justDisposerCrashes() {
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -349,9 +348,9 @@ public class CompletableUsingTest {
 
     @Test
     public void emptyDisposerCrashes() {
-        Completable.using(new Callable<Object>() {
+        Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -371,9 +370,9 @@ public class CompletableUsingTest {
 
     @Test
     public void errorDisposerCrash() {
-        TestObserver<Void> to = Completable.using(new Callable<Object>() {
+        TestObserver<Void> to = Completable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, CompletableSource>() {
@@ -400,9 +399,9 @@ public class CompletableUsingTest {
     public void doubleOnSubscribe() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Completable.using(new Callable<Object>() {
+            Completable.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, CompletableSource>() {
@@ -443,9 +442,9 @@ public class CompletableUsingTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Void> to = Completable.using(new Callable<Object>() {
+            final TestObserver<Void> to = Completable.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, CompletableSource>() {
@@ -488,9 +487,9 @@ public class CompletableUsingTest {
 
                 final PublishSubject<Integer> ps = PublishSubject.create();
 
-                final TestObserver<Void> to = Completable.using(new Callable<Object>() {
+                final TestObserver<Void> to = Completable.using(new Supplier<Object>() {
                     @Override
-                    public Object call() throws Exception {
+                    public Object get() throws Exception {
                         return 1;
                     }
                 }, new Function<Object, CompletableSource>() {
@@ -534,9 +533,9 @@ public class CompletableUsingTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Void> to = Completable.using(new Callable<Object>() {
+            final TestObserver<Void> to = Completable.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, CompletableSource>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -2771,6 +2771,7 @@ public class FlowableBufferTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void bufferExactFailingSupplier() {
         Flowable.empty()
                 .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Supplier<List<Object>>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -253,9 +253,9 @@ public class FlowableBufferTest {
             }
         });
 
-        Callable<Flowable<Object>> closer = new Callable<Flowable<Object>>() {
+        Supplier<Flowable<Object>> closer = new Supplier<Flowable<Object>>() {
             @Override
-            public Flowable<Object> call() {
+            public Flowable<Object> get() {
                 return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> subscriber) {
@@ -1301,9 +1301,9 @@ public class FlowableBufferTest {
     @Test
     public void bufferIntoCustomCollection() {
         Flowable.just(1, 1, 2, 2, 3, 3, 4, 4)
-        .buffer(3, new Callable<Collection<Integer>>() {
+        .buffer(3, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 return new HashSet<Integer>();
             }
         })
@@ -1315,9 +1315,9 @@ public class FlowableBufferTest {
     @Test
     public void bufferSkipIntoCustomCollection() {
         Flowable.just(1, 1, 2, 2, 3, 3, 4, 4)
-        .buffer(3, 3, new Callable<Collection<Integer>>() {
+        .buffer(3, 3, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 return new HashSet<Integer>();
             }
         })
@@ -1337,9 +1337,9 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBufferSupplierThrows() {
         Flowable.never()
-        .buffer(Functions.justCallable(Flowable.never()), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Flowable.never()), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -1351,14 +1351,14 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBoundarySupplierThrows() {
         Flowable.never()
-        .buffer(new Callable<Publisher<Object>>() {
+        .buffer(new Supplier<Publisher<Object>>() {
             @Override
-            public Publisher<Object> call() throws Exception {
+            public Publisher<Object> get() throws Exception {
                 throw new TestException();
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1370,10 +1370,10 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBufferSupplierThrows2() {
         Flowable.never()
-        .buffer(Functions.justCallable(Flowable.timer(1, TimeUnit.MILLISECONDS)), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Flowable.timer(1, TimeUnit.MILLISECONDS)), new Supplier<Collection<Object>>() {
             int count;
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
@@ -1390,10 +1390,10 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBufferSupplierReturnsNull() {
         Flowable.never()
-        .buffer(Functions.justCallable(Flowable.timer(1, TimeUnit.MILLISECONDS)), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Flowable.timer(1, TimeUnit.MILLISECONDS)), new Supplier<Collection<Object>>() {
             int count;
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 } else {
@@ -1410,18 +1410,18 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBoundarySupplierThrows2() {
         Flowable.never()
-        .buffer(new Callable<Publisher<Long>>() {
+        .buffer(new Supplier<Publisher<Long>>() {
             int count;
             @Override
-            public Publisher<Long> call() throws Exception {
+            public Publisher<Long> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 }
                 return Flowable.timer(1, TimeUnit.MILLISECONDS);
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1435,9 +1435,9 @@ public class FlowableBufferTest {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
         TestSubscriber<Collection<Object>> ts = pp
-        .buffer(Functions.justCallable(Flowable.never()), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Flowable.never()), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1454,18 +1454,18 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBoundarySupplierReturnsNull() {
         Flowable.never()
-        .buffer(new Callable<Publisher<Long>>() {
+        .buffer(new Supplier<Publisher<Long>>() {
             int count;
             @Override
-            public Publisher<Long> call() throws Exception {
+            public Publisher<Long> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 }
                 return Flowable.timer(1, TimeUnit.MILLISECONDS);
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1478,18 +1478,18 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBoundarySupplierReturnsNull2() {
         Flowable.never()
-        .buffer(new Callable<Publisher<Long>>() {
+        .buffer(new Supplier<Publisher<Long>>() {
             int count;
             @Override
-            public Publisher<Long> call() throws Exception {
+            public Publisher<Long> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 }
                 return Flowable.empty();
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1504,9 +1504,9 @@ public class FlowableBufferTest {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
         TestSubscriber<Collection<Object>> ts = pp
-        .buffer(Functions.justCallable(Flowable.never()), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Flowable.never()), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1523,9 +1523,9 @@ public class FlowableBufferTest {
         PublishProcessor<Object> pp = PublishProcessor.create();
 
         TestSubscriber<Collection<Object>> ts = pp
-        .buffer(Functions.justCallable(Flowable.error(new TestException())), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Flowable.error(new TestException())), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1558,10 +1558,10 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierReturnsNull() {
         Flowable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 } else {
@@ -1578,10 +1578,10 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierReturnsNull2() {
         Flowable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 } else {
@@ -1598,10 +1598,10 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierReturnsNull3() {
         Flowable.<Integer>never()
-        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Callable<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 } else {
@@ -1618,9 +1618,9 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows() {
         Flowable.just(1)
-        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         }, false)
@@ -1632,9 +1632,9 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows2() {
         Flowable.just(1)
-        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         }, false)
@@ -1646,9 +1646,9 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows3() {
         Flowable.just(1)
-        .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), new Callable<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -1660,10 +1660,10 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows4() {
         Flowable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
@@ -1680,10 +1680,10 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows5() {
         Flowable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
@@ -1700,10 +1700,10 @@ public class FlowableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows6() {
         Flowable.<Integer>never()
-        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Callable<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
@@ -1738,10 +1738,10 @@ public class FlowableBufferTest {
     @Test
     public void bufferSupplierCrash2() {
         Flowable.range(1, 2)
-        .buffer(1, new Callable<List<Integer>>() {
+        .buffer(1, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -1756,10 +1756,10 @@ public class FlowableBufferTest {
     @Test
     public void bufferSkipSupplierCrash2() {
         Flowable.range(1, 2)
-        .buffer(1, 2, new Callable<List<Integer>>() {
+        .buffer(1, 2, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 1) {
                     throw new TestException();
                 }
@@ -1774,10 +1774,10 @@ public class FlowableBufferTest {
     @Test
     public void bufferOverlapSupplierCrash2() {
         Flowable.range(1, 2)
-        .buffer(2, 1, new Callable<List<Integer>>() {
+        .buffer(2, 1, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -1865,10 +1865,10 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<List<Integer>> ts = pp
-        .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, new Callable<List<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -2469,10 +2469,10 @@ public class FlowableBufferTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> b = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp.buffer(b, new Callable<List<Integer>>() {
+        TestSubscriber<List<Integer>> ts = pp.buffer(b, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -2552,7 +2552,7 @@ public class FlowableBufferTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             BehaviorProcessor.createDefault(1)
-            .buffer(Functions.justCallable(new Flowable<Integer>() {
+            .buffer(Functions.justSupplier(new Flowable<Integer>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -2576,8 +2576,8 @@ public class FlowableBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         BufferBoundarySupplierSubscriber<Integer, List<Integer>, Integer> sub =
                 new BufferBoundarySupplierSubscriber<Integer, List<Integer>, Integer>(
-                        ts, Functions.justCallable((List<Integer>)new ArrayList<Integer>()),
-                        Functions.justCallable(Flowable.<Integer>never())
+                        ts, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()),
+                        Functions.justSupplier(Flowable.<Integer>never())
         );
 
         BooleanSubscription bs = new BooleanSubscription();
@@ -2605,8 +2605,8 @@ public class FlowableBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
         BufferBoundarySupplierSubscriber<Integer, List<Integer>, Integer> sub =
                 new BufferBoundarySupplierSubscriber<Integer, List<Integer>, Integer>(
-                        ts, Functions.justCallable((List<Integer>)new ArrayList<Integer>()),
-                        Functions.justCallable(Flowable.<Integer>never())
+                        ts, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()),
+                        Functions.justSupplier(Flowable.<Integer>never())
         );
 
         BooleanSubscription bs = new BooleanSubscription();
@@ -2653,7 +2653,7 @@ public class FlowableBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
 
         BufferExactUnboundedSubscriber<Integer, List<Integer>> sub = new BufferExactUnboundedSubscriber<Integer, List<Integer>>(
-                ts, Functions.justCallable((List<Integer>)new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
+                ts, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2703,7 +2703,7 @@ public class FlowableBufferTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
 
         BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<Integer, List<Integer>>(
-                ts, Functions.justCallable((List<Integer>)new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
+                ts, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2722,10 +2722,10 @@ public class FlowableBufferTest {
         final TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
 
         BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<Integer, List<Integer>>(
-                ts, new Callable<List<Integer>>() {
+                ts, new Supplier<List<Integer>>() {
                     int calls;
                     @Override
-                    public List<Integer> call() throws Exception {
+                    public List<Integer> get() throws Exception {
                         if (++calls == 2) {
                             ts.cancel();
                         }
@@ -2748,7 +2748,7 @@ public class FlowableBufferTest {
 
         BufferExactBoundedSubscriber<Integer, List<Integer>> sub =
                 new BufferExactBoundedSubscriber<Integer, List<Integer>>(
-                        ts, Functions.justCallable((List<Integer>)new ArrayList<Integer>()),
+                        ts, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()),
                         1, TimeUnit.SECONDS, 1, false, sch.createWorker())
         ;
 
@@ -2773,9 +2773,9 @@ public class FlowableBufferTest {
     @Test
     public void bufferExactFailingSupplier() {
         Flowable.empty()
-                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Callable<List<Object>>() {
+                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Supplier<List<Object>>() {
                     @Override
-                    public List<Object> call() throws Exception {
+                    public List<Object> get() throws Exception {
                         throw new TestException();
                     }
                 }, false)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -133,7 +133,7 @@ public class FlowableCacheTest {
     }
 
     @Test
-    public void testUnsubscribeSource() throws Exception {
+    public void testUnsubscribeSource() throws Throwable {
         Action unsubscribe = mock(Action.class);
         Flowable<Integer> f = Flowable.just(1).doOnCancel(unsubscribe).cache();
         f.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDeferTest.java
@@ -13,15 +13,15 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Supplier;
 
 @SuppressWarnings("unchecked")
 public class FlowableDeferTest {
@@ -29,11 +29,11 @@ public class FlowableDeferTest {
     @Test
     public void testDefer() throws Throwable {
 
-        Callable<Flowable<String>> factory = mock(Callable.class);
+        Supplier<Flowable<String>> factory = mock(Supplier.class);
 
         Flowable<String> firstObservable = Flowable.just("one", "two");
         Flowable<String> secondObservable = Flowable.just("three", "four");
-        when(factory.call()).thenReturn(firstObservable, secondObservable);
+        when(factory.get()).thenReturn(firstObservable, secondObservable);
 
         Flowable<String> deferred = Flowable.defer(factory);
 
@@ -42,7 +42,7 @@ public class FlowableDeferTest {
         Subscriber<String> firstSubscriber = TestHelper.mockSubscriber();
         deferred.subscribe(firstSubscriber);
 
-        verify(factory, times(1)).call();
+        verify(factory, times(1)).get();
         verify(firstSubscriber, times(1)).onNext("one");
         verify(firstSubscriber, times(1)).onNext("two");
         verify(firstSubscriber, times(0)).onNext("three");
@@ -52,7 +52,7 @@ public class FlowableDeferTest {
         Subscriber<String> secondSubscriber = TestHelper.mockSubscriber();
         deferred.subscribe(secondSubscriber);
 
-        verify(factory, times(2)).call();
+        verify(factory, times(2)).get();
         verify(secondSubscriber, times(0)).onNext("one");
         verify(secondSubscriber, times(0)).onNext("two");
         verify(secondSubscriber, times(1)).onNext("three");
@@ -62,10 +62,10 @@ public class FlowableDeferTest {
     }
 
     @Test
-    public void testDeferFunctionThrows() throws Exception {
-        Callable<Flowable<String>> factory = mock(Callable.class);
+    public void testDeferFunctionThrows() throws Throwable {
+        Supplier<Flowable<String>> factory = mock(Supplier.class);
 
-        when(factory.call()).thenThrow(new TestException());
+        when(factory.get()).thenThrow(new TestException());
 
         Flowable<String> result = Flowable.defer(factory);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
@@ -396,9 +396,9 @@ public class FlowableDelayTest {
     public void testDelayWithFlowableSubscriptionFunctionThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
-        Callable<Flowable<Integer>> subFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> subFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 throw new TestException();
             }
         };
@@ -430,9 +430,9 @@ public class FlowableDelayTest {
     public void testDelayWithFlowableSubscriptionThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
-        Callable<Flowable<Integer>> subFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> subFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 return delay;
             }
         };
@@ -490,9 +490,9 @@ public class FlowableDelayTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> sdelay = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
-        Callable<Flowable<Integer>> subFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> subFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 return sdelay;
             }
         };
@@ -727,10 +727,10 @@ public class FlowableDelayTest {
     public void testBackpressureWithSelectorDelayAndSubscriptionDelay() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Flowable.range(1, Flowable.bufferSize() * 2)
-                .delay(Flowable.defer(new Callable<Flowable<Long>>() {
+                .delay(Flowable.defer(new Supplier<Flowable<Long>>() {
 
                     @Override
-                    public Flowable<Long> call() {
+                    public Flowable<Long> get() {
                         return Flowable.timer(500, TimeUnit.MILLISECONDS);
                     }
                 }), new Function<Integer, Flowable<Long>>() {
@@ -795,9 +795,9 @@ public class FlowableDelayTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        source.delaySubscription(Flowable.defer(new Callable<Publisher<Integer>>() {
+        source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> call() {
+            public Publisher<Integer> get() {
                 return pp;
             }
         })).subscribe(ts);
@@ -821,9 +821,9 @@ public class FlowableDelayTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        source.delaySubscription(Flowable.defer(new Callable<Publisher<Integer>>() {
+        source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> call() {
+            public Publisher<Integer> get() {
                 return pp;
             }
         })).subscribe(ts);
@@ -848,9 +848,9 @@ public class FlowableDelayTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        source.delaySubscription(Flowable.defer(new Callable<Publisher<Integer>>() {
+        source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> call() {
+            public Publisher<Integer> get() {
                 return pp;
             }
         })).subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.*;
 import org.mockito.InOrder;
@@ -26,7 +25,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -202,9 +201,9 @@ public class FlowableDistinctTest {
     @Test
     public void collectionSupplierThrows() {
         Flowable.just(1)
-        .distinct(Functions.identity(), new Callable<Collection<Object>>() {
+        .distinct(Functions.identity(), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -215,9 +214,9 @@ public class FlowableDistinctTest {
     @Test
     public void collectionSupplierIsNull() {
         Flowable.just(1)
-        .distinct(Functions.identity(), new Callable<Collection<Object>>() {
+        .distinct(Functions.identity(), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return null;
             }
         })

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterTerminateTest.java
@@ -84,7 +84,7 @@ public class FlowableDoAfterTerminateTest {
     }
 
     @Test
-    public void ifFinallyActionThrowsExceptionShouldNotBeSwallowedAndActionShouldBeCalledOnce() throws Exception {
+    public void ifFinallyActionThrowsExceptionShouldNotBeSwallowedAndActionShouldBeCalledOnce() throws Throwable {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Action finallyAction = Mockito.mock(Action.class);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -160,11 +160,11 @@ public class FlowableFlatMapTest {
         };
     }
 
-    <R> Callable<R> just0(final R value) {
-        return new Callable<R>() {
+    <R> Supplier<R> just0(final R value) {
+        return new Supplier<R>() {
 
             @Override
-            public R call() {
+            public R get() {
                 return value;
             }
         };
@@ -217,10 +217,10 @@ public class FlowableFlatMapTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    <R> Callable<R> funcThrow0(R r) {
-        return new Callable<R>() {
+    <R> Supplier<R> funcThrow0(R r) {
+        return new Supplier<R>() {
             @Override
-            public R call() {
+            public R get() {
                 throw new TestException();
             }
         };
@@ -423,7 +423,7 @@ public class FlowableFlatMapTest {
 
         Function<Integer, Flowable<Integer>> just = just(onNext);
         Function<Throwable, Flowable<Integer>> just2 = just(onError);
-        Callable<Flowable<Integer>> just0 = just0(onComplete);
+        Supplier<Flowable<Integer>> just0 = just0(onComplete);
         source.flatMap(just, just2, just0, m).subscribe(ts);
 
         ts.awaitTerminalEvent(1, TimeUnit.SECONDS);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -1057,7 +1057,7 @@ public class FlowableFlattenIterableTest {
     }
 
     @Test
-    public void fusedCurrentIteratorEmpty() throws Exception {
+    public void fusedCurrentIteratorEmpty() throws Throwable {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
         FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<Integer, Integer>(ts,
                 Functions.justFunction(Arrays.<Integer>asList(1, 2)), 128);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
@@ -21,7 +21,7 @@ import org.junit.*;
 import io.reactivex.*;
 import io.reactivex.functions.Predicate;
 import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 import io.reactivex.subscribers.TestSubscriber;
 
 public class FlowableFromArrayTest {
@@ -101,7 +101,7 @@ public class FlowableFromArrayTest {
     @Test
     public void just() {
         Flowable<Integer> source = Flowable.fromArray(new Integer[] { 1 });
-        Assert.assertTrue(source.getClass().toString(), source instanceof ScalarCallable);
+        Assert.assertTrue(source.getClass().toString(), source instanceof ScalarSupplier);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -580,7 +580,7 @@ public class FlowableFromIterableTest {
 
                 try {
                     assertEquals(1, qs.poll().intValue());
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     throw new AssertionError(ex);
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.flowable;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
@@ -31,9 +30,9 @@ public class FlowableGenerateTest {
 
     @Test
     public void statefulBiconsumer() {
-        Flowable.generate(new Callable<Object>() {
+        Flowable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 10;
             }
         }, new BiConsumer<Object, Emitter<Object>>() {
@@ -54,9 +53,9 @@ public class FlowableGenerateTest {
 
     @Test
     public void stateSupplierThrows() {
-        Flowable.generate(new Callable<Object>() {
+        Flowable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 throw new TestException();
             }
         }, new BiConsumer<Object, Emitter<Object>>() {
@@ -71,9 +70,9 @@ public class FlowableGenerateTest {
 
     @Test
     public void generatorThrows() {
-        Flowable.generate(new Callable<Object>() {
+        Flowable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new BiConsumer<Object, Emitter<Object>>() {
@@ -90,9 +89,9 @@ public class FlowableGenerateTest {
     public void disposerThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.generate(new Callable<Object>() {
+            Flowable.generate(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new BiConsumer<Object, Emitter<Object>>() {
@@ -117,9 +116,9 @@ public class FlowableGenerateTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Flowable.generate(new Callable<Object>() {
+        TestHelper.checkDisposed(Flowable.generate(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new BiConsumer<Object, Emitter<Object>>() {
@@ -133,7 +132,7 @@ public class FlowableGenerateTest {
     @Test
     public void nullError() {
         final int[] call = { 0 };
-        Flowable.generate(Functions.justCallable(1),
+        Flowable.generate(Functions.justSupplier(1),
         new BiConsumer<Integer, Emitter<Object>>() {
             @Override
             public void accept(Integer s, Emitter<Object> e) throws Exception {
@@ -152,9 +151,9 @@ public class FlowableGenerateTest {
 
     @Test
     public void badRequest() {
-        TestHelper.assertBadRequestReported(Flowable.generate(new Callable<Object>() {
+        TestHelper.assertBadRequestReported(Flowable.generate(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new BiConsumer<Object, Emitter<Object>>() {
@@ -167,9 +166,9 @@ public class FlowableGenerateTest {
 
     @Test
     public void rebatchAndTake() {
-        Flowable.generate(new Callable<Object>() {
+        Flowable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new BiConsumer<Object, Emitter<Object>>() {
@@ -186,9 +185,9 @@ public class FlowableGenerateTest {
 
     @Test
     public void backpressure() {
-        Flowable.generate(new Callable<Object>() {
+        Flowable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new BiConsumer<Object, Emitter<Object>>() {
@@ -207,9 +206,9 @@ public class FlowableGenerateTest {
 
     @Test
     public void requestRace() {
-        Flowable<Object> source = Flowable.generate(new Callable<Object>() {
+        Flowable<Object> source = Flowable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new BiConsumer<Object, Emitter<Object>>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -1970,7 +1970,7 @@ public class FlowableGroupByTest {
                             public void onRemoval(RemovalNotification<Object, Object> notification) {
                                 try {
                                     action.accept(notification.getValue());
-                                } catch (Exception ex) {
+                                } catch (Throwable ex) {
                                     throw new RuntimeException(ex);
                                 }
                             }
@@ -2123,7 +2123,7 @@ public class FlowableGroupByTest {
             if (v != null) {
                 try {
                     evictedListener.accept(v);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     throw new RuntimeException(e);
                 }
             }
@@ -2178,7 +2178,7 @@ public class FlowableGroupByTest {
                             public void onRemoval(RemovalNotification<Integer, Object> notification) {
                                 try {
                                     notify.accept(notification.getValue());
-                                } catch (Exception e) {
+                                } catch (Throwable e) {
                                     throw new RuntimeException(e);
                                 }
                             }})
@@ -2199,7 +2199,7 @@ public class FlowableGroupByTest {
                                     public void accept(Object object) {
                                         try {
                                             notify.accept(object);
-                                        } catch (Exception e) {
+                                        } catch (Throwable e) {
                                             throw new RuntimeException(e);
                                         }
                                     }});

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -68,7 +68,7 @@ public class FlowableGroupJoinTest {
         public Flowable<Integer> apply(final Integer leftValue, Flowable<Integer> rightValues) {
             return rightValues.map(new Function<Integer, Integer>() {
                 @Override
-                public Integer apply(Integer rightValue) throws Exception {
+                public Integer apply(Integer rightValue) throws Throwable {
                     return add.apply(leftValue, rightValue);
                 }
             });

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -273,7 +273,7 @@ public class FlowableIgnoreElementsTest {
 
                 try {
                     assertNull(qs.poll());
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     throw new AssertionError(ex);
                 }
 
@@ -285,7 +285,7 @@ public class FlowableIgnoreElementsTest {
 
                 try {
                     assertNull(qs.poll());
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     throw new AssertionError(ex);
                 }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
@@ -13,14 +13,12 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.flowable.FlowableMapNotification.MapNotificationSubscriber;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
@@ -45,9 +43,9 @@ public class FlowableMapNotificationTest {
                         return Flowable.error(e);
                     }
                 },
-                new Callable<Flowable<Object>>() {
+                new Supplier<Flowable<Object>>() {
                     @Override
-                    public Flowable<Object> call() {
+                    public Flowable<Object> get() {
                         return Flowable.never();
                     }
                 }
@@ -75,9 +73,9 @@ public class FlowableMapNotificationTest {
                         return 0;
                     }
                 },
-                new Callable<Integer>() {
+                new Supplier<Integer>() {
                     @Override
-                    public Integer call() {
+                    public Integer get() {
                         return 5;
                     }
                 }
@@ -119,9 +117,9 @@ public class FlowableMapNotificationTest {
                         return 0;
                     }
                 },
-                new Callable<Integer>() {
+                new Supplier<Integer>() {
                     @Override
-                    public Integer call() {
+                    public Integer get() {
                         return 5;
                     }
                 }
@@ -158,7 +156,7 @@ public class FlowableMapNotificationTest {
                         subscriber,
                         Functions.justFunction(Flowable.just(1)),
                         Functions.justFunction(Flowable.just(2)),
-                        Functions.justCallable(Flowable.just(3))
+                        Functions.justSupplier(Flowable.just(3))
                 );
                 mn.onSubscribe(new BooleanSubscription());
             }
@@ -173,7 +171,7 @@ public class FlowableMapNotificationTest {
                 return f.flatMap(
                         Functions.justFunction(Flowable.just(1)),
                         Functions.justFunction(Flowable.just(2)),
-                        Functions.justCallable(Flowable.just(3))
+                        Functions.justSupplier(Flowable.just(3))
                 );
             }
         });
@@ -189,7 +187,7 @@ public class FlowableMapNotificationTest {
                         throw new TestException("Inner");
                     }
                 },
-                Functions.justCallable(Flowable.just(3)))
+                Functions.justSupplier(Flowable.just(3)))
         .test()
         .assertFailure(CompositeException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingleTest.java
@@ -24,7 +24,7 @@ public class FlowableReduceWithSingleTest {
     @Test
     public void normal() {
         Flowable.range(1, 5)
-        .reduceWith(Functions.justCallable(1), new BiFunction<Integer, Integer, Integer>() {
+        .reduceWith(Functions.justSupplier(1), new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer a, Integer b) throws Exception {
                 return a + b;
@@ -37,7 +37,7 @@ public class FlowableReduceWithSingleTest {
     @Test
     public void disposed() {
         TestHelper.checkDisposed(Flowable.range(1, 5)
-        .reduceWith(Functions.justCallable(1), new BiFunction<Integer, Integer, Integer>() {
+        .reduceWith(Functions.justSupplier(1), new BiFunction<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer a, Integer b) throws Exception {
                 return a + b;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -548,10 +548,10 @@ public class FlowableRefCountTest {
                             .flatMap(new Function<Long, Publisher<String>>() {
                                 @Override
                                 public Publisher<String> apply(Long t1) {
-                                        return Flowable.defer(new Callable<Publisher<String>>() {
+                                        return Flowable.defer(new Supplier<Publisher<String>>() {
                                             @Override
-                                            public Publisher<String> call() {
-                                                    return Flowable.<String>error(new TestException("Some exception"));
+                                            public Publisher<String> get() {
+                                                return Flowable.<String>error(new TestException("Some exception"));
                                             }
                                         });
                                 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -512,7 +512,7 @@ public class FlowableReplayTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testIssue2191_UnsubscribeSource() throws Exception {
+    public void testIssue2191_UnsubscribeSource() throws Throwable {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
         Action sourceCompleted = mock(Action.class);
@@ -562,7 +562,7 @@ public class FlowableReplayTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testIssue2191_SchedulerUnsubscribe() throws Exception {
+    public void testIssue2191_SchedulerUnsubscribe() throws Throwable {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
         Action sourceCompleted = mock(Action.class);
@@ -622,7 +622,7 @@ public class FlowableReplayTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testIssue2191_SchedulerUnsubscribeOnError() throws Exception {
+    public void testIssue2191_SchedulerUnsubscribeOnError() throws Throwable {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
         Action sourceCompleted = mock(Action.class);
@@ -950,7 +950,7 @@ public class FlowableReplayTest {
     }
 
     @Test
-    public void testUnsubscribeSource() throws Exception {
+    public void testUnsubscribeSource() throws Throwable {
         Action unsubscribe = mock(Action.class);
         Flowable<Integer> f = Flowable.just(1).doOnCancel(unsubscribe).replay().autoConnect();
         f.subscribe();
@@ -1756,9 +1756,9 @@ public class FlowableReplayTest {
 
     @Test
     public void multicastSelectorCallableConnectableCrash() {
-        FlowableReplay.multicastSelector(new Callable<ConnectableFlowable<Object>>() {
+        FlowableReplay.multicastSelector(new Supplier<ConnectableFlowable<Object>>() {
             @Override
-            public ConnectableFlowable<Object> call() throws Exception {
+            public ConnectableFlowable<Object> get() throws Exception {
                 throw new TestException();
             }
         }, Functions.<Flowable<Object>>identity())
@@ -1944,9 +1944,9 @@ public class FlowableReplayTest {
 
     @Test(expected = TestException.class)
     public void createBufferFactoryCrash() {
-        FlowableReplay.create(Flowable.just(1), new Callable<ReplayBuffer<Integer>>() {
+        FlowableReplay.create(Flowable.just(1), new Supplier<ReplayBuffer<Integer>>() {
             @Override
-            public ReplayBuffer<Integer> call() throws Exception {
+            public ReplayBuffer<Integer> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -1955,9 +1955,9 @@ public class FlowableReplayTest {
 
     @Test
     public void createBufferFactoryCrashOnSubscribe() {
-        FlowableReplay.create(Flowable.just(1), new Callable<ReplayBuffer<Integer>>() {
+        FlowableReplay.create(Flowable.just(1), new Supplier<ReplayBuffer<Integer>>() {
             @Override
-            public ReplayBuffer<Integer> call() throws Exception {
+            public ReplayBuffer<Integer> get() throws Exception {
                 throw new TestException();
             }
         })

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -558,7 +558,7 @@ public class FlowableReplayTest {
     /**
      * Specifically test interaction with a Scheduler with subscribeOn.
      *
-     * @throws Exception functional interfaces declare throws Exception
+     * @throws Throwable functional interfaces declare throws Exception
      */
     @SuppressWarnings("unchecked")
     @Test
@@ -618,7 +618,7 @@ public class FlowableReplayTest {
     /**
      * Specifically test interaction with a Scheduler with subscribeOn.
      *
-     * @throws Exception functional interfaces declare throws Exception
+     * @throws Throwable functional interfaces declare throws Exception
      */
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
@@ -347,7 +347,7 @@ public class FlowableRetryTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testRetrySubscribesAgainAfterError() throws Exception {
+    public void testRetrySubscribesAgainAfterError() throws Throwable {
 
         // record emitted values with this action
         Consumer<Integer> record = mock(Consumer.class);
@@ -1034,9 +1034,9 @@ public class FlowableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Callable<Flowable<Integer>>() {
+        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() throws Exception {
+            public Flowable<Integer> get() throws Exception {
                 if (times.getAndIncrement() < 4) {
                     return Flowable.error(new TestException());
                 }
@@ -1063,9 +1063,9 @@ public class FlowableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Callable<Flowable<Integer>>() {
+        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() throws Exception {
+            public Flowable<Integer> get() throws Exception {
                 if (times.getAndIncrement() < 4) {
                     return Flowable.error(new TestException());
                 }
@@ -1092,9 +1092,9 @@ public class FlowableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Callable<Flowable<Integer>>() {
+        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() throws Exception {
+            public Flowable<Integer> get() throws Exception {
                 if (times.getAndIncrement() < 4) {
                     return Flowable.error(new TestException());
                 }
@@ -1126,9 +1126,9 @@ public class FlowableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Callable<Flowable<Integer>>() {
+        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() throws Exception {
+            public Flowable<Integer> get() throws Exception {
                 if (times.getAndIncrement() < 4) {
                     return Flowable.error(new TestException());
                 }
@@ -1160,9 +1160,9 @@ public class FlowableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Callable<Flowable<Integer>>() {
+        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() throws Exception {
+            public Flowable<Integer> get() throws Exception {
                 if (times.get() < 4) {
                     return Flowable.error(new TestException());
                 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
@@ -15,14 +15,12 @@ package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.*;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -33,38 +31,38 @@ public class FlowableScalarXMapTest {
         TestHelper.checkUtilityClass(FlowableScalarXMap.class);
     }
 
-    static final class CallablePublisher implements Publisher<Integer>, Callable<Integer> {
+    static final class CallablePublisher implements Publisher<Integer>, Supplier<Integer> {
         @Override
         public void subscribe(Subscriber<? super Integer> s) {
             EmptySubscription.error(new TestException(), s);
         }
 
         @Override
-        public Integer call() throws Exception {
+        public Integer get() throws Exception {
             throw new TestException();
         }
     }
 
-    static final class EmptyCallablePublisher implements Publisher<Integer>, Callable<Integer> {
+    static final class EmptyCallablePublisher implements Publisher<Integer>, Supplier<Integer> {
         @Override
         public void subscribe(Subscriber<? super Integer> s) {
             EmptySubscription.complete(s);
         }
 
         @Override
-        public Integer call() throws Exception {
+        public Integer get() throws Exception {
             return null;
         }
     }
 
-    static final class OneCallablePublisher implements Publisher<Integer>, Callable<Integer> {
+    static final class OneCallablePublisher implements Publisher<Integer>, Supplier<Integer> {
         @Override
         public void subscribe(Subscriber<? super Integer> s) {
             s.onSubscribe(new ScalarSubscription<Integer>(s, 1));
         }
 
         @Override
-        public Integer call() throws Exception {
+        public Integer get() throws Exception {
             return 1;
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
@@ -258,10 +258,10 @@ public class FlowableScanTest {
     @Test
     public void testSeedFactory() {
         Single<List<Integer>> o = Flowable.range(1, 10)
-                .collect(new Callable<List<Integer>>() {
+                .collect(new Supplier<List<Integer>>() {
 
                     @Override
-                    public List<Integer> call() {
+                    public List<Integer> get() {
                         return new ArrayList<Integer>();
                     }
 
@@ -284,10 +284,10 @@ public class FlowableScanTest {
     @Test
     public void testSeedFactoryFlowable() {
         Flowable<List<Integer>> f = Flowable.range(1, 10)
-                .collect(new Callable<List<Integer>>() {
+                .collect(new Supplier<List<Integer>>() {
 
                     @Override
-                    public List<Integer> call() {
+                    public List<Integer> get() {
                         return new ArrayList<Integer>();
                     }
 
@@ -562,7 +562,7 @@ public class FlowableScanTest {
     @Test
     public void testScanWithSeedWhenScanSeedProviderThrows() {
         final RuntimeException e = new RuntimeException();
-        Flowable.just(1, 2, 3).scanWith(throwingCallable(e),
+        Flowable.just(1, 2, 3).scanWith(throwingSupplier(e),
             SUM)
           .test()
           .assertError(e)
@@ -648,10 +648,10 @@ public class FlowableScanTest {
         }
     };
 
-    private static Callable<Integer> throwingCallable(final RuntimeException e) {
-        return new Callable<Integer>() {
+    private static Supplier<Integer> throwingSupplier(final RuntimeException e) {
+        return new Supplier<Integer>() {
             @Override
-            public Integer call() throws Exception {
+            public Integer get() throws Exception {
                 throw e;
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -182,7 +182,7 @@ public class FlowableThrottleLatestTest {
     }
 
     @Test
-    public void missingBackpressureExceptionFirst() throws Exception {
+    public void missingBackpressureExceptionFirst() throws Throwable {
         TestScheduler sch = new TestScheduler();
         Action onCancel = mock(Action.class);
 
@@ -196,7 +196,7 @@ public class FlowableThrottleLatestTest {
     }
 
     @Test
-    public void missingBackpressureExceptionLatest() throws Exception {
+    public void missingBackpressureExceptionLatest() throws Throwable {
         TestScheduler sch = new TestScheduler();
         Action onCancel = mock(Action.class);
 
@@ -214,7 +214,7 @@ public class FlowableThrottleLatestTest {
     }
 
     @Test
-    public void missingBackpressureExceptionLatestComplete() throws Exception {
+    public void missingBackpressureExceptionLatestComplete() throws Throwable {
         TestScheduler sch = new TestScheduler();
         Action onCancel = mock(Action.class);
 
@@ -238,7 +238,7 @@ public class FlowableThrottleLatestTest {
     }
 
     @Test
-    public void take() throws Exception {
+    public void take() throws Throwable {
         Action onCancel = mock(Action.class);
 
         Flowable.range(1, 5)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -111,9 +111,9 @@ public class FlowableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Flowable<Integer>> firstTimeoutFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> firstTimeoutFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 throw new TestException();
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
@@ -342,9 +342,9 @@ public class FlowableToListTest {
     @Test
     public void collectionSupplierThrows() {
         Flowable.just(1)
-        .toList(new Callable<Collection<Integer>>() {
+        .toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -357,9 +357,9 @@ public class FlowableToListTest {
     @Test
     public void collectionSupplierReturnsNull() {
         Flowable.just(1)
-        .toList(new Callable<Collection<Integer>>() {
+        .toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 return null;
             }
         })
@@ -373,9 +373,9 @@ public class FlowableToListTest {
     @Test
     public void singleCollectionSupplierThrows() {
         Flowable.just(1)
-        .toList(new Callable<Collection<Integer>>() {
+        .toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -387,9 +387,9 @@ public class FlowableToListTest {
     @Test
     public void singleCollectionSupplierReturnsNull() {
         Flowable.just(1)
-        .toList(new Callable<Collection<Integer>>() {
+        .toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 return null;
             }
         })

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMapTest.java
@@ -13,16 +13,16 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.*;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 
 public class FlowableToMapTest {
     Subscriber<Object> objectSubscriber;
@@ -148,9 +148,9 @@ public class FlowableToMapTest {
     public void testToMapWithFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
             @Override
-            public Map<Integer, String> call() {
+            public Map<Integer, String> get() {
                 return new LinkedHashMap<Integer, String>() {
 
                     private static final long serialVersionUID = -3296811238780863394L;
@@ -192,9 +192,9 @@ public class FlowableToMapTest {
     public void testToMapWithErrorThrowingFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
             @Override
-            public Map<Integer, String> call() {
+            public Map<Integer, String> get() {
                 throw new RuntimeException("Forced failure");
             }
         };
@@ -321,9 +321,9 @@ public class FlowableToMapTest {
     public void testToMapWithFactory() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
             @Override
-            public Map<Integer, String> call() {
+            public Map<Integer, String> get() {
                 return new LinkedHashMap<Integer, String>() {
 
                     private static final long serialVersionUID = -3296811238780863394L;
@@ -364,9 +364,9 @@ public class FlowableToMapTest {
     public void testToMapWithErrorThrowingFactory() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
             @Override
-            public Map<Integer, String> call() {
+            public Map<Integer, String> get() {
                 throw new RuntimeException("Forced failure");
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
@@ -13,16 +13,16 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.*;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 
 public class FlowableToMultimapTest {
     Subscriber<Object> objectSubscriber;
@@ -86,9 +86,9 @@ public class FlowableToMultimapTest {
     public void testToMultimapWithMapFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new LinkedHashMap<Integer, Collection<String>>() {
 
                     private static final long serialVersionUID = -2084477070717362859L;
@@ -149,9 +149,9 @@ public class FlowableToMultimapTest {
                 return v;
             }
         };
-        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new HashMap<Integer, Collection<String>>();
             }
         };
@@ -228,9 +228,9 @@ public class FlowableToMultimapTest {
     public void testToMultimapWithMapThrowingFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 throw new RuntimeException("Forced failure");
             }
         };
@@ -275,9 +275,9 @@ public class FlowableToMultimapTest {
                 return v;
             }
         };
-        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new HashMap<Integer, Collection<String>>();
             }
         };
@@ -332,9 +332,9 @@ public class FlowableToMultimapTest {
     public void testToMultimapWithMapFactory() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new LinkedHashMap<Integer, Collection<String>>() {
 
                     private static final long serialVersionUID = -2084477070717362859L;
@@ -394,9 +394,9 @@ public class FlowableToMultimapTest {
                 return v;
             }
         };
-        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new HashMap<Integer, Collection<String>>();
             }
         };
@@ -470,9 +470,9 @@ public class FlowableToMultimapTest {
     public void testToMultimapWithMapThrowingFactory() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 throw new RuntimeException("Forced failure");
             }
         };
@@ -516,9 +516,9 @@ public class FlowableToMultimapTest {
                 return v;
             }
         };
-        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new HashMap<Integer, Collection<String>>();
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.*;
@@ -73,9 +72,9 @@ public class FlowableUsingTest {
         final Resource resource = mock(Resource.class);
         when(resource.getTextFromWeb()).thenReturn("Hello world!");
 
-        Callable<Resource> resourceFactory = new Callable<Resource>() {
+        Supplier<Resource> resourceFactory = new Supplier<Resource>() {
             @Override
-            public Resource call() {
+            public Resource get() {
                 return resource;
             }
         };
@@ -115,9 +114,9 @@ public class FlowableUsingTest {
 
     private void performTestUsingWithSubscribingTwice(boolean disposeEagerly) {
         // When subscribe is called, a new resource should be created.
-        Callable<Resource> resourceFactory = new Callable<Resource>() {
+        Supplier<Resource> resourceFactory = new Supplier<Resource>() {
             @Override
-            public Resource call() {
+            public Resource get() {
                 return new Resource() {
 
                     boolean first = true;
@@ -177,9 +176,9 @@ public class FlowableUsingTest {
     }
 
     private void performTestUsingWithResourceFactoryError(boolean disposeEagerly) {
-        Callable<Disposable> resourceFactory = new Callable<Disposable>() {
+        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
             @Override
-            public Disposable call() {
+            public Disposable get() {
                 throw new TestException();
             }
         };
@@ -207,9 +206,9 @@ public class FlowableUsingTest {
 
     private void performTestUsingWithFlowableFactoryError(boolean disposeEagerly) {
         final Runnable unsubscribe = mock(Runnable.class);
-        Callable<Disposable> resourceFactory = new Callable<Disposable>() {
+        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
             @Override
-            public Disposable call() {
+            public Disposable get() {
                 return Disposables.fromRunnable(unsubscribe);
             }
         };
@@ -245,9 +244,9 @@ public class FlowableUsingTest {
 
     private void performTestUsingWithFlowableFactoryErrorInOnSubscribe(boolean disposeEagerly) {
         final Runnable unsubscribe = mock(Runnable.class);
-        Callable<Disposable> resourceFactory = new Callable<Disposable>() {
+        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
             @Override
-            public Disposable call() {
+            public Disposable get() {
                 return Disposables.fromRunnable(unsubscribe);
             }
         };
@@ -280,7 +279,7 @@ public class FlowableUsingTest {
     @Test
     public void testUsingDisposesEagerlyBeforeCompletion() {
         final List<String> events = new ArrayList<String>();
-        Callable<Resource> resourceFactory = createResourceFactory(events);
+        Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
 
@@ -307,7 +306,7 @@ public class FlowableUsingTest {
     @Test
     public void testUsingDoesNotDisposesEagerlyBeforeCompletion() {
         final List<String> events = new ArrayList<String>();
-        Callable<Resource> resourceFactory = createResourceFactory(events);
+        Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
 
@@ -334,7 +333,7 @@ public class FlowableUsingTest {
     @Test
     public void testUsingDisposesEagerlyBeforeError() {
         final List<String> events = new ArrayList<String>();
-        Callable<Resource> resourceFactory = createResourceFactory(events);
+        Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
 
@@ -362,7 +361,7 @@ public class FlowableUsingTest {
     @Test
     public void testUsingDoesNotDisposesEagerlyBeforeError() {
         final List<String> events = new ArrayList<String>();
-        final Callable<Resource> resourceFactory = createResourceFactory(events);
+        final Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
 
@@ -404,10 +403,10 @@ public class FlowableUsingTest {
         };
     }
 
-    private static Callable<Resource> createResourceFactory(final List<String> events) {
-        return new Callable<Resource>() {
+    private static Supplier<Resource> createResourceFactory(final List<String> events) {
+        return new Supplier<Resource>() {
             @Override
-            public Resource call() {
+            public Resource get() {
                 return new Resource() {
 
                     @Override
@@ -441,9 +440,9 @@ public class FlowableUsingTest {
         final AtomicInteger count = new AtomicInteger();
 
         Flowable.<Integer, Integer>using(
-                new Callable<Integer>() {
+                new Supplier<Integer>() {
                     @Override
-                    public Integer call() {
+                    public Integer get() {
                         return 1;
                     }
                 },
@@ -475,9 +474,9 @@ public class FlowableUsingTest {
         final AtomicInteger count = new AtomicInteger();
 
         Flowable.<Integer, Integer>using(
-                new Callable<Integer>() {
+                new Supplier<Integer>() {
                     @Override
-                    public Integer call() {
+                    public Integer get() {
                         return 1;
                     }
                 },
@@ -506,9 +505,9 @@ public class FlowableUsingTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Flowable.using(
-                new Callable<Object>() {
+                new Supplier<Object>() {
                     @Override
-                    public Object call() throws Exception {
+                    public Object get() throws Exception {
                         return 1;
                     }
                 },
@@ -524,9 +523,9 @@ public class FlowableUsingTest {
 
     @Test
     public void supplierDisposerCrash() {
-        TestSubscriber<Object> ts = Flowable.using(new Callable<Object>() {
+        TestSubscriber<Object> ts = Flowable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, Flowable<Object>>() {
@@ -551,9 +550,9 @@ public class FlowableUsingTest {
 
     @Test
     public void eagerOnErrorDisposerCrash() {
-        TestSubscriber<Object> ts = Flowable.using(new Callable<Object>() {
+        TestSubscriber<Object> ts = Flowable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, Flowable<Object>>() {
@@ -578,9 +577,9 @@ public class FlowableUsingTest {
 
     @Test
     public void eagerOnCompleteDisposerCrash() {
-        Flowable.using(new Callable<Object>() {
+        Flowable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, Flowable<Object>>() {
@@ -602,9 +601,9 @@ public class FlowableUsingTest {
     public void nonEagerDisposerCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.using(new Callable<Object>() {
+            Flowable.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, Flowable<Object>>() {
@@ -629,7 +628,7 @@ public class FlowableUsingTest {
 
     @Test
     public void sourceSupplierReturnsNull() {
-        Flowable.using(Functions.justCallable(1),
+        Flowable.using(Functions.justSupplier(1),
                 Functions.justFunction((Publisher<Object>)null),
                 Functions.emptyConsumer())
         .test()
@@ -643,7 +642,7 @@ public class FlowableUsingTest {
             @Override
             public Flowable<Object> apply(Flowable<Object> f)
                     throws Exception {
-                return Flowable.using(Functions.justCallable(1), Functions.justFunction(f), Functions.emptyConsumer());
+                return Flowable.using(Functions.justSupplier(1), Functions.justFunction(f), Functions.emptyConsumer());
             }
         });
     }
@@ -652,7 +651,7 @@ public class FlowableUsingTest {
     public void eagerDisposedOnComplete() {
         final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        Flowable.using(Functions.justCallable(1), Functions.justFunction(new Flowable<Integer>() {
+        Flowable.using(Functions.justSupplier(1), Functions.justFunction(new Flowable<Integer>() {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -667,7 +666,7 @@ public class FlowableUsingTest {
     public void eagerDisposedOnError() {
         final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
 
-        Flowable.using(Functions.justCallable(1), Functions.justFunction(new Flowable<Integer>() {
+        Flowable.using(Functions.justSupplier(1), Functions.justFunction(new Flowable<Integer>() {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -26,7 +26,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -269,9 +269,9 @@ public class FlowableWindowWithFlowableTest {
                 super.onNext(t);
             }
         };
-        source.window(new Callable<Flowable<Object>>() {
+        source.window(new Supplier<Flowable<Object>>() {
             @Override
-            public Flowable<Object> call() {
+            public Flowable<Object> get() {
                 return Flowable.never();
             }
         }).subscribe(ts);
@@ -286,9 +286,9 @@ public class FlowableWindowWithFlowableTest {
     @Test
     public void testWindowViaFlowableNoUnsubscribe() {
         Flowable<Integer> source = Flowable.range(1, 10);
-        Callable<Flowable<String>> boundary = new Callable<Flowable<String>>() {
+        Supplier<Flowable<String>> boundary = new Supplier<Flowable<String>>() {
             @Override
-            public Flowable<String> call() {
+            public Flowable<String> get() {
                 return Flowable.empty();
             }
         };
@@ -303,9 +303,9 @@ public class FlowableWindowWithFlowableTest {
     public void testBoundaryUnsubscribedOnMainCompletion() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> boundary = PublishProcessor.create();
-        Callable<Flowable<Integer>> boundaryFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> boundaryFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 return boundary;
             }
         };
@@ -330,9 +330,9 @@ public class FlowableWindowWithFlowableTest {
     public void testMainUnsubscribedOnBoundaryCompletion() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> boundary = PublishProcessor.create();
-        Callable<Flowable<Integer>> boundaryFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> boundaryFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 return boundary;
             }
         };
@@ -357,9 +357,9 @@ public class FlowableWindowWithFlowableTest {
     public void testChildUnsubscribed() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> boundary = PublishProcessor.create();
-        Callable<Flowable<Integer>> boundaryFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> boundaryFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 return boundary;
             }
         };
@@ -389,9 +389,9 @@ public class FlowableWindowWithFlowableTest {
     public void testInnerBackpressure() {
         Flowable<Integer> source = Flowable.range(1, 10);
         final PublishProcessor<Integer> boundary = PublishProcessor.create();
-        Callable<Flowable<Integer>> boundaryFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> boundaryFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 return boundary;
             }
         };
@@ -427,9 +427,9 @@ public class FlowableWindowWithFlowableTest {
         final AtomicInteger calls = new AtomicInteger();
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> boundary = PublishProcessor.create();
-        Callable<Flowable<Integer>> boundaryFunc = new Callable<Flowable<Integer>>() {
+        Supplier<Flowable<Integer>> boundaryFunc = new Supplier<Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> call() {
+            public Flowable<Integer> get() {
                 calls.getAndIncrement();
                 return boundary;
             }
@@ -468,7 +468,7 @@ public class FlowableWindowWithFlowableTest {
 
     @Test
     public void boundaryDispose2() {
-        TestHelper.checkDisposed(Flowable.never().window(Functions.justCallable(Flowable.never())));
+        TestHelper.checkDisposed(Flowable.never().window(Functions.justSupplier(Flowable.never())));
     }
 
     @Test
@@ -487,7 +487,7 @@ public class FlowableWindowWithFlowableTest {
     @Test
     public void mainError() {
         Flowable.error(new TestException())
-        .window(Functions.justCallable(Flowable.never()))
+        .window(Functions.justSupplier(Flowable.never()))
         .test()
         .assertError(TestException.class);
     }
@@ -509,10 +509,10 @@ public class FlowableWindowWithFlowableTest {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
             public Object apply(final Flowable<Integer> f) throws Exception {
-                return Flowable.just(1).window(new Callable<Publisher<Integer>>() {
+                return Flowable.just(1).window(new Supplier<Publisher<Integer>>() {
                     int count;
                     @Override
-                    public Publisher<Integer> call() throws Exception {
+                    public Publisher<Integer> get() throws Exception {
                         if (++count > 1) {
                             return Flowable.never();
                         }
@@ -575,10 +575,10 @@ public class FlowableWindowWithFlowableTest {
             }
         };
 
-        ps.window(new Callable<Flowable<Integer>>() {
+        ps.window(new Supplier<Flowable<Integer>>() {
             boolean once;
             @Override
-            public Flowable<Integer> call() throws Exception {
+            public Flowable<Integer> get() throws Exception {
                 if (!once) {
                     once = true;
                     return BehaviorProcessor.createDefault(1);
@@ -621,7 +621,7 @@ public class FlowableWindowWithFlowableTest {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
             @Override
             public Object apply(Flowable<Object> f) throws Exception {
-                return f.window(Functions.justCallable(Flowable.never())).flatMap(new Function<Flowable<Object>, Flowable<Object>>() {
+                return f.window(Functions.justSupplier(Flowable.never())).flatMap(new Function<Flowable<Object>, Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Flowable<Object> v) throws Exception {
                         return v;
@@ -634,7 +634,7 @@ public class FlowableWindowWithFlowableTest {
     @Test
     public void boundaryError() {
         BehaviorProcessor.createDefault(1)
-        .window(Functions.justCallable(Flowable.error(new TestException())))
+        .window(Functions.justSupplier(Flowable.error(new TestException())))
         .test()
         .assertValueCount(1)
         .assertNotComplete()
@@ -645,7 +645,7 @@ public class FlowableWindowWithFlowableTest {
     @Test
     public void boundaryMissingBackpressure() {
         BehaviorProcessor.createDefault(1)
-        .window(Functions.justCallable(Flowable.error(new TestException())))
+        .window(Functions.justSupplier(Flowable.error(new TestException())))
         .test(0)
         .assertFailure(MissingBackpressureException.class);
     }
@@ -653,10 +653,10 @@ public class FlowableWindowWithFlowableTest {
     @Test
     public void boundaryCallableCrashOnCall2() {
         BehaviorProcessor.createDefault(1)
-        .window(new Callable<Flowable<Integer>>() {
+        .window(new Supplier<Flowable<Integer>>() {
             int calls;
             @Override
-            public Flowable<Integer> call() throws Exception {
+            public Flowable<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -671,7 +671,7 @@ public class FlowableWindowWithFlowableTest {
     @Test
     public void boundarySecondMissingBackpressure() {
         BehaviorProcessor.createDefault(1)
-        .window(Functions.justCallable(Flowable.just(1)))
+        .window(Functions.justSupplier(Flowable.just(1)))
         .test(1)
         .assertError(MissingBackpressureException.class)
         .assertNotComplete();
@@ -682,7 +682,7 @@ public class FlowableWindowWithFlowableTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Flowable<Integer>> ts = BehaviorProcessor.createDefault(1)
-        .window(Functions.justCallable(pp))
+        .window(Functions.justSupplier(pp))
         .take(1)
         .test();
 
@@ -1047,7 +1047,7 @@ public class FlowableWindowWithFlowableTest {
             @Override
             public Flowable<Flowable<Object>> apply(Flowable<Object> f)
                     throws Exception {
-                return f.window(Functions.justCallable(Flowable.never())).takeLast(1);
+                return f.window(Functions.justSupplier(Flowable.never())).takeLast(1);
             }
         });
     }
@@ -1057,7 +1057,7 @@ public class FlowableWindowWithFlowableTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.window(Functions.justCallable(boundary))
+        TestSubscriber<Integer> ts = source.window(Functions.justSupplier(boundary))
         .take(1)
         .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
@@ -1083,7 +1083,7 @@ public class FlowableWindowWithFlowableTest {
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
 
             TestSubscriber<Flowable<Object>> ts = Flowable.error(new TestException("main"))
-            .window(Functions.justCallable(new Flowable<Object>() {
+            .window(Functions.justSupplier(new Flowable<Object>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -1123,7 +1123,7 @@ public class FlowableWindowWithFlowableTest {
                         refMain.set(subscriber);
                     }
                 }
-                .window(Functions.justCallable(new Flowable<Object>() {
+                .window(Functions.justSupplier(new Flowable<Object>() {
                     @Override
                     protected void subscribeActual(Subscriber<? super Object> subscriber) {
                         subscriber.onSubscribe(new BooleanSubscription());
@@ -1173,7 +1173,7 @@ public class FlowableWindowWithFlowableTest {
                     refMain.set(subscriber);
                 }
             }
-            .window(Functions.justCallable(new Flowable<Object>() {
+            .window(Functions.justSupplier(new Flowable<Object>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -1216,7 +1216,7 @@ public class FlowableWindowWithFlowableTest {
                 refMain.set(subscriber);
             }
         }
-        .window(Functions.justCallable(new Flowable<Object>() {
+        .window(Functions.justSupplier(new Flowable<Object>() {
             @Override
             protected void subscribeActual(Subscriber<? super Object> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -1248,7 +1248,7 @@ public class FlowableWindowWithFlowableTest {
                      refMain.set(subscriber);
                  }
              }
-             .window(Functions.justCallable(new Flowable<Object>() {
+             .window(Functions.justSupplier(new Flowable<Object>() {
                  @Override
                  protected void subscribeActual(Subscriber<? super Object> subscriber) {
                      final AtomicInteger counter = new AtomicInteger();
@@ -1307,10 +1307,10 @@ public class FlowableWindowWithFlowableTest {
                         refMain.set(subscriber);
                     }
                 }
-                .window(new Callable<Flowable<Object>>() {
+                .window(new Supplier<Flowable<Object>>() {
                     int count;
                     @Override
-                    public Flowable<Object> call() throws Exception {
+                    public Flowable<Object> get() throws Exception {
                         if (++count > 1) {
                             return Flowable.never();
                         }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -112,10 +112,10 @@ public class FlowableWindowWithStartEndFlowableTest {
             }
         });
 
-        Callable<Flowable<Object>> closer = new Callable<Flowable<Object>>() {
+        Supplier<Flowable<Object>> closer = new Supplier<Flowable<Object>>() {
             int calls;
             @Override
-            public Flowable<Object> call() {
+            public Flowable<Object> get() {
                 return Flowable.unsafeCreate(new Publisher<Object>() {
                     @Override
                     public void subscribe(Subscriber<? super Object> subscriber) {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeEmptyTest.java
@@ -18,16 +18,16 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 
 public class MaybeEmptyTest {
 
     @Test
-    public void scalarCallable() {
+    public void scalarSupplier() {
         Maybe<Integer> m = Maybe.empty();
 
-        assertTrue(m.getClass().toString(), m instanceof ScalarCallable);
+        assertTrue(m.getClass().toString(), m instanceof ScalarSupplier);
 
-        assertNull(((ScalarCallable<?>)m).call());
+        assertNull(((ScalarSupplier<?>)m).get());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeErrorTest.java
@@ -13,20 +13,19 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 
 import io.reactivex.Maybe;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Supplier;
 
 public class MaybeErrorTest {
 
     @Test
-    public void errorCallableThrows() {
-        Maybe.error(new Callable<Throwable>() {
+    public void errorSupplierThrows() {
+        Maybe.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() throws Exception {
+            public Throwable get() throws Exception {
                 throw new TestException();
             }
         })

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapNotificationTest.java
@@ -29,7 +29,7 @@ public class MaybeFlatMapNotificationTest {
     public void dispose() {
         TestHelper.checkDisposed(Maybe.just(1)
                 .flatMap(Functions.justFunction(Maybe.just(1)),
-                        Functions.justFunction(Maybe.just(1)), Functions.justCallable(Maybe.just(1))));
+                        Functions.justFunction(Maybe.just(1)), Functions.justSupplier(Maybe.just(1))));
     }
 
     @Test
@@ -39,7 +39,7 @@ public class MaybeFlatMapNotificationTest {
             public MaybeSource<Integer> apply(Maybe<Integer> m) throws Exception {
                 return m
                         .flatMap(Functions.justFunction(Maybe.just(1)),
-                                Functions.justFunction(Maybe.just(1)), Functions.justCallable(Maybe.just(1)));
+                                Functions.justFunction(Maybe.just(1)), Functions.justSupplier(Maybe.just(1)));
             }
         });
     }
@@ -49,7 +49,7 @@ public class MaybeFlatMapNotificationTest {
         Maybe.just(1)
         .flatMap(Functions.justFunction((Maybe<Integer>)null),
                 Functions.justFunction(Maybe.just(1)),
-                Functions.justCallable(Maybe.just(1)))
+                Functions.justSupplier(Maybe.just(1)))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -59,7 +59,7 @@ public class MaybeFlatMapNotificationTest {
         TestObserver<Integer> to = Maybe.<Integer>error(new TestException())
         .flatMap(Functions.justFunction(Maybe.just(1)),
                 Functions.justFunction((Maybe<Integer>)null),
-                Functions.justCallable(Maybe.just(1)))
+                Functions.justSupplier(Maybe.just(1)))
         .test()
         .assertFailure(CompositeException.class);
 
@@ -74,7 +74,7 @@ public class MaybeFlatMapNotificationTest {
         Maybe.<Integer>empty()
         .flatMap(Functions.justFunction(Maybe.just(1)),
                 Functions.justFunction(Maybe.just(1)),
-                Functions.justCallable((Maybe<Integer>)null))
+                Functions.justSupplier((Maybe<Integer>)null))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -84,7 +84,7 @@ public class MaybeFlatMapNotificationTest {
         Maybe.just(1)
         .flatMap(Functions.justFunction(Maybe.<Integer>empty()),
                 Functions.justFunction(Maybe.just(1)),
-                Functions.justCallable(Maybe.just(1)))
+                Functions.justSupplier(Maybe.just(1)))
         .test()
         .assertResult();
     }
@@ -94,7 +94,7 @@ public class MaybeFlatMapNotificationTest {
         Maybe.just(1)
         .flatMap(Functions.justFunction(Maybe.<Integer>error(new TestException())),
                 Functions.justFunction((Maybe<Integer>)null),
-                Functions.justCallable(Maybe.just(1)))
+                Functions.justSupplier(Maybe.just(1)))
         .test()
         .assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import io.reactivex.*;
-import io.reactivex.functions.Action;
+import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
@@ -108,7 +108,7 @@ public class MaybeFromActionTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void callable() throws Exception {
+    public void callable() throws Throwable {
         final int[] counter = { 0 };
 
         Maybe<Void> m = Maybe.fromAction(new Action() {
@@ -118,9 +118,9 @@ public class MaybeFromActionTest {
             }
         });
 
-        assertTrue(m.getClass().toString(), m instanceof Callable);
+        assertTrue(m.getClass().toString(), m instanceof Supplier);
 
-        assertNull(((Callable<Void>)m).call());
+        assertNull(((Supplier<Void>)m).get());
 
         assertEquals(1, counter[0]);
     }
@@ -157,7 +157,7 @@ public class MaybeFromActionTest {
     }
 
     @Test
-    public void disposedUpfront() throws Exception {
+    public void disposedUpfront() throws Throwable {
         Action run = mock(Action.class);
 
         Maybe.fromAction(run)

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
@@ -21,15 +21,16 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.disposables.Disposable;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Supplier;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 public class MaybeFromCallableTest {
     @Test(expected = NullPointerException.class)
@@ -114,7 +115,7 @@ public class MaybeFromCallableTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void callable() throws Exception {
+    public void callable() throws Throwable {
         final int[] counter = { 0 };
 
         Maybe<Integer> m = Maybe.fromCallable(new Callable<Integer>() {
@@ -125,9 +126,9 @@ public class MaybeFromCallableTest {
             }
         });
 
-        assertTrue(m.getClass().toString(), m instanceof Callable);
+        assertTrue(m.getClass().toString(), m instanceof Supplier);
 
-        assertEquals(0, ((Callable<Void>)m).call());
+        assertEquals(0, ((Supplier<Void>)m).get());
 
         assertEquals(1, counter[0]);
     }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import io.reactivex.*;
+import io.reactivex.functions.Supplier;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
@@ -106,7 +107,7 @@ public class MaybeFromRunnableTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void callable() throws Exception {
+    public void callable() throws Throwable {
         final int[] counter = { 0 };
 
         Maybe<Void> m = Maybe.fromRunnable(new Runnable() {
@@ -116,9 +117,9 @@ public class MaybeFromRunnableTest {
             }
         });
 
-        assertTrue(m.getClass().toString(), m instanceof Callable);
+        assertTrue(m.getClass().toString(), m instanceof Supplier);
 
-        assertNull(((Callable<Void>)m).call());
+        assertNull(((Supplier<Void>)m).get());
 
         assertEquals(1, counter[0]);
     }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeHideTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 import io.reactivex.processors.PublishProcessor;
 
 public class MaybeHideTest {
@@ -51,9 +51,9 @@ public class MaybeHideTest {
 
     @Test
     public void hidden() {
-        assertTrue(Maybe.just(1) instanceof ScalarCallable);
+        assertTrue(Maybe.just(1) instanceof ScalarSupplier);
 
-        assertFalse(Maybe.just(1).hide() instanceof ScalarCallable);
+        assertFalse(Maybe.just(1).hide() instanceof ScalarSupplier);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeJustTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeJustTest.java
@@ -18,17 +18,17 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
-import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.fuseable.ScalarSupplier;
 
 public class MaybeJustTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void scalarCallable() {
+    public void scalarSupplier() {
         Maybe<Integer> m = Maybe.just(1);
 
-        assertTrue(m.getClass().toString(), m instanceof ScalarCallable);
+        assertTrue(m.getClass().toString(), m instanceof ScalarSupplier);
 
-        assertEquals(1, ((ScalarCallable<Integer>)m).call().intValue());
+        assertEquals(1, ((ScalarSupplier<Integer>)m).get().intValue());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.maybe;
 import static org.junit.Assert.*;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
@@ -33,9 +32,9 @@ public class MaybeUsingTest {
     @Test
     public void resourceSupplierThrows() {
 
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 throw new TestException();
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -56,9 +55,9 @@ public class MaybeUsingTest {
     @Test
     public void errorEager() {
 
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -79,9 +78,9 @@ public class MaybeUsingTest {
     @Test
     public void emptyEager() {
 
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -102,9 +101,9 @@ public class MaybeUsingTest {
     @Test
     public void errorNonEager() {
 
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -125,9 +124,9 @@ public class MaybeUsingTest {
     @Test
     public void emptyNonEager() {
 
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -148,9 +147,9 @@ public class MaybeUsingTest {
     @Test
     public void supplierCrashEager() {
 
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -171,9 +170,9 @@ public class MaybeUsingTest {
     @Test
     public void supplierCrashNonEager() {
 
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -193,9 +192,9 @@ public class MaybeUsingTest {
 
     @Test
     public void supplierAndDisposerCrashEager() {
-        TestObserver<Integer> to = Maybe.using(new Callable<Object>() {
+        TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -222,9 +221,9 @@ public class MaybeUsingTest {
     public void supplierAndDisposerCrashNonEager() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Maybe.using(new Callable<Object>() {
+            Maybe.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, MaybeSource<Integer>>() {
@@ -251,9 +250,9 @@ public class MaybeUsingTest {
     public void dispose() {
         final int[] call = {0 };
 
-        TestObserver<Integer> to = Maybe.using(new Callable<Object>() {
+        TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -278,9 +277,9 @@ public class MaybeUsingTest {
     public void disposeCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> to = Maybe.using(new Callable<Object>() {
+            TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, MaybeSource<Integer>>() {
@@ -306,9 +305,9 @@ public class MaybeUsingTest {
 
     @Test
     public void isDisposed() {
-        TestHelper.checkDisposed(Maybe.using(new Callable<Object>() {
+        TestHelper.checkDisposed(Maybe.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, MaybeSource<Integer>>() {
@@ -326,9 +325,9 @@ public class MaybeUsingTest {
 
     @Test
     public void justDisposerCrashes() {
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -348,9 +347,9 @@ public class MaybeUsingTest {
 
     @Test
     public void emptyDisposerCrashes() {
-        Maybe.using(new Callable<Object>() {
+        Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -370,9 +369,9 @@ public class MaybeUsingTest {
 
     @Test
     public void errorDisposerCrash() {
-        TestObserver<Integer> to = Maybe.using(new Callable<Object>() {
+        TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, MaybeSource<Integer>>() {
@@ -399,9 +398,9 @@ public class MaybeUsingTest {
     public void doubleOnSubscribe() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Maybe.using(new Callable<Object>() {
+            Maybe.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, MaybeSource<Integer>>() {
@@ -442,9 +441,9 @@ public class MaybeUsingTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> to = Maybe.using(new Callable<Object>() {
+            final TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, MaybeSource<Integer>>() {
@@ -485,9 +484,9 @@ public class MaybeUsingTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> to = Maybe.using(new Callable<Object>() {
+            final TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, MaybeSource<Integer>>() {
@@ -528,9 +527,9 @@ public class MaybeUsingTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> to = Maybe.using(new Callable<Object>() {
+            final TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, MaybeSource<Integer>>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -254,9 +254,9 @@ public class ObservableBufferTest {
             }
         });
 
-        Callable<Observable<Object>> closer = new Callable<Observable<Object>>() {
+        Supplier<Observable<Object>> closer = new Supplier<Observable<Object>>() {
             @Override
-            public Observable<Object> call() {
+            public Observable<Object> get() {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> observer) {
@@ -833,9 +833,9 @@ public class ObservableBufferTest {
     @Test
     public void bufferIntoCustomCollection() {
         Observable.just(1, 1, 2, 2, 3, 3, 4, 4)
-        .buffer(3, new Callable<Collection<Integer>>() {
+        .buffer(3, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 return new HashSet<Integer>();
             }
         })
@@ -847,9 +847,9 @@ public class ObservableBufferTest {
     @Test
     public void bufferSkipIntoCustomCollection() {
         Observable.just(1, 1, 2, 2, 3, 3, 4, 4)
-        .buffer(3, 3, new Callable<Collection<Integer>>() {
+        .buffer(3, 3, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 return new HashSet<Integer>();
             }
         })
@@ -861,9 +861,9 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows() {
         Observable.just(1)
-        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         }, false)
@@ -875,9 +875,9 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows2() {
         Observable.just(1)
-        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         }, false)
@@ -889,9 +889,9 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows3() {
         Observable.just(1)
-        .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), new Callable<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -903,10 +903,10 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows4() {
         Observable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
@@ -923,10 +923,10 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows5() {
         Observable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
@@ -943,10 +943,10 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierThrows6() {
         Observable.<Integer>never()
-        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Callable<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
@@ -963,10 +963,10 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierReturnsNull() {
         Observable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 } else {
@@ -983,10 +983,10 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierReturnsNull2() {
         Observable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Callable<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 } else {
@@ -1003,10 +1003,10 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void supplierReturnsNull3() {
         Observable.<Integer>never()
-        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Callable<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
             int count;
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 } else {
@@ -1023,9 +1023,9 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBufferSupplierThrows() {
         Observable.never()
-        .buffer(Functions.justCallable(Observable.never()), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Observable.never()), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -1037,14 +1037,14 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBoundarySupplierThrows() {
         Observable.never()
-        .buffer(new Callable<ObservableSource<Object>>() {
+        .buffer(new Supplier<ObservableSource<Object>>() {
             @Override
-            public ObservableSource<Object> call() throws Exception {
+            public ObservableSource<Object> get() throws Exception {
                 throw new TestException();
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1056,10 +1056,10 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBufferSupplierThrows2() {
         Observable.never()
-        .buffer(Functions.justCallable(Observable.timer(1, TimeUnit.MILLISECONDS)), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Observable.timer(1, TimeUnit.MILLISECONDS)), new Supplier<Collection<Object>>() {
             int count;
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
@@ -1076,10 +1076,10 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBufferSupplierReturnsNull() {
         Observable.never()
-        .buffer(Functions.justCallable(Observable.timer(1, TimeUnit.MILLISECONDS)), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Observable.timer(1, TimeUnit.MILLISECONDS)), new Supplier<Collection<Object>>() {
             int count;
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 } else {
@@ -1096,18 +1096,18 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBoundarySupplierThrows2() {
         Observable.never()
-        .buffer(new Callable<ObservableSource<Long>>() {
+        .buffer(new Supplier<ObservableSource<Long>>() {
             int count;
             @Override
-            public ObservableSource<Long> call() throws Exception {
+            public ObservableSource<Long> get() throws Exception {
                 if (count++ == 1) {
                     throw new TestException();
                 }
                 return Observable.timer(1, TimeUnit.MILLISECONDS);
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1121,9 +1121,9 @@ public class ObservableBufferTest {
         PublishSubject<Object> ps = PublishSubject.create();
 
         TestObserver<Collection<Object>> to = ps
-        .buffer(Functions.justCallable(Observable.never()), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Observable.never()), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1140,18 +1140,18 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBoundarySupplierReturnsNull() {
         Observable.never()
-        .buffer(new Callable<ObservableSource<Long>>() {
+        .buffer(new Supplier<ObservableSource<Long>>() {
             int count;
             @Override
-            public ObservableSource<Long> call() throws Exception {
+            public ObservableSource<Long> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 }
                 return Observable.timer(1, TimeUnit.MILLISECONDS);
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1164,18 +1164,18 @@ public class ObservableBufferTest {
     @SuppressWarnings("unchecked")
     public void boundaryBoundarySupplierReturnsNull2() {
         Observable.never()
-        .buffer(new Callable<ObservableSource<Long>>() {
+        .buffer(new Supplier<ObservableSource<Long>>() {
             int count;
             @Override
-            public ObservableSource<Long> call() throws Exception {
+            public ObservableSource<Long> get() throws Exception {
                 if (count++ == 1) {
                     return null;
                 }
                 return Observable.empty();
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1190,9 +1190,9 @@ public class ObservableBufferTest {
         PublishSubject<Object> ps = PublishSubject.create();
 
         TestObserver<Collection<Object>> to = ps
-        .buffer(Functions.justCallable(Observable.never()), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Observable.never()), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1209,9 +1209,9 @@ public class ObservableBufferTest {
         PublishSubject<Object> ps = PublishSubject.create();
 
         TestObserver<Collection<Object>> to = ps
-        .buffer(Functions.justCallable(Observable.error(new TestException())), new Callable<Collection<Object>>() {
+        .buffer(Functions.justSupplier(Observable.error(new TestException())), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return new ArrayList<Object>();
             }
         })
@@ -1241,7 +1241,7 @@ public class ObservableBufferTest {
 
         TestHelper.checkDisposed(PublishSubject.create().buffer(Observable.never()));
 
-        TestHelper.checkDisposed(PublishSubject.create().buffer(Functions.justCallable(Observable.never())));
+        TestHelper.checkDisposed(PublishSubject.create().buffer(Functions.justSupplier(Observable.never())));
 
         TestHelper.checkDisposed(PublishSubject.create().buffer(Observable.never(), Functions.justFunction(Observable.never())));
     }
@@ -1259,10 +1259,10 @@ public class ObservableBufferTest {
     @Test
     public void bufferSupplierCrash2() {
         Observable.range(1, 2)
-        .buffer(1, new Callable<List<Integer>>() {
+        .buffer(1, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -1277,10 +1277,10 @@ public class ObservableBufferTest {
     @Test
     public void bufferSkipSupplierCrash2() {
         Observable.range(1, 2)
-        .buffer(2, 1, new Callable<List<Integer>>() {
+        .buffer(2, 1, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -1377,10 +1377,10 @@ public class ObservableBufferTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<List<Integer>> to = ps
-        .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, new Callable<List<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -1830,10 +1830,10 @@ public class ObservableBufferTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         PublishSubject<Integer> b = PublishSubject.create();
 
-        TestObserver<List<Integer>> to = ps.buffer(b, new Callable<List<Integer>>() {
+        TestObserver<List<Integer>> to = ps.buffer(b, new Supplier<List<Integer>>() {
             int calls;
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 if (++calls == 2) {
                     throw new TestException();
                 }
@@ -1880,7 +1880,7 @@ public class ObservableBufferTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             BehaviorSubject.createDefault(1)
-            .buffer(Functions.justCallable(new Observable<Integer>() {
+            .buffer(Functions.justSupplier(new Observable<Integer>() {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposables.empty());
@@ -1904,8 +1904,8 @@ public class ObservableBufferTest {
         TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
         BufferBoundarySupplierObserver<Integer, List<Integer>, Integer> sub =
                 new BufferBoundarySupplierObserver<Integer, List<Integer>, Integer>(
-                        to, Functions.justCallable((List<Integer>)new ArrayList<Integer>()),
-                        Functions.justCallable(Observable.<Integer>never())
+                        to, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()),
+                        Functions.justSupplier(Observable.<Integer>never())
         );
 
         Disposable bs = Disposables.empty();
@@ -1933,8 +1933,8 @@ public class ObservableBufferTest {
         TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
         BufferBoundarySupplierObserver<Integer, List<Integer>, Integer> sub =
                 new BufferBoundarySupplierObserver<Integer, List<Integer>, Integer>(
-                        to, Functions.justCallable((List<Integer>)new ArrayList<Integer>()),
-                        Functions.justCallable(Observable.<Integer>never())
+                        to, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()),
+                        Functions.justSupplier(Observable.<Integer>never())
         );
 
         Disposable bs = Disposables.empty();
@@ -1981,7 +1981,7 @@ public class ObservableBufferTest {
         TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
         BufferExactUnboundedObserver<Integer, List<Integer>> sub = new BufferExactUnboundedObserver<Integer, List<Integer>>(
-                to, Functions.justCallable((List<Integer>)new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
+                to, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
 
         sub.onSubscribe(Disposables.empty());
 
@@ -2031,7 +2031,7 @@ public class ObservableBufferTest {
         TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
         BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<Integer, List<Integer>>(
-                to, Functions.justCallable((List<Integer>)new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
+                to, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(Disposables.empty());
 
@@ -2050,10 +2050,10 @@ public class ObservableBufferTest {
         final TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
         BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<Integer, List<Integer>>(
-                to, new Callable<List<Integer>>() {
+                to, new Supplier<List<Integer>>() {
                     int calls;
                     @Override
-                    public List<Integer> call() throws Exception {
+                    public List<Integer> get() throws Exception {
                         if (++calls == 2) {
                             to.cancel();
                         }
@@ -2076,7 +2076,7 @@ public class ObservableBufferTest {
 
         BufferExactBoundedObserver<Integer, List<Integer>> sub =
                 new BufferExactBoundedObserver<Integer, List<Integer>>(
-                        to, Functions.justCallable((List<Integer>)new ArrayList<Integer>()),
+                        to, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()),
                         1, TimeUnit.SECONDS, 1, false, sch.createWorker())
         ;
 
@@ -2118,7 +2118,7 @@ public class ObservableBufferTest {
         TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
 
         BufferExactObserver<Integer, List<Integer>> sub = new BufferExactObserver<Integer, List<Integer>>(
-                to, 1, Functions.justCallable((List<Integer>)new ArrayList<Integer>())
+                to, 1, Functions.justSupplier((List<Integer>)new ArrayList<Integer>())
         );
 
         sub.onComplete();
@@ -2140,9 +2140,9 @@ public class ObservableBufferTest {
     @Test
     public void bufferExactFailingSupplier() {
         Observable.empty()
-                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Callable<List<Object>>() {
+                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Supplier<List<Object>>() {
                     @Override
-                    public List<Object> call() throws Exception {
+                    public List<Object> get() throws Exception {
                         throw new TestException();
                     }
                 }, false)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableBufferTest.java
@@ -2138,6 +2138,7 @@ public class ObservableBufferTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void bufferExactFailingSupplier() {
         Observable.empty()
                 .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Supplier<List<Object>>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCacheTest.java
@@ -107,7 +107,7 @@ public class ObservableCacheTest {
     }
 
     @Test
-    public void testUnsubscribeSource() throws Exception {
+    public void testUnsubscribeSource() throws Throwable {
         Action unsubscribe = mock(Action.class);
         Observable<Integer> o = Observable.just(1).doOnDispose(unsubscribe).cache();
         o.subscribe();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableCollectTest.java
@@ -32,9 +32,9 @@ public final class ObservableCollectTest {
     @Test
     public void testCollectToListObservable() {
         Observable<List<Integer>> o = Observable.just(1, 2, 3)
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() {
+            public List<Integer> get() {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -62,9 +62,9 @@ public final class ObservableCollectTest {
 
     @Test
     public void testCollectToStringObservable() {
-        String value = Observable.just(1, 2, 3).collect(new Callable<StringBuilder>() {
+        String value = Observable.just(1, 2, 3).collect(new Supplier<StringBuilder>() {
             @Override
-            public StringBuilder call() {
+            public StringBuilder get() {
                 return new StringBuilder();
             }
         },
@@ -90,7 +90,7 @@ public final class ObservableCollectTest {
             final RuntimeException e2 = new RuntimeException();
 
             Burst.items(1).error(e2) //
-                    .collect(callableListCreator(), biConsumerThrows(e1)) //
+                    .collect(supplierListCreator(), biConsumerThrows(e1)) //
                     .toObservable()
                     .test() //
                     .assertError(e1) //
@@ -107,7 +107,7 @@ public final class ObservableCollectTest {
     public void testCollectorFailureDoesNotResultInErrorAndCompletedEmissionsObservable() {
         final RuntimeException e = new RuntimeException();
         Burst.item(1).create() //
-                .collect(callableListCreator(), biConsumerThrows(e)) //
+                .collect(supplierListCreator(), biConsumerThrows(e)) //
                 .toObservable()
                 .test() //
                 .assertError(e) //
@@ -133,7 +133,7 @@ public final class ObservableCollectTest {
             }
         };
         Burst.items(1, 2).create() //
-                .collect(callableListCreator(), throwOnFirstOnly)//
+                .collect(supplierListCreator(), throwOnFirstOnly)//
                 .test() //
                 .assertError(e) //
                 .assertNoValues() //
@@ -158,9 +158,9 @@ public final class ObservableCollectTest {
     @Test
     public void testCollectToList() {
         Single<List<Integer>> o = Observable.just(1, 2, 3)
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() {
+            public List<Integer> get() {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -188,9 +188,9 @@ public final class ObservableCollectTest {
 
     @Test
     public void testCollectToString() {
-        String value = Observable.just(1, 2, 3).collect(new Callable<StringBuilder>() {
+        String value = Observable.just(1, 2, 3).collect(new Supplier<StringBuilder>() {
             @Override
-            public StringBuilder call() {
+            public StringBuilder get() {
                 return new StringBuilder();
             }
         },
@@ -216,7 +216,7 @@ public final class ObservableCollectTest {
             final RuntimeException e2 = new RuntimeException();
 
             Burst.items(1).error(e2) //
-                    .collect(callableListCreator(), biConsumerThrows(e1)) //
+                    .collect(supplierListCreator(), biConsumerThrows(e1)) //
                     .test() //
                     .assertError(e1) //
                     .assertNotComplete();
@@ -232,7 +232,7 @@ public final class ObservableCollectTest {
     public void testCollectorFailureDoesNotResultInErrorAndCompletedEmissions() {
         final RuntimeException e = new RuntimeException();
         Burst.item(1).create() //
-                .collect(callableListCreator(), biConsumerThrows(e)) //
+                .collect(supplierListCreator(), biConsumerThrows(e)) //
                 .test() //
                 .assertError(e) //
                 .assertNotComplete();
@@ -257,7 +257,7 @@ public final class ObservableCollectTest {
             }
         };
         Burst.items(1, 2).create() //
-                .collect(callableListCreator(), throwOnFirstOnly)//
+                .collect(supplierListCreator(), throwOnFirstOnly)//
                 .test() //
                 .assertError(e) //
                 .assertNoValues() //
@@ -281,9 +281,9 @@ public final class ObservableCollectTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Observable.range(1, 3).collect(new Callable<List<Integer>>() {
+        TestHelper.checkDisposed(Observable.range(1, 3).collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -293,9 +293,9 @@ public final class ObservableCollectTest {
             }
         }));
 
-        TestHelper.checkDisposed(Observable.range(1, 3).collect(new Callable<List<Integer>>() {
+        TestHelper.checkDisposed(Observable.range(1, 3).collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -311,9 +311,9 @@ public final class ObservableCollectTest {
         TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Integer>, SingleSource<List<Integer>>>() {
             @Override
             public SingleSource<List<Integer>> apply(Observable<Integer> o) throws Exception {
-                return o.collect(new Callable<List<Integer>>() {
+                return o.collect(new Supplier<List<Integer>>() {
                     @Override
-                    public List<Integer> call() throws Exception {
+                    public List<Integer> get() throws Exception {
                         return new ArrayList<Integer>();
                     }
                 }, new BiConsumer<List<Integer>, Integer>() {
@@ -328,9 +328,9 @@ public final class ObservableCollectTest {
         TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Integer>, ObservableSource<List<Integer>>>() {
             @Override
             public ObservableSource<List<Integer>> apply(Observable<Integer> o) throws Exception {
-                return o.collect(new Callable<List<Integer>>() {
+                return o.collect(new Supplier<List<Integer>>() {
                     @Override
-                    public List<Integer> call() throws Exception {
+                    public List<Integer> get() throws Exception {
                         return new ArrayList<Integer>();
                     }
                 }, new BiConsumer<List<Integer>, Integer>() {
@@ -348,9 +348,9 @@ public final class ObservableCollectTest {
         TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
             @Override
             public Object apply(Observable<Integer> o) throws Exception {
-                return o.collect(new Callable<List<Integer>>() {
+                return o.collect(new Supplier<List<Integer>>() {
                     @Override
-                    public List<Integer> call() throws Exception {
+                    public List<Integer> get() throws Exception {
                         return new ArrayList<Integer>();
                     }
                 }, new BiConsumer<List<Integer>, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDeferTest.java
@@ -13,14 +13,14 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Supplier;
 
 @SuppressWarnings("unchecked")
 public class ObservableDeferTest {
@@ -28,11 +28,11 @@ public class ObservableDeferTest {
     @Test
     public void testDefer() throws Throwable {
 
-        Callable<Observable<String>> factory = mock(Callable.class);
+        Supplier<Observable<String>> factory = mock(Supplier.class);
 
         Observable<String> firstObservable = Observable.just("one", "two");
         Observable<String> secondObservable = Observable.just("three", "four");
-        when(factory.call()).thenReturn(firstObservable, secondObservable);
+        when(factory.get()).thenReturn(firstObservable, secondObservable);
 
         Observable<String> deferred = Observable.defer(factory);
 
@@ -41,7 +41,7 @@ public class ObservableDeferTest {
         Observer<String> firstObserver = TestHelper.mockObserver();
         deferred.subscribe(firstObserver);
 
-        verify(factory, times(1)).call();
+        verify(factory, times(1)).get();
         verify(firstObserver, times(1)).onNext("one");
         verify(firstObserver, times(1)).onNext("two");
         verify(firstObserver, times(0)).onNext("three");
@@ -51,7 +51,7 @@ public class ObservableDeferTest {
         Observer<String> secondObserver = TestHelper.mockObserver();
         deferred.subscribe(secondObserver);
 
-        verify(factory, times(2)).call();
+        verify(factory, times(2)).get();
         verify(secondObserver, times(0)).onNext("one");
         verify(secondObserver, times(0)).onNext("two");
         verify(secondObserver, times(1)).onNext("three");
@@ -61,10 +61,10 @@ public class ObservableDeferTest {
     }
 
     @Test
-    public void testDeferFunctionThrows() throws Exception {
-        Callable<Observable<String>> factory = mock(Callable.class);
+    public void testDeferFunctionThrows() throws Throwable {
+        Supplier<Observable<String>> factory = mock(Supplier.class);
 
-        when(factory.call()).thenThrow(new TestException());
+        when(factory.get()).thenThrow(new TestException());
 
         Observable<String> result = Observable.defer(factory);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
@@ -368,9 +368,9 @@ public class ObservableDelayTest {
     public void testDelayWithObservableSubscriptionNormal() {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
-        Callable<Observable<Integer>> subFunc = new Callable<Observable<Integer>>() {
+        Supplier<Observable<Integer>> subFunc = new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return delay;
             }
         };
@@ -403,9 +403,9 @@ public class ObservableDelayTest {
     public void testDelayWithObservableSubscriptionFunctionThrows() {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
-        Callable<Observable<Integer>> subFunc = new Callable<Observable<Integer>>() {
+        Supplier<Observable<Integer>> subFunc = new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 throw new TestException();
             }
         };
@@ -437,9 +437,9 @@ public class ObservableDelayTest {
     public void testDelayWithObservableSubscriptionThrows() {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
-        Callable<Observable<Integer>> subFunc = new Callable<Observable<Integer>>() {
+        Supplier<Observable<Integer>> subFunc = new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return delay;
             }
         };
@@ -497,9 +497,9 @@ public class ObservableDelayTest {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> sdelay = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
-        Callable<Observable<Integer>> subFunc = new Callable<Observable<Integer>>() {
+        Supplier<Observable<Integer>> subFunc = new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return sdelay;
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDistinctTest.java
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.*;
 import org.mockito.InOrder;
@@ -28,7 +27,7 @@ import io.reactivex.Observer;
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.*;
 import io.reactivex.observers.*;
@@ -203,9 +202,9 @@ public class ObservableDistinctTest {
     @Test
     public void collectionSupplierThrows() {
         Observable.just(1)
-        .distinct(Functions.identity(), new Callable<Collection<Object>>() {
+        .distinct(Functions.identity(), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -216,9 +215,9 @@ public class ObservableDistinctTest {
     @Test
     public void collectionSupplierIsNull() {
         Observable.just(1)
-        .distinct(Functions.identity(), new Callable<Collection<Object>>() {
+        .distinct(Functions.identity(), new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() throws Exception {
+            public Collection<Object> get() throws Exception {
                 return null;
             }
         })

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -162,11 +162,11 @@ public class ObservableFlatMapTest {
         };
     }
 
-    <R> Callable<R> just0(final R value) {
-        return new Callable<R>() {
+    <R> Supplier<R> just0(final R value) {
+        return new Supplier<R>() {
 
             @Override
-            public R call() {
+            public R get() {
                 return value;
             }
         };
@@ -219,10 +219,10 @@ public class ObservableFlatMapTest {
         verify(o, never()).onError(any(Throwable.class));
     }
 
-    <R> Callable<R> funcThrow0(R r) {
-        return new Callable<R>() {
+    <R> Supplier<R> funcThrow0(R r) {
+        return new Supplier<R>() {
             @Override
-            public R call() {
+            public R get() {
                 throw new TestException();
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFromTest.java
@@ -57,7 +57,7 @@ public class ObservableFromTest {
 
     @Test
     public void fromArraySingle() {
-        assertTrue(Observable.fromArray(1) instanceof ScalarCallable);
+        assertTrue(Observable.fromArray(1) instanceof ScalarSupplier);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGenerateTest.java
@@ -13,10 +13,10 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.List;
-import java.util.concurrent.Callable;
+import static org.junit.Assert.assertEquals;
 
-import static org.junit.Assert.*;
+import java.util.List;
+
 import org.junit.Test;
 
 import io.reactivex.*;
@@ -29,9 +29,9 @@ public class ObservableGenerateTest {
 
     @Test
     public void statefulBiconsumer() {
-        Observable.generate(new Callable<Object>() {
+        Observable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 10;
             }
         }, new BiConsumer<Object, Emitter<Object>>() {
@@ -52,9 +52,9 @@ public class ObservableGenerateTest {
 
     @Test
     public void stateSupplierThrows() {
-        Observable.generate(new Callable<Object>() {
+        Observable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 throw new TestException();
             }
         }, new BiConsumer<Object, Emitter<Object>>() {
@@ -69,9 +69,9 @@ public class ObservableGenerateTest {
 
     @Test
     public void generatorThrows() {
-        Observable.generate(new Callable<Object>() {
+        Observable.generate(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new BiConsumer<Object, Emitter<Object>>() {
@@ -88,9 +88,9 @@ public class ObservableGenerateTest {
     public void disposerThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable.generate(new Callable<Object>() {
+            Observable.generate(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new BiConsumer<Object, Emitter<Object>>() {
@@ -115,9 +115,9 @@ public class ObservableGenerateTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Observable.generate(new Callable<Object>() {
+        TestHelper.checkDisposed(Observable.generate(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new BiConsumer<Object, Emitter<Object>>() {
@@ -131,7 +131,7 @@ public class ObservableGenerateTest {
     @Test
     public void nullError() {
         final int[] call = { 0 };
-        Observable.generate(Functions.justCallable(1),
+        Observable.generate(Functions.justSupplier(1),
         new BiConsumer<Integer, Emitter<Object>>() {
             @Override
             public void accept(Integer s, Emitter<Object> e) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableGroupJoinTest.java
@@ -70,7 +70,7 @@ public class ObservableGroupJoinTest {
         public Observable<Integer> apply(final Integer leftValue, Observable<Integer> rightValues) {
             return rightValues.map(new Function<Integer, Integer>() {
                 @Override
-                public Integer apply(Integer rightValue) throws Exception {
+                public Integer apply(Integer rightValue) throws Throwable {
                     return add.apply(leftValue, rightValue);
                 }
             });

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMapNotificationTest.java
@@ -13,14 +13,12 @@
 
 package io.reactivex.internal.operators.observable;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.*;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.operators.observable.ObservableMapNotification.MapNotificationObserver;
 import io.reactivex.observers.TestObserver;
@@ -43,9 +41,9 @@ public class ObservableMapNotificationTest {
                         return Observable.error(e);
                     }
                 },
-                new Callable<Observable<Object>>() {
+                new Supplier<Observable<Object>>() {
                     @Override
-                    public Observable<Object> call() {
+                    public Observable<Object> get() {
                         return Observable.never();
                     }
                 }
@@ -66,7 +64,7 @@ public class ObservableMapNotificationTest {
                         observer,
                         Functions.justFunction(Observable.just(1)),
                         Functions.justFunction(Observable.just(2)),
-                        Functions.justCallable(Observable.just(3))
+                        Functions.justSupplier(Observable.just(3))
                 );
                 mn.onSubscribe(Disposables.empty());
             }
@@ -81,7 +79,7 @@ public class ObservableMapNotificationTest {
                 return o.flatMap(
                         Functions.justFunction(Observable.just(1)),
                         Functions.justFunction(Observable.just(2)),
-                        Functions.justCallable(Observable.just(3))
+                        Functions.justSupplier(Observable.just(3))
                 );
             }
         });
@@ -97,7 +95,7 @@ public class ObservableMapNotificationTest {
                         throw new TestException("Inner");
                     }
                 },
-                Functions.justCallable(Observable.just(3)))
+                Functions.justSupplier(Observable.just(3)))
         .test()
         .assertFailure(CompositeException.class);
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReduceTest.java
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.junit.*;
 
@@ -243,9 +242,9 @@ public class ObservableReduceTest {
     @Test
     public void reduceWithSingle() {
         Observable.range(1, 5)
-        .reduceWith(new Callable<Integer>() {
+        .reduceWith(new Supplier<Integer>() {
             @Override
-            public Integer call() throws Exception {
+            public Integer get() throws Exception {
                 return 0;
             }
         }, new BiFunction<Integer, Integer, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -527,9 +527,9 @@ public class ObservableRefCountTest {
                         .flatMap(new Function<Long, Observable<String>>() {
                             @Override
                             public Observable<String> apply(Long t1) {
-                                    return Observable.defer(new Callable<Observable<String>>() {
+                                    return Observable.defer(new Supplier<Observable<String>>() {
                                         @Override
-                                        public Observable<String> call() {
+                                        public Observable<String> get() {
                                                 return Observable.<String>error(new Exception("Some exception"));
                                         }
                                     });

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -558,7 +558,7 @@ public class ObservableReplayTest {
     /**
      * Specifically test interaction with a Scheduler with subscribeOn.
      *
-     * @throws Exception functional interfaces are declared with throws Exception
+     * @throws Throwable functional interfaces are declared with throws Exception
      */
     @SuppressWarnings("unchecked")
     @Test
@@ -611,7 +611,7 @@ public class ObservableReplayTest {
     /**
      * Specifically test interaction with a Scheduler with subscribeOn.
      *
-     * @throws Exception functional interfaces are declared with throws Exception
+     * @throws Throwable functional interfaces are declared with throws Exception
      */
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -512,7 +512,7 @@ public class ObservableReplayTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testIssue2191_UnsubscribeSource() throws Exception {
+    public void testIssue2191_UnsubscribeSource() throws Throwable {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
         Action sourceCompleted = mock(Action.class);
@@ -562,7 +562,7 @@ public class ObservableReplayTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testIssue2191_SchedulerUnsubscribe() throws Exception {
+    public void testIssue2191_SchedulerUnsubscribe() throws Throwable {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
         Action sourceCompleted = mock(Action.class);
@@ -615,7 +615,7 @@ public class ObservableReplayTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testIssue2191_SchedulerUnsubscribeOnError() throws Exception {
+    public void testIssue2191_SchedulerUnsubscribeOnError() throws Throwable {
         // setup mocks
         Consumer<Integer> sourceNext = mock(Consumer.class);
         Action sourceCompleted = mock(Action.class);
@@ -937,7 +937,7 @@ public class ObservableReplayTest {
     }
 
     @Test
-    public void testUnsubscribeSource() throws Exception {
+    public void testUnsubscribeSource() throws Throwable {
         Action unsubscribe = mock(Action.class);
         Observable<Integer> o = Observable.just(1).doOnDispose(unsubscribe).replay().autoConnect();
         o.subscribe();
@@ -1555,7 +1555,7 @@ public class ObservableReplayTest {
 
     @Test
     public void replaySelectorConnectableReturnsNull() {
-        ObservableReplay.multicastSelector(Functions.justCallable((ConnectableObservable<Integer>)null), Functions.justFunction(Observable.just(1)))
+        ObservableReplay.multicastSelector(Functions.justSupplier((ConnectableObservable<Integer>)null), Functions.justFunction(Observable.just(1)))
         .test()
         .assertFailureAndMessage(NullPointerException.class, "The connectableFactory returned a null ConnectableObservable");
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRetryTest.java
@@ -349,7 +349,7 @@ public class ObservableRetryTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testRetrySubscribesAgainAfterError() throws Exception {
+    public void testRetrySubscribesAgainAfterError() throws Throwable {
 
         // record emitted values with this action
         Consumer<Integer> record = mock(Consumer.class);
@@ -945,9 +945,9 @@ public class ObservableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+        Observable<Integer> source = Observable.defer(new Supplier<ObservableSource<Integer>>() {
             @Override
-            public ObservableSource<Integer> call() throws Exception {
+            public ObservableSource<Integer> get() throws Exception {
                 if (times.getAndIncrement() < 4) {
                     return Observable.error(new TestException());
                 }
@@ -974,9 +974,9 @@ public class ObservableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+        Observable<Integer> source = Observable.defer(new Supplier<ObservableSource<Integer>>() {
             @Override
-            public ObservableSource<Integer> call() throws Exception {
+            public ObservableSource<Integer> get() throws Exception {
                 if (times.getAndIncrement() < 4) {
                     return Observable.error(new TestException());
                 }
@@ -1003,9 +1003,9 @@ public class ObservableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+        Observable<Integer> source = Observable.defer(new Supplier<ObservableSource<Integer>>() {
             @Override
-            public ObservableSource<Integer> call() throws Exception {
+            public ObservableSource<Integer> get() throws Exception {
                 if (times.getAndIncrement() < 4) {
                     return Observable.error(new TestException());
                 }
@@ -1037,9 +1037,9 @@ public class ObservableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+        Observable<Integer> source = Observable.defer(new Supplier<ObservableSource<Integer>>() {
             @Override
-            public ObservableSource<Integer> call() throws Exception {
+            public ObservableSource<Integer> get() throws Exception {
                 if (times.getAndIncrement() < 4) {
                     return Observable.error(new TestException());
                 }
@@ -1071,9 +1071,9 @@ public class ObservableRetryTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Observable<Integer> source = Observable.defer(new Callable<ObservableSource<Integer>>() {
+        Observable<Integer> source = Observable.defer(new Supplier<ObservableSource<Integer>>() {
             @Override
-            public ObservableSource<Integer> call() throws Exception {
+            public ObservableSource<Integer> get() throws Exception {
                 if (times.get() < 4) {
                     return Observable.error(new TestException());
                 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScalarXMapTest.java
@@ -15,13 +15,11 @@ package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.EmptyDisposable;
 import io.reactivex.internal.operators.observable.ObservableScalarXMap.ScalarDisposable;
 import io.reactivex.observers.TestObserver;
@@ -33,31 +31,31 @@ public class ObservableScalarXMapTest {
         TestHelper.checkUtilityClass(ObservableScalarXMap.class);
     }
 
-    static final class CallablePublisher implements ObservableSource<Integer>, Callable<Integer> {
+    static final class CallablePublisher implements ObservableSource<Integer>, Supplier<Integer> {
         @Override
         public void subscribe(Observer<? super Integer> observer) {
             EmptyDisposable.error(new TestException(), observer);
         }
 
         @Override
-        public Integer call() throws Exception {
+        public Integer get() throws Exception {
             throw new TestException();
         }
     }
 
-    static final class EmptyCallablePublisher implements ObservableSource<Integer>, Callable<Integer> {
+    static final class EmptyCallablePublisher implements ObservableSource<Integer>, Supplier<Integer> {
         @Override
         public void subscribe(Observer<? super Integer> observer) {
             EmptyDisposable.complete(observer);
         }
 
         @Override
-        public Integer call() throws Exception {
+        public Integer get() throws Exception {
             return null;
         }
     }
 
-    static final class OneCallablePublisher implements ObservableSource<Integer>, Callable<Integer> {
+    static final class OneCallablePublisher implements ObservableSource<Integer>, Supplier<Integer> {
         @Override
         public void subscribe(Observer<? super Integer> observer) {
             ScalarDisposable<Integer> sd = new ScalarDisposable<Integer>(observer, 1);
@@ -66,7 +64,7 @@ public class ObservableScalarXMapTest {
         }
 
         @Override
-        public Integer call() throws Exception {
+        public Integer get() throws Exception {
             return 1;
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableScanTest.java
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -27,8 +26,7 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.observers.*;
@@ -178,10 +176,10 @@ public class ObservableScanTest {
     @Test
     public void testSeedFactory() {
         Observable<List<Integer>> o = Observable.range(1, 10)
-                .collect(new Callable<List<Integer>>() {
+                .collect(new Supplier<List<Integer>>() {
 
                     @Override
-                    public List<Integer> call() {
+                    public List<Integer> get() {
                         return new ArrayList<Integer>();
                     }
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -181,7 +181,7 @@ public class ObservableThrottleLatestTest {
     }
 
     @Test
-    public void take() throws Exception {
+    public void take() throws Throwable {
         Action onCancel = mock(Action.class);
 
         Observable.range(1, 5)

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -111,9 +111,9 @@ public class ObservableTimeoutWithSelectorTest {
             }
         };
 
-        Callable<Observable<Integer>> firstTimeoutFunc = new Callable<Observable<Integer>>() {
+        Supplier<Observable<Integer>> firstTimeoutFunc = new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 throw new TestException();
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToListTest.java
@@ -26,7 +26,7 @@ import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 
 public class ObservableToListTest {
 
@@ -216,9 +216,9 @@ public class ObservableToListTest {
     @Test
     public void collectionSupplierThrows() {
         Observable.just(1)
-        .toList(new Callable<Collection<Integer>>() {
+        .toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -231,9 +231,9 @@ public class ObservableToListTest {
     @Test
     public void collectionSupplierReturnsNull() {
         Observable.just(1)
-        .toList(new Callable<Collection<Integer>>() {
+        .toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 return null;
             }
         })
@@ -247,9 +247,9 @@ public class ObservableToListTest {
     @Test
     public void singleCollectionSupplierThrows() {
         Observable.just(1)
-        .toList(new Callable<Collection<Integer>>() {
+        .toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -261,9 +261,9 @@ public class ObservableToListTest {
     @Test
     public void singleCollectionSupplierReturnsNull() {
         Observable.just(1)
-        .toList(new Callable<Collection<Integer>>() {
+        .toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() throws Exception {
+            public Collection<Integer> get() throws Exception {
                 return null;
             }
         })

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToMapTest.java
@@ -13,17 +13,17 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.*;
 
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 
 public class ObservableToMapTest {
     Observer<Object> objectObserver;
@@ -149,9 +149,9 @@ public class ObservableToMapTest {
     public void testToMapWithFactoryObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
             @Override
-            public Map<Integer, String> call() {
+            public Map<Integer, String> get() {
                 return new LinkedHashMap<Integer, String>() {
 
                     private static final long serialVersionUID = -3296811238780863394L;
@@ -193,9 +193,9 @@ public class ObservableToMapTest {
     public void testToMapWithErrorThrowingFactoryObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
             @Override
-            public Map<Integer, String> call() {
+            public Map<Integer, String> get() {
                 throw new RuntimeException("Forced failure");
             }
         };
@@ -322,9 +322,9 @@ public class ObservableToMapTest {
     public void testToMapWithFactory() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
             @Override
-            public Map<Integer, String> call() {
+            public Map<Integer, String> get() {
                 return new LinkedHashMap<Integer, String>() {
 
                     private static final long serialVersionUID = -3296811238780863394L;
@@ -365,9 +365,9 @@ public class ObservableToMapTest {
     public void testToMapWithErrorThrowingFactory() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Callable<Map<Integer, String>> mapFactory = new Callable<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
             @Override
-            public Map<Integer, String> call() {
+            public Map<Integer, String> get() {
                 throw new RuntimeException("Forced failure");
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableToMultimapTest.java
@@ -13,17 +13,17 @@
 
 package io.reactivex.internal.operators.observable;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.*;
 
 import io.reactivex.*;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 
 public class ObservableToMultimapTest {
     Observer<Object> objectObserver;
@@ -86,9 +86,9 @@ public class ObservableToMultimapTest {
     public void testToMultimapWithMapFactoryObservable() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new LinkedHashMap<Integer, Collection<String>>() {
 
                     private static final long serialVersionUID = -2084477070717362859L;
@@ -149,9 +149,9 @@ public class ObservableToMultimapTest {
                 return v;
             }
         };
-        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new HashMap<Integer, Collection<String>>();
             }
         };
@@ -228,9 +228,9 @@ public class ObservableToMultimapTest {
     public void testToMultimapWithMapThrowingFactoryObservable() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 throw new RuntimeException("Forced failure");
             }
         };
@@ -275,9 +275,9 @@ public class ObservableToMultimapTest {
                 return v;
             }
         };
-        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new HashMap<Integer, Collection<String>>();
             }
         };
@@ -332,9 +332,9 @@ public class ObservableToMultimapTest {
     public void testToMultimapWithMapFactory() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new LinkedHashMap<Integer, Collection<String>>() {
 
                     private static final long serialVersionUID = -2084477070717362859L;
@@ -394,9 +394,9 @@ public class ObservableToMultimapTest {
                 return v;
             }
         };
-        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new HashMap<Integer, Collection<String>>();
             }
         };
@@ -470,9 +470,9 @@ public class ObservableToMultimapTest {
     public void testToMultimapWithMapThrowingFactory() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Callable<Map<Integer, Collection<String>>> mapFactory = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 throw new RuntimeException("Forced failure");
             }
         };
@@ -516,9 +516,9 @@ public class ObservableToMultimapTest {
                 return v;
             }
         };
-        Callable<Map<Integer, Collection<String>>> mapSupplier = new Callable<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
-            public Map<Integer, Collection<String>> call() {
+            public Map<Integer, Collection<String>> get() {
                 return new HashMap<Integer, Collection<String>>();
             }
         };

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableUsingTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.*;
 import org.mockito.InOrder;
@@ -72,9 +71,9 @@ public class ObservableUsingTest {
         final Resource resource = mock(Resource.class);
         when(resource.getTextFromWeb()).thenReturn("Hello world!");
 
-        Callable<Resource> resourceFactory = new Callable<Resource>() {
+        Supplier<Resource> resourceFactory = new Supplier<Resource>() {
             @Override
-            public Resource call() {
+            public Resource get() {
                 return resource;
             }
         };
@@ -114,9 +113,9 @@ public class ObservableUsingTest {
 
     private void performTestUsingWithSubscribingTwice(boolean disposeEagerly) {
         // When subscribe is called, a new resource should be created.
-        Callable<Resource> resourceFactory = new Callable<Resource>() {
+        Supplier<Resource> resourceFactory = new Supplier<Resource>() {
             @Override
-            public Resource call() {
+            public Resource get() {
                 return new Resource() {
 
                     boolean first = true;
@@ -176,9 +175,9 @@ public class ObservableUsingTest {
     }
 
     private void performTestUsingWithResourceFactoryError(boolean disposeEagerly) {
-        Callable<Disposable> resourceFactory = new Callable<Disposable>() {
+        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
             @Override
-            public Disposable call() {
+            public Disposable get() {
                 throw new TestException();
             }
         };
@@ -206,9 +205,9 @@ public class ObservableUsingTest {
 
     private void performTestUsingWithObservableFactoryError(boolean disposeEagerly) {
         final Runnable unsubscribe = mock(Runnable.class);
-        Callable<Disposable> resourceFactory = new Callable<Disposable>() {
+        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
             @Override
-            public Disposable call() {
+            public Disposable get() {
                 return Disposables.fromRunnable(unsubscribe);
             }
         };
@@ -244,9 +243,9 @@ public class ObservableUsingTest {
 
     private void performTestUsingWithObservableFactoryErrorInOnSubscribe(boolean disposeEagerly) {
         final Runnable unsubscribe = mock(Runnable.class);
-        Callable<Disposable> resourceFactory = new Callable<Disposable>() {
+        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
             @Override
-            public Disposable call() {
+            public Disposable get() {
                 return Disposables.fromRunnable(unsubscribe);
             }
         };
@@ -279,7 +278,7 @@ public class ObservableUsingTest {
     @Test
     public void testUsingDisposesEagerlyBeforeCompletion() {
         final List<String> events = new ArrayList<String>();
-        Callable<Resource> resourceFactory = createResourceFactory(events);
+        Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
 
@@ -306,7 +305,7 @@ public class ObservableUsingTest {
     @Test
     public void testUsingDoesNotDisposesEagerlyBeforeCompletion() {
         final List<String> events = new ArrayList<String>();
-        Callable<Resource> resourceFactory = createResourceFactory(events);
+        Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
 
@@ -333,7 +332,7 @@ public class ObservableUsingTest {
     @Test
     public void testUsingDisposesEagerlyBeforeError() {
         final List<String> events = new ArrayList<String>();
-        Callable<Resource> resourceFactory = createResourceFactory(events);
+        Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
 
@@ -361,7 +360,7 @@ public class ObservableUsingTest {
     @Test
     public void testUsingDoesNotDisposesEagerlyBeforeError() {
         final List<String> events = new ArrayList<String>();
-        final Callable<Resource> resourceFactory = createResourceFactory(events);
+        final Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
 
@@ -403,10 +402,10 @@ public class ObservableUsingTest {
         };
     }
 
-    private static Callable<Resource> createResourceFactory(final List<String> events) {
-        return new Callable<Resource>() {
+    private static Supplier<Resource> createResourceFactory(final List<String> events) {
+        return new Supplier<Resource>() {
             @Override
-            public Resource call() {
+            public Resource get() {
                 return new Resource() {
 
                     @Override
@@ -435,9 +434,9 @@ public class ObservableUsingTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Observable.using(
-                new Callable<Object>() {
+                new Supplier<Object>() {
                     @Override
-                    public Object call() throws Exception {
+                    public Object get() throws Exception {
                         return 1;
                     }
                 },
@@ -453,9 +452,9 @@ public class ObservableUsingTest {
 
     @Test
     public void supplierDisposerCrash() {
-        TestObserver<Object> to = Observable.using(new Callable<Object>() {
+        TestObserver<Object> to = Observable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, ObservableSource<Object>>() {
@@ -480,9 +479,9 @@ public class ObservableUsingTest {
 
     @Test
     public void eagerOnErrorDisposerCrash() {
-        TestObserver<Object> to = Observable.using(new Callable<Object>() {
+        TestObserver<Object> to = Observable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, ObservableSource<Object>>() {
@@ -507,9 +506,9 @@ public class ObservableUsingTest {
 
     @Test
     public void eagerOnCompleteDisposerCrash() {
-        Observable.using(new Callable<Object>() {
+        Observable.using(new Supplier<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object get() throws Exception {
                 return 1;
             }
         }, new Function<Object, ObservableSource<Object>>() {
@@ -531,9 +530,9 @@ public class ObservableUsingTest {
     public void nonEagerDisposerCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable.using(new Callable<Object>() {
+            Observable.using(new Supplier<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object get() throws Exception {
                     return 1;
                 }
             }, new Function<Object, ObservableSource<Object>>() {
@@ -558,7 +557,7 @@ public class ObservableUsingTest {
 
     @Test
     public void sourceSupplierReturnsNull() {
-        Observable.using(Functions.justCallable(1),
+        Observable.using(Functions.justSupplier(1),
                 Functions.justFunction((Observable<Object>)null),
                 Functions.emptyConsumer())
         .test()
@@ -572,7 +571,7 @@ public class ObservableUsingTest {
             @Override
             public ObservableSource<Object> apply(Observable<Object> o)
                     throws Exception {
-                return Observable.using(Functions.justCallable(1), Functions.justFunction(o), Functions.emptyConsumer());
+                return Observable.using(Functions.justSupplier(1), Functions.justFunction(o), Functions.emptyConsumer());
             }
         });
     }
@@ -581,7 +580,7 @@ public class ObservableUsingTest {
     public void eagerDisposedOnComplete() {
         final TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.using(Functions.justCallable(1), Functions.justFunction(new Observable<Integer>() {
+        Observable.using(Functions.justSupplier(1), Functions.justFunction(new Observable<Integer>() {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposables.empty());
@@ -596,7 +595,7 @@ public class ObservableUsingTest {
     public void eagerDisposedOnError() {
         final TestObserver<Integer> to = new TestObserver<Integer>();
 
-        Observable.using(Functions.justCallable(1), Functions.justFunction(new Observable<Integer>() {
+        Observable.using(Functions.justSupplier(1), Functions.justFunction(new Observable<Integer>() {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposables.empty());

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -113,10 +113,10 @@ public class ObservableWindowWithStartEndObservableTest {
             }
         });
 
-        Callable<Observable<Object>> closer = new Callable<Observable<Object>>() {
+        Supplier<Observable<Object>> closer = new Supplier<Observable<Object>>() {
             int calls;
             @Override
-            public Observable<Object> call() {
+            public Observable<Object> get() {
                 return Observable.unsafeCreate(new ObservableSource<Object>() {
                     @Override
                     public void subscribe(Observer<? super Object> innerObserver) {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDeferTest.java
@@ -13,21 +13,20 @@
 
 package io.reactivex.internal.operators.single;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 
 import io.reactivex.Single;
+import io.reactivex.functions.Supplier;
 
 public class SingleDeferTest {
 
     @Test
     public void normal() {
 
-        Single<Integer> s = Single.defer(new Callable<Single<Integer>>() {
+        Single<Integer> s = Single.defer(new Supplier<Single<Integer>>() {
             int counter;
             @Override
-            public Single<Integer> call() throws Exception {
+            public Single<Integer> get() throws Exception {
                 return Single.just(++counter);
             }
         });

--- a/src/test/java/io/reactivex/internal/operators/single/SingleErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleErrorTest.java
@@ -13,20 +13,19 @@
 
 package io.reactivex.internal.operators.single;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 
 import io.reactivex.Single;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.functions.Supplier;
 
 public class SingleErrorTest {
 
     @Test
-    public void errorCallableThrows() {
-        Single.error(new Callable<Throwable>() {
+    public void errorSupplierThrows() {
+        Single.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() throws Exception {
+            public Throwable get() throws Exception {
                 throw new TestException();
             }
         })

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
@@ -16,7 +16,6 @@ package io.reactivex.internal.operators.single;
 import static org.junit.Assert.*;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
@@ -61,9 +60,9 @@ public class SingleUsingTest {
 
     @Test
     public void resourceSupplierThrows() {
-        Single.using(new Callable<Integer>() {
+        Single.using(new Supplier<Integer>() {
             @Override
-            public Integer call() throws Exception {
+            public Integer get() throws Exception {
                 throw new TestException();
             }
         }, Functions.justFunction(Single.just(1)), Functions.emptyConsumer())
@@ -73,35 +72,35 @@ public class SingleUsingTest {
 
     @Test
     public void normalEager() {
-        Single.using(Functions.justCallable(1), Functions.justFunction(Single.just(1)), Functions.emptyConsumer())
+        Single.using(Functions.justSupplier(1), Functions.justFunction(Single.just(1)), Functions.emptyConsumer())
         .test()
         .assertResult(1);
     }
 
     @Test
     public void normalNonEager() {
-        Single.using(Functions.justCallable(1), Functions.justFunction(Single.just(1)), Functions.emptyConsumer(), false)
+        Single.using(Functions.justSupplier(1), Functions.justFunction(Single.just(1)), Functions.emptyConsumer(), false)
         .test()
         .assertResult(1);
     }
 
     @Test
     public void errorEager() {
-        Single.using(Functions.justCallable(1), Functions.justFunction(Single.error(new TestException())), Functions.emptyConsumer())
+        Single.using(Functions.justSupplier(1), Functions.justFunction(Single.error(new TestException())), Functions.emptyConsumer())
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void errorNonEager() {
-        Single.using(Functions.justCallable(1), Functions.justFunction(Single.error(new TestException())), Functions.emptyConsumer(), false)
+        Single.using(Functions.justSupplier(1), Functions.justFunction(Single.error(new TestException())), Functions.emptyConsumer(), false)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void eagerMapperThrowsDisposerThrows() {
-        TestObserver<Integer> to = Single.using(Functions.justCallable(Disposables.empty()), mapperThrows, disposerThrows)
+        TestObserver<Integer> to = Single.using(Functions.justSupplier(Disposables.empty()), mapperThrows, disposerThrows)
         .test()
         .assertFailure(CompositeException.class);
 
@@ -116,7 +115,7 @@ public class SingleUsingTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.using(Functions.justCallable(Disposables.empty()), mapperThrows, disposerThrows, false)
+            Single.using(Functions.justSupplier(Disposables.empty()), mapperThrows, disposerThrows, false)
             .test()
             .assertFailureAndMessage(TestException.class, "Mapper");
 
@@ -130,7 +129,7 @@ public class SingleUsingTest {
     public void resourceDisposedIfMapperCrashes() {
         Disposable d = Disposables.empty();
 
-        Single.using(Functions.justCallable(d), mapperThrows, disposer)
+        Single.using(Functions.justSupplier(d), mapperThrows, disposer)
         .test()
         .assertFailure(TestException.class);
 
@@ -141,7 +140,7 @@ public class SingleUsingTest {
     public void resourceDisposedIfMapperCrashesNonEager() {
         Disposable d = Disposables.empty();
 
-        Single.using(Functions.justCallable(d), mapperThrows, disposer, false)
+        Single.using(Functions.justSupplier(d), mapperThrows, disposer, false)
         .test()
         .assertFailure(TestException.class);
 
@@ -152,7 +151,7 @@ public class SingleUsingTest {
     public void dispose() {
         Disposable d = Disposables.empty();
 
-        Single.using(Functions.justCallable(d), mapper, disposer, false)
+        Single.using(Functions.justSupplier(d), mapper, disposer, false)
         .test(true);
 
         assertTrue(d.isDisposed());
@@ -160,7 +159,7 @@ public class SingleUsingTest {
 
     @Test
     public void disposerThrowsEager() {
-        Single.using(Functions.justCallable(Disposables.empty()), mapper, disposerThrows)
+        Single.using(Functions.justSupplier(Disposables.empty()), mapper, disposerThrows)
         .test()
         .assertFailure(TestException.class);
     }
@@ -171,7 +170,7 @@ public class SingleUsingTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.using(Functions.justCallable(Disposables.empty()), mapper, disposerThrows, false)
+            Single.using(Functions.justSupplier(Disposables.empty()), mapper, disposerThrows, false)
             .test()
             .assertResult(1);
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "Disposer");
@@ -182,7 +181,7 @@ public class SingleUsingTest {
 
     @Test
     public void errorAndDisposerThrowsEager() {
-        TestObserver<Integer> to = Single.using(Functions.justCallable(Disposables.empty()),
+        TestObserver<Integer> to = Single.using(Functions.justSupplier(Disposables.empty()),
         new Function<Disposable, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(Disposable v) throws Exception {
@@ -202,7 +201,7 @@ public class SingleUsingTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.using(Functions.justCallable(Disposables.empty()),
+            Single.using(Functions.justSupplier(Disposables.empty()),
             new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
@@ -224,7 +223,7 @@ public class SingleUsingTest {
 
             Disposable d = Disposables.empty();
 
-            final TestObserver<Integer> to = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
+            final TestObserver<Integer> to = Single.using(Functions.justSupplier(d), new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
                     return pp.single(-99);
@@ -258,7 +257,7 @@ public class SingleUsingTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.using(Functions.justCallable(1), new Function<Integer, SingleSource<Integer>>() {
+            Single.using(Functions.justSupplier(1), new Function<Integer, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Integer v) throws Exception {
                     return new Single<Integer>() {
@@ -299,7 +298,7 @@ public class SingleUsingTest {
 
             Disposable d = Disposables.empty();
 
-            final TestObserver<Integer> to = Single.using(Functions.justCallable(d), new Function<Disposable, SingleSource<Integer>>() {
+            final TestObserver<Integer> to = Single.using(Functions.justSupplier(d), new Function<Disposable, SingleSource<Integer>>() {
                 @Override
                 public SingleSource<Integer> apply(Disposable v) throws Exception {
                     return pp.single(-99);

--- a/src/test/java/io/reactivex/internal/schedulers/SchedulerWhenTest.java
+++ b/src/test/java/io/reactivex/internal/schedulers/SchedulerWhenTest.java
@@ -17,7 +17,6 @@ import static io.reactivex.Flowable.*;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.*;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
@@ -26,7 +25,7 @@ import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Function;
+import io.reactivex.functions.*;
 import io.reactivex.internal.schedulers.SchedulerWhen.*;
 import io.reactivex.observers.DisposableCompletableObserver;
 import io.reactivex.processors.PublishProcessor;
@@ -164,9 +163,9 @@ public class SchedulerWhenTest {
         return Flowable.range(1, 5).flatMap(new Function<Integer, Flowable<Long>>() {
             @Override
             public Flowable<Long> apply(Integer t) {
-                return Flowable.defer(new Callable<Flowable<Long>>() {
+                return Flowable.defer(new Supplier<Flowable<Long>>() {
                     @Override
-                    public Flowable<Long> call() {
+                    public Flowable<Long> get() {
                         return Flowable.just(0l);
                     }
                 }).subscribeOn(sched);

--- a/src/test/java/io/reactivex/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/internal/util/MiscUtilTest.java
@@ -87,7 +87,7 @@ public class MiscUtilTest {
     }
 
     @Test
-    public void appendOnlyLinkedArrayListForEachWhileBi() throws Exception {
+    public void appendOnlyLinkedArrayListForEachWhileBi() throws Throwable {
         AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(2);
 
         list.add(1);
@@ -98,7 +98,7 @@ public class MiscUtilTest {
 
         list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
             @Override
-            public boolean test(Integer t1, Integer t2) throws Exception {
+            public boolean test(Integer t1, Integer t2) throws Throwable {
                 out.add(t2);
                 return t1.equals(t2);
             }
@@ -192,7 +192,7 @@ public class MiscUtilTest {
     }
 
     @Test
-    public void appendOnlyLinkedArrayListForEachWhileBiPreGrow() throws Exception {
+    public void appendOnlyLinkedArrayListForEachWhileBiPreGrow() throws Throwable {
         AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(12);
 
         list.add(1);
@@ -203,7 +203,7 @@ public class MiscUtilTest {
 
         list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
             @Override
-            public boolean test(Integer t1, Integer t2) throws Exception {
+            public boolean test(Integer t1, Integer t2) throws Throwable {
                 out.add(t2);
                 return t1.equals(t2);
             }
@@ -213,7 +213,7 @@ public class MiscUtilTest {
     }
 
     @Test
-    public void appendOnlyLinkedArrayListForEachWhileBiExact() throws Exception {
+    public void appendOnlyLinkedArrayListForEachWhileBiExact() throws Throwable {
         AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(3);
 
         list.add(1);
@@ -234,7 +234,7 @@ public class MiscUtilTest {
     }
 
     @Test
-    public void appendOnlyLinkedArrayListForEachWhileBiAll() throws Exception {
+    public void appendOnlyLinkedArrayListForEachWhileBiAll() throws Throwable {
         AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(2);
 
         list.add(1);

--- a/src/test/java/io/reactivex/internal/util/TestingHelper.java
+++ b/src/test/java/io/reactivex/internal/util/TestingHelper.java
@@ -15,12 +15,9 @@
  */
 package io.reactivex.internal.util;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
+import java.util.*;
 
-import io.reactivex.functions.BiConsumer;
-import io.reactivex.functions.Consumer;
+import io.reactivex.functions.*;
 
 public final class TestingHelper {
 
@@ -38,11 +35,11 @@ public final class TestingHelper {
         };
     }
 
-    public static <T> Callable<List<T>> callableListCreator() {
-        return new Callable<List<T>>() {
+    public static <T> Supplier<List<T>> supplierListCreator() {
+        return new Supplier<List<T>>() {
 
             @Override
-            public List<T> call() {
+            public List<T> get() {
                 return new ArrayList<T>();
             }
         };

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -199,8 +199,8 @@ public class MaybeTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void errorCallableNull() {
-        Maybe.error((Callable<Throwable>)null);
+    public void errorSupplierNull() {
+        Maybe.error((Supplier<Throwable>)null);
     }
 
     @Test
@@ -212,14 +212,14 @@ public class MaybeTest {
 
     @Test
     public void errorCallable() {
-        Maybe.error(Functions.justCallable(new TestException()))
+        Maybe.error(Functions.justSupplier(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void errorCallableReturnsNull() {
-        Maybe.error(Functions.justCallable((Throwable)null))
+        Maybe.error(Functions.justSupplier((Throwable)null))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -293,9 +293,9 @@ public class MaybeTest {
 
     @Test
     public void deferThrows() {
-        Maybe.defer(new Callable<Maybe<Integer>>() {
+        Maybe.defer(new Supplier<Maybe<Integer>>() {
             @Override
-            public Maybe<Integer> call() throws Exception {
+            public Maybe<Integer> get() throws Exception {
                 throw new TestException();
             }
         })
@@ -305,9 +305,9 @@ public class MaybeTest {
 
     @Test
     public void deferReturnsNull() {
-        Maybe.defer(new Callable<Maybe<Integer>>() {
+        Maybe.defer(new Supplier<Maybe<Integer>>() {
             @Override
-            public Maybe<Integer> call() throws Exception {
+            public Maybe<Integer> get() throws Exception {
                 return null;
             }
         })
@@ -317,10 +317,10 @@ public class MaybeTest {
 
     @Test
     public void defer() {
-        Maybe<Integer> source = Maybe.defer(new Callable<Maybe<Integer>>() {
+        Maybe<Integer> source = Maybe.defer(new Supplier<Maybe<Integer>>() {
             int count;
             @Override
-            public Maybe<Integer> call() throws Exception {
+            public Maybe<Integer> get() throws Exception {
                 return Maybe.just(count++);
             }
         });
@@ -1087,9 +1087,9 @@ public class MaybeTest {
             }
         },
 
-        new Callable<MaybeSource<Integer>>() {
+        new Supplier<MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> call() throws Exception {
+            public MaybeSource<Integer> get() throws Exception {
                 return Maybe.just(200);
             }
         })
@@ -1113,9 +1113,9 @@ public class MaybeTest {
             }
         },
 
-        new Callable<MaybeSource<Integer>>() {
+        new Supplier<MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> call() throws Exception {
+            public MaybeSource<Integer> get() throws Exception {
                 return Maybe.just(200);
             }
         })
@@ -1139,9 +1139,9 @@ public class MaybeTest {
             }
         },
 
-        new Callable<MaybeSource<Integer>>() {
+        new Supplier<MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> call() throws Exception {
+            public MaybeSource<Integer> get() throws Exception {
                 return Maybe.just(200);
             }
         })
@@ -2825,7 +2825,7 @@ public class MaybeTest {
     public void using() {
         final AtomicInteger disposeCount = new AtomicInteger();
 
-        Maybe.using(Functions.justCallable(1), new Function<Integer, MaybeSource<Integer>>() {
+        Maybe.using(Functions.justSupplier(1), new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v) throws Exception {
                 return Maybe.just(v);
@@ -2850,7 +2850,7 @@ public class MaybeTest {
     public void usingNonEager() {
         final AtomicInteger disposeCount = new AtomicInteger();
 
-        Maybe.using(Functions.justCallable(1), new Function<Integer, MaybeSource<Integer>>() {
+        Maybe.using(Functions.justSupplier(1), new Function<Integer, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(Integer v) throws Exception {
                 return Maybe.just(v);
@@ -3188,9 +3188,9 @@ public class MaybeTest {
 
         final AtomicInteger calls = new AtomicInteger();
         try {
-            Maybe.error(new Callable<Throwable>() {
+            Maybe.error(new Supplier<Throwable>() {
                 @Override
-                public Throwable call() {
+                public Throwable get() {
                     calls.incrementAndGet();
                     return new TestException();
                 }

--- a/src/test/java/io/reactivex/observable/ObservableMergeTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableMergeTests.java
@@ -16,11 +16,11 @@ package io.reactivex.observable;
 import static org.junit.Assert.*;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
 import io.reactivex.Observable;
+import io.reactivex.functions.Supplier;
 import io.reactivex.observable.ObservableCovarianceTest.*;
 
 public class ObservableMergeTests {
@@ -75,9 +75,9 @@ public class ObservableMergeTests {
     @Test
     public void testMergeCovariance4() {
 
-        Observable<Movie> o1 = Observable.defer(new Callable<Observable<Movie>>() {
+        Observable<Movie> o1 = Observable.defer(new Supplier<Observable<Movie>>() {
             @Override
-            public Observable<Movie> call() {
+            public Observable<Movie> get() {
                 return Observable.just(
                         new HorrorMovie(),
                         new Movie()

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -305,9 +305,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void deferFunctionReturnsNull() {
-        Observable.defer(new Callable<Observable<Object>>() {
+        Observable.defer(new Supplier<Observable<Object>>() {
             @Override
-            public Observable<Object> call() {
+            public Observable<Object> get() {
                 return null;
             }
         }).blockingLast();
@@ -315,14 +315,14 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void errorFunctionNull() {
-        Observable.error((Callable<Throwable>)null);
+        Observable.error((Supplier<Throwable>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void errorFunctionReturnsNull() {
-        Observable.error(new Callable<Throwable>() {
+        Observable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -459,9 +459,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void generateStateConsumerNull() {
-        Observable.generate(new Callable<Integer>() {
+        Observable.generate(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         }, (BiConsumer<Integer, Emitter<Object>>)null);
@@ -475,9 +475,9 @@ public class ObservableNullTests {
                 o.onComplete();
             }
         };
-        Observable.generate(new Callable<Integer>() {
+        Observable.generate(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return null;
             }
         }, generator).blockingSubscribe();
@@ -485,9 +485,9 @@ public class ObservableNullTests {
 
     @Test
     public void generateFunctionStateNullAllowed() {
-        Observable.generate(new Callable<Object>() {
+        Observable.generate(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }, new BiFunction<Object, Emitter<Object>, Object>() {
@@ -504,9 +504,9 @@ public class ObservableNullTests {
                 o.onNext(1);
             }
         };
-        Observable.generate(new Callable<Integer>() {
+        Observable.generate(new Supplier<Integer>() {
             @Override
-            public Integer call() {
+            public Integer get() {
                 return 1;
             }
         }, generator, null);
@@ -514,9 +514,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void generateFunctionDisposeNull() {
-        Observable.generate(new Callable<Object>() {
+        Observable.generate(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new BiFunction<Object, Emitter<Object>, Object>() {
@@ -690,9 +690,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingObservableSupplierNull() {
-        Observable.using(new Callable<Object>() {
+        Observable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, null, new Consumer<Object>() {
@@ -703,9 +703,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingObservableSupplierReturnsNull() {
-        Observable.using(new Callable<Object>() {
+        Observable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new Function<Object, Observable<Object>>() {
@@ -721,9 +721,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingDisposeNull() {
-        Observable.using(new Callable<Object>() {
+        Observable.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new Function<Object, Observable<Integer>>() {
@@ -864,14 +864,14 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferSupplierNull() {
-        just1.buffer(1, 1, (Callable<List<Integer>>)null);
+        just1.buffer(1, 1, (Supplier<List<Integer>>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferSupplierReturnsNull() {
-        just1.buffer(1, 1, new Callable<Collection<Integer>>() {
+        just1.buffer(1, 1, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -894,9 +894,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferTimedSupplierReturnsNull() {
-        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), new Callable<Collection<Integer>>() {
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -934,14 +934,14 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplierNull() {
-        just1.buffer(just1, (Callable<List<Integer>>)null);
+        just1.buffer(just1, (Supplier<List<Integer>>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplierReturnsNull() {
-        just1.buffer(just1, new Callable<Collection<Integer>>() {
+        just1.buffer(just1, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -949,14 +949,14 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplier2Null() {
-        just1.buffer((Callable<Observable<Integer>>)null);
+        just1.buffer((Supplier<Observable<Integer>>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplier2ReturnsNull() {
-        just1.buffer(new Callable<Observable<Object>>() {
+        just1.buffer(new Supplier<Observable<Object>>() {
             @Override
-            public Observable<Object> call() {
+            public Observable<Object> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -964,9 +964,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplier2SupplierNull() {
-        just1.buffer(new Callable<Observable<Integer>>() {
+        just1.buffer(new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return just1;
             }
         }, null);
@@ -974,14 +974,14 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplier2SupplierReturnsNull() {
-        just1.buffer(new Callable<Observable<Integer>>() {
+        just1.buffer(new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return just1;
             }
-        }, new Callable<Collection<Integer>>() {
+        }, new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -994,7 +994,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void collectInitialSupplierNull() {
-        just1.collect((Callable<Integer>)null, new BiConsumer<Integer, Integer>() {
+        just1.collect((Supplier<Integer>)null, new BiConsumer<Integer, Integer>() {
             @Override
             public void accept(Integer a, Integer b) { }
         });
@@ -1002,9 +1002,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void collectInitialSupplierReturnsNull() {
-        just1.collect(new Callable<Object>() {
+        just1.collect(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }, new BiConsumer<Object, Integer>() {
@@ -1015,9 +1015,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void collectInitialCollectorNull() {
-        just1.collect(new Callable<Object>() {
+        just1.collect(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, null);
@@ -1229,9 +1229,9 @@ public class ObservableNullTests {
             public Object apply(Integer v) {
                 return v;
             }
-        }, new Callable<Collection<Object>>() {
+        }, new Supplier<Collection<Object>>() {
             @Override
-            public Collection<Object> call() {
+            public Collection<Object> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -1362,9 +1362,9 @@ public class ObservableNullTests {
             public Observable<Integer> apply(Throwable e) {
                 return just1;
             }
-        }, new Callable<Observable<Integer>>() {
+        }, new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return just1;
             }
         });
@@ -1382,9 +1382,9 @@ public class ObservableNullTests {
             public Observable<Integer> apply(Throwable e) {
                 return just1;
             }
-        }, new Callable<Observable<Integer>>() {
+        }, new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return just1;
             }
         }).blockingSubscribe();
@@ -1397,9 +1397,9 @@ public class ObservableNullTests {
             public Observable<Integer> apply(Integer v) {
                 return just1;
             }
-        }, null, new Callable<Observable<Integer>>() {
+        }, null, new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return just1;
             }
         });
@@ -1418,9 +1418,9 @@ public class ObservableNullTests {
             public Observable<Integer> apply(Throwable e) {
                 return null;
             }
-        }, new Callable<Observable<Integer>>() {
+        }, new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return just1;
             }
         }).blockingSubscribe();
@@ -1453,9 +1453,9 @@ public class ObservableNullTests {
             public Observable<Integer> apply(Throwable e) {
                 return just1;
             }
-        }, new Callable<Observable<Integer>>() {
+        }, new Supplier<Observable<Integer>>() {
             @Override
-            public Observable<Integer> call() {
+            public Observable<Integer> get() {
                 return null;
             }
         }).blockingSubscribe();
@@ -1810,9 +1810,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void reduceWithSeedReturnsNull() {
-        just1.reduceWith(new Callable<Object>() {
+        just1.reduceWith(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }, new BiFunction<Object, Integer, Object>() {
@@ -2065,9 +2065,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void scanSeedSupplierReturnsNull() {
-        just1.scanWith(new Callable<Object>() {
+        just1.scanWith(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return null;
             }
         }, new BiFunction<Object, Integer, Object>() {
@@ -2080,9 +2080,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void scanSeedSupplierFunctionNull() {
-        just1.scanWith(new Callable<Object>() {
+        just1.scanWith(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, null);
@@ -2090,9 +2090,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void scanSeedSupplierFunctionReturnsNull() {
-        just1.scanWith(new Callable<Object>() {
+        just1.scanWith(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new BiFunction<Object, Integer, Object>() {
@@ -2420,9 +2420,9 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void toListSupplierReturnsNull() {
-        just1.toList(new Callable<Collection<Integer>>() {
+        just1.toList(new Supplier<Collection<Integer>>() {
             @Override
-            public Collection<Integer> call() {
+            public Collection<Integer> get() {
                 return null;
             }
         }).blockingGet();
@@ -2490,9 +2490,9 @@ public class ObservableNullTests {
             public Object apply(Integer v) {
                 return v;
             }
-        }, new Callable<Map<Object, Object>>() {
+        }, new Supplier<Map<Object, Object>>() {
             @Override
-            public Map<Object, Object> call() {
+            public Map<Object, Object> get() {
                 return null;
             }
         }).blockingGet();
@@ -2555,9 +2555,9 @@ public class ObservableNullTests {
             public Object apply(Integer v) {
                 return v;
             }
-        }, new Callable<Map<Object, Collection<Object>>>() {
+        }, new Supplier<Map<Object, Collection<Object>>>() {
             @Override
-            public Map<Object, Collection<Object>> call() {
+            public Map<Object, Collection<Object>> get() {
                 return null;
             }
         }).blockingGet();
@@ -2575,9 +2575,9 @@ public class ObservableNullTests {
             public Integer apply(Integer v) {
                 return v;
             }
-        }, new Callable<Map<Integer, Collection<Integer>>>() {
+        }, new Supplier<Map<Integer, Collection<Integer>>>() {
             @Override
-            public Map<Integer, Collection<Integer>> call() {
+            public Map<Integer, Collection<Integer>> get() {
                 return new HashMap<Integer, Collection<Integer>>();
             }
         }, null);
@@ -2595,9 +2595,9 @@ public class ObservableNullTests {
             public Integer apply(Integer v) {
                 return v;
             }
-        }, new Callable<Map<Integer, Collection<Integer>>>() {
+        }, new Supplier<Map<Integer, Collection<Integer>>>() {
             @Override
-            public Map<Integer, Collection<Integer>> call() {
+            public Map<Integer, Collection<Integer>> get() {
                 return new HashMap<Integer, Collection<Integer>>();
             }
         }, new Function<Integer, Collection<Integer>>() {
@@ -2670,14 +2670,14 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void windowBoundarySupplierNull() {
-        just1.window((Callable<Observable<Integer>>)null);
+        just1.window((Supplier<Observable<Integer>>)null);
     }
 
     @Test(expected = NullPointerException.class)
     public void windowBoundarySupplierReturnsNull() {
-        just1.window(new Callable<Observable<Object>>() {
+        just1.window(new Supplier<Observable<Object>>() {
             @Override
-            public Observable<Object> call() {
+            public Observable<Object> get() {
                 return null;
             }
         }).blockingSubscribe();

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -134,9 +134,9 @@ public class ObservableTest {
 
     @Test
     public void testCountErrorObservable() {
-        Observable<String> o = Observable.error(new Callable<Throwable>() {
+        Observable<String> o = Observable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new RuntimeException();
             }
         });
@@ -171,9 +171,9 @@ public class ObservableTest {
 
     @Test
     public void testCountError() {
-        Observable<String> o = Observable.error(new Callable<Throwable>() {
+        Observable<String> o = Observable.error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new RuntimeException();
             }
         });
@@ -476,9 +476,9 @@ public class ObservableTest {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         // FIXME custom built???
-        Observable.just("1", "2").concatWith(Observable.<String>error(new Callable<Throwable>() {
+        Observable.just("1", "2").concatWith(Observable.<String>error(new Supplier<Throwable>() {
             @Override
-            public Throwable call() {
+            public Throwable get() {
                 return new NumberFormatException();
             }
         }))

--- a/src/test/java/io/reactivex/parallel/ParallelCollectTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelCollectTest.java
@@ -16,7 +16,6 @@ package io.reactivex.parallel;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
@@ -32,9 +31,9 @@ public class ParallelCollectTest {
     @Test
     public void subscriberCount() {
         ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -50,9 +49,9 @@ public class ParallelCollectTest {
     public void initialCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 throw new TestException();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -71,9 +70,9 @@ public class ParallelCollectTest {
     public void reducerCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -96,9 +95,9 @@ public class ParallelCollectTest {
 
         TestSubscriber<List<Integer>> ts = pp
         .parallel()
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -122,9 +121,9 @@ public class ParallelCollectTest {
     public void error() {
         Flowable.<Integer>error(new TestException())
         .parallel()
-        .collect(new Callable<List<Integer>>() {
+        .collect(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
@@ -144,9 +143,9 @@ public class ParallelCollectTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             new ParallelInvalid()
-            .collect(new Callable<List<Object>>() {
+            .collect(new Supplier<List<Object>>() {
                 @Override
-                public List<Object> call() throws Exception {
+                public List<Object> get() throws Exception {
                     return new ArrayList<Object>();
                 }
             }, new BiConsumer<List<Object>, Object>() {

--- a/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
@@ -274,9 +274,9 @@ public class ParallelFlowableTest {
 
     @Test
     public void collect() {
-        Callable<List<Integer>> as = new Callable<List<Integer>>() {
+        Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         };
@@ -367,9 +367,9 @@ public class ParallelFlowableTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
-                public List<Integer> call() throws Exception {
+                public List<Integer> get() throws Exception {
                     return new ArrayList<Integer>();
                 }
             };
@@ -414,9 +414,9 @@ public class ParallelFlowableTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
-                public List<Integer> call() throws Exception {
+                public List<Integer> get() throws Exception {
                     return new ArrayList<Integer>();
                 }
             };
@@ -461,9 +461,9 @@ public class ParallelFlowableTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
-                public List<Integer> call() throws Exception {
+                public List<Integer> get() throws Exception {
                     return new ArrayList<Integer>();
                 }
             };
@@ -509,9 +509,9 @@ public class ParallelFlowableTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
-                public List<Integer> call() throws Exception {
+                public List<Integer> get() throws Exception {
                     return new ArrayList<Integer>();
                 }
             };
@@ -557,9 +557,9 @@ public class ParallelFlowableTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
-                public List<Integer> call() throws Exception {
+                public List<Integer> get() throws Exception {
                     return new ArrayList<Integer>();
                 }
             };
@@ -605,9 +605,9 @@ public class ParallelFlowableTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
-                public List<Integer> call() throws Exception {
+                public List<Integer> get() throws Exception {
                     return new ArrayList<Integer>();
                 }
             };
@@ -654,9 +654,9 @@ public class ParallelFlowableTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Callable<List<Integer>> as = new Callable<List<Integer>>() {
+            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
-                public List<Integer> call() throws Exception {
+                public List<Integer> get() throws Exception {
                     return new ArrayList<Integer>();
                 }
             };

--- a/src/test/java/io/reactivex/parallel/ParallelFromPublisherTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFromPublisherTest.java
@@ -101,7 +101,7 @@ public class ParallelFromPublisherTest {
             }
 
             @Override
-            public T poll() throws Exception {
+            public T poll() throws Throwable {
                 return qs.poll();
             }
         }

--- a/src/test/java/io/reactivex/parallel/ParallelReduceTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelReduceTest.java
@@ -14,8 +14,8 @@
 package io.reactivex.parallel;
 
 import static org.junit.Assert.*;
+
 import java.util.*;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
@@ -31,9 +31,9 @@ public class ParallelReduceTest {
     @Test
     public void subscriberCount() {
         ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
-        .reduce(new Callable<List<Integer>>() {
+        .reduce(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
@@ -50,9 +50,9 @@ public class ParallelReduceTest {
     public void initialCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .reduce(new Callable<List<Integer>>() {
+        .reduce(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 throw new TestException();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
@@ -72,9 +72,9 @@ public class ParallelReduceTest {
     public void reducerCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .reduce(new Callable<List<Integer>>() {
+        .reduce(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
@@ -98,9 +98,9 @@ public class ParallelReduceTest {
 
         TestSubscriber<List<Integer>> ts = pp
         .parallel()
-        .reduce(new Callable<List<Integer>>() {
+        .reduce(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
@@ -125,9 +125,9 @@ public class ParallelReduceTest {
     public void error() {
         Flowable.<Integer>error(new TestException())
         .parallel()
-        .reduce(new Callable<List<Integer>>() {
+        .reduce(new Supplier<List<Integer>>() {
             @Override
-            public List<Integer> call() throws Exception {
+            public List<Integer> get() throws Exception {
                 return new ArrayList<Integer>();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
@@ -148,9 +148,9 @@ public class ParallelReduceTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             new ParallelInvalid()
-            .reduce(new Callable<List<Object>>() {
+            .reduce(new Supplier<List<Object>>() {
                 @Override
-                public List<Object> call() throws Exception {
+                public List<Object> get() throws Exception {
                     return new ArrayList<Object>();
                 }
             }, new BiFunction<List<Object>, Object, List<Object>>() {

--- a/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/plugins/RxJavaPluginsTest.java
@@ -158,9 +158,9 @@ public class RxJavaPluginsTest {
     }
 
 //    static Completable createCompletable() {
-//        return Completable.error(new Callable<Throwable>() {
+//        return Completable.error(new Supplier<Throwable>() {
 //            @Override
-//            public Throwable call() {
+//            public Throwable get() {
 //                return new TestException();
 //            }
 //        });
@@ -212,9 +212,9 @@ public class RxJavaPluginsTest {
         try {
             assertTrue(RxJavaPlugins.isLockdown());
             Consumer a1 = Functions.emptyConsumer();
-            Callable f0 = new Callable() {
+            Supplier f0 = new Supplier() {
                 @Override
-                public Object call() {
+                public Object get() {
                     return null;
                 }
             };
@@ -252,7 +252,7 @@ public class RxJavaPluginsTest {
                         if (paramType.isAssignableFrom(Boolean.TYPE)) {
                             m.invoke(null, true);
                         } else
-                        if (paramType.isAssignableFrom(Callable.class)) {
+                        if (paramType.isAssignableFrom(Supplier.class)) {
                             m.invoke(null, f0);
                         } else
                         if (paramType.isAssignableFrom(Function.class)) {
@@ -364,9 +364,9 @@ public class RxJavaPluginsTest {
         assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.newThread());
     }
 
-    Function<Callable<Scheduler>, Scheduler> initReplaceWithImmediate = new Function<Callable<Scheduler>, Scheduler>() {
+    Function<Supplier<Scheduler>, Scheduler> initReplaceWithImmediate = new Function<Supplier<Scheduler>, Scheduler>() {
         @Override
-        public Scheduler apply(Callable<Scheduler> t) {
+        public Scheduler apply(Supplier<Scheduler> t) {
             return ImmediateThinScheduler.INSTANCE;
         }
     };
@@ -374,9 +374,9 @@ public class RxJavaPluginsTest {
     @Test
     public void overrideInitSingleScheduler() {
         final Scheduler s = Schedulers.single(); // make sure the Schedulers is initialized
-        Callable<Scheduler> c = new Callable<Scheduler>() {
+        Supplier<Scheduler> c = new Supplier<Scheduler>() {
             @Override
-            public Scheduler call() throws Exception {
+            public Scheduler get() throws Exception {
                 return s;
             }
         };
@@ -394,9 +394,9 @@ public class RxJavaPluginsTest {
     @Test
     public void overrideInitComputationScheduler() {
         final Scheduler s = Schedulers.computation(); // make sure the Schedulers is initialized
-        Callable<Scheduler> c = new Callable<Scheduler>() {
+        Supplier<Scheduler> c = new Supplier<Scheduler>() {
             @Override
-            public Scheduler call() throws Exception {
+            public Scheduler get() throws Exception {
                 return s;
             }
         };
@@ -414,9 +414,9 @@ public class RxJavaPluginsTest {
     @Test
     public void overrideInitIoScheduler() {
         final Scheduler s = Schedulers.io(); // make sure the Schedulers is initialized;
-        Callable<Scheduler> c = new Callable<Scheduler>() {
+        Supplier<Scheduler> c = new Supplier<Scheduler>() {
             @Override
-            public Scheduler call() throws Exception {
+            public Scheduler get() throws Exception {
                 return s;
             }
         };
@@ -434,9 +434,9 @@ public class RxJavaPluginsTest {
     @Test
     public void overrideInitNewThreadScheduler() {
         final Scheduler s = Schedulers.newThread(); // make sure the Schedulers is initialized;
-        Callable<Scheduler> c = new Callable<Scheduler>() {
+        Supplier<Scheduler> c = new Supplier<Scheduler>() {
             @Override
-            public Scheduler call() throws Exception {
+            public Scheduler get() throws Exception {
                 return s;
             }
         };
@@ -451,100 +451,100 @@ public class RxJavaPluginsTest {
         assertSame(s, RxJavaPlugins.initNewThreadScheduler(c));
     }
 
-    Callable<Scheduler> nullResultCallable = new Callable<Scheduler>() {
+    Supplier<Scheduler> nullResultSupplier = new Supplier<Scheduler>() {
         @Override
-        public Scheduler call() throws Exception {
+        public Scheduler get() throws Exception {
             return null;
         }
     };
 
     @Test
     public void overrideInitSingleSchedulerCrashes() {
-        // fail when Callable is null
+        // fail when Supplier is null
         try {
             RxJavaPlugins.initSingleScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable can't be null", npe.getMessage());
+            assertEquals("Scheduler Supplier can't be null", npe.getMessage());
         }
 
-        // fail when Callable result is null
+        // fail when Supplier result is null
         try {
-            RxJavaPlugins.initSingleScheduler(nullResultCallable);
+            RxJavaPlugins.initSingleScheduler(nullResultSupplier);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable result can't be null", npe.getMessage());
+            assertEquals("Scheduler Supplier result can't be null", npe.getMessage());
         }
     }
 
     @Test
     public void overrideInitComputationSchedulerCrashes() {
-        // fail when Callable is null
+        // fail when Supplier is null
         try {
             RxJavaPlugins.initComputationScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable can't be null", npe.getMessage());
+            assertEquals("Scheduler Supplier can't be null", npe.getMessage());
         }
 
-        // fail when Callable result is null
+        // fail when Supplier result is null
         try {
-            RxJavaPlugins.initComputationScheduler(nullResultCallable);
+            RxJavaPlugins.initComputationScheduler(nullResultSupplier);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable result can't be null", npe.getMessage());
+            assertEquals("Scheduler Supplier result can't be null", npe.getMessage());
         }
     }
 
     @Test
     public void overrideInitIoSchedulerCrashes() {
-        // fail when Callable is null
+        // fail when Supplier is null
         try {
             RxJavaPlugins.initIoScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable can't be null", npe.getMessage());
+            assertEquals("Scheduler Supplier can't be null", npe.getMessage());
         }
 
-        // fail when Callable result is null
+        // fail when Supplier result is null
         try {
-            RxJavaPlugins.initIoScheduler(nullResultCallable);
+            RxJavaPlugins.initIoScheduler(nullResultSupplier);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable result can't be null", npe.getMessage());
+            assertEquals("Scheduler Supplier result can't be null", npe.getMessage());
         }
     }
 
     @Test
     public void overrideInitNewThreadSchedulerCrashes() {
-        // fail when Callable is null
+        // fail when Supplier is null
         try {
             RxJavaPlugins.initNewThreadScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             // expected
-            assertEquals("Scheduler Callable can't be null", npe.getMessage());
+            assertEquals("Scheduler Supplier can't be null", npe.getMessage());
         }
 
-        // fail when Callable result is null
+        // fail when Supplier result is null
         try {
-            RxJavaPlugins.initNewThreadScheduler(nullResultCallable);
+            RxJavaPlugins.initNewThreadScheduler(nullResultSupplier);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable result can't be null", npe.getMessage());
+            assertEquals("Scheduler Supplier result can't be null", npe.getMessage());
         }
     }
 
-    Callable<Scheduler> unsafeDefault = new Callable<Scheduler>() {
+    Supplier<Scheduler> unsafeDefault = new Supplier<Scheduler>() {
         @Override
-        public Scheduler call() throws Exception {
+        public Scheduler get() throws Exception {
             throw new AssertionError("Default Scheduler instance should not have been evaluated");
         }
     };
 
     @Test
     public void testDefaultSingleSchedulerIsInitializedLazily() {
-        // unsafe default Scheduler Callable should not be evaluated
+        // unsafe default Scheduler Supplier should not be evaluated
         try {
             RxJavaPlugins.setInitSingleSchedulerHandler(initReplaceWithImmediate);
             RxJavaPlugins.initSingleScheduler(unsafeDefault);
@@ -558,7 +558,7 @@ public class RxJavaPluginsTest {
 
     @Test
     public void testDefaultIoSchedulerIsInitializedLazily() {
-        // unsafe default Scheduler Callable should not be evaluated
+        // unsafe default Scheduler Supplier should not be evaluated
         try {
             RxJavaPlugins.setInitIoSchedulerHandler(initReplaceWithImmediate);
             RxJavaPlugins.initIoScheduler(unsafeDefault);
@@ -572,7 +572,7 @@ public class RxJavaPluginsTest {
 
     @Test
     public void testDefaultComputationSchedulerIsInitializedLazily() {
-        // unsafe default Scheduler Callable should not be evaluated
+        // unsafe default Scheduler Supplier should not be evaluated
         try {
             RxJavaPlugins.setInitComputationSchedulerHandler(initReplaceWithImmediate);
             RxJavaPlugins.initComputationScheduler(unsafeDefault);
@@ -586,7 +586,7 @@ public class RxJavaPluginsTest {
 
     @Test
     public void testDefaultNewThreadSchedulerIsInitializedLazily() {
-        // unsafe default Scheduler Callable should not be evaluated
+        // unsafe default Scheduler Supplier should not be evaluated
         try {
             RxJavaPlugins.setInitNewThreadSchedulerHandler(initReplaceWithImmediate);
             RxJavaPlugins.initNewThreadScheduler(unsafeDefault);
@@ -1194,10 +1194,10 @@ public class RxJavaPluginsTest {
                     return scheduler;
                 }
             };
-            Function<? super Callable<Scheduler>, ? extends Scheduler> callable2scheduler = new Function<Callable<Scheduler>, Scheduler>() {
+            Function<? super Supplier<Scheduler>, ? extends Scheduler> callable2scheduler = new Function<Supplier<Scheduler>, Scheduler>() {
                 @Override
-                public Scheduler apply(Callable<Scheduler> schedulerCallable) throws Exception {
-                    return schedulerCallable.call();
+                public Scheduler apply(Supplier<Scheduler> schedulerSupplier) throws Throwable {
+                    return schedulerSupplier.get();
                 }
             };
             Function<? super ConnectableFlowable, ? extends ConnectableFlowable> connectableFlowable2ConnectableFlowable = new Function<ConnectableFlowable, ConnectableFlowable>() {
@@ -1488,9 +1488,9 @@ public class RxJavaPluginsTest {
 //            assertSame(cop, RxJavaPlugins.onCompletableLift(cop));
 
             final Scheduler s = ImmediateThinScheduler.INSTANCE;
-            Callable<Scheduler> c = new Callable<Scheduler>() {
+            Supplier<Scheduler> c = new Supplier<Scheduler>() {
                 @Override
-                public Scheduler call() throws Exception {
+                public Scheduler get() throws Exception {
                     return s;
                 }
             };

--- a/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/TestSchedulerTest.java
@@ -36,7 +36,7 @@ public class TestSchedulerTest {
     @SuppressWarnings("unchecked")
     // mocking is unchecked, unfortunately
     @Test
-    public final void testPeriodicScheduling() throws Exception {
+    public final void testPeriodicScheduling() throws Throwable {
         final Function<Long, Void> calledOp = mock(Function.class);
 
         final TestScheduler scheduler = new TestScheduler();
@@ -86,7 +86,7 @@ public class TestSchedulerTest {
     @SuppressWarnings("unchecked")
     // mocking is unchecked, unfortunately
     @Test
-    public final void testPeriodicSchedulingUnsubscription() throws Exception {
+    public final void testPeriodicSchedulingUnsubscription() throws Throwable {
         final Function<Long, Void> calledOp = mock(Function.class);
 
         final TestScheduler scheduler = new TestScheduler();

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -142,7 +142,7 @@ public class SingleNullTests {
 
     @Test(expected = NullPointerException.class)
     public void errorSupplierNull() {
-        Single.error((Callable<Throwable>)null);
+        Single.error((Supplier<Throwable>)null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -321,9 +321,9 @@ public class SingleNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingSingleSupplierNull() {
-        Single.using(new Callable<Object>() {
+        Single.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, null, Functions.emptyConsumer());
@@ -331,9 +331,9 @@ public class SingleNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingSingleSupplierReturnsNull() {
-        Single.using(new Callable<Object>() {
+        Single.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new Function<Object, Single<Object>>() {
@@ -346,9 +346,9 @@ public class SingleNullTests {
 
     @Test(expected = NullPointerException.class)
     public void usingDisposeNull() {
-        Single.using(new Callable<Object>() {
+        Single.using(new Supplier<Object>() {
             @Override
-            public Object call() {
+            public Object get() {
                 return 1;
             }
         }, new Function<Object, Single<Integer>>() {

--- a/src/test/java/io/reactivex/tck/DeferTckTest.java
+++ b/src/test/java/io/reactivex/tck/DeferTckTest.java
@@ -13,12 +13,11 @@
 
 package io.reactivex.tck;
 
-import java.util.concurrent.Callable;
-
 import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Supplier;
 
 @Test
 public class DeferTckTest extends BaseTck<Long> {
@@ -26,9 +25,9 @@ public class DeferTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createPublisher(final long elements) {
         return
-                Flowable.defer(new Callable<Publisher<Long>>() {
+                Flowable.defer(new Supplier<Publisher<Long>>() {
                     @Override
-                    public Publisher<Long> call() throws Exception {
+                    public Publisher<Long> get() throws Exception {
                         return Flowable.fromIterable(iterate(elements));
                     }
                 }

--- a/src/test/java/io/reactivex/tck/GenerateTckTest.java
+++ b/src/test/java/io/reactivex/tck/GenerateTckTest.java
@@ -26,7 +26,7 @@ public class GenerateTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createPublisher(final long elements) {
         return
-            Flowable.generate(Functions.justCallable(0L),
+            Flowable.generate(Functions.justSupplier(0L),
             new BiFunction<Long, Emitter<Long>, Long>() {
                 @Override
                 public Long apply(Long s, Emitter<Long> e) throws Exception {

--- a/src/test/java/io/reactivex/tck/ReduceWithTckTest.java
+++ b/src/test/java/io/reactivex/tck/ReduceWithTckTest.java
@@ -26,7 +26,7 @@ public class ReduceWithTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createPublisher(final long elements) {
         return
-                Flowable.range(1, 1000).reduceWith(Functions.justCallable(0),
+                Flowable.range(1, 1000).reduceWith(Functions.justSupplier(0),
                 new BiFunction<Integer, Integer, Integer>() {
                     @Override
                     public Integer apply(Integer a, Integer b) throws Exception {

--- a/src/test/java/io/reactivex/tck/UsingTckTest.java
+++ b/src/test/java/io/reactivex/tck/UsingTckTest.java
@@ -25,7 +25,7 @@ public class UsingTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return
-            Flowable.using(Functions.justCallable(1),
+            Flowable.using(Functions.justSupplier(1),
                     Functions.justFunction(Flowable.fromIterable(iterate(elements))),
                     Functions.emptyConsumer()
             )

--- a/src/test/java/io/reactivex/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/validators/ParamValidationCheckerTest.java
@@ -110,15 +110,15 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Integer.TYPE));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Scheduler.class, Integer.TYPE));
-        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Scheduler.class, Integer.TYPE, Callable.class, Boolean.TYPE));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Scheduler.class, Integer.TYPE, Supplier.class, Boolean.TYPE));
 
         // negative time/skip is considered zero time/skip
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class));
-        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Callable.class));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Supplier.class));
         addOverride(new ParamOverride(Flowable.class, 1, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Flowable.class, 1, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class));
-        addOverride(new ParamOverride(Flowable.class, 1, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Callable.class));
+        addOverride(new ParamOverride(Flowable.class, 1, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Supplier.class));
 
         // negative timeout is allowed
         addOverride(new ParamOverride(Flowable.class, 1, ParamMode.ANY, "fromFuture", Future.class, Long.TYPE, TimeUnit.class));
@@ -366,15 +366,15 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Integer.TYPE));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Scheduler.class, Integer.TYPE));
-        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Scheduler.class, Integer.TYPE, Callable.class, Boolean.TYPE));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, TimeUnit.class, Scheduler.class, Integer.TYPE, Supplier.class, Boolean.TYPE));
 
         // negative time/skip is considered zero time/skip
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class));
-        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Callable.class));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Supplier.class));
         addOverride(new ParamOverride(Observable.class, 1, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Observable.class, 1, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class));
-        addOverride(new ParamOverride(Observable.class, 1, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Callable.class));
+        addOverride(new ParamOverride(Observable.class, 1, ParamMode.ANY, "buffer", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Supplier.class));
 
         // negative timeout is allowed
         addOverride(new ParamOverride(Observable.class, 1, ParamMode.ANY, "fromFuture", Future.class, Long.TYPE, TimeUnit.class));
@@ -551,6 +551,7 @@ public class ParamValidationCheckerTest {
         defaultValues.put(LongConsumer.class, Functions.EMPTY_LONG_CONSUMER);
         defaultValues.put(Function.class, Functions.justFunction(1));
         defaultValues.put(Callable.class, Functions.justCallable(1));
+        defaultValues.put(Supplier.class, Functions.justSupplier(1));
         defaultValues.put(Iterable.class, Collections.emptyList());
         defaultValues.put(Object.class, 1);
         defaultValues.put(Class.class, Integer.class);


### PR DESCRIPTION
This PR widens the `throws Exception` into `throws Throwable` in the functional interfaces and adjusts `catch (Exception` to `catch(Throwable` where needed.

The major change is the replacement of `java.util.concurrent.Callable` in almost all API with `io.reactivex.functions.Supplier` which is defined with `throws Throwable`. Since subinterfaces can't widen the throws clause, only narrow it, `Supplier` can't extend `Callable`.

`fromCallable` remained in all base classes and a separate PR will introduce `fromSupplier`.

The single-valued fusion now works with `Supplier` and `ScalarSupplier` types instead of `Callable` and `ScalarCallable` (removed).