### PR TITLE
3.x: remove no-arg dematerialize(); remove replay(Scheduler) variants

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableInternalHelper.java
@@ -209,10 +209,6 @@ public final class FlowableInternalHelper {
         return new TimedReplay<T>(parent, time, unit, scheduler, eagerTruncate);
     }
 
-    public static <T, R> Function<Flowable<T>, Publisher<R>> replayFunction(final Function<? super Flowable<T>, ? extends Publisher<R>> selector, final Scheduler scheduler) {
-        return new ReplayFunction<T, R>(selector, scheduler);
-    }
-
     public enum RequestMax implements Consumer<Subscription> {
         INSTANCE;
         @Override
@@ -316,22 +312,6 @@ public final class FlowableInternalHelper {
         @Override
         public ConnectableFlowable<T> get() {
             return parent.replay(time, unit, scheduler, eagerTruncate);
-        }
-    }
-
-    static final class ReplayFunction<T, R> implements Function<Flowable<T>, Publisher<R>> {
-        private final Function<? super Flowable<T>, ? extends Publisher<R>> selector;
-        private final Scheduler scheduler;
-
-        ReplayFunction(Function<? super Flowable<T>, ? extends Publisher<R>> selector, Scheduler scheduler) {
-            this.selector = selector;
-            this.scheduler = scheduler;
-        }
-
-        @Override
-        public Publisher<R> apply(Flowable<T> t) throws Throwable {
-            Publisher<R> p = ObjectHelper.requireNonNull(selector.apply(t), "The selector returned a null Publisher");
-            return Flowable.fromPublisher(p).observeOn(scheduler);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableReplay.java
@@ -61,19 +61,6 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     }
 
     /**
-     * Child Subscribers will observe the events of the ConnectableObservable on the
-     * specified scheduler.
-     * @param <T> the value type
-     * @param cf the ConnectableFlowable to wrap
-     * @param scheduler the target scheduler
-     * @return the new ConnectableObservable instance
-     */
-    public static <T> ConnectableFlowable<T> observeOn(final ConnectableFlowable<T> cf, final Scheduler scheduler) {
-        final Flowable<T> flowable = cf.observeOn(scheduler);
-        return RxJavaPlugins.onAssembly(new ConnectableFlowableReplay<T>(cf, flowable));
-    }
-
-    /**
      * Creates a replaying ConnectableObservable with an unbounded buffer.
      * @param <T> the value type
      * @param source the source Publisher to use

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableInternalHelper.java
@@ -214,10 +214,6 @@ public final class ObservableInternalHelper {
         return new TimedReplayCallable<T>(parent, time, unit, scheduler, eagerTruncate);
     }
 
-    public static <T, R> Function<Observable<T>, ObservableSource<R>> replayFunction(final Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final Scheduler scheduler) {
-        return new ReplayFunction<T, R>(selector, scheduler);
-    }
-
     static final class ZipIterableFunction<T, R>
     implements Function<List<ObservableSource<? extends T>>, ObservableSource<? extends R>> {
         private final Function<? super Object[], ? extends R> zipper;
@@ -310,22 +306,6 @@ public final class ObservableInternalHelper {
         @Override
         public ConnectableObservable<T> get() {
             return parent.replay(time, unit, scheduler, eagerTruncate);
-        }
-    }
-
-    static final class ReplayFunction<T, R> implements Function<Observable<T>, ObservableSource<R>> {
-        private final Function<? super Observable<T>, ? extends ObservableSource<R>> selector;
-        private final Scheduler scheduler;
-
-        ReplayFunction(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, Scheduler scheduler) {
-            this.selector = selector;
-            this.scheduler = scheduler;
-        }
-
-        @Override
-        public ObservableSource<R> apply(Observable<T> t) throws Throwable {
-            ObservableSource<R> apply = ObjectHelper.requireNonNull(selector.apply(t), "The selector returned a null ObservableSource");
-            return Observable.wrap(apply).observeOn(scheduler);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -64,19 +64,6 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
     }
 
     /**
-     * Child Observers will observe the events of the ConnectableObservable on the
-     * specified scheduler.
-     * @param <T> the value type
-     * @param co the connectable observable instance
-     * @param scheduler the target scheduler
-     * @return the new ConnectableObservable instance
-     */
-    public static <T> ConnectableObservable<T> observeOn(final ConnectableObservable<T> co, final Scheduler scheduler) {
-        final Observable<T> observable = co.observeOn(scheduler);
-        return RxJavaPlugins.onAssembly(new Replay<T>(co, observable));
-    }
-
-    /**
      * Creates a replaying ConnectableObservable with an unbounded buffer.
      * @param <T> the value type
      * @param source the source observable

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1837,11 +1837,6 @@ public class FlowableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void replaySchedulerNull() {
-        just1.replay((Scheduler)null);
-    }
-
-    @Test(expected = NullPointerException.class)
     public void replayBoundedUnitNull() {
         just1.replay(new Function<Flowable<Integer>, Publisher<Integer>>() {
             @Override
@@ -1904,11 +1899,6 @@ public class FlowableNullTests {
     @Test(expected = NullPointerException.class)
     public void replayTimeSizeBoundedSchedulerNull() {
         just1.replay(1, 1, TimeUnit.SECONDS, null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void replayBufferSchedulerNull() {
-        just1.replay(1, (Scheduler)null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -1233,28 +1233,8 @@ public class FlowableReplayEagerTruncateTest {
     }
 
     @Test
-    public void replayScheduler() {
-
-        Flowable.just(1).replay(Schedulers.computation())
-        .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
     public void replayTime() {
         Flowable.just(1).replay(1, TimeUnit.MINUTES, Schedulers.computation(), true)
-        .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySizeScheduler() {
-
-        Flowable.just(1).replay(1, Schedulers.computation())
         .autoConnect()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1265,22 +1245,6 @@ public class FlowableReplayEagerTruncateTest {
     public void replaySizeAndTime() {
         Flowable.just(1).replay(1, 1, TimeUnit.MILLISECONDS, Schedulers.computation(), true)
         .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySelectorSizeScheduler() {
-        Flowable.just(1).replay(Functions.<Flowable<Integer>>identity(), 1, Schedulers.io())
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySelectorScheduler() {
-        Flowable.just(1).replay(Functions.<Flowable<Integer>>identity(), Schedulers.io())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);
@@ -1739,19 +1703,6 @@ public class FlowableReplayEagerTruncateTest {
         scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
 
         source.test().assertResult();
-    }
-
-    @Test
-    public void replaySelectorReturnsNull() {
-        Flowable.just(1)
-        .replay(new Function<Flowable<Integer>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Integer> v) throws Exception {
-                return null;
-            }
-        }, Schedulers.trampoline())
-        .to(TestHelper.<Object>testConsumer())
-        .assertFailureAndMessage(NullPointerException.class, "The selector returned a null Publisher");
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -1234,28 +1234,8 @@ public class FlowableReplayTest {
     }
 
     @Test
-    public void replayScheduler() {
-
-        Flowable.just(1).replay(Schedulers.computation())
-        .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
     public void replayTime() {
         Flowable.just(1).replay(1, TimeUnit.MINUTES)
-        .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySizeScheduler() {
-
-        Flowable.just(1).replay(1, Schedulers.computation())
         .autoConnect()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1266,22 +1246,6 @@ public class FlowableReplayTest {
     public void replaySizeAndTime() {
         Flowable.just(1).replay(1, 1, TimeUnit.MILLISECONDS)
         .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySelectorSizeScheduler() {
-        Flowable.just(1).replay(Functions.<Flowable<Integer>>identity(), 1, Schedulers.io())
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySelectorScheduler() {
-        Flowable.just(1).replay(Functions.<Flowable<Integer>>identity(), Schedulers.io())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);
@@ -1740,19 +1704,6 @@ public class FlowableReplayTest {
         scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
 
         source.test().assertResult();
-    }
-
-    @Test
-    public void replaySelectorReturnsNull() {
-        Flowable.just(1)
-        .replay(new Function<Flowable<Integer>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Integer> v) throws Exception {
-                return null;
-            }
-        }, Schedulers.trampoline())
-        .to(TestHelper.<Object>testConsumer())
-        .assertFailureAndMessage(NullPointerException.class, "The selector returned a null Publisher");
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -1098,28 +1098,8 @@ public class ObservableReplayEagerTruncateTest {
     }
 
     @Test
-    public void replayScheduler() {
-
-        Observable.just(1).replay(Schedulers.computation())
-        .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
     public void replayTime() {
         Observable.just(1).replay(1, TimeUnit.MINUTES, Schedulers.computation(), true)
-        .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySizeScheduler() {
-
-        Observable.just(1).replay(1, Schedulers.computation())
         .autoConnect()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1130,22 +1110,6 @@ public class ObservableReplayEagerTruncateTest {
     public void replaySizeAndTime() {
         Observable.just(1).replay(1, 1, TimeUnit.MILLISECONDS, Schedulers.computation(), true)
         .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySelectorSizeScheduler() {
-        Observable.just(1).replay(Functions.<Observable<Integer>>identity(), 1, Schedulers.io())
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySelectorScheduler() {
-        Observable.just(1).replay(Functions.<Observable<Integer>>identity(), Schedulers.io())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);
@@ -1526,19 +1490,6 @@ public class ObservableReplayEagerTruncateTest {
         scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
 
         source.test().assertResult();
-    }
-
-    @Test
-    public void replaySelectorReturnsNullScheduled() {
-        Observable.just(1)
-        .replay(new Function<Observable<Integer>, Observable<Object>>() {
-            @Override
-            public Observable<Object> apply(Observable<Integer> v) throws Exception {
-                return null;
-            }
-        }, Schedulers.trampoline())
-        .to(TestHelper.<Object>testConsumer())
-        .assertFailureAndMessage(NullPointerException.class, "The selector returned a null ObservableSource");
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayTest.java
@@ -1098,28 +1098,8 @@ public class ObservableReplayTest {
     }
 
     @Test
-    public void replayScheduler() {
-
-        Observable.just(1).replay(Schedulers.computation())
-        .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
     public void replayTime() {
         Observable.just(1).replay(1, TimeUnit.MINUTES)
-        .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySizeScheduler() {
-
-        Observable.just(1).replay(1, Schedulers.computation())
         .autoConnect()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1130,22 +1110,6 @@ public class ObservableReplayTest {
     public void replaySizeAndTime() {
         Observable.just(1).replay(1, 1, TimeUnit.MILLISECONDS)
         .autoConnect()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySelectorSizeScheduler() {
-        Observable.just(1).replay(Functions.<Observable<Integer>>identity(), 1, Schedulers.io())
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(1);
-    }
-
-    @Test
-    public void replaySelectorScheduler() {
-        Observable.just(1).replay(Functions.<Observable<Integer>>identity(), Schedulers.io())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);
@@ -1526,19 +1490,6 @@ public class ObservableReplayTest {
         scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
 
         source.test().assertResult();
-    }
-
-    @Test
-    public void replaySelectorReturnsNullScheduled() {
-        Observable.just(1)
-        .replay(new Function<Observable<Integer>, Observable<Object>>() {
-            @Override
-            public Observable<Object> apply(Observable<Integer> v) throws Exception {
-                return null;
-            }
-        }, Schedulers.trampoline())
-        .to(TestHelper.<Object>testConsumer())
-        .assertFailureAndMessage(NullPointerException.class, "The selector returned a null ObservableSource");
     }
 
     @Test

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1874,11 +1874,6 @@ public class ObservableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void replaySchedulerNull() {
-        just1.replay((Scheduler)null);
-    }
-
-    @Test(expected = NullPointerException.class)
     public void replayBoundedUnitNull() {
         just1.replay(new Function<Observable<Integer>, Observable<Integer>>() {
             @Override
@@ -1941,11 +1936,6 @@ public class ObservableNullTests {
     @Test(expected = NullPointerException.class)
     public void replayTimeSizeBoundedSchedulerNull() {
         just1.replay(1, 1, TimeUnit.SECONDS, null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void replayBufferSchedulerNull() {
-        just1.replay(1, (Scheduler)null);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
This PR removes some obsolete API.

The `Flowable.dematerialize()` and `Observable.dematerialize()` were inherently type-unsafe and have been removed. In Rx.NET, the extension methods allowed `dematerialize()` to be applied to `Observable<Notification<T>>` only, but there is no way for doing it in Java as it has no extension methods and one can't restrict a method to appear only with a certain type argument scheme.

The`replay(Scheduler)` and other overloads were carried over from the original Rx.NET API set but I can't rememeber if they had any use in the field. Most use cases capture the connectable anyway so there is no much benefit from inlining an `observeOn` into a connectable:

```java
ConnectableFlowable<Integer> connectable = source.replay();

Flowable<Integr> flowable = connectable.observeOn(Schedulers.io());

// hand flowable to consumers
flowable.subscribe();

connectable.connect();
```