### PR TITLE
2.x: Fix concatMapDelayError not continuing on fused inner source crash

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -520,10 +520,13 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                     vr = supplier.call();
                                 } catch (Throwable e) {
                                     Exceptions.throwIfFatal(e);
-                                    upstream.cancel();
                                     errors.addThrowable(e);
-                                    downstream.onError(errors.terminate());
-                                    return;
+                                    if (!veryEnd) {
+                                        upstream.cancel();
+                                        downstream.onError(errors.terminate());
+                                        return;
+                                    }
+                                    vr = null;
                                 }
 
                                 if (vr == null) {


### PR DESCRIPTION
The `Callable` fused path didn't consider the error-delay settings and cut the sequence short.

Fixes: #6520 