### PR TITLE
3.x: Promote Beta/Experimental to Standard

### DIFF
--- a/src/main/java/io/reactivex/Completable.java
+++ b/src/main/java/io/reactivex/Completable.java
@@ -1412,15 +1412,15 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code delaySubscription} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.2.3 - experimental
      *
      * @param delay the time to delay the subscription
      * @param unit  the time unit of {@code delay}
      * @return a Completable that delays the subscription to the source CompletableSource by the given amount
-     * @since 2.2.3 - experimental
+     * @since 3.0.0
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     public final Completable delaySubscription(long delay, TimeUnit unit) {
         return delaySubscription(delay, unit, Schedulers.computation());
@@ -1435,17 +1435,16 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
      * </dl>
-     *
+     * <p>History: 2.2.3 - experimental
      * @param delay     the time to delay the subscription
      * @param unit      the time unit of {@code delay}
      * @param scheduler the Scheduler on which the waiting and subscription will happen
      * @return a Completable that delays the subscription to the source CompletableSource by a given
      * amount, waiting and subscribing on the given Scheduler
-     * @since 2.2.3 - experimental
+     * @since 3.0.0
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
     @CheckReturnValue
-    @Experimental
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Completable delaySubscription(long delay, TimeUnit unit, Scheduler scheduler) {
         return Completable.timer(delay, unit, scheduler).andThen(this);
@@ -1809,12 +1808,12 @@ public abstract class Completable implements CompletableSource {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code materialize} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.2.4 - experimental
      * @param <T> the intended target element type of the notification
      * @return the new Single instance
-     * @since 2.2.4 - experimental
+     * @since 3.0.0
      * @see Single#dematerialize(Function)
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Single<Notification<T>> materialize() {

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -8825,6 +8825,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code dematerialize} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.2.4 - experimental
      *
      * @param <R> the output value type
      * @param selector function that returns the upstream item and should return a Notification to signal
@@ -8832,9 +8833,8 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the items and notifications embedded in the {@link Notification} objects
      *         selected from the items emitted by the source Flowable
      * @see <a href="http://reactivex.io/documentation/operators/materialize-dematerialize.html">ReactiveX operators documentation: Dematerialize</a>
-     * @since 2.2.4 - experimental
+     * @since 3.0.0
      */
-    @Experimental
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -2936,13 +2936,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code doOnTerminate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.2.7 - experimental
      * @param onTerminate the action to invoke when the consumer calls {@code onComplete} or {@code onError}
      * @return the new Maybe instance
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      * @see #doOnTerminate(Action)
-     * @since 2.2.7 - experimental
+     * @since 3.0.0
      */
-    @Experimental
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3521,11 +3521,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code materialize} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.2.4 - experimental
      * @return the new Single instance
-     * @since 2.2.4 - experimental
+     * @since 3.0.0
      * @see Single#dematerialize(Function)
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<Notification<T>> materialize() {

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7778,6 +7778,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code dematerialize} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.2.4 - experimental
      *
      * @param <R> the output value type
      * @param selector function that returns the upstream item and should return a Notification to signal
@@ -7785,9 +7786,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the items and notifications embedded in the {@link Notification} objects
      *         selected from the items emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/materialize-dematerialize.html">ReactiveX operators documentation: Dematerialize</a>
-     * @since 2.2.4 - experimental
+     * @since 3.0.0
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> dematerialize(Function<? super T, Notification<R>> selector) {

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2402,17 +2402,17 @@ public abstract class Single<T> implements SingleSource<T> {
      * .test()
      * .assertResult(1);
      * </code></pre>
+     * <p>History: 2.2.4 - experimental
      * @param <R> the result type
      * @param selector the function called with the success item and should
      * return a {@link Notification} instance.
      * @return the new Maybe instance
-     * @since 2.2.4 - experimental
+     * @since 3.0.0
      * @see #materialize()
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Experimental
     public final <R> Maybe<R> dematerialize(Function<? super T, Notification<R>> selector) {
         ObjectHelper.requireNonNull(selector, "selector is null");
         return RxJavaPlugins.onAssembly(new SingleDematerialize<T, R>(this, selector));
@@ -2532,13 +2532,13 @@ public abstract class Single<T> implements SingleSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code doOnTerminate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.2.7 - experimental
      * @param onTerminate the action to invoke when the consumer calls {@code onComplete} or {@code onError}
      * @return the new Single instance
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      * @see #doOnTerminate(Action)
-     * @since 2.2.7 - experimental
+     * @since 3.0.0
      */
-    @Experimental
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3042,11 +3042,11 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code materialize} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 2.2.4 - experimental
      * @return the new Single instance
-     * @since 2.2.4 - experimental
+     * @since 3.0.0
      * @see #dematerialize(Function)
      */
-    @Experimental
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<Notification<T>> materialize() {

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMaterialize.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMaterialize.java
@@ -14,17 +14,16 @@
 package io.reactivex.internal.operators.completable;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.internal.operators.mixed.MaterializeSingleObserver;
 
 /**
  * Turn the signal types of a Completable source into a single Notification of
  * equal kind.
+ * <p>History: 2.2.4 - experimental
  *
  * @param <T> the element type of the source
- * @since 2.2.4 - experimental
+ * @since 3.0.0
  */
-@Experimental
 public final class CompletableMaterialize<T> extends Single<Notification<T>> {
 
     final Completable source;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeMaterialize.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeMaterialize.java
@@ -14,17 +14,16 @@
 package io.reactivex.internal.operators.maybe;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.internal.operators.mixed.MaterializeSingleObserver;
 
 /**
  * Turn the signal types of a Maybe source into a single Notification of
  * equal kind.
+ * <p>History: 2.2.4 - experimental
  *
  * @param <T> the element type of the source
- * @since 2.2.4 - experimental
+ * @since 3.0.0
  */
-@Experimental
 public final class MaybeMaterialize<T> extends Single<Notification<T>> {
 
     final Maybe<T> source;

--- a/src/main/java/io/reactivex/internal/operators/mixed/MaterializeSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/MaterializeSingleObserver.java
@@ -14,17 +14,16 @@
 package io.reactivex.internal.operators.mixed;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
  * A consumer that implements the consumer types of Maybe, Single and Completable
  * and turns their signals into Notifications for a SingleObserver.
+ * <p>History: 2.2.4 - experimental
  * @param <T> the element type of the source
- * @since 2.2.4 - experimental
+ * @since 3.0.0
  */
-@Experimental
 public final class MaterializeSingleObserver<T>
 implements SingleObserver<T>, MaybeObserver<T>, CompletableObserver, Disposable {
 

--- a/src/main/java/io/reactivex/internal/operators/single/SingleDematerialize.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleDematerialize.java
@@ -14,7 +14,6 @@
 package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
@@ -24,11 +23,11 @@ import io.reactivex.internal.functions.ObjectHelper;
 /**
  * Maps the success value of the source to a Notification, then
  * maps it back to the corresponding signal type.
+ * <p>History: 2.2.4 - experimental
  * @param <T> the element type of the source
  * @param <R> the element type of the Notification and result
- * @since 2.2.4 - experimental
+ * @since 3.0.0
  */
-@Experimental
 public final class SingleDematerialize<T, R> extends Maybe<R> {
 
     final Single<T> source;

--- a/src/main/java/io/reactivex/internal/operators/single/SingleMaterialize.java
+++ b/src/main/java/io/reactivex/internal/operators/single/SingleMaterialize.java
@@ -14,17 +14,16 @@
 package io.reactivex.internal.operators.single;
 
 import io.reactivex.*;
-import io.reactivex.annotations.Experimental;
 import io.reactivex.internal.operators.mixed.MaterializeSingleObserver;
 
 /**
  * Turn the signal types of a Single source into a single Notification of
  * equal kind.
+ * <p>History: 2.2.4 - experimental
  *
  * @param <T> the element type of the source
- * @since 2.2.4 - experimental
+ * @since 3.0.0
  */
-@Experimental
 public final class SingleMaterialize<T> extends Single<Notification<T>> {
 
     final Single<T> source;

--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -394,6 +394,7 @@ public final class Schedulers {
      * execute those tasks "unexpectedly".
      * <p>
      * Note that this method returns a new {@link Scheduler} instance, even for the same {@link Executor} instance.
+     * <p>History: 2.2.6 - experimental
      * @param executor
      *          the executor to wrap
      * @param interruptibleWorker if {@code true} the tasks submitted to the {@link io.reactivex.Scheduler.Worker Scheduler.Worker} will
@@ -402,7 +403,6 @@ public final class Schedulers {
      * @since 2.2.6 - experimental
      */
     @NonNull
-    @Experimental
     public static Scheduler from(@NonNull Executor executor, boolean interruptibleWorker) {
         return new ExecutorScheduler(executor, interruptibleWorker);
     }

--- a/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
+++ b/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
@@ -24,7 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Check verifying there are no methods with the prefix "test" in the name
+ * Check verifying there are no methods with the prefix "test" in the name.
  */
 public class TestPrefixInMethodName {
 
@@ -70,7 +70,7 @@ public class TestPrefixInMethodName {
                             int lineNum = 0;
                             List<String> lines = new ArrayList<String>();
                             BufferedReader in = new BufferedReader(new FileReader(u));
-                            boolean found = false;
+                            //boolean found = false;
                             try {
                                 for (; ; ) {
                                     String line = in.readLine();
@@ -81,7 +81,7 @@ public class TestPrefixInMethodName {
 
                                     Matcher matcher = p.matcher(line);
                                     if (!line.startsWith("//") && !line.startsWith("*") && matcher.find()) {
-                                        found = true;
+                                        // found = true;
                                         fail
                                                 .append(fname)
                                                 .append("#L").append(lineNum)


### PR DESCRIPTION
Promote the following experimental operators to standard:

- `Completable.delaySubscription(long, TimeUnit [, Scheduler])`
- `Completable.materialize()`
- `Flowable.dematerialize(Function)`
- `Maybe.doOnTerminate()`
- `Maybe.materialize()`
- `Observable.dematerialize(Function)`
- `Single.dematerialize(Function)`
- `Single.materialize()`

There were no `Beta` operators in 2.2.x.