### PR TITLE
2.x: Remove redundant type casts and type arguments

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -2219,7 +2219,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return fromFuture((Future<T>)future, timeout, unit).subscribeOn(scheduler);
+        return fromFuture(future, timeout, unit).subscribeOn(scheduler);
     }
 
     /**
@@ -2258,7 +2258,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public static <T> Flowable<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
-        return fromFuture((Future<T>)future).subscribeOn(scheduler);
+        return fromFuture(future).subscribeOn(scheduler);
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java
@@ -132,7 +132,7 @@ extends Flowable<R> {
             return;
         }
         if (n == 1) {
-            ((Publisher<T>)a[0]).subscribe(new MapSubscriber<T, R>(s, new SingletonArrayFunc()));
+            a[0].subscribe(new MapSubscriber<T, R>(s, new SingletonArrayFunc()));
             return;
         }
 

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -236,7 +236,7 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = NullPointerException.class)
     public void concatIterableWithNull() {
-        Completable c = Completable.concat(Arrays.asList(normal.completable, (Completable)null));
+        Completable c = Completable.concat(Arrays.asList(normal.completable, null));
 
         c.blockingAwait();
     }
@@ -746,7 +746,7 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = NullPointerException.class)
     public void mergeIterableWithNull() {
-        Completable c = Completable.merge(Arrays.asList(normal.completable, (Completable)null));
+        Completable c = Completable.merge(Arrays.asList(normal.completable, null));
 
         c.blockingAwait();
     }
@@ -962,7 +962,7 @@ public class CompletableTest {
 
     @Test(timeout = 5000, expected = NullPointerException.class)
     public void mergeDelayErrorIterableWithNull() {
-        Completable c = Completable.mergeDelayError(Arrays.asList(normal.completable, (Completable)null));
+        Completable c = Completable.mergeDelayError(Arrays.asList(normal.completable, null));
 
         c.blockingAwait();
     }
@@ -3149,7 +3149,7 @@ public class CompletableTest {
 
     @Test(expected = NullPointerException.class)
     public void ambIterableNull() {
-        Completable.amb((Iterable<Completable>)null);
+        Completable.amb(null);
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/io/reactivex/flowable/FlowableCombineLatestTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableCombineLatestTests.java
@@ -68,7 +68,7 @@ public class FlowableCombineLatestTests {
     @Test
     public void testNullEmitting() throws Exception {
         // FIXME this is no longer allowed
-        Flowable<Boolean> nullObservable = BehaviorProcessor.createDefault((Boolean) null);
+        Flowable<Boolean> nullObservable = BehaviorProcessor.createDefault(null);
         Flowable<Boolean> nonNullObservable = BehaviorProcessor.createDefault(true);
         Flowable<Boolean> combined =
                 combineLatest(nullObservable, nonNullObservable, new BiFunction<Boolean, Boolean, Boolean>() {

--- a/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
@@ -166,7 +166,7 @@ public class FlowableConversionTest {
             }
         });
 
-        List<Object> crewOfBattlestarGalactica = Arrays.asList(new Object[] {"William Adama", "Laura Roslin", "Lee Adama", new Cylon()});
+        List<Object> crewOfBattlestarGalactica = Arrays.asList("William Adama", "Laura Roslin", "Lee Adama", new Cylon());
 
         Flowable.fromIterable(crewOfBattlestarGalactica)
             .doOnNext(new Consumer<Object>() {

--- a/src/test/java/io/reactivex/flowable/FlowableFuseableTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableFuseableTest.java
@@ -36,7 +36,7 @@ public class FlowableFuseableTest {
     @Test
     public void syncArray() {
 
-        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        Flowable.fromArray(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertOf(SubscriberFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
@@ -69,7 +69,7 @@ public class FlowableFuseableTest {
 
     @Test
     public void syncArrayHidden() {
-        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        Flowable.fromArray(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .hide()
         .to(SubscriberFusion.<Integer>test(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertOf(SubscriberFusion.<Integer>assertNotFuseable())

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -53,7 +53,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void ambIterableNull() {
-        Flowable.amb((Iterable<Publisher<Object>>)null);
+        Flowable.amb(null);
     }
 
     @Test
@@ -503,7 +503,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void mergeIterableNull() {
-        Flowable.merge((Iterable<Publisher<Object>>)null, 128, 128);
+        Flowable.merge(null, 128, 128);
     }
 
     @Test(expected = NullPointerException.class)
@@ -535,7 +535,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableNull() {
-        Flowable.mergeDelayError((Iterable<Publisher<Object>>)null, 128, 128);
+        Flowable.mergeDelayError(null, 128, 128);
     }
 
     @Test(expected = NullPointerException.class)
@@ -714,7 +714,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2Null() {
-        Flowable.zipIterable((Iterable<Publisher<Object>>)null, new Function<Object[], Object>() {
+        Flowable.zipIterable(null, new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] a) {
                 return 1;
@@ -905,7 +905,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void collectInitialSupplierNull() {
-        just1.collect((Callable<Integer>)null, new BiConsumer<Integer, Integer>() {
+        just1.collect(null, new BiConsumer<Integer, Integer>() {
             @Override
             public void accept(Integer a, Integer b) { }
         });
@@ -1074,12 +1074,12 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void delaySubscriptionSupplierNull() {
-        just1.delaySubscription((Publisher<Object>)null);
+        just1.delaySubscription(null);
     }
 
     @Test(expected = NullPointerException.class)
     public void delaySubscriptionFunctionNull() {
-        just1.delaySubscription((Publisher<Object>)null);
+        just1.delaySubscription(null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -2321,7 +2321,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void timeoutFirstNull() {
-        just1.timeout((Publisher<Integer>)null, new Function<Integer, Publisher<Integer>>() {
+        just1.timeout(null, new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer v) {
                 return just1;
@@ -2968,7 +2968,7 @@ public class FlowableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void delaySubscriptionOtherNull() {
-        just1.delaySubscription((Flowable<Object>)null);
+        just1.delaySubscription(null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -118,7 +118,7 @@ public class BlockingFlowableToFutureTest {
     @Ignore("null value is not allowed")
     @Test
     public void testGetWithASingleNullItem() throws Exception {
-        Flowable<String> obs = Flowable.just((String)null);
+        Flowable<String> obs = Flowable.just(null);
         Future<String> f = obs.toFuture();
         assertEquals(null, f.get());
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -872,7 +872,7 @@ public class FlowableCombineLatestTest {
     public void testCombineManyNulls() {
         int n = Flowable.bufferSize() * 3;
 
-        Flowable<Integer> source = Flowable.just((Integer)null);
+        Flowable<Integer> source = Flowable.just(null);
 
         List<Flowable<Integer>> sources = new ArrayList<Flowable<Integer>>();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -309,7 +309,7 @@ public class FlowableDelaySubscriptionOtherTest {
 
     @Test(expected = NullPointerException.class)
     public void otherNull() {
-        Flowable.just(1).delaySubscription((Flowable<Integer>)null);
+        Flowable.just(1).delaySubscription(null);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -261,7 +261,7 @@ public class FlowableFlatMapMaybeTest {
 
     @Test
     public void middleError() {
-        Flowable.fromArray(new String[]{"1", "a", "2"})
+        Flowable.fromArray("1", "a", "2")
         .flatMapMaybe(new Function<String, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(final String s) throws NumberFormatException {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -248,7 +248,7 @@ public class FlowableFlatMapSingleTest {
 
     @Test
     public void middleError() {
-        Flowable.fromArray(new String[]{"1", "a", "2"})
+        Flowable.fromArray("1", "a", "2")
         .flatMapSingle(new Function<String, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(final String s) throws NumberFormatException {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
@@ -95,12 +95,12 @@ public class FlowableFromArrayTest {
 
     @Test
     public void empty() {
-        Assert.assertSame(Flowable.empty(), Flowable.fromArray(new Object[0]));
+        Assert.assertSame(Flowable.empty(), Flowable.fromArray());
     }
 
     @Test
     public void just() {
-        Flowable<Integer> source = Flowable.fromArray(new Integer[] { 1 });
+        Flowable<Integer> source = Flowable.fromArray(1);
         Assert.assertTrue(source.getClass().toString(), source instanceof ScalarCallable);
     }
 
@@ -143,7 +143,7 @@ public class FlowableFromArrayTest {
 
     @Test
     public void conditionalFiltered() {
-        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
+        Flowable.fromArray(1, 2, 3, 4, 5)
         .filter(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) throws Exception {
@@ -173,7 +173,7 @@ public class FlowableFromArrayTest {
 
     @Test
     public void conditionalSlowPathSkipCancel() {
-        Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
+        Flowable.fromArray(1, 2, 3, 4, 5)
         .filter(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -344,7 +344,7 @@ public class FlowablePublishTest {
 
     @SuppressWarnings("unchecked")
     static boolean checkPublishDisposed(Disposable d) {
-        return ((FlowablePublish.PublishSubscriber<Object>)d).isDisposed();
+        return d.isDisposed();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -78,7 +78,7 @@ public class FlowableWindowWithSizeTest {
 
     @Test
     public void testOverlappingWindows() {
-        Flowable<String> subject = Flowable.fromArray(new String[] { "zero", "one", "two", "three", "four", "five" });
+        Flowable<String> subject = Flowable.fromArray("zero", "one", "two", "three", "four", "five");
         Flowable<Flowable<String>> windowed = subject.window(3, 1);
 
         List<List<String>> windows = toLists(windowed);

--- a/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/BlockingObservableToFutureTest.java
@@ -119,7 +119,7 @@ public class BlockingObservableToFutureTest {
     @Ignore("null value is not allowed")
     @Test
     public void testGetWithASingleNullItem() throws Exception {
-        Observable<String> obs = Observable.just((String)null);
+        Observable<String> obs = Observable.just(null);
         Future<String> f = obs.toFuture();
         assertEquals(null, f.get());
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -188,7 +188,7 @@ public class ObservableFlatMapMaybeTest {
 
     @Test
     public void middleError() {
-        Observable.fromArray(new String[]{"1", "a", "2"}).flatMapMaybe(new Function<String, MaybeSource<Integer>>() {
+        Observable.fromArray("1", "a", "2").flatMapMaybe(new Function<String, MaybeSource<Integer>>() {
             @Override
             public MaybeSource<Integer> apply(final String s) throws NumberFormatException {
                 //return Single.just(Integer.valueOf(s)); //This works

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -175,7 +175,7 @@ public class ObservableFlatMapSingleTest {
 
     @Test
     public void middleError() {
-        Observable.fromArray(new String[]{"1", "a", "2"}).flatMapSingle(new Function<String, SingleSource<Integer>>() {
+        Observable.fromArray("1", "a", "2").flatMapSingle(new Function<String, SingleSource<Integer>>() {
             @Override
             public SingleSource<Integer> apply(final String s) throws NumberFormatException {
                 //return Single.just(Integer.valueOf(s)); //This works

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservablePublishTest.java
@@ -342,7 +342,7 @@ public class ObservablePublishTest {
 
     @SuppressWarnings("unchecked")
     static boolean checkPublishDisposed(Disposable d) {
-        return ((ObservablePublish.PublishObserver<Object>)d).isDisposed();
+        return d.isDisposed();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -77,7 +77,7 @@ public class ObservableWindowWithSizeTest {
 
     @Test
     public void testOverlappingWindows() {
-        Observable<String> subject = Observable.fromArray(new String[] { "zero", "one", "two", "three", "four", "five" });
+        Observable<String> subject = Observable.fromArray("zero", "one", "two", "three", "four", "five");
         Observable<Observable<String>> windowed = subject.window(3, 1);
 
         List<List<String>> windows = toLists(windowed);

--- a/src/test/java/io/reactivex/observable/ObservableCombineLatestTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableCombineLatestTests.java
@@ -67,7 +67,7 @@ public class ObservableCombineLatestTests {
     @Test
     public void testNullEmitting() throws Exception {
         // FIXME this is no longer allowed
-        Observable<Boolean> nullObservable = BehaviorSubject.createDefault((Boolean) null);
+        Observable<Boolean> nullObservable = BehaviorSubject.createDefault(null);
         Observable<Boolean> nonNullObservable = BehaviorSubject.createDefault(true);
         Observable<Boolean> combined =
                 combineLatest(nullObservable, nonNullObservable, new BiFunction<Boolean, Boolean, Boolean>() {

--- a/src/test/java/io/reactivex/observable/ObservableFuseableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableFuseableTest.java
@@ -36,7 +36,7 @@ public class ObservableFuseableTest {
     @Test
     public void syncArray() {
 
-        Observable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        Observable.fromArray(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false))
         .assertOf(ObserverFusion.<Integer>assertFusionMode(QueueFuseable.SYNC))
         .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
@@ -69,7 +69,7 @@ public class ObservableFuseableTest {
 
     @Test
     public void syncArrayHidden() {
-        Observable.fromArray(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        Observable.fromArray(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         .hide()
         .to(ObserverFusion.<Integer>test(QueueFuseable.ANY, false))
         .assertOf(ObserverFusion.<Integer>assertNotFuseable())

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -53,7 +53,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void ambIterableNull() {
-        Observable.amb((Iterable<Observable<Object>>)null);
+        Observable.amb(null);
     }
 
     @Test
@@ -583,7 +583,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void mergeIterableNull() {
-        Observable.merge((Iterable<Observable<Object>>)null, 128, 128);
+        Observable.merge(null, 128, 128);
     }
 
     @Test(expected = NullPointerException.class)
@@ -615,7 +615,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableNull() {
-        Observable.mergeDelayError((Iterable<Observable<Object>>)null, 128, 128);
+        Observable.mergeDelayError(null, 128, 128);
     }
 
     @Test(expected = NullPointerException.class)
@@ -803,7 +803,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2Null() {
-        Observable.zipIterable((Iterable<Observable<Object>>)null, new Function<Object[], Object>() {
+        Observable.zipIterable(null, new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] a) {
                 return 1;
@@ -994,7 +994,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void collectInitialSupplierNull() {
-        just1.collect((Callable<Integer>)null, new BiConsumer<Integer, Integer>() {
+        just1.collect(null, new BiConsumer<Integer, Integer>() {
             @Override
             public void accept(Integer a, Integer b) { }
         });
@@ -1163,12 +1163,12 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void delaySubscriptionOtherNull() {
-        just1.delaySubscription((Observable<Object>)null);
+        just1.delaySubscription(null);
     }
 
     @Test(expected = NullPointerException.class)
     public void delaySubscriptionFunctionNull() {
-        just1.delaySubscription((Observable<Object>)null);
+        just1.delaySubscription(null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -2370,7 +2370,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void timeoutFirstNull() {
-        just1.timeout((Observable<Integer>)null, new Function<Integer, Observable<Integer>>() {
+        just1.timeout(null, new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer v) {
                 return just1;

--- a/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
@@ -1081,7 +1081,7 @@ public class ParallelFlowableTest {
     @SuppressWarnings("unchecked")
     @Test(expected = IllegalArgumentException.class)
     public void fromPublishers() {
-        ParallelFlowable.fromArray(new Publisher[0]);
+        ParallelFlowable.fromArray();
     }
 
     @Test
@@ -1378,6 +1378,6 @@ public class ParallelFlowableTest {
     @SuppressWarnings("unchecked")
     @Test
     public void fromArraySubscriberCount() {
-        ParallelFlowableTest.checkSubscriberCount(ParallelFlowable.fromArray(new Publisher[] { Flowable.just(1) }));
+        ParallelFlowableTest.checkSubscriberCount(ParallelFlowable.fromArray(Flowable.just(1)));
     }
 }

--- a/src/test/java/io/reactivex/schedulers/CachedThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/schedulers/CachedThreadSchedulerTest.java
@@ -89,11 +89,11 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
     public void workerDisposed() {
         Worker w = Schedulers.io().createWorker();
 
-        assertFalse(((Disposable)w).isDisposed());
+        assertFalse(w.isDisposed());
 
         w.dispose();
 
-        assertTrue(((Disposable)w).isDisposed());
+        assertTrue(w.isDisposed());
     }
 
     @Test

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -361,7 +361,7 @@ public class SingleNullTests {
 
     @Test(expected = NullPointerException.class)
     public void zipIterableNull() {
-        Single.zip((Iterable<Single<Integer>>)null, new Function<Object[], Object>() {
+        Single.zip(null, new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return 1;
@@ -691,7 +691,7 @@ public class SingleNullTests {
 
     @Test(expected = NullPointerException.class)
     public void onErrorReturnSupplierNull() {
-        just1.onErrorReturn((Function<Throwable, Integer>)null);
+        just1.onErrorReturn(null);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
This PR mostly tidies up some test code.

- Removes `redundant type arguments` for various `fromArray` calls in `tests`.
   - ParallelFlowable.fromArray
   - Flowable.fromArray
   - Observable.fromArray
- Remove `redundant type casts` mostly in tests
- Remove `redundant type casts` from 
   - src/main/java/io/reactivex/Flowable.java 
   - src/main/java/io/reactivex/internal/operators/flowable/FlowableCombineLatest.java 