### PR TITLE
3.x: Merge as() into to()

### DIFF
--- a/docs/What's-different-in-3.0.md
+++ b/docs/What's-different-in-3.0.md
@@ -5,9 +5,56 @@ TBD.
 
 ### API signature changes
 
+#### as() and to() operators
+
+In 2.x, the `to()` operator used the generic `Function` to allow assembly-time conversion of flows into arbitrary types. The drawback of this
+approach was that each base reactive type had the same `Function` interface in their method signature, 
+thus it was impossible to implement multiple converters for different reactive types within the same class. 
+To work around this issue, the `as` operator and `XConverter` interfaces have been introduced
+in 2.x, which interfaces are distinct and can be implemented on the same class. Changing the signature of `to` in 2.x was not possible due
+to the pledged binary compatibility of the library.
+
+From 3.x, the `as()` methods have been removed and the `to()` methods now each work with their respective `XConverer` interfaces:
+
+- `Flowable.to(Function<Flowable<T>, R>)` is now `Flowable.to(FlowableConverter<T, R>)`
+- `Observable.to(Function<Observable<T>, R>)` is now `Observable.to(ObservableConverter<T, R>)`
+- `Maybe.to(Function<Flowable<T>, R>)` is now `Maybe.to(MaybeConverter<T, R>)`
+- `Single.to(Function<Flowable<T>, R>)` is now `Maybe.to(SingleConverter<T, R>)`
+- `Completable.to(Function<Completable, R>)` is now `Completable.to(CompletableConverter<R>)`
+- `ParallelFlowable.to(Function<ParallelFlowable<T>, R)` is now `ParallelFlowable.to(ParallelFlowableConverter<T, R>)`
+
+If one was using these methods with a lambda expression, only a recompilation is needed:
+
+```java
+// before
+source.to(flowable -> flowable.blockingFirst());
+
+// after
+source.to(flowable -> flowable.blockingFirst());
+```
+
+If one was implementing a Function interface (typically anonymously), the interface type, type arguments and the `throws` clause have to be adjusted
+
+```java
+// before
+source.to(new Function<Flowable<Integer>, Integer>() {
+    @Override
+    public Integer apply(Flowable<Integer> t) throws Exception {
+        return t.blockingFirst();
+    }
+});
+
+// after
+source.to(new FlowableConverter<Integer, Integer>() {
+    @Override
+    public Integer apply(Flowable<Integer> t) {
+        return t.blockingFirst();
+    }
+});
+```
+
 TBD.
 
-- as() merged into to()
 - some operators returning a more appropriate Single or Maybe
 - functional interfaces throws widening to Throwable
 - standard methods removed

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -27,7 +27,6 @@ import io.reactivex.internal.operators.completable.*;
 import io.reactivex.internal.operators.maybe.*;
 import io.reactivex.internal.operators.mixed.*;
 import io.reactivex.internal.operators.single.*;
