### PR TITLE
3.x: Fix concatMapDelayError not continuing on fused inner source crash

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMap.java
@@ -519,10 +519,13 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                     vr = supplier.get();
                                 } catch (Throwable e) {
                                     Exceptions.throwIfFatal(e);
-                                    upstream.cancel();
                                     errors.addThrowable(e);
-                                    downstream.onError(errors.terminate());
-                                    return;
+                                    if (!veryEnd) {
+                                        upstream.cancel();
+                                        downstream.onError(errors.terminate());
+                                        return;
+                                    }
+                                    vr = null;
                                 }
 
                                 if (vr == null) {


### PR DESCRIPTION
The `Supplier` fused path didn't consider the error-delay settings and cut the sequence short.

Fixes: #6520 