### PR TITLE
3.x: remove getValues() from some subjects/processors

### DIFF
--- a/src/main/java/io/reactivex/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/processors/AsyncProcessor.java
@@ -12,7 +12,6 @@
  */
 package io.reactivex.processors;
 
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.*;
@@ -63,7 +62,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * This {@code AsyncProcessor} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
  * {@link #getThrowable()} and {@link #hasSubscribers()} as well as means to read the very last observed value -
  * after this {@code AsyncProcessor} has been completed - in a non-blocking and thread-safe
- * manner via {@link #hasValue()}, {@link #getValue()}, {@link #getValues()} or {@link #getValues(Object[])}.
+ * manner via {@link #hasValue()} or {@link #getValue()}.
  * <dl>
  *  <dt><b>Backpressure:</b></dt>
  *  <dd>The {@code AsyncProcessor} honors the backpressure of the downstream {@code Subscriber}s and won't emit
@@ -329,46 +328,6 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     @Nullable
     public T getValue() {
         return subscribers.get() == TERMINATED ? value : null;
-    }
-
-    /**
-     * Returns an Object array containing snapshot all values of this processor.
-     * <p>The method is thread-safe.
-     * @return the array containing the snapshot of all values of this processor
-     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
-     */
-    @Deprecated
-    public Object[] getValues() {
-        T v = getValue();
-        return v != null ? new Object[] { v } : new Object[0];
-    }
-
-    /**
-     * Returns a typed array containing a snapshot of all values of this processor.
-     * <p>The method follows the conventions of Collection.toArray by setting the array element
-     * after the last value to null (if the capacity permits).
-     * <p>The method is thread-safe.
-     * @param array the target array to copy values into if it fits
-     * @return the given array if the values fit into it or a new array containing all values
-     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
-     */
-    @Deprecated
-    public T[] getValues(T[] array) {
-        T v = getValue();
-        if (v == null) {
-            if (array.length != 0) {
-                array[0] = null;
-            }
-            return array;
-        }
-        if (array.length == 0) {
-            array = Arrays.copyOf(array, 1);
-        }
-        array[0] = v;
-        if (array.length != 1) {
-            array[1] = null;
-        }
-        return array;
     }
 
     static final class AsyncSubscription<T> extends DeferredScalarSubscription<T> {

--- a/src/main/java/io/reactivex/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/processors/BehaviorProcessor.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.processors;
 
-import java.lang.reflect.Array;
 import java.util.concurrent.atomic.*;
 import java.util.concurrent.locks.*;
 
@@ -95,8 +94,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * <p>
  * This {@code BehaviorProcessor} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
  * {@link #getThrowable()} and {@link #hasSubscribers()} as well as means to read the latest observed value
- * in a non-blocking and thread-safe manner via {@link #hasValue()}, {@link #getValue()},
- * {@link #getValues()} or {@link #getValues(Object[])}.
+ * in a non-blocking and thread-safe manner via {@link #hasValue()} or {@link #getValue()}.
  * <p>
  * Note that this processor signals {@code MissingBackpressureException} if a particular {@code Subscriber} is not
  * ready to receive {@code onNext} events. To avoid this exception being signaled, use {@link #offer(Object)} to only
@@ -372,56 +370,6 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
             return null;
         }
         return NotificationLite.getValue(o);
-    }
-
-    /**
-     * Returns an Object array containing snapshot all values of the BehaviorProcessor.
-     * <p>The method is thread-safe.
-     * @return the array containing the snapshot of all values of the BehaviorProcessor
-     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
-     */
-    @Deprecated
-    public Object[] getValues() {
-        @SuppressWarnings("unchecked")
-        T[] a = (T[])EMPTY_ARRAY;
-        T[] b = getValues(a);
-        if (b == EMPTY_ARRAY) {
-            return new Object[0];
-        }
-        return b;
-
-    }
-
-    /**
-     * Returns a typed array containing a snapshot of all values of the BehaviorProcessor.
-     * <p>The method follows the conventions of Collection.toArray by setting the array element
-     * after the last value to null (if the capacity permits).
-     * <p>The method is thread-safe.
-     * @param array the target array to copy values into if it fits
-     * @return the given array if the values fit into it or a new array containing all values
-     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
-     */
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public T[] getValues(T[] array) {
-        Object o = value.get();
-        if (o == null || NotificationLite.isComplete(o) || NotificationLite.isError(o)) {
-            if (array.length != 0) {
-                array[0] = null;
-            }
-            return array;
-        }
-        T v = NotificationLite.getValue(o);
-        if (array.length != 0) {
-            array[0] = v;
-            if (array.length != 1) {
-                array[1] = null;
-            }
-        } else {
-            array = (T[])Array.newInstance(array.getClass().getComponentType(), 1);
-            array[0] = v;
-        }
-        return array;
     }
 
     @Override

--- a/src/main/java/io/reactivex/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/subjects/AsyncSubject.java
@@ -13,13 +13,10 @@
 
 package io.reactivex.subjects;
 
-import io.reactivex.annotations.Nullable;
-import io.reactivex.annotations.NonNull;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.Observer;
-import io.reactivex.annotations.CheckReturnValue;
+import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.observers.DeferredScalarDisposable;
@@ -64,7 +61,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * This {@code AsyncSubject} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
  * {@link #getThrowable()} and {@link #hasObservers()} as well as means to read the very last observed value -
  * after this {@code AsyncSubject} has been completed - in a non-blocking and thread-safe
- * manner via {@link #hasValue()}, {@link #getValue()}, {@link #getValues()} or {@link #getValues(Object[])}.
+ * manner via {@link #hasValue()} or {@link #getValue()}.
  * <dl>
  *  <dt><b>Scheduler:</b></dt>
  *  <dd>{@code AsyncSubject} does not operate by default on a particular {@link io.reactivex.Scheduler} and
@@ -319,46 +316,6 @@ public final class AsyncSubject<T> extends Subject<T> {
     @Nullable
     public T getValue() {
         return subscribers.get() == TERMINATED ? value : null;
-    }
-
-    /**
-     * Returns an Object array containing snapshot all values of the Subject.
-     * <p>The method is thread-safe.
-     * @return the array containing the snapshot of all values of the Subject
-     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
-     */
-    @Deprecated
-    public Object[] getValues() {
-        T v = getValue();
-        return v != null ? new Object[] { v } : new Object[0];
-    }
-
-    /**
-     * Returns a typed array containing a snapshot of all values of the Subject.
-     * <p>The method follows the conventions of Collection.toArray by setting the array element
-     * after the last value to null (if the capacity permits).
-     * <p>The method is thread-safe.
-     * @param array the target array to copy values into if it fits
-     * @return the given array if the values fit into it or a new array containing all values
-     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
-     */
-    @Deprecated
-    public T[] getValues(T[] array) {
-        T v = getValue();
-        if (v == null) {
-            if (array.length != 0) {
-                array[0] = null;
-            }
-            return array;
-        }
-        if (array.length == 0) {
-            array = Arrays.copyOf(array, 1);
-        }
-        array[0] = v;
-        if (array.length != 1) {
-            array[1] = null;
-        }
-        return array;
     }
 
     static final class AsyncDisposable<T> extends DeferredScalarDisposable<T> {

--- a/src/main/java/io/reactivex/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/subjects/BehaviorSubject.java
@@ -13,14 +13,11 @@
 
 package io.reactivex.subjects;
 
-import io.reactivex.annotations.CheckReturnValue;
-import io.reactivex.annotations.Nullable;
-import io.reactivex.annotations.NonNull;
-import java.lang.reflect.Array;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.*;
 
 import io.reactivex.Observer;
+import io.reactivex.annotations.*;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.functions.ObjectHelper;
 import io.reactivex.internal.util.*;
@@ -97,8 +94,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  * <p>
  * This {@code BehaviorSubject} supports the standard state-peeking methods {@link #hasComplete()}, {@link #hasThrowable()},
  * {@link #getThrowable()} and {@link #hasObservers()} as well as means to read the latest observed value
- * in a non-blocking and thread-safe manner via {@link #hasValue()}, {@link #getValue()},
- * {@link #getValues()} or {@link #getValues(Object[])}.
+ * in a non-blocking and thread-safe manner via {@link #hasValue()} or {@link #getValue()}.
  * <dl>
  *  <dt><b>Scheduler:</b></dt>
  *  <dd>{@code BehaviorSubject} does not operate by default on a particular {@link io.reactivex.Scheduler} and
@@ -152,9 +148,6 @@ import io.reactivex.plugins.RxJavaPlugins;
  *          the type of item expected to be observed by the Subject
  */
 public final class BehaviorSubject<T> extends Subject<T> {
-
-    /** An empty array to avoid allocation in getValues(). */
-    private static final Object[] EMPTY_ARRAY = new Object[0];
 
     final AtomicReference<Object> value;
 
@@ -324,56 +317,6 @@ public final class BehaviorSubject<T> extends Subject<T> {
             return null;
         }
         return NotificationLite.getValue(o);
-    }
-
-    /**
-     * Returns an Object array containing snapshot all values of the Subject.
-     * <p>The method is thread-safe.
-     * @return the array containing the snapshot of all values of the Subject
-     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
-     */
-    @Deprecated
-    public Object[] getValues() {
-        @SuppressWarnings("unchecked")
-        T[] a = (T[])EMPTY_ARRAY;
-        T[] b = getValues(a);
-        if (b == EMPTY_ARRAY) {
-            return new Object[0];
-        }
-        return b;
-
-    }
-
-    /**
-     * Returns a typed array containing a snapshot of all values of the Subject.
-     * <p>The method follows the conventions of Collection.toArray by setting the array element
-     * after the last value to null (if the capacity permits).
-     * <p>The method is thread-safe.
-     * @param array the target array to copy values into if it fits
-     * @return the given array if the values fit into it or a new array containing all values
-     * @deprecated in 2.1.14; put the result of {@link #getValue()} into an array manually, will be removed in 3.x
-     */
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public T[] getValues(T[] array) {
-        Object o = value.get();
-        if (o == null || NotificationLite.isComplete(o) || NotificationLite.isError(o)) {
-            if (array.length != 0) {
-                array[0] = null;
-            }
-            return array;
-        }
-        T v = NotificationLite.getValue(o);
-        if (array.length != 0) {
-            array[0] = v;
-            if (array.length != 1) {
-                array[1] = null;
-            }
-        } else {
-            array = (T[])Array.newInstance(array.getClass().getComponentType(), 1);
-            array[0] = v;
-        }
-        return array;
     }
 
     @Override

--- a/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/SerializedProcessorTest.java
@@ -38,7 +38,6 @@ public class SerializedProcessorTest {
         ts.assertValue("hello");
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueRelay() {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
@@ -52,13 +51,8 @@ public class SerializedProcessorTest {
         assertNull(serial.getThrowable());
         assertEquals((Integer)1, async.getValue());
         assertTrue(async.hasValue());
-        assertArrayEquals(new Object[] { 1 }, async.getValues());
-        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueEmpty() {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
@@ -71,13 +65,8 @@ public class SerializedProcessorTest {
         assertNull(serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueError() {
         AsyncProcessor<Integer> async = AsyncProcessor.create();
@@ -91,10 +80,6 @@ public class SerializedProcessorTest {
         assertSame(te, serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
     @Test
@@ -135,7 +120,6 @@ public class SerializedProcessorTest {
         assertSame(te, serial.getThrowable());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectValueRelay() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -149,13 +133,8 @@ public class SerializedProcessorTest {
         assertNull(serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectValueRelayIncomplete() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -168,13 +147,8 @@ public class SerializedProcessorTest {
         assertNull(serial.getThrowable());
         assertEquals((Integer)1, async.getValue());
         assertTrue(async.hasValue());
-        assertArrayEquals(new Object[] { 1 }, async.getValues());
-        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectIncompleteEmpty() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -186,13 +160,8 @@ public class SerializedProcessorTest {
         assertNull(serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectEmpty() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -205,13 +174,8 @@ public class SerializedProcessorTest {
         assertNull(serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectError() {
         BehaviorProcessor<Integer> async = BehaviorProcessor.create();
@@ -225,10 +189,6 @@ public class SerializedProcessorTest {
         assertSame(te, serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
     @Test

--- a/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/SerializedSubjectTest.java
@@ -39,7 +39,6 @@ public class SerializedSubjectTest {
         to.assertValue("hello");
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueRelay() {
         AsyncSubject<Integer> async = AsyncSubject.create();
@@ -53,13 +52,8 @@ public class SerializedSubjectTest {
         assertNull(serial.getThrowable());
         assertEquals((Integer)1, async.getValue());
         assertTrue(async.hasValue());
-        assertArrayEquals(new Object[] { 1 }, async.getValues());
-        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueEmpty() {
         AsyncSubject<Integer> async = AsyncSubject.create();
@@ -72,13 +66,8 @@ public class SerializedSubjectTest {
         assertNull(serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testAsyncSubjectValueError() {
         AsyncSubject<Integer> async = AsyncSubject.create();
@@ -92,10 +81,6 @@ public class SerializedSubjectTest {
         assertSame(te, serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
     @Test
@@ -136,7 +121,6 @@ public class SerializedSubjectTest {
         assertSame(te, serial.getThrowable());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectValueRelay() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -150,13 +134,8 @@ public class SerializedSubjectTest {
         assertNull(serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectValueRelayIncomplete() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -169,13 +148,8 @@ public class SerializedSubjectTest {
         assertNull(serial.getThrowable());
         assertEquals((Integer)1, async.getValue());
         assertTrue(async.hasValue());
-        assertArrayEquals(new Object[] { 1 }, async.getValues());
-        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { 1 }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { 1, null }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectIncompleteEmpty() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -187,13 +161,8 @@ public class SerializedSubjectTest {
         assertNull(serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectEmpty() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -206,13 +175,8 @@ public class SerializedSubjectTest {
         assertNull(serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testBehaviorSubjectError() {
         BehaviorSubject<Integer> async = BehaviorSubject.create();
@@ -226,10 +190,6 @@ public class SerializedSubjectTest {
         assertSame(te, serial.getThrowable());
         assertNull(async.getValue());
         assertFalse(async.hasValue());
-        assertArrayEquals(new Object[] { }, async.getValues());
-        assertArrayEquals(new Integer[] { }, async.getValues(new Integer[0]));
-        assertArrayEquals(new Integer[] { null }, async.getValues(new Integer[] { 0 }));
-        assertArrayEquals(new Integer[] { null, 0 }, async.getValues(new Integer[] { 0, 0 }));
     }
 
     @Test


### PR DESCRIPTION
The `getValue()` and `getValues(T[])` methods were a remnant from a time where `Subject` and `FlowableProcessor` was unifying all state peeking methods for every kind of subject/processor. These have been marked as `@Deprecated` in 2.x and are now removed from 3.x. They can be trivially replaced with `getValue()` if necessary, for example:

```java
Object value = subject.getValue();
if (value == null) {
   return new Object[1];
}
return new Object[] { value };
```

Related: #5622