### PR TITLE
2.x: Use @Code instead of using <code> </code> markup

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -43,9 +43,9 @@ import io.reactivex.schedulers.Schedulers;
  * The {@code Completable} class implements the {@link CompletableSource} base interface and the default consumer
  * type it interacts with is the {@link CompletableObserver} via the {@link #subscribe(CompletableObserver)} method.
  * The {@code Completable} operates with the following sequential protocol:
- * <pre><code>
+ * <pre>{@code
  *     onSubscribe (onError | onComplete)?
- * </code></pre>
+ * }</pre>
  * <p>
  * Note that as with the {@code Observable} protocol, {@code onError} and {@code onComplete} are mutually exclusive events.
  * <p>
@@ -65,7 +65,7 @@ import io.reactivex.schedulers.Schedulers;
  * implementation of the Reactive Pattern for a stream or vector of values.
  * <p>
  * Example:
- * <pre><code>
+ * <pre>{@code
  * Disposable d = Completable.complete()
  *    .delay(10, TimeUnit.SECONDS, Schedulers.io())
  *    .subscribeWith(new DisposableCompletableObserver() {
@@ -84,11 +84,11 @@ import io.reactivex.schedulers.Schedulers;
  *            System.out.println("Done!");
  *        }
  *    });
- * 
+ *
  * Thread.sleep(5000);
- * 
+ *
  * d.dispose();
- * </code></pre>
+ * }</pre>
  * <p>
  * Note that by design, subscriptions via {@link #subscribe(CompletableObserver)} can't be disposed
  * from the outside (hence the
@@ -273,8 +273,8 @@ public abstract class Completable implements CompletableSource {
      * <img width="640" height="442" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.create.png" alt="">
      * <p>
      * Example:
-     * <pre><code>
-     * Completable.create(emitter -&gt; {
+     * <pre>{@code
+     * Completable.create(emitter -> {
      *     Callback listener = new Callback() {
      *         &#64;Override
      *         public void onEvent(Event e) {
@@ -292,7 +292,7 @@ public abstract class Completable implements CompletableSource {
      *     emitter.setCancellable(c::close);
      *
      * });
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1709,9 +1709,9 @@ public abstract class Completable implements CompletableSource {
      * additional actions depending on the same business logic requirements.
      * <p>
      * Example:
-     * <pre><code>
+     * <pre>{@code
      * // Step 1: Create the consumer type that will be returned by the CompletableOperator.apply():
-     * 
+     *
      * public final class CustomCompletableObserver implements CompletableObserver, Disposable {
      *
      *     // The downstream's CompletableObserver that will receive the onXXX events
@@ -1791,7 +1791,7 @@ public abstract class Completable implements CompletableSource {
      * .lift(new CustomCompletableOperator())
      * .test()
      * .assertResult();
-     * </code></pre>
+     * }</pre>
      * <p>
      * Creating custom operators can be complicated and it is recommended one consults the
      * <a href="https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0">RxJava wiki: Writing operators</a> page about
@@ -2160,21 +2160,21 @@ public abstract class Completable implements CompletableSource {
      * active, the sequence is terminated with the same signal immediately.
      * <p>
      * The following example demonstrates how to retry an asynchronous source with a delay:
-     * <pre><code>
+     * <pre>{@code
      * Completable.timer(1, TimeUnit.SECONDS)
-     *     .doOnSubscribe(s -&gt; System.out.println("subscribing"))
-     *     .doOnComplete(() -&gt; { throw new RuntimeException(); })
-     *     .retryWhen(errors -&gt; {
+     *     .doOnSubscribe(s -> System.out.println("subscribing"))
+     *     .doOnComplete(() -> { throw new RuntimeException(); })
+     *     .retryWhen(errors -> {
      *         AtomicInteger counter = new AtomicInteger();
      *         return errors
-     *                   .takeWhile(e -&gt; counter.getAndIncrement() != 3)
-     *                   .flatMap(e -&gt; {
+     *                   .takeWhile(e -> counter.getAndIncrement() != 3)
+     *                   .flatMap(e -> {
      *                       System.out.println("delay retry by " + counter.get() + " second(s)");
      *                       return Flowable.timer(counter.get(), TimeUnit.SECONDS);
      *                   });
      *     })
      *     .blockingAwait();
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2332,7 +2332,7 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * <img width="640" height="349" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.subscribeWith.png" alt="">
      * <p>Usage example:
-     * <pre><code>
+     * <pre>{@code
      * Completable source = Completable.complete().delay(1, TimeUnit.SECONDS);
      * CompositeDisposable composite = new CompositeDisposable();
      *
@@ -2341,7 +2341,7 @@ public abstract class Completable implements CompletableSource {
      * };
      *
      * composite.add(source.subscribeWith(ds));
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/CompletableObserver.java
+++ b/src/main/java/io/reactivex/CompletableObserver.java
@@ -28,7 +28,7 @@ import io.reactivex.disposables.Disposable;
  * Calling the {@code CompletableObserver}'s method must happen in a serialized fashion, that is, they must not
  * be invoked concurrently by multiple threads in an overlapping fashion and the invocation pattern must
  * adhere to the following protocol:
- * <pre><code>    onSubscribe (onError | onComplete)?</code></pre>
+ * <pre>{@code    onSubscribe (onError | onComplete)?}</pre>
  * <p>
  * Subscribing a {@code CompletableObserver} to multiple {@code CompletableSource}s is not recommended. If such reuse
  * happens, it is the duty of the {@code CompletableObserver} implementation to be ready to receive multiple calls to

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -52,9 +52,9 @@ import io.reactivex.subscribers.*;
  * <img width="640" height="317" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/legend.png" alt="">
  * <p>
  * The {@code Flowable} follows the protocol
- * <pre><code>
+ * <pre>{@code
  *      onSubscribe onNext* (onError | onComplete)?
- * </code></pre>
+ * }</pre>
  * where the stream can be disposed through the {@link Subscription} instance provided to consumers through
  * {@link Subscriber#onSubscribe(Subscription)}.
  * Unlike the {@code Observable.subscribe()} of version 1.x, {@link #subscribe(Subscriber)} does not allow external cancellation
@@ -63,10 +63,10 @@ import io.reactivex.subscribers.*;
  * Flowables support backpressure and require {@link Subscriber}s to signal demand via {@link Subscription#request(long)}.
  * <p>
  * Example:
- * <pre><code>
+ * <pre>{@code
  * Disposable d = Flowable.just("Hello world!")
  *     .delay(1, TimeUnit.SECONDS)
- *     .subscribeWith(new DisposableSubscriber&lt;String&gt;() {
+ *     .subscribeWith(new DisposableSubscriber<String>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *             request(1);
@@ -86,7 +86,7 @@ import io.reactivex.subscribers.*;
  * Thread.sleep(500);
  * // the sequence can now be cancelled via dispose()
  * d.dispose();
- * </code></pre>
+ * }</pre>
  * <p>
  * The Reactive Streams specification is relatively strict when defining interactions between {@code Publisher}s and {@code Subscriber}s, so much so
  * that there is a significant performance penalty due certain timing requirements and the need to prepare for invalid 
@@ -102,17 +102,17 @@ import io.reactivex.subscribers.*;
  * some guidance if such custom implementations are necessary.
  * <p>
  * The recommended way of creating custom {@code Flowable}s is by using the {@link #create(FlowableOnSubscribe, BackpressureStrategy)} factory method:
- * <pre><code>
- * Flowable&lt;String&gt; source = Flowable.create(new FlowableOnSubscribe&lt;String&gt;() {
+ * <pre>{@code
+ * Flowable<String> source = Flowable.create(new FlowableOnSubscribe<String>() {
  *     &#64;Override
- *     public void subscribe(FlowableEmitter&lt;String&gt; emitter) throws Exception {
+ *     public void subscribe(FlowableEmitter<String> emitter) throws Exception {
  *
  *         // signal an item
  *         emitter.onNext("Hello");
  *
  *         // could be some blocking operation
  *         Thread.sleep(1000);
- *         
+ *
  *         // the consumer might have cancelled the flow
  *         if (emitter.isCancelled() {
  *             return;
@@ -129,11 +129,11 @@ import io.reactivex.subscribers.*;
  * }, BackpressureStrategy.BUFFER);
  *
  * System.out.println("Subscribe!");
- * 
+ *
  * source.subscribe(System.out::println);
- * 
+ *
  * System.out.println("Done!");
- * </code></pre>
+ * }</pre>
  * <p>
  * RxJava reactive sources, such as {@code Flowable}, are generally synchronous and sequential in nature. In the ReactiveX design, the location (thread)
  * where operators run is <i>orthogonal</i> to when the operators can work with data. This means that asynchrony and parallelism
@@ -1853,8 +1853,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * generally non-backpressured world.
      * <p>
      * Example:
-     * <pre><code>
-     * Flowable.&lt;Event&gt;create(emitter -&gt; {
+     * <pre>{@code
+     * Flowable.<Event>create(emitter -> {
      *     Callback listener = new Callback() {
      *         &#64;Override
      *         public void onEvent(Event e) {
@@ -1875,7 +1875,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *     emitter.setCancellable(c::close);
      *
      * }, BackpressureStrategy.BUFFER);
-     * </code></pre>
+     * }</pre>
      * <p>
      * You should call the FlowableEmitter onNext, onError and onComplete methods in a serialized fashion. The
      * rest of its methods are thread-safe.
@@ -4598,7 +4598,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
+     * <pre>{@code zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -> a)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4652,7 +4652,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
+     * <pre>{@code zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -> a)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4710,7 +4710,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4771,7 +4771,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4833,7 +4833,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4897,7 +4897,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4963,7 +4963,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -5034,7 +5034,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -5108,7 +5108,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -5186,7 +5186,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -5269,7 +5269,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -5356,7 +5356,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h, i) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h, i) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -5445,8 +5445,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(new Publisher[]{range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)}, (a) -&gt;
-     * a)</code></pre>
+     * <pre>{@code zip(new Publisher[]{range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)}, (a) ->
+     * a)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -5508,7 +5508,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
+     * <pre>{@code zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -> a)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -7008,27 +7008,27 @@ public abstract class Flowable<T> implements Publisher<T> {
      * of items that will use up memory.
      * A possible workaround is to apply `takeUntil` with a predicate or
      * another source before (and perhaps after) the application of cache().
-     * <pre><code>
+     * <pre>{@code
      * AtomicBoolean shouldStop = new AtomicBoolean();
      *
-     * source.takeUntil(v -&gt; shouldStop.get())
+     * source.takeUntil(v -> shouldStop.get())
      *       .cache()
-     *       .takeUntil(v -&gt; shouldStop.get())
+     *       .takeUntil(v -> shouldStop.get())
      *       .subscribe(...);
-     * </code></pre>
+     * }</pre>
      * Since the operator doesn't allow clearing the cached values either, the possible workaround is
      * to forget all references to it via {@link #onTerminateDetach()} applied along with the previous
      * workaround:
-     * <pre><code>
+     * <pre>{@code
      * AtomicBoolean shouldStop = new AtomicBoolean();
      *
-     * source.takeUntil(v -&gt; shouldStop.get())
+     * source.takeUntil(v -> shouldStop.get())
      *       .onTerminateDetach()
      *       .cache()
-     *       .takeUntil(v -&gt; shouldStop.get())
+     *       .takeUntil(v -> shouldStop.get())
      *       .onTerminateDetach()
      *       .subscribe(...);
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes this Publisher in an unbounded fashion but respects the backpressure
@@ -7066,27 +7066,27 @@ public abstract class Flowable<T> implements Publisher<T> {
      * of items that will use up memory.
      * A possible workaround is to apply `takeUntil` with a predicate or
      * another source before (and perhaps after) the application of cache().
-     * <pre><code>
+     * <pre>{@code
      * AtomicBoolean shouldStop = new AtomicBoolean();
      *
-     * source.takeUntil(v -&gt; shouldStop.get())
+     * source.takeUntil(v -> shouldStop.get())
      *       .cache()
-     *       .takeUntil(v -&gt; shouldStop.get())
+     *       .takeUntil(v -> shouldStop.get())
      *       .subscribe(...);
-     * </code></pre>
+     * }</pre>
      * Since the operator doesn't allow clearing the cached values either, the possible workaround is
      * to forget all references to it via {@link #onTerminateDetach()} applied along with the previous
      * workaround:
-     * <pre><code>
+     * <pre>{@code
      * AtomicBoolean shouldStop = new AtomicBoolean();
      *
-     * source.takeUntil(v -&gt; shouldStop.get())
+     * source.takeUntil(v -> shouldStop.get())
      *       .onTerminateDetach()
      *       .cache()
-     *       .takeUntil(v -&gt; shouldStop.get())
+     *       .takeUntil(v -> shouldStop.get())
      *       .onTerminateDetach()
      *       .subscribe(...);
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes this Publisher in an unbounded fashion but respects the backpressure
@@ -8718,21 +8718,21 @@ public abstract class Flowable<T> implements Publisher<T> {
      * When the upstream signals an {@link Notification#createOnError(Throwable) onError} or
      * {@link Notification#createOnComplete() onComplete} item, the
      * returned Flowable cancels the flow and terminates with that type of terminal event:
-     * <pre><code>
+     * <pre>{@code
      * Flowable.just(createOnNext(1), createOnComplete(), createOnNext(2))
-     * .doOnCancel(() -&gt; System.out.println("Cancelled!"));
+     * .doOnCancel(() -> System.out.println("Cancelled!"));
      * .dematerialize()
      * .test()
      * .assertResult(1);
-     * </code></pre>
+     * }</pre>
      * If the upstream signals {@code onError} or {@code onComplete} directly, the flow is terminated
      * with the same event.
-     * <pre><code>
+     * <pre>{@code
      * Flowable.just(createOnNext(1), createOnNext(2))
      * .dematerialize()
      * .test()
      * .assertResult(1, 2);
-     * </code></pre>
+     * }</pre>
      * If this behavior is not desired, the completion can be suppressed by applying {@link #concatWith(Publisher)}
      * with a {@link #never()} source.
      * <dl>
@@ -8775,21 +8775,21 @@ public abstract class Flowable<T> implements Publisher<T> {
      * When the upstream signals an {@link Notification#createOnError(Throwable) onError} or
      * {@link Notification#createOnComplete() onComplete} item, the
      * returned Flowable cancels of the flow and terminates with that type of terminal event:
-     * <pre><code>
+     * <pre>{@code
      * Flowable.just(createOnNext(1), createOnComplete(), createOnNext(2))
-     * .doOnCancel(() -&gt; System.out.println("Canceled!"));
-     * .dematerialize(notification -&gt; notification)
+     * .doOnCancel(() -> System.out.println("Canceled!"));
+     * .dematerialize(notification -> notification)
      * .test()
      * .assertResult(1);
-     * </code></pre>
+     * }</pre>
      * If the upstream signals {@code onError} or {@code onComplete} directly, the flow is terminated
      * with the same event.
-     * <pre><code>
+     * <pre>{@code
      * Flowable.just(createOnNext(1), createOnNext(2))
-     * .dematerialize(notification -&gt; notification)
+     * .dematerialize(notification -> notification)
      * .test()
      * .assertResult(1, 2);
-     * </code></pre>
+     * }</pre>
      * If this behavior is not desired, the completion can be suppressed by applying {@link #concatWith(Publisher)}
      * with a {@link #never()} source.
      * <dl>
@@ -10874,13 +10874,13 @@ public abstract class Flowable<T> implements Publisher<T> {
      * 
      * <p>An example of an {@code evictingMapFactory} using <a href="https://google.github.io/guava/releases/24.0-jre/api/docs/com/google/common/cache/CacheBuilder.html">CacheBuilder</a> from the Guava library is below:
      * 
-     * <pre><code>
-     * Function&lt;Consumer&lt;Object&gt;, Map&lt;Integer, Object&gt;&gt; evictingMapFactory =
-     *   notify -&gt;
+     * <pre>{@code
+     * Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory =
+     *   notify ->
      *       CacheBuilder
      *         .newBuilder()
      *         .maximumSize(3)
-     *         .removalListener(entry -&gt; {
+     *         .removalListener(entry -> {
      *              try {
      *                  // emit the value not the key!
      *                  notify.accept(entry.getValue());
@@ -10888,7 +10888,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *                  throw new RuntimeException(e);
      *              }
      *            })
-     *         .&lt;Integer, Object&gt; build()
+     *         .<Integer, Object> build()
      *         .asMap();
      *
      * // Emit 1000 items but ensure that the
@@ -10896,10 +10896,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Flowable
      *   .range(1, 1000)
      *   // note that number of keys is 10
-     *   .groupBy(x -&gt; x % 10, x -&gt; x, true, 16, evictingMapFactory)
-     *   .flatMap(g -&gt; g)
+     *   .groupBy(x -> x % 10, x -> x, true, 16, evictingMapFactory)
+     *   .flatMap(g -> g)
      *   .forEach(System.out::println);
-     * </code></pre>
+     * }</pre>
      * 
      * <p>
      * <img width="640" height="360" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/groupBy.png" alt="">
@@ -11231,19 +11231,19 @@ public abstract class Flowable<T> implements Publisher<T> {
      * additional actions depending on the same business logic requirements.
      * <p>
      * Example:
-     * <pre><code>
+     * <pre>{@code
      * // Step 1: Create the consumer type that will be returned by the FlowableOperator.apply():
-     * 
-     * public final class CustomSubscriber&lt;T&gt; implements FlowableSubscriber&lt;T&gt;, Subscription {
+     *
+     * public final class CustomSubscriber<T> implements FlowableSubscriber<T>, Subscription {
      *
      *     // The downstream's Subscriber that will receive the onXXX events
-     *     final Subscriber&lt;? super String&gt; downstream;
+     *     final Subscriber<? super String> downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods
      *     Subscription upstream;
      *
      *     // The constructor takes the downstream subscriber and usually any other parameters
-     *     public CustomSubscriber(Subscriber&lt;? super String&gt; downstream) {
+     *     public CustomSubscriber(Subscriber<? super String> downstream) {
      *         this.downstream = downstream;
      *     }
      *
@@ -11267,7 +11267,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *     &#64;Override
      *     public void onNext(T item) {
      *         String str = item.toString();
-     *         if (str.length() &lt; 2) {
+     *         if (str.length() < 2) {
      *             downstream.onNext(str);
      *         } else {
      *             upstream.request(1);
@@ -11312,10 +11312,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * //         Such class may define additional parameters to be submitted to
      * //         the custom consumer type.
      *
-     * final class CustomOperator&lt;T&gt; implements FlowableOperator&lt;String&gt; {
+     * final class CustomOperator<T> implements FlowableOperator<String> {
      *     &#64;Override
-     *     public Subscriber&lt;? super String&gt; apply(Subscriber&lt;? super T&gt; upstream) {
-     *         return new CustomSubscriber&lt;T&gt;(upstream);
+     *     public Subscriber<? super String> apply(Subscriber<? super T> upstream) {
+     *         return new CustomSubscriber<T>(upstream);
      *     }
      * }
      *
@@ -11323,10 +11323,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * //         or reusing an existing one.
      *
      * Flowable.range(5, 10)
-     * .lift(new CustomOperator&lt;Integer&gt;())
+     * .lift(new CustomOperator<Integer>())
      * .test()
      * .assertResult("5", "6", "7", "8", "9");
-     * </code></pre>
+     * }</pre>
      * <p>
      * Creating custom operators can be complicated and it is recommended one consults the
      * <a href="https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0">RxJava wiki: Writing operators</a> page about
@@ -12595,20 +12595,20 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that the {@code seed} is shared among all subscribers to the resulting Publisher
      * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
      * the application of this operator via {@link #defer(Callable)}:
-     * <pre><code>
-     * Publisher&lt;T&gt; source = ...
-     * Single.defer(() -&gt; source.reduce(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
+     * <pre>{@code
+     * Publisher<T> source = ...
+     * Single.defer(() -> source.reduce(new ArrayList<>(), (list, item) -> list.add(item)));
      *
      * // alternatively, by using compose to stay fluent
      *
-     * source.compose(o -&gt;
-     *     Flowable.defer(() -&gt; o.reduce(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)).toFlowable())
+     * source.compose(o ->
+     *     Flowable.defer(() -> o.reduce(new ArrayList<>(), (list, item) -> list.add(item)).toFlowable())
      * ).firstOrError();
      *
      * // or, by using reduceWith instead of reduce
      *
-     * source.reduceWith(() -&gt; new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
-     * </code></pre>
+     * source.reduceWith(() -> new ArrayList<>(), (list, item) -> list.add(item)));
+     * }</pre>
      * <p>
      * Note that this operator requires the upstream to signal {@code onComplete} for the accumulator object to
      * be emitted. Sources that are infinite and never complete will never emit anything through this
@@ -13583,17 +13583,17 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * This retries 3 times, each time incrementing the number of seconds it waits.
      *
-     * <pre><code>
-     *  Flowable.create((FlowableEmitter&lt;? super String&gt; s) -&gt; {
+     * <pre>{@code
+     *  Flowable.create((FlowableEmitter<? super String> s) -> {
      *      System.out.println("subscribing");
      *      s.onError(new RuntimeException("always fails"));
-     *  }, BackpressureStrategy.BUFFER).retryWhen(attempts -&gt; {
-     *      return attempts.zipWith(Flowable.range(1, 3), (n, i) -&gt; i).flatMap(i -&gt; {
+     *  }, BackpressureStrategy.BUFFER).retryWhen(attempts -> {
+     *      return attempts.zipWith(Flowable.range(1, 3), (n, i) -> i).flatMap(i -> {
      *          System.out.println("delay retry by " + i + " second(s)");
      *          return Flowable.timer(i, TimeUnit.SECONDS);
      *      });
      *  }).blockingForEach(System.out::println);
-     * </code></pre>
+     * }</pre>
      *
      * Output is:
      *
@@ -13616,21 +13616,21 @@ public abstract class Flowable<T> implements Publisher<T> {
      * active, the sequence is terminated with the same signal immediately.
      * <p>
      * The following example demonstrates how to retry an asynchronous source with a delay:
-     * <pre><code>
+     * <pre>{@code
      * Flowable.timer(1, TimeUnit.SECONDS)
-     *     .doOnSubscribe(s -&gt; System.out.println("subscribing"))
-     *     .map(v -&gt; { throw new RuntimeException(); })
-     *     .retryWhen(errors -&gt; {
+     *     .doOnSubscribe(s -> System.out.println("subscribing"))
+     *     .map(v -> { throw new RuntimeException(); })
+     *     .retryWhen(errors -> {
      *         AtomicInteger counter = new AtomicInteger();
      *         return errors
-     *                   .takeWhile(e -&gt; counter.getAndIncrement() != 3)
-     *                   .flatMap(e -&gt; {
+     *                   .takeWhile(e -> counter.getAndIncrement() != 3)
+     *                   .flatMap(e -> {
      *                       System.out.println("delay retry by " + counter.get() + " second(s)");
      *                       return Flowable.timer(counter.get(), TimeUnit.SECONDS);
      *                   });
      *     })
      *     .blockingSubscribe(System.out::println, System.out::println);
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors downstream backpressure and expects both the source
@@ -13939,16 +13939,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that the {@code initialValue} is shared among all subscribers to the resulting Publisher
      * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
      * the application of this operator via {@link #defer(Callable)}:
-     * <pre><code>
-     * Publisher&lt;T&gt; source = ...
-     * Flowable.defer(() -&gt; source.scan(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
+     * <pre>{@code
+     * Publisher<T> source = ...
+     * Flowable.defer(() -> source.scan(new ArrayList<>(), (list, item) -> list.add(item)));
      *
      * // alternatively, by using compose to stay fluent
      *
-     * source.compose(o -&gt;
-     *     Flowable.defer(() -&gt; o.scan(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)))
+     * source.compose(o ->
+     *     Flowable.defer(() -> o.scan(new ArrayList<>(), (list, item) -> list.add(item)))
      * );
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
@@ -14944,16 +14944,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Subscribes a given Subscriber (subclass) to this Flowable and returns the given
      * Subscriber as is.
      * <p>Usage example:
-     * <pre><code>
-     * Flowable&lt;Integer&gt; source = Flowable.range(1, 10);
+     * <pre>{@code
+     * Flowable<Integer> source = Flowable.range(1, 10);
      * CompositeDisposable composite = new CompositeDisposable();
      *
-     * ResourceSubscriber&lt;Integer&gt; rs = new ResourceSubscriber&lt;&gt;() {
+     * ResourceSubscriber<Integer> rs = new ResourceSubscriber<>() {
      *     // ...
      * };
      *
      * composite.add(source.subscribeWith(rs));
-     * </code></pre>
+     * }</pre>
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -18454,7 +18454,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -18502,7 +18502,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -18552,7 +18552,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will cancel B immediately. For example:
-     * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnCancel(Action)} as well or use {@code using()} to do cleanup in case of completion

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -40,9 +40,9 @@ import io.reactivex.schedulers.Schedulers;
  * type it interacts with is the {@link MaybeObserver} via the {@link #subscribe(MaybeObserver)} method.
  * <p>
  * The {@code Maybe} operates with the following sequential protocol:
- * <pre><code>
+ * <pre>{@code
  *     onSubscribe (onSuccess | onError | onComplete)?
- * </code></pre>
+ * }</pre>
  * <p>
  * Note that {@code onSuccess}, {@code onError} and {@code onComplete} are mutually exclusive events; unlike {@code Observable},
  * {@code onSuccess} is never followed by {@code onError} or {@code onComplete}.
@@ -63,10 +63,10 @@ import io.reactivex.schedulers.Schedulers;
  * implementation of the Reactive Pattern for a stream or vector of values.
  * <p>
  * Example:
- * <pre><code>
+ * <pre>{@code
  * Disposable d = Maybe.just("Hello World")
  *    .delay(10, TimeUnit.SECONDS, Schedulers.io())
- *    .subscribeWith(new DisposableMaybeObserver&lt;String&gt;() {
+ *    .subscribeWith(new DisposableMaybeObserver<String>() {
  *        &#64;Override
  *        public void onStart() {
  *            System.out.println("Started");
@@ -87,11 +87,11 @@ import io.reactivex.schedulers.Schedulers;
  *            System.out.println("Done!");
  *        }
  *    });
- * 
+ *
  * Thread.sleep(5000);
- * 
+ *
  * d.dispose();
- * </code></pre>
+ * }</pre>
  * <p>
  * Note that by design, subscriptions via {@link #subscribe(MaybeObserver)} can't be disposed
  * from the outside (hence the
@@ -530,8 +530,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Provides an API (via a cold Maybe) that bridges the reactive world with the callback-style world.
      * <p>
      * Example:
-     * <pre><code>
-     * Maybe.&lt;Event&gt;create(emitter -&gt; {
+     * <pre>{@code
+     * Maybe.<Event>create(emitter -> {
      *     Callback listener = new Callback() {
      *         &#64;Override
      *         public void onEvent(Event e) {
@@ -553,7 +553,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *     emitter.setCancellable(c::close);
      *
      * });
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3317,19 +3317,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * additional actions depending on the same business logic requirements.
      * <p>
      * Example:
-     * <pre><code>
+     * <pre>{@code
      * // Step 1: Create the consumer type that will be returned by the MaybeOperator.apply():
-     * 
-     * public final class CustomMaybeObserver&lt;T&gt; implements MaybeObserver&lt;T&gt;, Disposable {
+     *
+     * public final class CustomMaybeObserver<T> implements MaybeObserver<T>, Disposable {
      *
      *     // The downstream's MaybeObserver that will receive the onXXX events
-     *     final MaybeObserver&lt;? super String&gt; downstream;
+     *     final MaybeObserver<? super String> downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods
      *     Disposable upstream;
      *
      *     // The constructor takes the downstream subscriber and usually any other parameters
-     *     public CustomMaybeObserver(MaybeObserver&lt;? super String&gt; downstream) {
+     *     public CustomMaybeObserver(MaybeObserver<? super String> downstream) {
      *         this.downstream = downstream;
      *     }
      *
@@ -3353,7 +3353,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *     &#64;Override
      *     public void onSuccess(T item) {
      *         String str = item.toString();
-     *         if (str.length() &lt; 2) {
+     *         if (str.length() < 2) {
      *             downstream.onSuccess(str);
      *         } else {
      *             // Maybe is usually expected to produce one of the onXXX events
@@ -3398,10 +3398,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * //         Such class may define additional parameters to be submitted to
      * //         the custom consumer type.
      *
-     * final class CustomMaybeOperator&lt;T&gt; implements MaybeOperator&lt;String&gt; {
+     * final class CustomMaybeOperator<T> implements MaybeOperator<String> {
      *     &#64;Override
-     *     public MaybeObserver&lt;? super String&gt; apply(MaybeObserver&lt;? super T&gt; upstream) {
-     *         return new CustomMaybeObserver&lt;T&gt;(upstream);
+     *     public MaybeObserver<? super String> apply(MaybeObserver<? super T> upstream) {
+     *         return new CustomMaybeObserver<T>(upstream);
      *     }
      * }
      *
@@ -3409,15 +3409,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * //         or reusing an existing one.
      *
      * Maybe.just(5)
-     * .lift(new CustomMaybeOperator&lt;Integer&gt;())
+     * .lift(new CustomMaybeOperator<Integer>())
      * .test()
      * .assertResult("5");
      *
      * Maybe.just(15)
-     * .lift(new CustomMaybeOperator&lt;Integer&gt;())
+     * .lift(new CustomMaybeOperator<Integer>())
      * .test()
      * .assertResult();
-     * </code></pre>
+     * }</pre>
      * <p>
      * Creating custom operators can be complicated and it is recommended one consults the
      * <a href="https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0">RxJava wiki: Writing operators</a> page about
@@ -4105,17 +4105,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * This retries 3 times, each time incrementing the number of seconds it waits.
      *
-     * <pre><code>
-     *  Maybe.create((MaybeEmitter&lt;? super String&gt; s) -&gt; {
+     * <pre>{@code
+     *  Maybe.create((MaybeEmitter<? super String> s) -> {
      *      System.out.println("subscribing");
      *      s.onError(new RuntimeException("always fails"));
-     *  }, BackpressureStrategy.BUFFER).retryWhen(attempts -&gt; {
-     *      return attempts.zipWith(Publisher.range(1, 3), (n, i) -&gt; i).flatMap(i -&gt; {
+     *  }, BackpressureStrategy.BUFFER).retryWhen(attempts -> {
+     *      return attempts.zipWith(Publisher.range(1, 3), (n, i) -> i).flatMap(i -> {
      *          System.out.println("delay retry by " + i + " second(s)");
      *          return Flowable.timer(i, TimeUnit.SECONDS);
      *      });
      *  }).blockingForEach(System.out::println);
-     * </code></pre>
+     * }</pre>
      *
      * Output is:
      *
@@ -4138,21 +4138,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * active, the sequence is terminated with the same signal immediately.
      * <p>
      * The following example demonstrates how to retry an asynchronous source with a delay:
-     * <pre><code>
+     * <pre>{@code
      * Maybe.timer(1, TimeUnit.SECONDS)
-     *     .doOnSubscribe(s -&gt; System.out.println("subscribing"))
-     *     .map(v -&gt; { throw new RuntimeException(); })
-     *     .retryWhen(errors -&gt; {
+     *     .doOnSubscribe(s -> System.out.println("subscribing"))
+     *     .map(v -> { throw new RuntimeException(); })
+     *     .retryWhen(errors -> {
      *         AtomicInteger counter = new AtomicInteger();
      *         return errors
-     *                   .takeWhile(e -&gt; counter.getAndIncrement() != 3)
-     *                   .flatMap(e -&gt; {
+     *                   .takeWhile(e -> counter.getAndIncrement() != 3)
+     *                   .flatMap(e -> {
      *                       System.out.println("delay retry by " + counter.get() + " second(s)");
      *                       return Flowable.timer(counter.get(), TimeUnit.SECONDS);
      *                   });
      *     })
      *     .blockingGet();
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -4335,16 +4335,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Subscribes a given MaybeObserver (subclass) to this Maybe and returns the given
      * MaybeObserver as is.
      * <p>Usage example:
-     * <pre><code>
-     * Maybe&lt;Integer&gt; source = Maybe.just(1);
+     * <pre>{@code
+     * Maybe<Integer> source = Maybe.just(1);
      * CompositeDisposable composite = new CompositeDisposable();
      *
-     * DisposableMaybeObserver&lt;Integer&gt; ds = new DisposableMaybeObserver&lt;&gt;() {
+     * DisposableMaybeObserver<Integer> ds = new DisposableMaybeObserver<>() {
      *     // ...
      * };
      *
      * composite.add(source.subscribeWith(ds));
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/MaybeObserver.java
+++ b/src/main/java/io/reactivex/MaybeObserver.java
@@ -28,7 +28,7 @@ import io.reactivex.disposables.Disposable;
  * Calling the {@code MaybeObserver}'s method must happen in a serialized fashion, that is, they must not
  * be invoked concurrently by multiple threads in an overlapping fashion and the invocation pattern must
  * adhere to the following protocol:
- * <pre><code>    onSubscribe (onSuccess | onError | onComplete)?</code></pre>
+ * <pre>{@code    onSubscribe (onSuccess | onError | onComplete)?}</pre>
  * <p>
  * Note that unlike with the {@code Observable} protocol, {@link #onComplete()} is not called after the success item has been
  * signalled via {@link #onSuccess(Object)}.

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -57,9 +57,9 @@ import io.reactivex.schedulers.*;
  * a flow.
  * <p>
  * The {@code Observable} follows the protocol
- * <pre><code>
+ * <pre>{@code
  *      onSubscribe onNext* (onError | onComplete)?
- * </code></pre>
+ * }</pre>
  * where
  * the stream can be disposed through the {@code Disposable} instance provided to consumers through
  * {@code Observer.onSubscribe}.
@@ -67,10 +67,10 @@ import io.reactivex.schedulers.*;
  * Unlike the {@code Observable} of version 1.x, {@link #subscribe(Observer)} does not allow external disposal
  * of a subscription and the {@code Observer} instance is expected to expose such capability.
  * <p>Example:
- * <pre><code>
+ * <pre>{@code
  * Disposable d = Observable.just("Hello world!")
  *     .delay(1, TimeUnit.SECONDS)
- *     .subscribeWith(new DisposableObserver&lt;String&gt;() {
+ *     .subscribeWith(new DisposableObserver<String>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *         }
@@ -88,7 +88,7 @@ import io.reactivex.schedulers.*;
  * Thread.sleep(500);
  * // the sequence can now be disposed via dispose()
  * d.dispose();
- * </code></pre>
+ * }</pre>
  *
  * @param <T>
  *            the type of the items emitted by the Observable
@@ -1587,8 +1587,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Provides an API (via a cold Observable) that bridges the reactive world with the callback-style world.
      * <p>
      * Example:
-     * <pre><code>
-     * Observable.&lt;Event&gt;create(emitter -&gt; {
+     * <pre>{@code
+     * Observable.<Event>create(emitter -> {
      *     Callback listener = new Callback() {
      *         &#64;Override
      *         public void onEvent(Event e) {
@@ -1609,7 +1609,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *     emitter.setCancellable(c::close);
      *
      * });
-     * </code></pre>
+     * }</pre>
      * <p>
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/create.png" alt="">
      * <p>
@@ -4107,7 +4107,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
+     * <pre>{@code zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -> a)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4160,7 +4160,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
+     * <pre>{@code zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -> a)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4218,7 +4218,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4273,7 +4273,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4329,7 +4329,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4387,7 +4387,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4447,7 +4447,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4512,7 +4512,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4580,7 +4580,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4652,7 +4652,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4729,7 +4729,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4810,7 +4810,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h, i) -&gt; a + b)</code></pre>
+     * <pre>{@code zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), ..., (a, b, c, d, e, f, g, h, i) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4892,8 +4892,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(new ObservableSource[]{range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)}, (a) -&gt;
-     * a)</code></pre>
+     * <pre>{@code zip(new ObservableSource[]{range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)}, (a) ->
+     * a)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4954,7 +4954,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
+     * <pre>{@code zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -> a)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -6204,27 +6204,27 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * of items that will use up memory.
      * A possible workaround is to apply `takeUntil` with a predicate or
      * another source before (and perhaps after) the application of cache().
-     * <pre><code>
+     * <pre>{@code
      * AtomicBoolean shouldStop = new AtomicBoolean();
      *
-     * source.takeUntil(v -&gt; shouldStop.get())
+     * source.takeUntil(v -> shouldStop.get())
      *       .cache()
-     *       .takeUntil(v -&gt; shouldStop.get())
+     *       .takeUntil(v -> shouldStop.get())
      *       .subscribe(...);
-     * </code></pre>
+     * }</pre>
      * Since the operator doesn't allow clearing the cached values either, the possible workaround is
      * to forget all references to it via {@link #onTerminateDetach()} applied along with the previous
      * workaround:
-     * <pre><code>
+     * <pre>{@code
      * AtomicBoolean shouldStop = new AtomicBoolean();
      *
-     * source.takeUntil(v -&gt; shouldStop.get())
+     * source.takeUntil(v -> shouldStop.get())
      *       .onTerminateDetach()
      *       .cache()
-     *       .takeUntil(v -&gt; shouldStop.get())
+     *       .takeUntil(v -> shouldStop.get())
      *       .onTerminateDetach()
      *       .subscribe(...);
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -6258,27 +6258,27 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * of items that will use up memory.
      * A possible workaround is to apply `takeUntil` with a predicate or
      * another source before (and perhaps after) the application of cache().
-     * <pre><code>
+     * <pre>{@code
      * AtomicBoolean shouldStop = new AtomicBoolean();
      *
-     * source.takeUntil(v -&gt; shouldStop.get())
+     * source.takeUntil(v -> shouldStop.get())
      *       .cache()
-     *       .takeUntil(v -&gt; shouldStop.get())
+     *       .takeUntil(v -> shouldStop.get())
      *       .subscribe(...);
-     * </code></pre>
+     * }</pre>
      * Since the operator doesn't allow clearing the cached values either, the possible workaround is
      * to forget all references to it via {@link #onTerminateDetach()} applied along with the previous
      * workaround:
-     * <pre><code>
+     * <pre>{@code
      * AtomicBoolean shouldStop = new AtomicBoolean();
      *
-     * source.takeUntil(v -&gt; shouldStop.get())
+     * source.takeUntil(v -> shouldStop.get())
      *       .onTerminateDetach()
      *       .cache()
-     *       .takeUntil(v -&gt; shouldStop.get())
+     *       .takeUntil(v -> shouldStop.get())
      *       .onTerminateDetach()
      *       .subscribe(...);
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code cacheWithInitialCapacity} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -7679,21 +7679,21 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * When the upstream signals an {@link Notification#createOnError(Throwable) onError} or
      * {@link Notification#createOnComplete() onComplete} item, the
      * returned Observable disposes of the flow and terminates with that type of terminal event:
-     * <pre><code>
+     * <pre>{@code
      * Observable.just(createOnNext(1), createOnComplete(), createOnNext(2))
-     * .doOnDispose(() -&gt; System.out.println("Disposed!"));
+     * .doOnDispose(() -> System.out.println("Disposed!"));
      * .dematerialize()
      * .test()
      * .assertResult(1);
-     * </code></pre>
+     * }</pre>
      * If the upstream signals {@code onError} or {@code onComplete} directly, the flow is terminated
      * with the same event.
-     * <pre><code>
+     * <pre>{@code
      * Observable.just(createOnNext(1), createOnNext(2))
      * .dematerialize()
      * .test()
      * .assertResult(1, 2);
-     * </code></pre>
+     * }</pre>
      * If this behavior is not desired, the completion can be suppressed by applying {@link #concatWith(ObservableSource)}
      * with a {@link #never()} source.
      * <dl>
@@ -7732,21 +7732,21 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * When the upstream signals an {@link Notification#createOnError(Throwable) onError} or
      * {@link Notification#createOnComplete() onComplete} item, the
      * returned Observable disposes of the flow and terminates with that type of terminal event:
-     * <pre><code>
+     * <pre>{@code
      * Observable.just(createOnNext(1), createOnComplete(), createOnNext(2))
-     * .doOnDispose(() -&gt; System.out.println("Disposed!"));
-     * .dematerialize(notification -&gt; notification)
+     * .doOnDispose(() -> System.out.println("Disposed!"));
+     * .dematerialize(notification -> notification)
      * .test()
      * .assertResult(1);
-     * </code></pre>
+     * }</pre>
      * If the upstream signals {@code onError} or {@code onComplete} directly, the flow is terminated
      * with the same event.
-     * <pre><code>
+     * <pre>{@code
      * Observable.just(createOnNext(1), createOnNext(2))
-     * .dematerialize(notification -&gt; notification)
+     * .dematerialize(notification -> notification)
      * .test()
      * .assertResult(1, 2);
-     * </code></pre>
+     * }</pre>
      * If this behavior is not desired, the completion can be suppressed by applying {@link #concatWith(ObservableSource)}
      * with a {@link #never()} source.
      * <dl>
@@ -9624,19 +9624,19 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * additional actions depending on the same business logic requirements.
      * <p>
      * Example:
-     * <pre><code>
+     * <pre>{@code
      * // Step 1: Create the consumer type that will be returned by the ObservableOperator.apply():
      *
-     * public final class CustomObserver&lt;T&gt; implements Observer&lt;T&gt;, Disposable {
+     * public final class CustomObserver<T> implements Observer<T>, Disposable {
      *
      *     // The downstream's Observer that will receive the onXXX events
-     *     final Observer&lt;? super String&gt; downstream;
+     *     final Observer<? super String> downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods
      *     Disposable upstream;
      *
      *     // The constructor takes the downstream subscriber and usually any other parameters
-     *     public CustomObserver(Observer&lt;? super String&gt; downstream) {
+     *     public CustomObserver(Observer<? super String> downstream) {
      *         this.downstream = downstream;
      *     }
      *
@@ -9660,7 +9660,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *     &#64;Override
      *     public void onNext(T item) {
      *         String str = item.toString();
-     *         if (str.length() &lt; 2) {
+     *         if (str.length() < 2) {
      *             downstream.onNext(str);
      *         }
      *         // Observable doesn't support backpressure, therefore, there is no
@@ -9705,10 +9705,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * //         Such class may define additional parameters to be submitted to
      * //         the custom consumer type.
      *
-     * final class CustomOperator&lt;T&gt; implements ObservableOperator&lt;String, T&gt; {
+     * final class CustomOperator<T> implements ObservableOperator<String, T> {
      *     &#64;Override
-     *     public Observer&lt;T&gt; apply(Observer&lt;? super String&gt; downstream) {
-     *         return new CustomObserver&lt;T&gt;(downstream);
+     *     public Observer<T> apply(Observer<? super String> downstream) {
+     *         return new CustomObserver<T>(downstream);
      *     }
      * }
      *
@@ -9716,10 +9716,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * //         or reusing an existing one.
      *
      * Observable.range(5, 10)
-     * .lift(new CustomOperator&lt;Integer&gt;())
+     * .lift(new CustomOperator<Integer>())
      * .test()
      * .assertResult("5", "6", "7", "8", "9");
-     * </code></pre>
+     * }</pre>
      * <p>
      * Creating custom operators can be complicated and it is recommended one consults the
      * <a href="https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0">RxJava wiki: Writing operators</a> page about
@@ -10307,20 +10307,20 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that the {@code seed} is shared among all subscribers to the resulting ObservableSource
      * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
      * the application of this operator via {@link #defer(Callable)}:
-     * <pre><code>
-     * ObservableSource&lt;T&gt; source = ...
-     * Single.defer(() -&gt; source.reduce(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
+     * <pre>{@code
+     * ObservableSource<T> source = ...
+     * Single.defer(() -> source.reduce(new ArrayList<>(), (list, item) -> list.add(item)));
      *
      * // alternatively, by using compose to stay fluent
      *
-     * source.compose(o -&gt;
-     *     Observable.defer(() -&gt; o.reduce(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)).toObservable())
+     * source.compose(o ->
+     *     Observable.defer(() -> o.reduce(new ArrayList<>(), (list, item) -> list.add(item)).toObservable())
      * ).firstOrError();
      *
      * // or, by using reduceWith instead of reduce
      *
-     * source.reduceWith(() -&gt; new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
-     * </code></pre>
+     * source.reduceWith(() -> new ArrayList<>(), (list, item) -> list.add(item)));
+     * }</pre>
      * <p>
      * Note that this operator requires the upstream to signal {@code onComplete} for the accumulator object to
      * be emitted. Sources that are infinite and never complete will never emit anything through this
@@ -11158,17 +11158,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * This retries 3 times, each time incrementing the number of seconds it waits.
      *
-     * <pre><code>
-     *  Observable.create((ObservableEmitter&lt;? super String&gt; s) -&gt; {
+     * <pre>{@code
+     *  Observable.create((ObservableEmitter<? super String> s) -> {
      *      System.out.println("subscribing");
      *      s.onError(new RuntimeException("always fails"));
-     *  }).retryWhen(attempts -&gt; {
-     *      return attempts.zipWith(Observable.range(1, 3), (n, i) -&gt; i).flatMap(i -&gt; {
+     *  }).retryWhen(attempts -> {
+     *      return attempts.zipWith(Observable.range(1, 3), (n, i) -> i).flatMap(i -> {
      *          System.out.println("delay retry by " + i + " second(s)");
      *          return Observable.timer(i, TimeUnit.SECONDS);
      *      });
      *  }).blockingForEach(System.out::println);
-     * </code></pre>
+     * }</pre>
      *
      * Output is:
      *
@@ -11191,21 +11191,21 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * active, the sequence is terminated with the same signal immediately.
      * <p>
      * The following example demonstrates how to retry an asynchronous source with a delay:
-     * <pre><code>
+     * <pre>{@code
      * Observable.timer(1, TimeUnit.SECONDS)
-     *     .doOnSubscribe(s -&gt; System.out.println("subscribing"))
-     *     .map(v -&gt; { throw new RuntimeException(); })
-     *     .retryWhen(errors -&gt; {
+     *     .doOnSubscribe(s -> System.out.println("subscribing"))
+     *     .map(v -> { throw new RuntimeException(); })
+     *     .retryWhen(errors -> {
      *         AtomicInteger counter = new AtomicInteger();
      *         return errors
-     *                   .takeWhile(e -&gt; counter.getAndIncrement() != 3)
-     *                   .flatMap(e -&gt; {
+     *                   .takeWhile(e -> counter.getAndIncrement() != 3)
+     *                   .flatMap(e -> {
      *                       System.out.println("delay retry by " + counter.get() + " second(s)");
      *                       return Observable.timer(counter.get(), TimeUnit.SECONDS);
      *                   });
      *     })
      *     .blockingSubscribe(System.out::println, System.out::println);
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -11469,16 +11469,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that the {@code initialValue} is shared among all subscribers to the resulting ObservableSource
      * and may cause problems if it is mutable. To make sure each subscriber gets its own value, defer
      * the application of this operator via {@link #defer(Callable)}:
-     * <pre><code>
-     * ObservableSource&lt;T&gt; source = ...
-     * Observable.defer(() -&gt; source.scan(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)));
+     * <pre>{@code
+     * ObservableSource<T> source = ...
+     * Observable.defer(() -> source.scan(new ArrayList<>(), (list, item) -> list.add(item)));
      *
      * // alternatively, by using compose to stay fluent
      *
-     * source.compose(o -&gt;
-     *     Observable.defer(() -&gt; o.scan(new ArrayList&lt;&gt;(), (list, item) -&gt; list.add(item)))
+     * source.compose(o ->
+     *     Observable.defer(() -> o.scan(new ArrayList<>(), (list, item) -> list.add(item)))
      * );
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code scan} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -12293,16 +12293,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Subscribes a given Observer (subclass) to this Observable and returns the given
      * Observer as is.
      * <p>Usage example:
-     * <pre><code>
-     * Observable&lt;Integer&gt; source = Observable.range(1, 10);
+     * <pre>{@code
+     * Observable<Integer> source = Observable.range(1, 10);
      * CompositeDisposable composite = new CompositeDisposable();
      *
-     * DisposableObserver&lt;Integer&gt; ds = new DisposableObserver&lt;&gt;() {
+     * DisposableObserver<Integer> ds = new DisposableObserver<>() {
      *     // ...
      * };
      *
      * composite.add(source.subscribeWith(ds));
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -15321,7 +15321,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -15364,7 +15364,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -15409,7 +15409,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
+     * <pre>{@code range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -> a + b)}</pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion

--- a/src/main/java/io/reactivex/Observer.java
+++ b/src/main/java/io/reactivex/Observer.java
@@ -30,7 +30,7 @@ import io.reactivex.disposables.Disposable;
  * Calling the {@code Observer}'s method must happen in a serialized fashion, that is, they must not
  * be invoked concurrently by multiple threads in an overlapping fashion and the invocation pattern must
  * adhere to the following protocol:
- * <pre><code>    onSubscribe onNext* (onError | onComplete)?</code></pre>
+ * <pre>{@code    onSubscribe onNext* (onError | onComplete)?}</pre>
  * <p>
  * Subscribing an {@code Observer} to multiple {@code ObservableSource}s is not recommended. If such reuse
  * happens, it is the duty of the {@code Observer} implementation to be ready to receive multiple calls to

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -47,7 +47,7 @@ import io.reactivex.schedulers.Schedulers;
  * <p>
  * The {@code Single} operates with the following sequential protocol:
  * <pre>
- *     <code>onSubscribe (onSuccess | onError)?</code>
+ *     {@code onSubscribe (onSuccess | onError)?}
  * </pre>
  * <p>
  * Note that {@code onSuccess} and {@code onError} are mutually exclusive events; unlike {@code Observable},
@@ -72,10 +72,10 @@ import io.reactivex.schedulers.Schedulers;
  * documentation</a>.
  * <p>
  * Example:
- * <pre><code>
+ * <pre>{@code
  * Disposable d = Single.just("Hello World")
  *    .delay(10, TimeUnit.SECONDS, Schedulers.io())
- *    .subscribeWith(new DisposableSingleObserver&lt;String&gt;() {
+ *    .subscribeWith(new DisposableSingleObserver<String>() {
  *        &#64;Override
  *        public void onStart() {
  *            System.out.println("Started");
@@ -91,11 +91,11 @@ import io.reactivex.schedulers.Schedulers;
  *            error.printStackTrace();
  *        }
  *    });
- * 
+ *
  * Thread.sleep(5000);
- * 
+ *
  * d.dispose();
- * </code></pre>
+ * }</pre>
  * <p>
  * Note that by design, subscriptions via {@link #subscribe(SingleObserver)} can't be disposed
  * from the outside (hence the
@@ -258,7 +258,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({ "unchecked" })
     public static <T> Flowable<T> concat(Publisher<? extends SingleSource<? extends T>> sources, int prefetch) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -481,8 +481,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="454" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.create.png" alt="">
      * <p>
      * Example:
-     * <pre><code>
-     * Single.&lt;Event&gt;create(emitter -&gt; {
+     * <pre>{@code
+     * Single.<Event>create(emitter -> {
      *     Callback listener = new Callback() {
      *         &#64;Override
      *         public void onEvent(Event e) {
@@ -500,7 +500,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *     emitter.setCancellable(c::close);
      *
      * });
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2371,12 +2371,12 @@ public abstract class Single<T> implements SingleSource<T> {
      * </dl>
      * <p>
      * Example:
-     * <pre><code>
+     * <pre>{@code
      * Single.just(Notification.createOnNext(1))
-     * .dematerialize(notification -&gt; notification)
+     * .dematerialize(notification -> notification)
      * .test()
      * .assertResult(1);
-     * </code></pre>
+     * }</pre>
      * @param <R> the result type
      * @param selector the function called with the success item and should
      * return a {@link Notification} instance.
@@ -2851,19 +2851,19 @@ public abstract class Single<T> implements SingleSource<T> {
      * additional actions depending on the same business logic requirements.
      * <p>
      * Example:
-     * <pre><code>
+     * <pre>{@code
      * // Step 1: Create the consumer type that will be returned by the SingleOperator.apply():
      *
-     * public final class CustomSingleObserver&lt;T&gt; implements SingleObserver&lt;T&gt;, Disposable {
+     * public final class CustomSingleObserver<T> implements SingleObserver<T>, Disposable {
      *
      *     // The downstream's SingleObserver that will receive the onXXX events
-     *     final SingleObserver&lt;? super String&gt; downstream;
+     *     final SingleObserver<? super String> downstream;
      *
      *     // The connection to the upstream source that will call this class' onXXX methods
      *     Disposable upstream;
      *
      *     // The constructor takes the downstream subscriber and usually any other parameters
-     *     public CustomSingleObserver(SingleObserver&lt;? super String&gt; downstream) {
+     *     public CustomSingleObserver(SingleObserver<? super String> downstream) {
      *         this.downstream = downstream;
      *     }
      *
@@ -2887,7 +2887,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *     &#64;Override
      *     public void onSuccess(T item) {
      *         String str = item.toString();
-     *         if (str.length() &lt; 2) {
+     *         if (str.length() < 2) {
      *             downstream.onSuccess(str);
      *         } else {
      *             // Single is usually expected to produce one of the onXXX events
@@ -2926,10 +2926,10 @@ public abstract class Single<T> implements SingleSource<T> {
      * //         Such class may define additional parameters to be submitted to
      * //         the custom consumer type.
      *
-     * final class CustomSingleOperator&lt;T&gt; implements SingleOperator&lt;String&gt; {
+     * final class CustomSingleOperator<T> implements SingleOperator<String> {
      *     &#64;Override
-     *     public SingleObserver&lt;? super String&gt; apply(SingleObserver&lt;? super T&gt; upstream) {
-     *         return new CustomSingleObserver&lt;T&gt;(upstream);
+     *     public SingleObserver<? super String> apply(SingleObserver<? super T> upstream) {
+     *         return new CustomSingleObserver<T>(upstream);
      *     }
      * }
      *
@@ -2937,15 +2937,15 @@ public abstract class Single<T> implements SingleSource<T> {
      * //         or reusing an existing one.
      *
      * Single.just(5)
-     * .lift(new CustomSingleOperator&lt;Integer&gt;())
+     * .lift(new CustomSingleOperator<Integer>())
      * .test()
      * .assertResult("5");
      *
      * Single.just(15)
-     * .lift(new CustomSingleOperator&lt;Integer&gt;())
+     * .lift(new CustomSingleOperator<Integer>())
      * .test()
      * .assertFailure(NoSuchElementException.class);
-     * </code></pre>
+     * }</pre>
      * <p>
      * Creating custom operators can be complicated and it is recommended one consults the
      * <a href="https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0">RxJava wiki: Writing operators</a> page about
@@ -3457,21 +3457,21 @@ public abstract class Single<T> implements SingleSource<T> {
      * active, the sequence is terminated with the same signal immediately.
      * <p>
      * The following example demonstrates how to retry an asynchronous source with a delay:
-     * <pre><code>
+     * <pre>{@code
      * Single.timer(1, TimeUnit.SECONDS)
-     *     .doOnSubscribe(s -&gt; System.out.println("subscribing"))
-     *     .map(v -&gt; { throw new RuntimeException(); })
-     *     .retryWhen(errors -&gt; {
+     *     .doOnSubscribe(s -> System.out.println("subscribing"))
+     *     .map(v -> { throw new RuntimeException(); })
+     *     .retryWhen(errors -> {
      *         AtomicInteger counter = new AtomicInteger();
      *         return errors
-     *                   .takeWhile(e -&gt; counter.getAndIncrement() != 3)
-     *                   .flatMap(e -&gt; {
+     *                   .takeWhile(e -> counter.getAndIncrement() != 3)
+     *                   .flatMap(e -> {
      *                       System.out.println("delay retry by " + counter.get() + " second(s)");
      *                       return Flowable.timer(counter.get(), TimeUnit.SECONDS);
      *                   });
      *     })
      *     .blockingGet();
-     * </code></pre>
+     * }</pre>
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code retryWhen} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3624,16 +3624,16 @@ public abstract class Single<T> implements SingleSource<T> {
      * Subscribes a given SingleObserver (subclass) to this Single and returns the given
      * SingleObserver as is.
      * <p>Usage example:
-     * <pre><code>
-     * Single&lt;Integer&gt; source = Single.just(1);
+     * <pre>{@code
+     * Single<Integer> source = Single.just(1);
      * CompositeDisposable composite = new CompositeDisposable();
      *
-     * DisposableSingleObserver&lt;Integer&gt; ds = new DisposableSingleObserver&lt;&gt;() {
+     * DisposableSingleObserver<Integer> ds = new DisposableSingleObserver<>() {
      *     // ...
      * };
      *
      * composite.add(source.subscribeWith(ds));
-     * </code></pre>
+     * }</pre>
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/SingleObserver.java
+++ b/src/main/java/io/reactivex/SingleObserver.java
@@ -28,7 +28,7 @@ import io.reactivex.disposables.Disposable;
  * Calling the {@code SingleObserver}'s method must happen in a serialized fashion, that is, they must not
  * be invoked concurrently by multiple threads in an overlapping fashion and the invocation pattern must
  * adhere to the following protocol:
- * <pre><code>    onSubscribe (onSuccess | onError)?</code></pre>
+ * <pre>{@code    onSubscribe (onSuccess | onError)?}</pre>
  * <p>
  * Subscribing a {@code SingleObserver} to multiple {@code SingleSource}s is not recommended. If such reuse
  * happens, it is the duty of the {@code SingleObserver} implementation to be ready to receive multiple calls to

--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -47,7 +47,7 @@ public final class CompositeException extends RuntimeException {
      * list of suppressed exceptions.
      * @param exceptions the Throwables to have as initially suppressed exceptions
      *
-     * @throws IllegalArgumentException if <code>exceptions</code> is empty.
+     * @throws IllegalArgumentException if {@code exceptions} is empty.
      */
     public CompositeException(@NonNull Throwable... exceptions) {
         this(exceptions == null ?
@@ -59,7 +59,7 @@ public final class CompositeException extends RuntimeException {
      * list of suppressed exceptions.
      * @param errors the Throwables to have as initially suppressed exceptions
      *
-     * @throws IllegalArgumentException if <code>errors</code> is empty.
+     * @throws IllegalArgumentException if {@code errors} is empty.
      */
     public CompositeException(@NonNull Iterable<? extends Throwable> errors) {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<Throwable>();

--- a/src/main/java/io/reactivex/internal/disposables/ResettableConnectable.java
+++ b/src/main/java/io/reactivex/internal/disposables/ResettableConnectable.java
@@ -31,23 +31,23 @@ public interface ResettableConnectable {
      * is still representing a connection established by a previous {@code connect()} connection.
      * <p>
      * For example, an immediately previous connection should reset the connectable source:
-     * <pre><code>
+     * <pre>{@code
      * Disposable d = connectable.connect();
-     * 
+     *
      * ((ResettableConnectable)connectable).resetIf(d);
-     * </code></pre>
+     * }</pre>
      * However, if the connection indicator {@code Disposable} is from a much earlier connection,
      * it should not affect the current connection:
-     * <pre><code>
+     * <pre>{@code
      * Disposable d1 = connectable.connect();
      * d.dispose();
      *
      * Disposable d2 = connectable.connect();
      *
      * ((ResettableConnectable)connectable).resetIf(d);
-     * 
+     *
      * assertFalse(d2.isDisposed());
-     * </code></pre>
+     * }</pre>
      * @param connection the disposable received from a previous {@code connect()} call.
      */
     void resetIf(Disposable connection);

--- a/src/main/java/io/reactivex/observers/DefaultObserver.java
+++ b/src/main/java/io/reactivex/observers/DefaultObserver.java
@@ -38,9 +38,9 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * If for some reason this can't be avoided, use {@link io.reactivex.Observable#safeSubscribe(io.reactivex.Observer)}
  * instead of the standard {@code subscribe()} method.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Observable.range(1, 5)
- *     .subscribe(new DefaultObserver&lt;Integer&gt;() {
+ *     .subscribe(new DefaultObserver<Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *         }
@@ -57,7 +57,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *             System.out.println("Done!");
  *         }
  *     });
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableCompletableObserver.java
@@ -33,10 +33,10 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * <p>Implementation of {@link #onStart()}, {@link #onError(Throwable)} and
  * {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Completable.complete().delay(1, TimeUnit.SECONDS)
- *     .subscribeWith(new DisposableMaybeObserver&lt;Integer&gt;() {
+ *     .subscribeWith(new DisposableMaybeObserver<Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *         }
@@ -49,7 +49,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  */
 public abstract class DisposableCompletableObserver implements CompletableObserver, Disposable {
 

--- a/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableMaybeObserver.java
@@ -37,10 +37,10 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)}, {@link #onError(Throwable)} and
  * {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Maybe.just(1).delay(1, TimeUnit.SECONDS)
- *     .subscribeWith(new DisposableMaybeObserver&lt;Integer&gt;() {
+ *     .subscribeWith(new DisposableMaybeObserver<Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *         }
@@ -56,7 +56,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the received value type
  */

--- a/src/main/java/io/reactivex/observers/DisposableObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableObserver.java
@@ -38,10 +38,10 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * If for some reason this can't be avoided, use {@link io.reactivex.Observable#safeSubscribe(io.reactivex.Observer)}
  * instead of the standard {@code subscribe()} method.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Observable.range(1, 5)
- *     .subscribeWith(new DisposableObserver&lt;Integer&gt;() {
+ *     .subscribeWith(new DisposableObserver<Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *         }
@@ -60,7 +60,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the received value type
  */

--- a/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/DisposableSingleObserver.java
@@ -33,10 +33,10 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)} and {@link #onError(Throwable)}
  * are not allowed to throw any unchecked exceptions.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Single.just(1).delay(1, TimeUnit.SECONDS)
- *     .subscribeWith(new DisposableSingleObserver&lt;Integer&gt;() {
+ *     .subscribeWith(new DisposableSingleObserver<Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *         }
@@ -49,7 +49,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the received value type
  */

--- a/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceCompletableObserver.java
@@ -50,13 +50,13 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * <p>Implementation of {@link #onStart()}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Completable.complete().delay(1, TimeUnit.SECONDS)
  *     .subscribeWith(new ResourceCompletableObserver() {
  *         &#64;Override public void onStart() {
  *             add(Schedulers.single()
- *                 .scheduleDirect(() -&gt; System.out.println("Time!"),
+ *                 .scheduleDirect(() -> System.out.println("Time!"),
  *                     2, TimeUnit.SECONDS));
  *         }
  *         &#64;Override public void onError(Throwable t) {
@@ -70,7 +70,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  */
 public abstract class ResourceCompletableObserver implements CompletableObserver, Disposable {
     /** The active subscription. */

--- a/src/main/java/io/reactivex/observers/ResourceMaybeObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceMaybeObserver.java
@@ -54,13 +54,13 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Maybe.just(1).delay(1, TimeUnit.SECONDS)
- *     .subscribeWith(new ResourceMaybeObserver&lt;Integer&gt;() {
+ *     .subscribeWith(new ResourceMaybeObserver<Integer>() {
  *         &#64;Override public void onStart() {
  *             add(Schedulers.single()
- *                 .scheduleDirect(() -&gt; System.out.println("Time!"),
+ *                 .scheduleDirect(() -> System.out.println("Time!"),
  *                     2, TimeUnit.SECONDS));
  *         }
  *         &#64;Override public void onSuccess(Integer t) {
@@ -78,7 +78,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/observers/ResourceObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceObserver.java
@@ -49,13 +49,13 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * If for some reason this can't be avoided, use {@link io.reactivex.Observable#safeSubscribe(io.reactivex.Observer)}
  * instead of the standard {@code subscribe()} method.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Observable.range(1, 5)
- *     .subscribeWith(new ResourceObserver&lt;Integer&gt;() {
+ *     .subscribeWith(new ResourceObserver<Integer>() {
  *         &#64;Override public void onStart() {
  *             add(Schedulers.single()
- *                 .scheduleDirect(() -&gt; System.out.println("Time!"),
+ *                 .scheduleDirect(() -> System.out.println("Time!"),
  *                     2, TimeUnit.SECONDS));
  *             request(1);
  *         }
@@ -76,7 +76,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/observers/ResourceSingleObserver.java
+++ b/src/main/java/io/reactivex/observers/ResourceSingleObserver.java
@@ -51,13 +51,13 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)} and {@link #onError(Throwable)}
  * are not allowed to throw any unchecked exceptions.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Single.just(1).delay(1, TimeUnit.SECONDS)
- *     .subscribeWith(new ResourceSingleObserver&lt;Integer&gt;() {
+ *     .subscribeWith(new ResourceSingleObserver<Integer>() {
  *         &#64;Override public void onStart() {
  *             add(Schedulers.single()
- *                 .scheduleDirect(() -&gt; System.out.println("Time!"),
+ *                 .scheduleDirect(() -> System.out.println("Time!"),
  *                     2, TimeUnit.SECONDS));
  *         }
  *         &#64;Override public void onSuccess(Integer t) {
@@ -71,7 +71,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -89,10 +89,10 @@ import io.reactivex.plugins.RxJavaPlugins;
  * </dl>
  * <p>
  * Example usage:
- * <pre><code>
- * AsyncProcessor&lt;Object&gt; processor = AsyncProcessor.create();
- * 
- * TestSubscriber&lt;Object&gt; ts1 = processor.test();
+ * <pre>{@code
+ * AsyncProcessor<Object> processor = AsyncProcessor.create();
+ *
+ * TestSubscriber<Object> ts1 = processor.test();
  *
  * ts1.assertEmpty();
  *
@@ -107,11 +107,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * // onComplete triggers the emission of the last cached item and the onComplete event.
  * ts1.assertResult(2);
  *
- * TestSubscriber&lt;Object&gt; ts2 = processor.test();
+ * TestSubscriber<Object> ts2 = processor.test();
  *
  * // late Subscribers receive the last cached item too
  * ts2.assertResult(2);
- * </code></pre>
+ * }</pre>
  * @param <T> the value type
  */
 public final class AsyncProcessor<T> extends FlowableProcessor<T> {

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -49,35 +49,35 @@ import io.reactivex.plugins.RxJavaPlugins;
  * The {@code BehaviorProcessor} does not support clearing its cached value (to appear empty again), however, the
  * effect can be achieved by using a special item and making sure {@code Subscriber}s subscribe through a
  * filter whose predicate filters out this special item:
- * <pre><code>
- * BehaviorProcessor&lt;Integer&gt; processor = BehaviorProcessor.create();
+ * <pre>{@code
+ * BehaviorProcessor<Integer> processor = BehaviorProcessor.create();
  *
  * final Integer EMPTY = Integer.MIN_VALUE;
  *
- * Flowable&lt;Integer&gt; flowable = processor.filter(v -&gt; v != EMPTY);
+ * Flowable<Integer> flowable = processor.filter(v -> v != EMPTY);
  *
- * TestSubscriber&lt;Integer&gt; ts1 = flowable.test();
+ * TestSubscriber<Integer> ts1 = flowable.test();
  *
  * processor.onNext(1);
  * // this will "clear" the cache
  * processor.onNext(EMPTY);
- * 
- * TestSubscriber&lt;Integer&gt; ts2 = flowable.test();
- * 
+ *
+ * TestSubscriber<Integer> ts2 = flowable.test();
+ *
  * processor.onNext(2);
  * processor.onComplete();
- * 
+ *
  * // ts1 received both non-empty items
  * ts1.assertResult(1, 2);
- * 
+ *
  * // ts2 received only 2 even though the current item was EMPTY
  * // when it got subscribed
  * ts2.assertResult(2);
- * 
+ *
  * // Subscribers coming after the processor was terminated receive
  * // no items and only the onComplete event in this case.
  * flowable.test().assertResult();
- * </code></pre>
+ * }</pre>
  * <p>
  * Even though {@code BehaviorProcessor} implements the {@code Subscriber} interface, calling
  * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)

--- a/src/main/java/io/reactivex/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/processors/MulticastProcessor.java
@@ -101,15 +101,15 @@ import io.reactivex.plugins.RxJavaPlugins;
  * </dl>
  * <p>
  * Example:
- * <pre><code>
-    MulticastProcessor&lt;Integer&gt; mp = Flowable.range(1, 10)
+ * <pre>{@code
+    MulticastProcessor<Integer> mp = Flowable.range(1, 10)
     .subscribeWith(MulticastProcessor.create());
 
     mp.test().assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
     // --------------------
 
-    MulticastProcessor&lt;Integer&gt; mp2 = MulticastProcessor.create(4);
+    MulticastProcessor<Integer> mp2 = MulticastProcessor.create(4);
     mp2.start();
 
     assertTrue(mp2.offer(1));
@@ -122,7 +122,7 @@ import io.reactivex.plugins.RxJavaPlugins;
     mp2.onComplete();
 
     mp2.test().assertResult(1, 2, 3, 4);
- * </code></pre>
+ * }</pre>
  * <p>History: 2.1.14 - experimental
  * @param <T> the input and output value type
  * @since 2.2

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -108,15 +108,15 @@ import io.reactivex.plugins.RxJavaPlugins;
  * </dl>
  * <p>
  * Example usage:
- * <pre><code>
- * UnicastProcessor&lt;Integer&gt; processor = UnicastProcessor.create();
+ * <pre>{@code
+ * UnicastProcessor<Integer> processor = UnicastProcessor.create();
  *
- * TestSubscriber&lt;Integer&gt; ts1 = processor.test();
+ * TestSubscriber<Integer> ts1 = processor.test();
  *
  * // fresh UnicastProcessors are empty
  * ts1.assertEmpty();
  *
- * TestSubscriber&lt;Integer&gt; ts2 = processor.test();
+ * TestSubscriber<Integer> ts2 = processor.test();
  *
  * // A UnicastProcessor only allows one Subscriber during its lifetime
  * ts2.assertFailure(IllegalStateException.class);
@@ -132,18 +132,18 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * // ----------------------------------------------------
  *
- * UnicastProcessor&lt;Integer&gt; processor2 = UnicastProcessor.create();
+ * UnicastProcessor<Integer> processor2 = UnicastProcessor.create();
  *
  * // a UnicastProcessor caches events until its single Subscriber subscribes
  * processor2.onNext(1);
  * processor2.onNext(2);
  * processor2.onComplete();
  *
- * TestSubscriber&lt;Integer&gt; ts3 = processor2.test();
+ * TestSubscriber<Integer> ts3 = processor2.test();
  *
  * // the cached events are emitted in order
  * ts3.assertResult(1, 2);
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the value type received and emitted by this Processor subclass
  * @since 2.0

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -318,19 +318,19 @@ public final class Schedulers {
      * <p>
      * Starting, stopping and restarting this scheduler is not supported (no-op) and the provided
      * executor's lifecycle must be managed externally:
-     * <pre><code>
+     * <pre>{@code
      * ExecutorService exec = Executors.newSingleThreadedExecutor();
      * try {
      *     Scheduler scheduler = Schedulers.from(exec);
      *     Flowable.just(1)
      *        .subscribeOn(scheduler)
-     *        .map(v -&gt; v + 1)
+     *        .map(v -> v + 1)
      *        .observeOn(scheduler)
      *        .blockingSubscribe(System.out::println);
      * } finally {
      *     exec.shutdown();
      * }
-     * </code></pre>
+     * }</pre>
      * <p>
      * This type of scheduler is less sensitive to leaking {@link io.reactivex.Scheduler.Worker Scheduler.Worker} instances, although
      * not disposing a worker that has timed/delayed tasks not cancelled by other means may leak resources and/or
@@ -374,19 +374,19 @@ public final class Schedulers {
      * <p>
      * Starting, stopping and restarting this scheduler is not supported (no-op) and the provided
      * executor's lifecycle must be managed externally:
-     * <pre><code>
+     * <pre>{@code
      * ExecutorService exec = Executors.newSingleThreadedExecutor();
      * try {
      *     Scheduler scheduler = Schedulers.from(exec, true);
      *     Flowable.just(1)
      *        .subscribeOn(scheduler)
-     *        .map(v -&gt; v + 1)
+     *        .map(v -> v + 1)
      *        .observeOn(scheduler)
      *        .blockingSubscribe(System.out::println);
      * } finally {
      *     exec.shutdown();
      * }
-     * </code></pre>
+     * }</pre>
      * <p>
      * This type of scheduler is less sensitive to leaking {@link io.reactivex.Scheduler.Worker Scheduler.Worker} instances, although
      * not disposing a worker that has timed/delayed tasks not cancelled by other means may leak resources and/or

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -83,10 +83,10 @@ import io.reactivex.plugins.RxJavaPlugins;
  * </dl>
  * <p>
  * Example usage:
- * <pre><code>
- * AsyncSubject&lt;Object&gt; subject = AsyncSubject.create();
- * 
- * TestObserver&lt;Object&gt; to1 = subject.test();
+ * <pre>{@code
+ * AsyncSubject<Object> subject = AsyncSubject.create();
+ *
+ * TestObserver<Object> to1 = subject.test();
  *
  * to1.assertEmpty();
  *
@@ -101,11 +101,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * // onComplete triggers the emission of the last cached item and the onComplete event.
  * to1.assertResult(2);
  *
- * TestObserver&lt;Object&gt; to2 = subject.test();
+ * TestObserver<Object> to2 = subject.test();
  *
  * // late Observers receive the last cached item too
  * to2.assertResult(2);
- * </code></pre>
+ * }</pre>
  * @param <T> the value type
  */
 public final class AsyncSubject<T> extends Subject<T> {

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -53,20 +53,20 @@ import io.reactivex.plugins.RxJavaPlugins;
  * The {@code BehaviorSubject} does not support clearing its cached value (to appear empty again), however, the
  * effect can be achieved by using a special item and making sure {@code Observer}s subscribe through a
  * filter whose predicate filters out this special item:
- * <pre><code>
- * BehaviorSubject&lt;Integer&gt; subject = BehaviorSubject.create();
+ * <pre>{@code
+ * BehaviorSubject<Integer> subject = BehaviorSubject.create();
  *
  * final Integer EMPTY = Integer.MIN_VALUE;
  *
- * Observable&lt;Integer&gt; observable = subject.filter(v -&gt; v != EMPTY);
+ * Observable<Integer> observable = subject.filter(v -> v != EMPTY);
  *
- * TestObserver&lt;Integer&gt; to1 = observable.test();
+ * TestObserver<Integer> to1 = observable.test();
  *
  * observable.onNext(1);
  * // this will "clear" the cache
  * observable.onNext(EMPTY);
  *
- * TestObserver&lt;Integer&gt; to2 = observable.test();
+ * TestObserver<Integer> to2 = observable.test();
  *
  * subject.onNext(2);
  * subject.onComplete();
@@ -81,7 +81,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * // Observers coming after the subject was terminated receive
  * // no items and only the onComplete event in this case.
  * observable.test().assertResult();
- * </code></pre>
+ * }</pre>
  * <p>
  * Even though {@code BehaviorSubject} implements the {@code Observer} interface, calling
  * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)

--- a/src/main/java/io/reactivex/subjects/CompletableSubject.java
+++ b/src/main/java/io/reactivex/subjects/CompletableSubject.java
@@ -65,10 +65,10 @@ import io.reactivex.plugins.RxJavaPlugins;
  * </dl>
  * <p>
  * Example usage:
- * <pre><code>
+ * <pre>{@code
  * CompletableSubject subject = CompletableSubject.create();
  *
- * TestObserver&lt;Void&gt; to1 = subject.test();
+ * TestObserver<Void> to1 = subject.test();
  *
  * // a fresh CompletableSubject is empty
  * to1.assertEmpty();
@@ -78,11 +78,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  * // a CompletableSubject is always void of items
  * to1.assertResult();
  *
- * TestObserver&lt;Void&gt; to2 = subject.test()
+ * TestObserver<Void> to2 = subject.test()
  *
  * // late CompletableObservers receive the terminal event
  * to2.assertResult();
- * </code></pre>
+ * }</pre>
  * <p>History: 2.0.5 - experimental
  * @since 2.1
  */

--- a/src/main/java/io/reactivex/subjects/MaybeSubject.java
+++ b/src/main/java/io/reactivex/subjects/MaybeSubject.java
@@ -70,10 +70,10 @@ import io.reactivex.plugins.RxJavaPlugins;
  * </dl>
  * <p>
  * Example usage:
- * <pre><code>
- * MaybeSubject&lt;Integer&gt; subject1 = MaybeSubject.create();
+ * <pre>{@code
+ * MaybeSubject<Integer> subject1 = MaybeSubject.create();
  *
- * TestObserver&lt;Integer&gt; to1 = subject1.test();
+ * TestObserver<Integer> to1 = subject1.test();
  *
  * // MaybeSubjects are empty by default
  * to1.assertEmpty();
@@ -84,27 +84,27 @@ import io.reactivex.plugins.RxJavaPlugins;
  * // TestObserver converts onSuccess into onNext + onComplete
  * to1.assertResult(1);
  *
- * TestObserver&lt;Integer&gt; to2 = subject1.test();
+ * TestObserver<Integer> to2 = subject1.test();
  *
  * // late Observers receive the terminal signal (onSuccess) too
  * to2.assertResult(1);
  *
  * // -----------------------------------------------------
  *
- * MaybeSubject&lt;Integer&gt; subject2 = MaybeSubject.create();
+ * MaybeSubject<Integer> subject2 = MaybeSubject.create();
  *
- * TestObserver&lt;Integer&gt; to3 = subject2.test();
+ * TestObserver<Integer> to3 = subject2.test();
  *
  * subject2.onComplete();
  *
  * // a completed MaybeSubject completes its MaybeObservers
  * to3.assertResult();
  *
- * TestObserver&lt;Integer&gt; to4 = subject1.test();
+ * TestObserver<Integer> to4 = subject1.test();
  *
  * // late Observers receive the terminal signal (onComplete) too
  * to4.assertResult();
- * </code></pre>
+ * }</pre>
  * <p>History: 2.0.5 - experimental
  * @param <T> the value type received and emitted
  * @since 2.1

--- a/src/main/java/io/reactivex/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/subjects/SingleSubject.java
@@ -70,25 +70,25 @@ import io.reactivex.plugins.RxJavaPlugins;
  * </dl>
  * <p>
  * Example usage:
- * <pre><code>
- * SingleSubject&lt;Integer&gt; subject1 = SingleSubject.create();
- * 
- * TestObserver&lt;Integer&gt; to1 = subject1.test();
- * 
+ * <pre>{@code
+ * SingleSubject<Integer> subject1 = SingleSubject.create();
+ *
+ * TestObserver<Integer> to1 = subject1.test();
+ *
  * // SingleSubjects are empty by default
  * to1.assertEmpty();
- * 
+ *
  * subject1.onSuccess(1);
- * 
+ *
  * // onSuccess is a terminal event with SingleSubjects
  * // TestObserver converts onSuccess into onNext + onComplete
  * to1.assertResult(1);
  *
- * TestObserver&lt;Integer&gt; to2 = subject1.test();
- * 
+ * TestObserver<Integer> to2 = subject1.test();
+ *
  * // late Observers receive the terminal signal (onSuccess) too
  * to2.assertResult(1);
- * </code></pre>
+ * }</pre>
  * <p>History: 2.0.5 - experimental
  * @param <T> the value type received and emitted
  * @since 2.1

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -102,15 +102,15 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
  * </dl>
  * <p>
  * Example usage:
- * <pre><code>
- * UnicastSubject&lt;Integer&gt; subject = UnicastSubject.create();
+ * <pre>{@code
+ * UnicastSubject<Integer> subject = UnicastSubject.create();
  *
- * TestObserver&lt;Integer&gt; to1 = subject.test();
+ * TestObserver<Integer> to1 = subject.test();
  *
  * // fresh UnicastSubjects are empty
  * to1.assertEmpty();
  *
- * TestObserver&lt;Integer&gt; to2 = subject.test();
+ * TestObserver<Integer> to2 = subject.test();
  *
  * // A UnicastSubject only allows one Observer during its lifetime
  * to2.assertFailure(IllegalStateException.class);
@@ -126,18 +126,18 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
  *
  * // ----------------------------------------------------
  *
- * UnicastSubject&lt;Integer&gt; subject2 = UnicastSubject.create();
+ * UnicastSubject<Integer> subject2 = UnicastSubject.create();
  *
  * // a UnicastSubject caches events until its single Observer subscribes
  * subject2.onNext(1);
  * subject2.onNext(2);
  * subject2.onComplete();
  *
- * TestObserver&lt;Integer&gt; to3 = subject2.test();
+ * TestObserver<Integer> to3 = subject2.test();
  *
  * // the cached events are emitted in order
  * to3.assertResult(1, 2);
- * </code></pre>
+ * }</pre>
  * @param <T> the value type received and emitted by this Subject subclass
  * @since 2.0
  */

--- a/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DefaultSubscriber.java
@@ -49,9 +49,9 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * instead of the standard {@code subscribe()} method.
  * @param <T> the value type
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Flowable.range(1, 5)
- *     .subscribe(new DefaultSubscriber&lt;Integer&gt;() {
+ *     .subscribe(new DefaultSubscriber<Integer>() {
  *         &#64;Override public void onStart() {
  *             System.out.println("Start!");
  *             request(1);
@@ -70,7 +70,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *             System.out.println("Done!");
  *         }
  *     });
- * </code></pre>
+ * }</pre>
  */
 public abstract class DefaultSubscriber<T> implements FlowableSubscriber<T> {
 

--- a/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/DisposableSubscriber.java
@@ -47,10 +47,10 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * If for some reason this can't be avoided, use {@link io.reactivex.Flowable#safeSubscribe(org.reactivestreams.Subscriber)}
  * instead of the standard {@code subscribe()} method.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Flowable.range(1, 5)
- *     .subscribeWith(new DisposableSubscriber&lt;Integer&gt;() {
+ *     .subscribeWith(new DisposableSubscriber<Integer>() {
  *         &#64;Override public void onStart() {
  *             request(1);
  *         }
@@ -70,7 +70,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  * @param <T> the received value type.
  */
 public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/ResourceSubscriber.java
@@ -60,13 +60,13 @@ import io.reactivex.internal.util.EndConsumerHelper;
  * If for some reason this can't be avoided, use {@link io.reactivex.Flowable#safeSubscribe(org.reactivestreams.Subscriber)}
  * instead of the standard {@code subscribe()} method.
  *
- * <p>Example<pre><code>
+ * <p>Example<pre>{@code
  * Disposable d =
  *     Flowable.range(1, 5)
- *     .subscribeWith(new ResourceSubscriber&lt;Integer&gt;() {
+ *     .subscribeWith(new ResourceSubscriber<Integer>() {
  *         &#64;Override public void onStart() {
  *             add(Schedulers.single()
- *                 .scheduleDirect(() -&gt; System.out.println("Time!"),
+ *                 .scheduleDirect(() -> System.out.println("Time!"),
  *                     2, TimeUnit.SECONDS));
  *             request(1);
  *         }
@@ -88,7 +88,7 @@ import io.reactivex.internal.util.EndConsumerHelper;
  *     });
  * // ...
  * d.dispose();
- * </code></pre>
+ * }</pre>
  *
  * @param <T> the value type
  */

--- a/src/test/java/io/reactivex/validators/NewLinesBeforeAnnotation.java
+++ b/src/test/java/io/reactivex/validators/NewLinesBeforeAnnotation.java
@@ -23,18 +23,18 @@ import org.junit.Test;
  * and the next annotation &#64; indicator
  * are not separated by less than or more than one empty line.
  * <p>Thus this is detected:
- * <pre><code>
+ * <pre>{@code
  * }
  * &#64;Override
- * </code></pre>
+ * }</pre>
  * <p>
  * as well as
- * <pre><code>
+ * <pre>{@code
  * }
- * 
- * 
+ *
+ *
  * &#64;Override
- * </code></pre>
+ * }</pre>
  */
 public class NewLinesBeforeAnnotation {
 


### PR DESCRIPTION
Improves Javadoc @Code usage

- Uses `@Code` instead of `<code> </code>` markup
- Replaces escape characters inline with using `@Code` attribute
           1. `&gt;` changes to `>`
           2. `&lt;` changes to `<`