### PR TITLE
3.x: Make using() resource disposal order consistent with eager-mode

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1026,8 +1026,11 @@ public abstract class Completable implements CompletableSource {
      * @param completableFunction the function that given a resource returns a non-null
      * Completable instance that will be subscribed to
      * @param disposer the consumer that disposes the resource created by the resource supplier
-     * @param eager if true, the resource is disposed before the terminal event is emitted, if false, the
-     * resource is disposed after the terminal event has been emitted
+     * @param eager
+     *            If {@code true} then resource disposal will happen either on a {@code dispose()} call before the upstream is disposed
+     *            or just before the emission of a terminal event ({@code onComplete} or {@code onError}).
+     *            If {@code false} the resource disposal will happen either on a {@code dispose()} call after the upstream is disposed
+     *            or just after the emission of a terminal event ({@code onComplete} or {@code onError}).
      * @return the new Completable instance
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -4603,8 +4603,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param resourceDisposer
      *            the function that will dispose of the resource
      * @param eager
-     *            if {@code true} then disposal will happen either on cancellation or just before emission of
-     *            a terminal event ({@code onComplete} or {@code onError}).
+     *            If {@code true} then resource disposal will happen either on a {@code cancel()} call before the upstream is disposed
+     *            or just before the emission of a terminal event ({@code onComplete} or {@code onError}).
+     *            If {@code false} the resource disposal will happen either on a {@code cancel()} call after the upstream is disposed
+     *            or just after the emission of a terminal event ({@code onComplete} or {@code onError}).
      * @return the Publisher whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
      * @since 2.0

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -1766,8 +1766,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param resourceDisposer
      *            the function that will dispose of the resource
      * @param eager
-     *            if {@code true} then disposal will happen either on a dispose() call or just before emission of
-     *            a terminal event ({@code onComplete} or {@code onError}).
+     *            If {@code true} then resource disposal will happen either on a {@code dispose()} call before the upstream is disposed
+     *            or just before the emission of a terminal event ({@code onSuccess}, {@code onComplete} or {@code onError}).
+     *            If {@code false} the resource disposal will happen either on a {@code dispose()} call after the upstream is disposed
+     *            or just after the emission of a terminal event ({@code onSuccess}, {@code onComplete} or {@code onError}).
      * @return the Maybe whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
      */

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -4089,8 +4089,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param disposer
      *            the function that will dispose of the resource
      * @param eager
-     *            if {@code true} then disposal will happen either on a dispose() call or just before emission of
-     *            a terminal event ({@code onComplete} or {@code onError}).
+     *            If {@code true} then resource disposal will happen either on a {@code dispose()} call before the upstream is disposed
+     *            or just before the emission of a terminal event ({@code onComplete} or {@code onError}).
+     *            If {@code false} the resource disposal will happen either on a {@code dispose()} call after the upstream is disposed
+     *            or just after the emission of a terminal event ({@code onComplete} or {@code onError}).
      * @return the ObservableSource whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
      * @since 2.0

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -1477,8 +1477,10 @@ public abstract class Single<T> implements SingleSource<T> {
      *                  that particular resource when the generated SingleSource terminates
      *                  (successfully or with an error) or gets disposed.
      * @param eager
-     *                 if true, the disposer is called before the terminal event is signalled
-     *                 if false, the disposer is called after the terminal event is delivered to downstream
+     *            If {@code true} then resource disposal will happen either on a {@code dispose()} call before the upstream is disposed
+     *            or just before the emission of a terminal event ({@code onSuccess} or {@code onError}).
+     *            If {@code false} the resource disposal will happen either on a {@code dispose()} call after the upstream is disposed
+     *            or just after the emission of a terminal event ({@code onSuccess} or {@code onError}).
      * @return the new Single instance
      * @since 2.0
      */

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableUsing.java
@@ -106,13 +106,19 @@ public final class CompletableUsing<R> extends Completable {
 
         @Override
         public void dispose() {
-            upstream.dispose();
-            upstream = DisposableHelper.DISPOSED;
-            disposeResourceAfter();
+            if (eager) {
+                disposeResource();
+                upstream.dispose();
+                upstream = DisposableHelper.DISPOSED;
+            } else {
+                upstream.dispose();
+                upstream = DisposableHelper.DISPOSED;
+                disposeResource();
+            }
         }
 
         @SuppressWarnings("unchecked")
-        void disposeResourceAfter() {
+        void disposeResource() {
             Object resource = getAndSet(this);
             if (resource != this) {
                 try {
@@ -159,7 +165,7 @@ public final class CompletableUsing<R> extends Completable {
             downstream.onError(e);
 
             if (!eager) {
-                disposeResourceAfter();
+                disposeResource();
             }
         }
 
@@ -185,7 +191,7 @@ public final class CompletableUsing<R> extends Completable {
             downstream.onComplete();
 
             if (!eager) {
-                disposeResourceAfter();
+                disposeResource();
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeUsing.java
@@ -117,13 +117,19 @@ public final class MaybeUsing<T, D> extends Maybe<T> {
 
         @Override
         public void dispose() {
-            upstream.dispose();
-            upstream = DisposableHelper.DISPOSED;
-            disposeResourceAfter();
+            if (eager) {
+                disposeResource();
+                upstream.dispose();
+                upstream = DisposableHelper.DISPOSED;
+            } else {
+                upstream.dispose();
+                upstream = DisposableHelper.DISPOSED;
+                disposeResource();
+            }
         }
 
         @SuppressWarnings("unchecked")
-        void disposeResourceAfter() {
+        void disposeResource() {
             Object resource = getAndSet(this);
             if (resource != this) {
                 try {
@@ -171,7 +177,7 @@ public final class MaybeUsing<T, D> extends Maybe<T> {
             downstream.onSuccess(value);
 
             if (!eager) {
-                disposeResourceAfter();
+                disposeResource();
             }
         }
 
@@ -196,7 +202,7 @@ public final class MaybeUsing<T, D> extends Maybe<T> {
             downstream.onError(e);
 
             if (!eager) {
-                disposeResourceAfter();
+                disposeResource();
             }
         }
 
@@ -222,7 +228,7 @@ public final class MaybeUsing<T, D> extends Maybe<T> {
             downstream.onComplete();
 
             if (!eager) {
-                disposeResourceAfter();
+                disposeResource();
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleUsing.java
@@ -106,9 +106,15 @@ public final class SingleUsing<T, U> extends Single<T> {
 
         @Override
         public void dispose() {
-            upstream.dispose();
-            upstream = DisposableHelper.DISPOSED;
-            disposeAfter();
+            if (eager) {
+                disposeResource();
+                upstream.dispose();
+                upstream = DisposableHelper.DISPOSED;
+            } else {
+                upstream.dispose();
+                upstream = DisposableHelper.DISPOSED;
+                disposeResource();
+            }
         }
 
         @Override
@@ -148,7 +154,7 @@ public final class SingleUsing<T, U> extends Single<T> {
             downstream.onSuccess(value);
 
             if (!eager) {
-                disposeAfter();
+                disposeResource();
             }
         }
 
@@ -174,12 +180,12 @@ public final class SingleUsing<T, U> extends Single<T> {
             downstream.onError(e);
 
             if (!eager) {
-                disposeAfter();
+                disposeResource();
             }
         }
 
         @SuppressWarnings("unchecked")
-        void disposeAfter() {
+        void disposeResource() {
             Object u = getAndSet(this);
             if (u != this) {
                 try {


### PR DESCRIPTION
Make the resource disposal order in all `using` implementations are consistent with the eagerness of the operator:

**eager**: dispose resource then dispose the upstream
**non-eager**: dispose the upstream then dispose the resource.

Fixes: #6347