-import io.reactivex.internal.util.ExceptionHelper;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
@@ -1180,29 +1179,6 @@ public abstract class Completable implements CompletableSource {
     public final Completable andThen(CompletableSource next) {
         ObjectHelper.requireNonNull(next, "next is null");
         return RxJavaPlugins.onAssembly(new CompletableAndThenCompletable(this, next));
-    }
-
-    /**
-     * Calls the specified converter function during assembly time and returns its resulting value.
-     * <p>
-     * <img width="640" height="751" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.as.png" alt="">
-     * <p>
-     * This allows fluent conversion to any other type.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.7 - experimental
-     * @param <R> the resulting object type
-     * @param converter the function that receives the current Completable instance and returns a value
-     * @return the converted value
-     * @throws NullPointerException if converter is null
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(@NonNull CompletableConverter<? extends R> converter) {
-        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**
@@ -2578,27 +2554,26 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Allows fluent conversion to another type via a function callback.
+     * Calls the specified converter function during assembly time and returns its resulting value.
      * <p>
      * <img width="640" height="751" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.to.png" alt="">
+     * <p>
+     * This allows fluent conversion to any other type.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param <U> the output type
-     * @param converter the function called with this which should return some other value.
+     * <p>History: 2.1.7 - experimental
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current Completable instance and returns a value
      * @return the converted value
      * @throws NullPointerException if converter is null
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> U to(Function<? super Completable, U> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+    public final <R> R to(@NonNull CompletableConverter<? extends R> converter) {
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -2561,7 +2561,7 @@ public abstract class Completable implements CompletableSource {
      * This allows fluent conversion to any other type.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type

--- a/src/main/java/io/reactivex/CompletableConverter.java
+++ b/src/main/java/io/reactivex/CompletableConverter.java
@@ -16,7 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 
 /**
- * Convenience interface and callback used by the {@link Completable#as} operator to turn a Completable into another
+ * Convenience interface and callback used by the {@link Completable#to} operator to turn a Completable into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <R> the output type

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -16852,7 +16852,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The backpressure behavior depends on what happens in the {@code converter} function.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -5647,30 +5647,6 @@ public abstract class Flowable<T> implements Publisher<T> {
     }
 
     /**
-     * Calls the specified converter function during assembly time and returns its resulting value.
-     * <p>
-     * This allows fluent conversion to any other type.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The backpressure behavior depends on what happens in the {@code converter} function.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.7 - experimental
-     * @param <R> the resulting object type
-     * @param converter the function that receives the current Flowable instance and returns a value
-     * @return the converted value
-     * @throws NullPointerException if converter is null
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.SPECIAL)
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(@NonNull FlowableConverter<T, ? extends R> converter) {
-        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-    }
-
-    /**
      * Returns the first item emitted by this {@code Flowable}, or throws
      * {@code NoSuchElementException} if it emits no items.
      * <dl>
@@ -16876,22 +16852,20 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The backpressure behavior depends on what happens in the {@code converter} function.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
      * @param converter the function that receives the current Flowable instance and returns a value
-     * @return the value returned by the function
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     * @since 2.2
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R to(Function<? super Flowable<T>, R> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+    public final <R> R to(@NonNull FlowableConverter<T, ? extends R> converter) {
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/FlowableConverter.java
+++ b/src/main/java/io/reactivex/FlowableConverter.java
@@ -16,7 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 
 /**
- * Convenience interface and callback used by the {@link Flowable#as} operator to turn a Flowable into another
+ * Convenience interface and callback used by the {@link Flowable#to} operator to turn a Flowable into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2280,27 +2280,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the specified converter function during assembly time and returns its resulting value.
-     * <p>
-     * This allows fluent conversion to any other type.
-     * <dl>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.7 - experimental
-     * @param <R> the resulting object type
-     * @param converter the function that receives the current Maybe instance and returns a value
-     * @return the converted value
-     * @throws NullPointerException if converter is null
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(@NonNull MaybeConverter<T, ? extends R> converter) {
-        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-    }
-
-    /**
      * Waits in a blocking fashion until the current Maybe signals a success value (which is returned),
      * null if completed or an exception (which is propagated).
      * <dl>
@@ -3579,28 +3558,24 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the specified converter function with the current Maybe instance
-     * during assembly time and returns its result.
+     * Calls the specified converter function during assembly time and returns its resulting value.
+     * <p>
+     * This allows fluent conversion to any other type.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param <R> the result type
-     * @param convert the function that is called with the current Maybe instance during
-     *                assembly time that should return some value to be the result
-     *
-     * @return the value returned by the convert function
+     * <p>History: 2.1.7 - experimental
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current Maybe instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     * @since 2.2
      */
     @CheckReturnValue
-    @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R to(Function<? super Maybe<T>, R> convert) {
-        try {
-            return ObjectHelper.requireNonNull(convert, "convert is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+    public final <R> R to(@NonNull MaybeConverter<T, ? extends R> converter) {
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3563,7 +3563,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * This allows fluent conversion to any other type.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type

--- a/src/main/java/io/reactivex/MaybeConverter.java
+++ b/src/main/java/io/reactivex/MaybeConverter.java
@@ -16,7 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 
 /**
- * Convenience interface and callback used by the {@link Maybe#as} operator to turn a Maybe into another
+ * Convenience interface and callback used by the {@link Maybe#to} operator to turn a Maybe into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -5077,27 +5077,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     }
 
     /**
-     * Calls the specified converter function during assembly time and returns its resulting value.
-     * <p>
-     * This allows fluent conversion to any other type.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.7 - experimental
-     * @param <R> the resulting object type
-     * @param converter the function that receives the current Observable instance and returns a value
-     * @return the converted value
-     * @throws NullPointerException if converter is null
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(@NonNull ObservableConverter<T, ? extends R> converter) {
-        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-    }
-
-    /**
      * Returns the first item emitted by this {@code Observable}, or throws
      * {@code NoSuchElementException} if it emits no items.
      * <p>
@@ -13911,21 +13890,19 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * This allows fluent conversion to any other type.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
      * @param converter the function that receives the current Observable instance and returns a value
-     * @return the value returned by the function
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R to(Function<? super Observable<T>, R> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+    public final <R> R to(@NonNull ObservableConverter<T, ? extends R> converter) {
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -13890,7 +13890,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * This allows fluent conversion to any other type.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type

--- a/src/main/java/io/reactivex/ObservableConverter.java
+++ b/src/main/java/io/reactivex/ObservableConverter.java
@@ -16,7 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 
 /**
- * Convenience interface and callback used by the {@link Observable#as} operator to turn an Observable into another
+ * Convenience interface and callback used by the {@link Observable#to} operator to turn an Observable into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3835,7 +3835,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * This allows fluent conversion to any other type.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1997,29 +1997,6 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Calls the specified converter function during assembly time and returns its resulting value.
-     * <p>
-     * <img width="640" height="553" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.as.png" alt="">
-     * <p>
-     * This allows fluent conversion to any other type.
-     * <dl>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.7 - experimental
-     * @param <R> the resulting object type
-     * @param converter the function that receives the current Single instance and returns a value
-     * @return the converted value
-     * @throws NullPointerException if converter is null
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R as(@NonNull SingleConverter<T, ? extends R> converter) {
-        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-    }
-
-    /**
      * Hides the identity of the current Single, including the Disposable that is sent
      * to the downstream via {@code onSubscribe()}.
      * <p>
@@ -3851,29 +3828,26 @@ public abstract class Single<T> implements SingleSource<T> {
     }
 
     /**
-     * Calls the specified converter function with the current Single instance
-     * during assembly time and returns its result.
+     * Calls the specified converter function during assembly time and returns its resulting value.
      * <p>
      * <img width="640" height="553" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.to.png" alt="">
+     * <p>
+     * This allows fluent conversion to any other type.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code to} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code as} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param <R> the result type
-     * @param convert the function that is called with the current Single instance during
-     *                assembly time that should return some value to be the result
-     *
-     * @return the value returned by the convert function
+     * <p>History: 2.1.7 - experimental
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current Single instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> R to(Function<? super Single<T>, R> convert) {
-        try {
-            return ObjectHelper.requireNonNull(convert, "convert is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+    public final <R> R to(@NonNull SingleConverter<T, ? extends R> converter) {
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/SingleConverter.java
+++ b/src/main/java/io/reactivex/SingleConverter.java
@@ -16,7 +16,7 @@ package io.reactivex;
 import io.reactivex.annotations.*;
 
 /**
- * Convenience interface and callback used by the {@link Single#as} operator to turn a Single into another
+ * Convenience interface and callback used by the {@link Single#to} operator to turn a Single into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -743,7 +743,6 @@ public abstract class ParallelFlowable<T> {
         return RxJavaPlugins.onAssembly(new ParallelFromArray<T>(publishers));
     }
 
-
     /**
      * Calls the specified converter function during assembly time and returns its resulting value.
      * <p>

--- a/src/main/java/io/reactivex/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowable.java
@@ -15,16 +15,16 @@ package io.reactivex.parallel;
 
 import java.util.*;
 
+import org.reactivestreams.*;
+
 import io.reactivex.*;
 import io.reactivex.annotations.*;
-import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.*;
 import io.reactivex.internal.operators.parallel.*;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import org.reactivestreams.*;
 
 /**
  * Abstract base class for Parallel publishers that take an array of Subscribers.
@@ -118,23 +118,6 @@ public abstract class ParallelFlowable<T> {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
 
         return RxJavaPlugins.onAssembly(new ParallelFromPublisher<T>(source, parallelism, prefetch));
-    }
-
-    /**
-     * Calls the specified converter function during assembly time and returns its resulting value.
-     * <p>
-     * This allows fluent conversion to any other type.
-     * <p>History: 2.1.7 - experimental
-     * @param <R> the resulting object type
-     * @param converter the function that receives the current ParallelFlowable instance and returns a value
-     * @return the converted value
-     * @throws NullPointerException if converter is null
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @NonNull
-    public final <R> R as(@NonNull ParallelFlowableConverter<T, R> converter) {
-        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**
@@ -760,23 +743,22 @@ public abstract class ParallelFlowable<T> {
         return RxJavaPlugins.onAssembly(new ParallelFromArray<T>(publishers));
     }
 
+
     /**
-     * Perform a fluent transformation to a value via a converter function which
-     * receives this ParallelFlowable.
-     *
-     * @param <U> the output value type
-     * @param converter the converter function from ParallelFlowable to some type
-     * @return the value returned by the converter function
+     * Calls the specified converter function during assembly time and returns its resulting value.
+     * <p>
+     * This allows fluent conversion to any other type.
+     * <p>History: 2.1.7 - experimental
+     * @param <R> the resulting object type
+     * @param converter the function that receives the current ParallelFlowable instance and returns a value
+     * @return the converted value
+     * @throws NullPointerException if converter is null
+     * @since 2.2
      */
     @CheckReturnValue
     @NonNull
-    public final <U> U to(@NonNull Function<? super ParallelFlowable<T>, U> converter) {
-        try {
-            return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
-        } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
-            throw ExceptionHelper.wrapOrThrow(ex);
-        }
+    public final <R> R to(@NonNull ParallelFlowableConverter<T, R> converter) {
+        return ObjectHelper.requireNonNull(converter, "converter is null").apply(this);
     }
 
     /**

--- a/src/main/java/io/reactivex/parallel/ParallelFlowableConverter.java
+++ b/src/main/java/io/reactivex/parallel/ParallelFlowableConverter.java
@@ -16,7 +16,7 @@ package io.reactivex.parallel;
 import io.reactivex.annotations.*;
 
 /**
- * Convenience interface and callback used by the {@link ParallelFlowable#as} operator to turn a ParallelFlowable into
+ * Convenience interface and callback used by the {@link ParallelFlowable#to} operator to turn a ParallelFlowable into
  * another value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type

--- a/src/test/java/io/reactivex/ConverterTest.java
+++ b/src/test/java/io/reactivex/ConverterTest.java
@@ -25,7 +25,7 @@ public final class ConverterTest {
     @Test
     public void flowableConverterThrows() {
         try {
-            Flowable.just(1).as(new FlowableConverter<Integer, Integer>() {
+            Flowable.just(1).to(new FlowableConverter<Integer, Integer>() {
                 @Override
                 public Integer apply(Flowable<Integer> v) {
                     throw new TestException("Forced failure");
@@ -40,7 +40,7 @@ public final class ConverterTest {
     @Test
     public void observableConverterThrows() {
         try {
-            Observable.just(1).as(new ObservableConverter<Integer, Integer>() {
+            Observable.just(1).to(new ObservableConverter<Integer, Integer>() {
                 @Override
                 public Integer apply(Observable<Integer> v) {
                     throw new TestException("Forced failure");
@@ -55,7 +55,7 @@ public final class ConverterTest {
     @Test
     public void singleConverterThrows() {
         try {
-            Single.just(1).as(new SingleConverter<Integer, Integer>() {
+            Single.just(1).to(new SingleConverter<Integer, Integer>() {
                 @Override
                 public Integer apply(Single<Integer> v) {
                     throw new TestException("Forced failure");
@@ -70,7 +70,7 @@ public final class ConverterTest {
     @Test
     public void maybeConverterThrows() {
         try {
-            Maybe.just(1).as(new MaybeConverter<Integer, Integer>() {
+            Maybe.just(1).to(new MaybeConverter<Integer, Integer>() {
                 @Override
                 public Integer apply(Maybe<Integer> v) {
                     throw new TestException("Forced failure");
@@ -85,7 +85,7 @@ public final class ConverterTest {
     @Test
     public void completableConverterThrows() {
         try {
-            Completable.complete().as(new CompletableConverter<Completable>() {
+            Completable.complete().to(new CompletableConverter<Completable>() {
                 @Override
                 public Completable apply(Completable v) {
                     throw new TestException("Forced failure");
@@ -104,7 +104,7 @@ public final class ConverterTest {
     public void observableGenericsSignatureTest() {
         A<String, Integer> a = new A<String, Integer>() { };
 
-        Observable.just(a).as((ObservableConverter)ConverterTest.testObservableConverterCreator());
+        Observable.just(a).to((ObservableConverter)ConverterTest.testObservableConverterCreator());
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -112,7 +112,7 @@ public final class ConverterTest {
     public void singleGenericsSignatureTest() {
         A<String, Integer> a = new A<String, Integer>() { };
 
-        Single.just(a).as((SingleConverter)ConverterTest.<String>testSingleConverterCreator());
+        Single.just(a).to((SingleConverter)ConverterTest.<String>testSingleConverterCreator());
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -120,7 +120,7 @@ public final class ConverterTest {
     public void maybeGenericsSignatureTest() {
         A<String, Integer> a = new A<String, Integer>() { };
 
-        Maybe.just(a).as((MaybeConverter)ConverterTest.<String>testMaybeConverterCreator());
+        Maybe.just(a).to((MaybeConverter)ConverterTest.<String>testMaybeConverterCreator());
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -128,7 +128,7 @@ public final class ConverterTest {
     public void flowableGenericsSignatureTest() {
         A<String, Integer> a = new A<String, Integer>() { };
 
-        Flowable.just(a).as((FlowableConverter)ConverterTest.<String>testFlowableConverterCreator());
+        Flowable.just(a).to((FlowableConverter)ConverterTest.<String>testFlowableConverterCreator());
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -136,7 +136,7 @@ public final class ConverterTest {
     public void parallelFlowableGenericsSignatureTest() {
         A<String, Integer> a = new A<String, Integer>() { };
 
-        Flowable.just(a).parallel().as((ParallelFlowableConverter)ConverterTest.<String>testParallelFlowableConverterCreator());
+        Flowable.just(a).parallel().to((ParallelFlowableConverter)ConverterTest.<String>testParallelFlowableConverterCreator());
     }
 
     @Test
@@ -144,33 +144,33 @@ public final class ConverterTest {
         CompositeConverter converter = new CompositeConverter();
 
         Flowable.just(1)
-                .as(converter)
+                .to(converter)
                 .test()
                 .assertValue(1);
 
         Observable.just(1)
-                .as(converter)
+                .to(converter)
                 .test()
                 .assertValue(1);
 
         Maybe.just(1)
-                .as(converter)
+                .to(converter)
                 .test()
                 .assertValue(1);
 
         Single.just(1)
-                .as(converter)
+                .to(converter)
                 .test()
                 .assertValue(1);
 
         Completable.complete()
-                .as(converter)
+                .to(converter)
                 .test()
                 .assertComplete();
 
         Flowable.just(1)
         .parallel()
-        .as(converter)
+        .to(converter)
         .test()
         .assertValue(1);
     }

--- a/src/test/java/io/reactivex/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/completable/CompletableTest.java
@@ -2813,7 +2813,7 @@ public class CompletableTest {
     @Test(timeout = 5000)
     public void toNormal() {
         normal.completable
-                .to(new Function<Completable, Flowable<Object>>() {
+                .to(new CompletableConverter<Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Completable c) {
                         return c.toFlowable();
@@ -2827,7 +2827,7 @@ public class CompletableTest {
     @Test(timeout = 5000)
     public void asNormal() {
         normal.completable
-                .as(new CompletableConverter<Flowable<Object>>() {
+                .to(new CompletableConverter<Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Completable c) {
                         return c.toFlowable();
@@ -2840,7 +2840,7 @@ public class CompletableTest {
 
     @Test
     public void as() {
-        Completable.complete().as(new CompletableConverter<Flowable<Integer>>() {
+        Completable.complete().to(new CompletableConverter<Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Completable v) {
                 return v.toFlowable();
@@ -2853,11 +2853,6 @@ public class CompletableTest {
     @Test(expected = NullPointerException.class)
     public void toNull() {
         normal.completable.to(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void asNull() {
-        normal.completable.as(null);
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableConversionTest.java
@@ -131,9 +131,9 @@ public class FlowableConversionTest {
         }
     }
 
-    public static class ConvertToCylonDetector<T> implements Function<Publisher<T>, CylonDetectorObservable<T>> {
+    public static class ConvertToCylonDetector<T> implements FlowableConverter<T, CylonDetectorObservable<T>> {
         @Override
-        public CylonDetectorObservable<T> apply(final Publisher<T> onSubscribe) {
+        public CylonDetectorObservable<T> apply(final Flowable<T> onSubscribe) {
             return CylonDetectorObservable.create(onSubscribe);
         }
     }
@@ -225,7 +225,7 @@ public class FlowableConversionTest {
                                 });
                     }
                 })
-                    .to(new Function<Flowable<Integer>, ConcurrentLinkedQueue<Integer>>() {
+                    .to(new FlowableConverter<Integer, ConcurrentLinkedQueue<Integer>>() {
                         @Override
                         public ConcurrentLinkedQueue<Integer> apply(Flowable<Integer> onSubscribe) {
                             final ConcurrentLinkedQueue<Integer> q = new ConcurrentLinkedQueue<Integer>();

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -2361,11 +2361,6 @@ public class FlowableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void asNull() {
-        just1.as(null);
-    }
-
-    @Test(expected = NullPointerException.class)
     public void toListNull() {
         just1.toList(null);
     }

--- a/src/test/java/io/reactivex/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableTests.java
@@ -1118,7 +1118,7 @@ public class FlowableTests {
     public void testExtend() {
         final TestSubscriber<Object> subscriber = new TestSubscriber<Object>();
         final Object value = new Object();
-        Object returned = Flowable.just(value).to(new Function<Flowable<Object>, Object>() {
+        Object returned = Flowable.just(value).to(new FlowableConverter<Object, Object>() {
             @Override
             public Object apply(Flowable<Object> onSubscribe) {
                     onSubscribe.subscribe(subscriber);
@@ -1135,7 +1135,7 @@ public class FlowableTests {
     public void testAsExtend() {
         final TestSubscriber<Object> subscriber = new TestSubscriber<Object>();
         final Object value = new Object();
-        Object returned = Flowable.just(value).as(new FlowableConverter<Object, Object>() {
+        Object returned = Flowable.just(value).to(new FlowableConverter<Object, Object>() {
             @Override
             public Object apply(Flowable<Object> onSubscribe) {
                     onSubscribe.subscribe(subscriber);
@@ -1150,7 +1150,7 @@ public class FlowableTests {
 
     @Test
     public void as() {
-        Flowable.just(1).as(new FlowableConverter<Integer, Observable<Integer>>() {
+        Flowable.just(1).to(new FlowableConverter<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Flowable<Integer> v) {
                 return v.toObservable();

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -370,9 +370,9 @@ public class MaybeTest {
 
     @Test
     public void to() {
-        Maybe.just(1).to(new Function<Maybe<Integer>, Flowable<Integer>>() {
+        Maybe.just(1).to(new MaybeConverter<Integer, Flowable<Integer>>() {
             @Override
-            public Flowable<Integer> apply(Maybe<Integer> v) throws Exception {
+            public Flowable<Integer> apply(Maybe<Integer> v) {
                 return v.toFlowable();
             }
         })
@@ -382,7 +382,7 @@ public class MaybeTest {
 
     @Test
     public void as() {
-        Maybe.just(1).as(new MaybeConverter<Integer, Flowable<Integer>>() {
+        Maybe.just(1).to(new MaybeConverter<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Maybe<Integer> v) {
                 return v.toFlowable();
@@ -399,7 +399,7 @@ public class MaybeTest {
 
     @Test(expected = NullPointerException.class)
     public void asNull() {
-        Maybe.just(1).as(null);
+        Maybe.just(1).to(null);
     }
 
     @Test

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -2409,11 +2409,6 @@ public class ObservableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void asNull() {
-        just1.as(null);
-    }
-
-    @Test(expected = NullPointerException.class)
     public void toListNull() {
         just1.toList(null);
     }

--- a/src/test/java/io/reactivex/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/observable/ObservableTest.java
@@ -1155,7 +1155,7 @@ public class ObservableTest {
     public void testExtend() {
         final TestObserver<Object> to = new TestObserver<Object>();
         final Object value = new Object();
-        Object returned = Observable.just(value).to(new Function<Observable<Object>, Object>() {
+        Object returned = Observable.just(value).to(new ObservableConverter<Object, Object>() {
             @Override
             public Object apply(Observable<Object> onSubscribe) {
                     onSubscribe.subscribe(to);
@@ -1172,7 +1172,7 @@ public class ObservableTest {
     public void testAsExtend() {
         final TestObserver<Object> to = new TestObserver<Object>();
         final Object value = new Object();
-        Object returned = Observable.just(value).as(new ObservableConverter<Object, Object>() {
+        Object returned = Observable.just(value).to(new ObservableConverter<Object, Object>() {
             @Override
             public Object apply(Observable<Object> onSubscribe) {
                 onSubscribe.subscribe(to);
@@ -1187,7 +1187,7 @@ public class ObservableTest {
 
     @Test
     public void as() {
-        Observable.just(1).as(new ObservableConverter<Integer, Flowable<Integer>>() {
+        Observable.just(1).to(new ObservableConverter<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Observable<Integer> v) {
                 return v.toFlowable(BackpressureStrategy.MISSING);

--- a/src/test/java/io/reactivex/observers/ObserverFusion.java
+++ b/src/test/java/io/reactivex/observers/ObserverFusion.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.observers;
 
-import io.reactivex.Observable;
+import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.fuseable.*;
 
@@ -40,7 +40,7 @@ public enum ObserverFusion {
      * @param cancelled should the TestObserver cancelled before the subscription even happens?
      * @return the new Function instance
      */
-    public static <T> Function<Observable<T>, TestObserver<T>> test(
+    public static <T> ObservableConverter<T, TestObserver<T>> test(
             final int mode, final boolean cancelled) {
         return new TestFunctionCallback<T>(mode, cancelled);
     }
@@ -76,7 +76,7 @@ public enum ObserverFusion {
         }
     }
 
-    static final class TestFunctionCallback<T> implements Function<Observable<T>, TestObserver<T>> {
+    static final class TestFunctionCallback<T> implements ObservableConverter<T, TestObserver<T>> {
         private final int mode;
         private final boolean cancelled;
 
@@ -86,7 +86,7 @@ public enum ObserverFusion {
         }
 
         @Override
-        public TestObserver<T> apply(Observable<T> t) throws Exception {
+        public TestObserver<T> apply(Observable<T> t) {
             TestObserver<T> to = new TestObserver<T>();
             to.setInitialFusionMode(mode);
             if (cancelled) {

--- a/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/parallel/ParallelFlowableTest.java
@@ -1088,21 +1088,7 @@ public class ParallelFlowableTest {
     public void to() {
         Flowable.range(1, 5)
         .parallel()
-        .to(new Function<ParallelFlowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
-                return pf.sequential();
-            }
-        })
-        .test()
-        .assertResult(1, 2, 3, 4, 5);
-    }
-
-    @Test
-    public void as() {
-        Flowable.range(1, 5)
-        .parallel()
-        .as(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
+        .to(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(ParallelFlowable<Integer> pf) {
                 return pf.sequential();
@@ -1116,19 +1102,7 @@ public class ParallelFlowableTest {
     public void toThrows() {
         Flowable.range(1, 5)
         .parallel()
-        .to(new Function<ParallelFlowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) throws Exception {
-                throw new TestException();
-            }
-        });
-    }
-
-    @Test(expected = TestException.class)
-    public void asThrows() {
-        Flowable.range(1, 5)
-        .parallel()
-        .as(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
+        .to(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(ParallelFlowable<Integer> pf) {
                 throw new TestException();

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -845,11 +845,6 @@ public class SingleNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void asNull() {
-        just1.as(null);
-    }
-
-    @Test(expected = NullPointerException.class)
     public void zipWithNull() {
         just1.zipWith(null, new BiFunction<Integer, Object, Object>() {
             @Override

--- a/src/test/java/io/reactivex/single/SingleTest.java
+++ b/src/test/java/io/reactivex/single/SingleTest.java
@@ -535,17 +535,7 @@ public class SingleTest {
 
     @Test
     public void to() {
-        assertEquals(1, Single.just(1).to(new Function<Single<Integer>, Integer>() {
-            @Override
-            public Integer apply(Single<Integer> v) throws Exception {
-                return 1;
-            }
-        }).intValue());
-    }
-
-    @Test
-    public void as() {
-        Single.just(1).as(new SingleConverter<Integer, Flowable<Integer>>() {
+        Single.just(1).to(new SingleConverter<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Single<Integer> v) {
                 return v.toFlowable();

--- a/src/test/java/io/reactivex/subscribers/SubscriberFusion.java
+++ b/src/test/java/io/reactivex/subscribers/SubscriberFusion.java
@@ -13,9 +13,9 @@
 
 package io.reactivex.subscribers;
 
-import io.reactivex.Flowable;
-import io.reactivex.functions.*;
-import io.reactivex.internal.fuseable.*;
+import io.reactivex.*;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.fuseable.QueueFuseable;
 
 /**
  * Utility methods that return functional interfaces to support assertions regarding fusion
@@ -41,9 +41,9 @@ public enum SubscriberFusion {
      * @param cancelled should the TestSubscriber cancelled before the subscription even happens?
      * @return the new Function instance
      */
-    public static <T> Function<Flowable<T>, TestSubscriber<T>> test(
+    public static <T> FlowableConverter<T, TestSubscriber<T>> test(
             final long initialRequest, final int mode, final boolean cancelled) {
-        return new TestFusionCheckFunction<T>(mode, cancelled, initialRequest);
+        return new TestFusionCheckConverter<T>(mode, cancelled, initialRequest);
     }
     /**
      * Returns a Consumer that asserts on its TestSubscriber parameter that
@@ -76,19 +76,19 @@ public enum SubscriberFusion {
         }
     }
 
-    static final class TestFusionCheckFunction<T> implements Function<Flowable<T>, TestSubscriber<T>> {
+    static final class TestFusionCheckConverter<T> implements FlowableConverter<T, TestSubscriber<T>> {
         private final int mode;
         private final boolean cancelled;
         private final long initialRequest;
 
-        TestFusionCheckFunction(int mode, boolean cancelled, long initialRequest) {
+        TestFusionCheckConverter(int mode, boolean cancelled, long initialRequest) {
             this.mode = mode;
             this.cancelled = cancelled;
             this.initialRequest = initialRequest;
         }
 
         @Override
-        public TestSubscriber<T> apply(Flowable<T> t) throws Exception {
+        public TestSubscriber<T> apply(Flowable<T> t) {
             TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
             ts.setInitialFusionMode(mode);
             if (cancelled) {


### PR DESCRIPTION
In 2.x, the `to()` operator used the generic `Function` to allow assembly-time conversion of flows into arbitrary types. The drawback of this approach was that each base reactive type had the same `Function` interface in their method signature, thus it was impossible to implement multiple converters for different reactive types within the same class. To work around this issue, the `as` operator and `XConverter` interfaces have been introduced in 2.x, which interfaces are distinct and can be implemented on the same class. Changing the signature of `to` in 2.x was not possible due to the pledged binary compatibility of the library.

From 3.x, the `as()` methods have been removed and the `to()` methods now each work with their respective `XConverer` interfaces:

- `Flowable.to(Function<Flowable<T>, R>)` is now `Flowable.to(FlowableConverter<T, R>)`
- `Observable.to(Function<Observable<T>, R>)` is now `Observable.to(ObservableConverter<T, R>)`
- `Maybe.to(Function<Flowable<T>, R>)` is now `Maybe.to(MaybeConverter<T, R>)`
- `Single.to(Function<Flowable<T>, R>)` is now `Maybe.to(SingleConverter<T, R>)`
- `Completable.to(Function<Completable, R>)` is now `Completable.to(CompletableConverter<R>)`
- `ParallelFlowable.to(Function<ParallelFlowable<T>, R)` is now `ParallelFlowable.to(ParallelFlowableConverter<T, R>)`

If one was using these methods with a lambda expression, only a recompilation is needed:

```java
// before
source.to(flowable -> flowable.blockingFirst());

// after
source.to(flowable -> flowable.blockingFirst());
```

If one was implementing a Function interface (typically anonymously), the interface type, type arguments and the `throws` clause have to be adjusted

```java
// before
source.to(new Function<Flowable<Integer>, Integer>() {
    @Override
    public Integer apply(Flowable<Integer> t) throws Exception {
        return t.blockingFirst();
    }
});

// after
source.to(new FlowableConverter<Integer, Integer>() {
    @Override
    public Integer apply(Flowable<Integer> t) {
        return t.blockingFirst();
    }
});
```

Resolves: #5654