### PR TITLE
3.x: remove `test` from `testXXX` method names, create a validator

### DIFF
--- a/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
+++ b/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
@@ -104,7 +104,7 @@ public class TestPrefixInMethodName {
                                 in.close();
                             }
 
-                            if (found && System.getenv("CI") == null) {
+                            /*if (found && System.getenv("CI") == null) {
                                 PrintWriter w = new PrintWriter(new FileWriter(u));
 
                                 try {
@@ -114,7 +114,7 @@ public class TestPrefixInMethodName {
                                 } finally {
                                     w.close();
                                 }
-                            }
+                            }*/
                         }
                     }
                 }

--- a/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
+++ b/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.validators;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.*;
@@ -32,6 +33,7 @@ public class TestPrefixInMethodName {
     private static final String replacement = "void ";
 
     @Test
+    @Ignore
     public void checkAndUpdateTestMethodNames() throws Exception {
         File f = MaybeNo2Dot0Since.findSource("Flowable");
         if (f == null) {

--- a/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
+++ b/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
@@ -83,27 +83,26 @@ public class TestPrefixInMethodName {
                                     }
                                     lineNum++;
 
-                                    if (!line.startsWith("//") && !line.startsWith("*")) {
-                                        Matcher matcher = p.matcher(line);
-                                        if (matcher.find()) {
-                                            found = true;
-                                            fail
-                                                    .append(fname)
-                                                    .append("#L").append(lineNum)
-                                                    .append("    ").append(line)
-                                                    .append("\n");
-                                            total++;
+                                    Matcher matcher = p.matcher(line);
+                                    if (!line.startsWith("//") && !line.startsWith("*") && matcher.find()) {
+                                        found = true;
+                                        fail
+                                                .append(fname)
+                                                .append("#L").append(lineNum)
+                                                .append("    ").append(line)
+                                                .append("\n");
+                                        total++;
 
-                                            int methodNameStartIndex = matcher.end() - 1;
-                                            char firstChar = Character.toLowerCase(line.charAt(methodNameStartIndex));
+                                        int methodNameStartIndex = matcher.end() - 1;
+                                        char firstChar = Character.toLowerCase(line.charAt(methodNameStartIndex));
 
-                                            String newLine = matcher.replaceAll(replacement + firstChar);
+                                        String newLine = matcher.replaceAll(replacement + firstChar);
 
-                                            lines.add(newLine);
-                                        } else {
-                                            lines.add(line);
-                                        }
+                                        lines.add(newLine);
+                                    } else {
+                                        lines.add(line);
                                     }
+
                                 }
                             } finally {
                                 in.close();

--- a/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
+++ b/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.validators;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.regex.Pattern;
+
+/**
+ * Check verifying there are no methods with the prefix "test" in the name
+ */
+public class TestPrefixInMethodName {
+
+    private static final String pattern = "void\\s+test[a-zA-Z0-9]";
+
+    @Test
+    public void findTestPrefixInMethodName() throws Exception {
+        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        if (f == null) {
+            System.out.println("Unable to find sources of RxJava");
+            return;
+        }
+
+        Queue<File> dirs = new ArrayDeque<File>();
+
+        StringBuilder fail = new StringBuilder();
+        fail.append("The following code pattern was found: ").append(pattern).append("\n");
+
+        File parent = f.getParentFile();
+
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/')));
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/').replace("src/main/java", "src/test/java")));
+
+        Pattern p = Pattern.compile(pattern);
+
+        int total = 0;
+
+        while (!dirs.isEmpty()) {
+            f = dirs.poll();
+
+            File[] list = f.listFiles();
+            if (list != null && list.length != 0) {
+
+                for (File u : list) {
+                    if (u.isDirectory()) {
+                        dirs.offer(u);
+                    } else {
+                        String fname = u.getName();
+                        if (fname.endsWith(".java")) {
+
+                            int lineNum = 0;
+                            BufferedReader in = new BufferedReader(new FileReader(u));
+                            try {
+                                for (; ; ) {
+                                    String line = in.readLine();
+                                    if (line != null) {
+                                        lineNum++;
+
+                                        line = line.trim();
+
+                                        if (!line.startsWith("//") && !line.startsWith("*")) {
+                                            if (p.matcher(line).find()) {
+                                                fail
+                                                        .append(fname)
+                                                        .append("#L").append(lineNum)
+                                                        .append("    ").append(line)
+                                                        .append("\n");
+                                                total++;
+                                            }
+                                        }
+                                    } else {
+                                        break;
+                                    }
+                                }
+                            } finally {
+                                in.close();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (total != 0) {
+            fail.append("Found ")
+                    .append(total)
+                    .append(" instances");
+            System.out.println(fail);
+            throw new AssertionError(fail.toString());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
+++ b/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
@@ -33,10 +33,6 @@ public class TestPrefixInMethodName {
 
     @Test
     public void checkAndUpdateTestMethodNames() throws Exception {
-        if (System.getenv("CI") != null) {
-            // no point in changing the files in CI
-            return;
-        }
         File f = MaybeNo2Dot0Since.findSource("Flowable");
         if (f == null) {
             System.out.println("Unable to find sources of RxJava");
@@ -108,7 +104,7 @@ public class TestPrefixInMethodName {
                                 in.close();
                             }
 
-                            if (found) {
+                            if (found && System.getenv("CI") == null) {
                                 PrintWriter w = new PrintWriter(new FileWriter(u));
 
                                 try {


### PR DESCRIPTION
Fix #6518.

- [X] Create validator
- [X] Automatically rename methods "testXXX" to "xxx" (analog to [FixLicenseHeaders](https://github.com/ReactiveX/RxJava/blob/3.x/src/test/java/io/reactivex/validators/FixLicenseHeaders.java) check)
- [x] Rename methods