### PR TITLE
3.x: add marbles to X.fromSupplier

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -615,7 +615,7 @@ public abstract class Completable implements CompletableSource {
      * Returns a Completable which when subscribed, executes the supplier function, ignores its
      * normal result and emits onError or onComplete only.
      * <p>
-     * <img width="640" height="286" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.fromCallable.png" alt="">
+     * <img width="640" height="286" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.fromSupplier.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromSupplier} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -2336,7 +2336,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Returns a Flowable that, when a Subscriber subscribes to it, invokes a supplier function you specify and then
      * emits the value returned from that function.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromCallable.png" alt="">
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.fromSupplier.png" alt="">
      * <p>
      * This allows you to defer the execution of the function you specify until a Subscriber subscribes to the
      * Publisher. That is to say, it makes the function "lazy."

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -877,6 +877,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * subscribes to the  returned {@link Maybe}. In other terms, this source operator evaluates the given
      * {@code Supplier} "lazily".
      * <p>
+     * <img width="640" height="311" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.fromSupplier.png" alt="">
+     * <p>
      * Note that the {@code null} handling of this operator differs from the similar source operators in the other
      * {@link io.reactivex base reactive classes}. Those operators signal a {@code NullPointerException} if the value returned by their
      * {@code Supplier} is {@code null} while this {@code fromSupplier} considers it to indicate the

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -2026,7 +2026,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Returns an Observable that, when an observer subscribes to it, invokes a supplier function you specify and then
      * emits the value returned from that function.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromCallable.png" alt="">
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.fromSupplier.png" alt="">
      * <p>
      * This allows you to defer the execution of the function you specify until an observer subscribes to the
      * ObservableSource. That is to say, it makes the function "lazy."

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -821,7 +821,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * It makes passed function "lazy".
      * Result of the function invocation will be emitted by the {@link Single}.
      * <p>
-     * <img width="640" height="467" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.fromCallable.png" alt="">
+     * <img width="640" height="467" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.fromSupplier.png" alt="">
      * <dl>
      *   <dt><b>Scheduler:</b></dt>
      *   <dd>{@code fromSupplier} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
This PR adds marbles to the new `fromSupplier` operators:

#### Flowable:
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.fromSupplier.png)

#### Observable:
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.fromSupplier.png)

#### Maybe:
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.fromSupplier.png)

#### Single:
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.fromSupplier.png)

#### Completable:
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.fromSupplier.png)