### PR TITLE
2.x: Add concatMap with Scheduler guaranteeing where the mapper runs …

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -7254,6 +7254,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * that result from concatenating those resulting Publishers.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMap.png" alt="">
+     * <p>
+     * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
+     * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
+     * the {@code mapper} function is confined to a known thread, use the {@link #concatMap(Function, int, Scheduler)} overload.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. Both this and the inner {@code Publisher}s are
@@ -7286,6 +7290,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * that result from concatenating those resulting Publishers.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMap.png" alt="">
+     * <p>
+     * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
+     * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
+     * the {@code mapper} function is confined to a known thread, use the {@link #concatMap(Function, int, Scheduler)} overload.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. Both this and the inner {@code Publisher}s are
@@ -7306,6 +7314,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the result of applying the transformation function to each item emitted
      *         by the source Publisher and concatenating the Publishers obtained from this transformation
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #concatMap(Function, int, Scheduler)
      */
     @CheckReturnValue
     @NonNull
@@ -7323,6 +7332,52 @@ public abstract class Flowable<T> implements Publisher<T> {
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         return RxJavaPlugins.onAssembly(new FlowableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE));
+    }
+
+    /**
+     * Returns a new Flowable that emits items resulting from applying a function (on a designated scheduler)
+     * that you supply to each item emitted by the source Publisher, where that function returns a Publisher, and then emitting the items
+     * that result from concatenating those resulting Publishers.
+     * <p>
+     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMap.png" alt="">
+     * <p>
+     * The difference between {@link #concatMap(Function, int)} and this operator is that this operator guarantees the {@code mapper}
+     * function is executed on the specified scheduler.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both this and the inner {@code Publisher}s are
+     *  expected to honor backpressure as well. If the source {@code Publisher} violates the rule, the operator will
+     *  signal a {@code MissingBackpressureException}. If any of the inner {@code Publisher}s doesn't honor
+     *  backpressure, that <em>may</em> throw an {@code IllegalStateException} when that
+     *  {@code Publisher} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatMap} executes the given {@code mapper} function on the provided {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R> the type of the inner Publisher sources and thus the output type
+     * @param mapper
+     *            a function that, when applied to an item emitted by the source Publisher, returns a
+     *            Publisher
+     * @param prefetch
+     *            the number of elements to prefetch from the current Flowable
+     * @param scheduler
+     *            the scheduler where the {@code mapper} function will be executed
+     * @return a Flowable that emits the result of applying the transformation function to each item emitted
+     *         by the source Publisher and concatenating the Publishers obtained from this transformation
+     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @since 3.0.0
+     * @see #concatMap(Function, int)
+     * @see #concatMapDelayError(Function, int, boolean, Scheduler)
+     */
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    public final <R> Flowable<R> concatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, int prefetch, Scheduler scheduler) {
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        ObjectHelper.requireNonNull(scheduler, "scheduler");
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapScheduler<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE, scheduler));
     }
 
     /**
@@ -7494,7 +7549,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * one at a time and emits their values in order
      * while delaying any error from either this or any of the inner Publishers
      * till all of them terminate.
-     *
+     * <p>
+     * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
+     * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
+     * the {@code mapper} function is confined to a known thread, use the {@link #concatMapDelayError(Function, int, boolean, Scheduler)} overload.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. Both this and the inner {@code Publisher}s are
@@ -7509,6 +7567,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @param <R> the result value type
      * @param mapper the function that maps the items of this Publisher into the inner Publishers.
      * @return the new Publisher instance with the concatenation behavior
+     * @see #concatMapDelayError(Function, int, boolean, Scheduler)
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
@@ -7522,6 +7581,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * one at a time and emits their values in order
      * while delaying any error from either this or any of the inner Publishers
      * till all of them terminate.
+     * <p>
+     * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
+     * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
+     * the {@code mapper} function is confined to a known thread, use the {@link #concatMapDelayError(Function, int, boolean, Scheduler)} overload.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -7542,6 +7605,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            if true, all errors from the outer and inner Publisher sources are delayed until the end,
      *            if false, an error from the main source is signaled when the current Publisher source terminates
      * @return the new Publisher instance with the concatenation behavior
+     * @see #concatMapDelayError(Function, int, boolean, Scheduler)
      */
     @CheckReturnValue
     @NonNull
@@ -7560,6 +7624,51 @@ public abstract class Flowable<T> implements Publisher<T> {
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
         return RxJavaPlugins.onAssembly(new FlowableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
+    }
+
+    /**
+     * Maps each of the upstream items into a Publisher, subscribes to them one after the other,
+     * one at a time and emits their values in order
+     * while executing the mapper function on the designated scheduler, delaying any error from either this or any of the
+     * inner Publishers till all of them terminate.
+     * <p>
+     * The difference between {@link #concatMapDelayError(Function, int, boolean)} and this operator is that this operator guarantees the {@code mapper}
+     * function is executed on the specified scheduler.
+     *
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream. Both this and the inner {@code Publisher}s are
+     *  expected to honor backpressure as well. If the source {@code Publisher} violates the rule, the operator will
+     *  signal a {@code MissingBackpressureException}. If any of the inner {@code Publisher}s doesn't honor
+     *  backpressure, that <em>may</em> throw an {@code IllegalStateException} when that
+     *  {@code Publisher} completes.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code concatMapDelayError} executes the given {@code mapper} function on the provided {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <R> the result value type
+     * @param mapper the function that maps the items of this Publisher into the inner Publishers.
+     * @param prefetch
+     *            the number of elements to prefetch from the current Flowable
+     * @param tillTheEnd
+     *            if true, all errors from the outer and inner Publisher sources are delayed until the end,
+     *            if false, an error from the main source is signaled when the current Publisher source terminates
+     * @param scheduler
+     *            the scheduler where the {@code mapper} function will be executed
+     * @return the new Publisher instance with the concatenation behavior
+     * @see #concatMapDelayError(Function, int, boolean)
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    public final <R> Flowable<R> concatMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
+            int prefetch, boolean tillTheEnd, Scheduler scheduler) {
+        ObjectHelper.requireNonNull(mapper, "mapper is null");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapScheduler<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, scheduler));
     }
 
     /**

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapScheduler.java
@@ -1,0 +1,554 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.flowable;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.operators.flowable.FlowableConcatMap.*;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.*;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWithUpstream<T, R> {
+
+    final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+    final int prefetch;
+
+    final ErrorMode errorMode;
+
+    final Scheduler scheduler;
+
+    public FlowableConcatMapScheduler(Flowable<T> source,
+            Function<? super T, ? extends Publisher<? extends R>> mapper,
+            int prefetch, ErrorMode errorMode, Scheduler scheduler) {
+        super(source);
+        this.mapper = mapper;
+        this.prefetch = prefetch;
+        this.errorMode = errorMode;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        switch (errorMode) {
+        case BOUNDARY:
+            source.subscribe(new ConcatMapDelayed<T, R>(s, mapper, prefetch, false, scheduler.createWorker()));
+            break;
+        case END:
+            source.subscribe(new ConcatMapDelayed<T, R>(s, mapper, prefetch, true, scheduler.createWorker()));
+            break;
+        default:
+            source.subscribe(new ConcatMapImmediate<T, R>(s, mapper, prefetch, scheduler.createWorker()));
+        }
+    }
+
+    abstract static class BaseConcatMapSubscriber<T, R>
+    extends AtomicInteger
+    implements FlowableSubscriber<T>, ConcatMapSupport<R>, Subscription, Runnable {
+
+        private static final long serialVersionUID = -3511336836796789179L;
+
+        final ConcatMapInner<R> inner;
+
+        final Function<? super T, ? extends Publisher<? extends R>> mapper;
+
+        final int prefetch;
+
+        final int limit;
+
+        final Scheduler.Worker worker;
+
+        Subscription upstream;
+
+        int consumed;
+
+        SimpleQueue<T> queue;
+
+        volatile boolean done;
+
+        volatile boolean cancelled;
+
+        final AtomicThrowable errors;
+
+        volatile boolean active;
+
+        int sourceMode;
+
+        BaseConcatMapSubscriber(
+                Function<? super T, ? extends Publisher<? extends R>> mapper,
+                int prefetch, Scheduler.Worker worker) {
+            this.mapper = mapper;
+            this.prefetch = prefetch;
+            this.limit = prefetch - (prefetch >> 2);
+            this.inner = new ConcatMapInner<R>(this);
+            this.errors = new AtomicThrowable();
+            this.worker = worker;
+        }
+
+        @Override
+        public final void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.upstream, s))  {
+                this.upstream = s;
+
+                if (s instanceof QueueSubscription) {
+                    @SuppressWarnings("unchecked") QueueSubscription<T> f = (QueueSubscription<T>)s;
+                    int m = f.requestFusion(QueueSubscription.ANY | QueueSubscription.BOUNDARY);
+                    if (m == QueueSubscription.SYNC) {
+                        sourceMode = m;
+                        queue = f;
+                        done = true;
+
+                        subscribeActual();
+
+                        schedule();
+                        return;
+                    }
+                    if (m == QueueSubscription.ASYNC) {
+                        sourceMode = m;
+                        queue = f;
+
+                        subscribeActual();
+
+                        s.request(prefetch);
+                        return;
+                    }
+                }
+
+                queue = new SpscArrayQueue<T>(prefetch);
+
+                subscribeActual();
+
+                s.request(prefetch);
+            }
+        }
+
+        abstract void schedule();
+
+        abstract void subscribeActual();
+
+        @Override
+        public final void onNext(T t) {
+            if (sourceMode != QueueSubscription.ASYNC) {
+                if (!queue.offer(t)) {
+                    upstream.cancel();
+                    onError(new IllegalStateException("Queue full?!"));
+                    return;
+                }
+            }
+            schedule();
+        }
+
+        @Override
+        public final void onComplete() {
+            done = true;
+            schedule();
+        }
+
+        @Override
+        public final void innerComplete() {
+            active = false;
+            schedule();
+        }
+
+    }
+
+    static final class ConcatMapImmediate<T, R>
+    extends BaseConcatMapSubscriber<T, R> {
+
+        private static final long serialVersionUID = 7898995095634264146L;
+
+        final Subscriber<? super R> downstream;
+
+        final AtomicInteger wip;
+
+        ConcatMapImmediate(Subscriber<? super R> actual,
+                Function<? super T, ? extends Publisher<? extends R>> mapper,
+                int prefetch, Scheduler.Worker worker) {
+            super(mapper, prefetch, worker);
+            this.downstream = actual;
+            this.wip = new AtomicInteger();
+        }
+
+        @Override
+        void subscribeActual() {
+            downstream.onSubscribe(this);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (errors.addThrowable(t)) {
+                inner.cancel();
+
+                if (getAndIncrement() == 0) {
+                    downstream.onError(errors.terminate());
+                    worker.dispose();
+                }
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void innerNext(R value) {
+            if (get() == 0 && compareAndSet(0, 1)) {
+                downstream.onNext(value);
+                if (compareAndSet(1, 0)) {
+                    return;
+                }
+                downstream.onError(errors.terminate());
+                worker.dispose();
+            }
+        }
+
+        @Override
+        public void innerError(Throwable e) {
+            if (errors.addThrowable(e)) {
+                upstream.cancel();
+
+                if (getAndIncrement() == 0) {
+                    downstream.onError(errors.terminate());
+                    worker.dispose();
+                }
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            inner.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+
+                inner.cancel();
+                upstream.cancel();
+                worker.dispose();
+            }
+        }
+
+        @Override
+        void schedule() {
+            if (wip.getAndIncrement() == 0) {
+                worker.schedule(this);
+            }
+        }
+
+        @Override
+        public void run() {
+            for (;;) {
+                if (cancelled) {
+                    return;
+                }
+
+                if (!active) {
+                    boolean d = done;
+
+                    T v;
+
+                    try {
+                        v = queue.poll();
+                    } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
+                        upstream.cancel();
+                        errors.addThrowable(e);
+                        downstream.onError(errors.terminate());
+                        worker.dispose();
+                        return;
+                    }
+
+                    boolean empty = v == null;
+
+                    if (d && empty) {
+                        downstream.onComplete();
+                        worker.dispose();
+                        return;
+                    }
+
+                    if (!empty) {
+                        Publisher<? extends R> p;
+
+                        try {
+                            p = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null Publisher");
+                        } catch (Throwable e) {
+                            Exceptions.throwIfFatal(e);
+
+                            upstream.cancel();
+                            errors.addThrowable(e);
+                            downstream.onError(errors.terminate());
+                            worker.dispose();
+                            return;
+                        }
+
+                        if (sourceMode != QueueSubscription.SYNC) {
+                            int c = consumed + 1;
+                            if (c == limit) {
+                                consumed = 0;
+                                upstream.request(c);
+                            } else {
+                                consumed = c;
+                            }
+                        }
+
+                        if (p instanceof Callable) {
+                            @SuppressWarnings("unchecked")
+                            Callable<R> supplier = (Callable<R>) p;
+
+                            R vr;
+
+                            try {
+                                vr = supplier.call();
+                            } catch (Throwable e) {
+                                Exceptions.throwIfFatal(e);
+                                upstream.cancel();
+                                errors.addThrowable(e);
+                                downstream.onError(errors.terminate());
+                                worker.dispose();
+                                return;
+                            }
+
+                            if (vr == null) {
+                                continue;
+                            }
+
+                            if (inner.isUnbounded()) {
+                                if (get() == 0 && compareAndSet(0, 1)) {
+                                    downstream.onNext(vr);
+                                    if (!compareAndSet(1, 0)) {
+                                        downstream.onError(errors.terminate());
+                                        worker.dispose();
+                                        return;
+                                    }
+                                }
+                                continue;
+                            } else {
+                                active = true;
+                                inner.setSubscription(new WeakScalarSubscription<R>(vr, inner));
+                            }
+
+                        } else {
+                            active = true;
+                            p.subscribe(inner);
+                        }
+                    }
+                }
+                if (wip.decrementAndGet() == 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+    static final class ConcatMapDelayed<T, R>
+    extends BaseConcatMapSubscriber<T, R> {
+
+        private static final long serialVersionUID = -2945777694260521066L;
+
+        final Subscriber<? super R> downstream;
+
+        final boolean veryEnd;
+
+        ConcatMapDelayed(Subscriber<? super R> actual,
+                Function<? super T, ? extends Publisher<? extends R>> mapper,
+                int prefetch, boolean veryEnd, Scheduler.Worker worker) {
+            super(mapper, prefetch, worker);
+            this.downstream = actual;
+            this.veryEnd = veryEnd;
+        }
+
+        @Override
+        void subscribeActual() {
+            downstream.onSubscribe(this);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (errors.addThrowable(t)) {
+                done = true;
+                schedule();
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void innerNext(R value) {
+            downstream.onNext(value);
+        }
+
+        @Override
+        public void innerError(Throwable e) {
+            if (errors.addThrowable(e)) {
+                if (!veryEnd) {
+                    upstream.cancel();
+                    done = true;
+                }
+                active = false;
+                schedule();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            inner.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+
+                inner.cancel();
+                upstream.cancel();
+                worker.dispose();
+            }
+        }
+
+        @Override
+        void schedule() {
+            if (getAndIncrement() == 0) {
+                worker.schedule(this);
+            }
+        }
+
+        @Override
+        public void run() {
+
+            for (;;) {
+                if (cancelled) {
+                    return;
+                }
+
+                if (!active) {
+
+                    boolean d = done;
+
+                    if (d && !veryEnd) {
+                        Throwable ex = errors.get();
+                        if (ex != null) {
+                            downstream.onError(errors.terminate());
+                            worker.dispose();
+                            return;
+                        }
+                    }
+
+                    T v;
+
+                    try {
+                        v = queue.poll();
+                    } catch (Throwable e) {
+                        Exceptions.throwIfFatal(e);
+                        upstream.cancel();
+                        errors.addThrowable(e);
+                        downstream.onError(errors.terminate());
+                        worker.dispose();
+                        return;
+                    }
+
+                    boolean empty = v == null;
+
+                    if (d && empty) {
+                        Throwable ex = errors.terminate();
+                        if (ex != null) {
+                            downstream.onError(ex);
+                        } else {
+                            downstream.onComplete();
+                        }
+                        worker.dispose();
+                        return;
+                    }
+
+                    if (!empty) {
+                        Publisher<? extends R> p;
+
+                        try {
+                            p = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null Publisher");
+                        } catch (Throwable e) {
+                            Exceptions.throwIfFatal(e);
+
+                            upstream.cancel();
+                            errors.addThrowable(e);
+                            downstream.onError(errors.terminate());
+                            worker.dispose();
+                            return;
+                        }
+
+                        if (sourceMode != QueueSubscription.SYNC) {
+                            int c = consumed + 1;
+                            if (c == limit) {
+                                consumed = 0;
+                                upstream.request(c);
+                            } else {
+                                consumed = c;
+                            }
+                        }
+
+                        if (p instanceof Callable) {
+                            @SuppressWarnings("unchecked")
+                            Callable<R> supplier = (Callable<R>) p;
+
+                            R vr;
+
+                            try {
+                                vr = supplier.call();
+                            } catch (Throwable e) {
+                                Exceptions.throwIfFatal(e);
+                                errors.addThrowable(e);
+                                if (!veryEnd) {
+                                    upstream.cancel();
+                                    downstream.onError(errors.terminate());
+                                    worker.dispose();
+                                    return;
+                                }
+                                vr = null;
+                            }
+
+                            if (vr == null) {
+                                continue;
+                            }
+
+                            if (inner.isUnbounded()) {
+                                downstream.onNext(vr);
+                                continue;
+                            } else {
+                                active = true;
+                                inner.setSubscription(new WeakScalarSubscription<R>(vr, inner));
+                            }
+                        } else {
+                            active = true;
+                            p.subscribe(inner);
+                        }
+                    }
+                }
+                if (decrementAndGet() == 0) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableConcatMapScheduler.java
@@ -1,0 +1,558 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.internal.operators.observable;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.*;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.*;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.fuseable.*;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.internal.util.*;
+import io.reactivex.observers.SerializedObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class ObservableConcatMapScheduler<T, U> extends AbstractObservableWithUpstream<T, U> {
+
+    final Function<? super T, ? extends ObservableSource<? extends U>> mapper;
+
+    final int bufferSize;
+
+    final ErrorMode delayErrors;
+
+    final Scheduler scheduler;
+
+    public ObservableConcatMapScheduler(ObservableSource<T> source, Function<? super T, ? extends ObservableSource<? extends U>> mapper,
+            int bufferSize, ErrorMode delayErrors, Scheduler scheduler) {
+        super(source);
+        this.mapper = mapper;
+        this.delayErrors = delayErrors;
+        this.bufferSize = Math.max(8, bufferSize);
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public void subscribeActual(Observer<? super U> observer) {
+        if (delayErrors == ErrorMode.IMMEDIATE) {
+            SerializedObserver<U> serial = new SerializedObserver<U>(observer);
+            source.subscribe(new ConcatMapObserver<T, U>(serial, mapper, bufferSize, scheduler.createWorker()));
+        } else {
+            source.subscribe(new ConcatMapDelayErrorObserver<T, U>(observer, mapper, bufferSize, delayErrors == ErrorMode.END, scheduler.createWorker()));
+        }
+    }
+
+    static final class ConcatMapObserver<T, U> extends AtomicInteger implements Observer<T>, Disposable, Runnable {
+
+        private static final long serialVersionUID = 8828587559905699186L;
+        final Observer<? super U> downstream;
+        final Function<? super T, ? extends ObservableSource<? extends U>> mapper;
+        final InnerObserver<U> inner;
+        final int bufferSize;
+        final Scheduler.Worker worker;
+
+        SimpleQueue<T> queue;
+
+        Disposable upstream;
+
+        volatile boolean active;
+
+        volatile boolean disposed;
+
+        volatile boolean done;
+
+        int fusionMode;
+
+        ConcatMapObserver(Observer<? super U> actual,
+                                Function<? super T, ? extends ObservableSource<? extends U>> mapper, int bufferSize, Scheduler.Worker worker) {
+            this.downstream = actual;
+            this.mapper = mapper;
+            this.bufferSize = bufferSize;
+            this.inner = new InnerObserver<U>(actual, this);
+            this.worker = worker;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+                if (d instanceof QueueDisposable) {
+                    @SuppressWarnings("unchecked")
+                    QueueDisposable<T> qd = (QueueDisposable<T>) d;
+
+                    int m = qd.requestFusion(QueueDisposable.ANY);
+                    if (m == QueueDisposable.SYNC) {
+                        fusionMode = m;
+                        queue = qd;
+                        done = true;
+
+                        downstream.onSubscribe(this);
+
+                        drain();
+                        return;
+                    }
+
+                    if (m == QueueDisposable.ASYNC) {
+                        fusionMode = m;
+                        queue = qd;
+
+                        downstream.onSubscribe(this);
+
+                        return;
+                    }
+                }
+
+                queue = new SpscLinkedArrayQueue<T>(bufferSize);
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            if (fusionMode == QueueDisposable.NONE) {
+                queue.offer(t);
+            }
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+                return;
+            }
+            done = true;
+            dispose();
+            downstream.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+            done = true;
+            drain();
+        }
+
+        void innerComplete() {
+            active = false;
+            drain();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+
+        @Override
+        public void dispose() {
+            disposed = true;
+            inner.dispose();
+            upstream.dispose();
+            worker.dispose();
+
+            if (getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            worker.schedule(this);
+        }
+
+        @Override
+        public void run() {
+            for (;;) {
+                if (disposed) {
+                    queue.clear();
+                    return;
+                }
+                if (!active) {
+
+                    boolean d = done;
+
+                    T t;
+
+                    try {
+                        t = queue.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        dispose();
+                        queue.clear();
+                        downstream.onError(ex);
+                        worker.dispose();
+                        return;
+                    }
+
+                    boolean empty = t == null;
+
+                    if (d && empty) {
+                        disposed = true;
+                        downstream.onComplete();
+                        worker.dispose();
+                        return;
+                    }
+
+                    if (!empty) {
+                        ObservableSource<? extends U> o;
+
+                        try {
+                            o = ObjectHelper.requireNonNull(mapper.apply(t), "The mapper returned a null ObservableSource");
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            dispose();
+                            queue.clear();
+                            downstream.onError(ex);
+                            worker.dispose();
+                            return;
+                        }
+
+                        active = true;
+                        o.subscribe(inner);
+                    }
+                }
+
+                if (decrementAndGet() == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class InnerObserver<U> extends AtomicReference<Disposable> implements Observer<U> {
+
+            private static final long serialVersionUID = -7449079488798789337L;
+
+            final Observer<? super U> downstream;
+            final ConcatMapObserver<?, ?> parent;
+
+            InnerObserver(Observer<? super U> actual, ConcatMapObserver<?, ?> parent) {
+                this.downstream = actual;
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.replace(this, d);
+            }
+
+            @Override
+            public void onNext(U t) {
+                downstream.onNext(t);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                parent.dispose();
+                downstream.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.innerComplete();
+            }
+
+            void dispose() {
+                DisposableHelper.dispose(this);
+            }
+        }
+    }
+
+    static final class ConcatMapDelayErrorObserver<T, R>
+    extends AtomicInteger
+    implements Observer<T>, Disposable, Runnable {
+
+        private static final long serialVersionUID = -6951100001833242599L;
+
+        final Observer<? super R> downstream;
+
+        final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
+
+        final int bufferSize;
+
+        final AtomicThrowable error;
+
+        final DelayErrorInnerObserver<R> observer;
+
+        final boolean tillTheEnd;
+
+        final Scheduler.Worker worker;
+
+        SimpleQueue<T> queue;
+
+        Disposable upstream;
+
+        volatile boolean active;
+
+        volatile boolean done;
+
+        volatile boolean cancelled;
+
+        int sourceMode;
+
+        ConcatMapDelayErrorObserver(Observer<? super R> actual,
+                Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize,
+                        boolean tillTheEnd, Scheduler.Worker worker) {
+            this.downstream = actual;
+            this.mapper = mapper;
+            this.bufferSize = bufferSize;
+            this.tillTheEnd = tillTheEnd;
+            this.error = new AtomicThrowable();
+            this.observer = new DelayErrorInnerObserver<R>(actual, this);
+            this.worker = worker;
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+
+                if (d instanceof QueueDisposable) {
+                    @SuppressWarnings("unchecked")
+                    QueueDisposable<T> qd = (QueueDisposable<T>) d;
+
+                    int m = qd.requestFusion(QueueDisposable.ANY);
+                    if (m == QueueDisposable.SYNC) {
+                        sourceMode = m;
+                        queue = qd;
+                        done = true;
+
+                        downstream.onSubscribe(this);
+
+                        drain();
+                        return;
+                    }
+                    if (m == QueueDisposable.ASYNC) {
+                        sourceMode = m;
+                        queue = qd;
+
+                        downstream.onSubscribe(this);
+
+                        return;
+                    }
+                }
+
+                queue = new SpscLinkedArrayQueue<T>(bufferSize);
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T value) {
+            if (sourceMode == QueueDisposable.NONE) {
+                queue.offer(value);
+            }
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (error.addThrowable(e)) {
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return cancelled;
+        }
+
+        @Override
+        public void dispose() {
+            cancelled = true;
+            upstream.dispose();
+            observer.dispose();
+            worker.dispose();
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            worker.schedule(this);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void run() {
+            Observer<? super R> actual = this.downstream;
+            SimpleQueue<T> queue = this.queue;
+            AtomicThrowable error = this.error;
+
+            for (;;) {
+
+                if (!active) {
+
+                    if (cancelled) {
+                        queue.clear();
+                        return;
+                    }
+
+                    if (!tillTheEnd) {
+                        Throwable ex = error.get();
+                        if (ex != null) {
+                            queue.clear();
+                            cancelled = true;
+                            actual.onError(error.terminate());
+                            worker.dispose();
+                            return;
+                        }
+                    }
+
+                    boolean d = done;
+
+                    T v;
+
+                    try {
+                        v = queue.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        cancelled = true;
+                        this.upstream.dispose();
+                        error.addThrowable(ex);
+                        actual.onError(error.terminate());
+                        worker.dispose();
+                        return;
+                    }
+
+                    boolean empty = v == null;
+
+                    if (d && empty) {
+                        cancelled = true;
+                        Throwable ex = error.terminate();
+                        if (ex != null) {
+                            actual.onError(ex);
+                        } else {
+                            actual.onComplete();
+                        }
+                        worker.dispose();
+                        return;
+                    }
+
+                    if (!empty) {
+
+                        ObservableSource<? extends R> o;
+
+                        try {
+                            o = ObjectHelper.requireNonNull(mapper.apply(v), "The mapper returned a null ObservableSource");
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            cancelled = true;
+                            this.upstream.dispose();
+                            queue.clear();
+                            error.addThrowable(ex);
+                            actual.onError(error.terminate());
+                            worker.dispose();
+                            return;
+                        }
+
+                        if (o instanceof Callable) {
+                            R w;
+
+                            try {
+                                w = ((Callable<R>)o).call();
+                            } catch (Throwable ex) {
+                                Exceptions.throwIfFatal(ex);
+                                error.addThrowable(ex);
+                                continue;
+                            }
+
+                            if (w != null && !cancelled) {
+                                actual.onNext(w);
+                            }
+                            continue;
+                        } else {
+                            active = true;
+                            o.subscribe(observer);
+                        }
+                    }
+                }
+
+                if (decrementAndGet() == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class DelayErrorInnerObserver<R> extends AtomicReference<Disposable> implements Observer<R> {
+
+            private static final long serialVersionUID = 2620149119579502636L;
+
+            final Observer<? super R> downstream;
+
+            final ConcatMapDelayErrorObserver<?, R> parent;
+
+            DelayErrorInnerObserver(Observer<? super R> actual, ConcatMapDelayErrorObserver<?, R> parent) {
+                this.downstream = actual;
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.replace(this, d);
+            }
+
+            @Override
+            public void onNext(R value) {
+                downstream.onNext(value);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                ConcatMapDelayErrorObserver<?, R> p = parent;
+                if (p.error.addThrowable(e)) {
+                    if (!p.tillTheEnd) {
+                        p.upstream.dispose();
+                    }
+                    p.active = false;
+                    p.drain();
+                } else {
+                    RxJavaPlugins.onError(e);
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                ConcatMapDelayErrorObserver<?, R> p = parent;
+                p.active = false;
+                p.drain();
+            }
+
+            void dispose() {
+                DisposableHelper.dispose(this);
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -1,0 +1,1078 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.*;
+import org.reactivestreams.*;
+
+import io.reactivex.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.schedulers.ImmediateThinScheduler;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.processors.*;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.*;
+import io.reactivex.testsupport.*;
+
+public class FlowableConcatMapSchedulerTest {
+
+    @Test
+    public void boundaryFusion() {
+        Flowable.range(1, 10000)
+        .observeOn(Schedulers.single())
+        .map(new Function<Integer, String>() {
+            @Override
+            public String apply(Integer t) throws Exception {
+                String name = Thread.currentThread().getName();
+                if (name.contains("RxSingleScheduler")) {
+                    return "RxSingleScheduler";
+                }
+                return name;
+            }
+        })
+        .concatMap(new Function<String, Publisher<? extends Object>>() {
+            @Override
+            public Publisher<? extends Object> apply(String v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        }, 2, ImmediateThinScheduler.INSTANCE)
+        .observeOn(Schedulers.computation())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult("RxSingleScheduler");
+    }
+
+    @Test
+    public void boundaryFusionDelayError() {
+        Flowable.range(1, 10000)
+        .observeOn(Schedulers.single())
+        .map(new Function<Integer, String>() {
+            @Override
+            public String apply(Integer t) throws Exception {
+                String name = Thread.currentThread().getName();
+                if (name.contains("RxSingleScheduler")) {
+                    return "RxSingleScheduler";
+                }
+                return name;
+            }
+        })
+        .concatMapDelayError(new Function<String, Publisher<? extends Object>>() {
+            @Override
+            public Publisher<? extends Object> apply(String v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        .observeOn(Schedulers.computation())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult("RxSingleScheduler");
+    }
+
+    @Test
+    public void pollThrows() {
+        Flowable.just(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .compose(TestHelper.<Integer>flowableStripBoundary())
+        .concatMap(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        }, 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void pollThrowsDelayError() {
+        Flowable.just(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .compose(TestHelper.<Integer>flowableStripBoundary())
+        .concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Integer v)
+                    throws Exception {
+                return Flowable.just(v);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void noCancelPrevious() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        Flowable.range(1, 5)
+        .concatMap(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) throws Exception {
+                return Flowable.just(v).doOnCancel(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        counter.getAndIncrement();
+                    }
+                });
+            }
+        }, 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void delayErrorCallableTillTheEnd() {
+        Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+          @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
+            return Flowable.fromCallable(new Callable<Integer>() {
+              @Override public Integer call() throws Exception {
+                if (integer >= 100) {
+                  throw new NullPointerException("test null exp");
+                }
+                return integer;
+              }
+            });
+          }
+        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
+    }
+
+    @Test
+    public void delayErrorCallableEager() {
+        Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+          @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
+            return Flowable.fromCallable(new Callable<Integer>() {
+              @Override public Integer call() throws Exception {
+                if (integer >= 100) {
+                  throw new NullPointerException("test null exp");
+                }
+                return integer;
+              }
+            });
+          }
+        }, 2, false, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(NullPointerException.class, 1, 2, 3);
+    }
+
+    @Test
+    public void mapperScheduled() {
+        TestSubscriber<String> ts = Flowable.just(1)
+        .concatMap(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName());
+            }
+        }, 2, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperScheduledHidden() {
+        TestSubscriber<String> ts = Flowable.just(1)
+        .concatMap(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName()).hide();
+            }
+        }, 2, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayErrorScheduled() {
+        TestSubscriber<String> ts = Flowable.just(1)
+        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName());
+            }
+        }, 2, false, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayErrorScheduledHidden() {
+        TestSubscriber<String> ts = Flowable.just(1)
+        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName()).hide();
+            }
+        }, 2, false, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayError2Scheduled() {
+        TestSubscriber<String> ts = Flowable.just(1)
+        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName());
+            }
+        }, 2, true, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayError2ScheduledHidden() {
+        TestSubscriber<String> ts = Flowable.just(1)
+        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName()).hide();
+            }
+        }, 2, true, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test(timeout = 30000)
+    public void issue2890NoStackoverflow() throws InterruptedException {
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        final Scheduler sch = Schedulers.from(executor);
+
+        Function<Integer, Flowable<Integer>> func = new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer t) {
+                Flowable<Integer> flowable = Flowable.just(t)
+                        .subscribeOn(sch)
+                ;
+                FlowableProcessor<Integer> processor = UnicastProcessor.create();
+                flowable.subscribe(processor);
+                return processor;
+            }
+        };
+
+        int n = 5000;
+        final AtomicInteger counter = new AtomicInteger();
+
+        Flowable.range(1, n).concatMap(func, 2, ImmediateThinScheduler.INSTANCE).subscribe(new DefaultSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                // Consume after sleep for 1 ms
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    // ignored
+                }
+                if (counter.getAndIncrement() % 100 == 0) {
+                    System.out.print("testIssue2890NoStackoverflow -> ");
+                    System.out.println(counter.get());
+                };
+            }
+
+            @Override
+            public void onComplete() {
+                executor.shutdown();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                executor.shutdown();
+            }
+        });
+
+        executor.awaitTermination(20000, TimeUnit.MILLISECONDS);
+
+        assertEquals(n, counter.get());
+    }
+
+    @Test//(timeout = 100000)
+    public void concatMapRangeAsyncLoopIssue2876() {
+        final long durationSeconds = 2;
+        final long startTime = System.currentTimeMillis();
+        for (int i = 0;; i++) {
+            //only run this for a max of ten seconds
+            if (System.currentTimeMillis() - startTime > TimeUnit.SECONDS.toMillis(durationSeconds)) {
+                return;
+            }
+            if (i % 1000 == 0) {
+                System.out.println("concatMapRangeAsyncLoop > " + i);
+            }
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            Flowable.range(0, 1000)
+            .concatMap(new Function<Integer, Flowable<Integer>>() {
+                @Override
+                public Flowable<Integer> apply(Integer t) {
+                    return Flowable.fromIterable(Arrays.asList(t));
+                }
+            }, 2, ImmediateThinScheduler.INSTANCE)
+            .observeOn(Schedulers.computation()).subscribe(ts);
+
+            ts.awaitDone(2500, TimeUnit.MILLISECONDS);
+            ts.assertTerminated();
+            ts.assertNoErrors();
+            assertEquals(1000, ts.values().size());
+            assertEquals((Integer)999, ts.values().get(999));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @Ignore("concat(a, b, ...) replaced by concatArray(T...)")
+    public void concatMany() throws Exception {
+        for (int i = 2; i < 10; i++) {
+            Class<?>[] clazz = new Class[i];
+            Arrays.fill(clazz, Flowable.class);
+
+            Flowable<Integer>[] obs = new Flowable[i];
+            Arrays.fill(obs, Flowable.just(1));
+
+            Integer[] expected = new Integer[i];
+            Arrays.fill(expected, 1);
+
+            Method m = Flowable.class.getMethod("concat", clazz);
+
+            TestSubscriber<Integer> ts = TestSubscriber.create();
+
+            ((Flowable<Integer>)m.invoke(null, (Object[])obs)).subscribe(ts);
+
+            ts.assertValues(expected);
+            ts.assertNoErrors();
+            ts.assertComplete();
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void concatMapJustJust() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(Flowable.just(1)).concatMap((Function)Functions.identity(), 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void concatMapJustRange() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(Flowable.range(1, 5)).concatMap((Function)Functions.identity(), 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void concatMapDelayErrorJustJust() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(Flowable.just(1)).concatMapDelayError((Function)Functions.identity(), 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertValue(1);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void concatMapDelayErrorJustRange() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(Flowable.range(1, 5)).concatMapDelayError((Function)Functions.identity(), 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 4, 5);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @Ignore("startWith(a, b, ...) replaced by startWithArray(T...)")
+    public void startWith() throws Exception {
+        for (int i = 2; i < 10; i++) {
+            Class<?>[] clazz = new Class[i];
+            Arrays.fill(clazz, Object.class);
+
+            Object[] obs = new Object[i];
+            Arrays.fill(obs, 1);
+
+            Integer[] expected = new Integer[i];
+            Arrays.fill(expected, 1);
+
+            Method m = Flowable.class.getMethod("startWith", clazz);
+
+            TestSubscriber<Integer> ts = TestSubscriber.create();
+
+            ((Flowable<Integer>)m.invoke(Flowable.empty(), obs)).subscribe(ts);
+
+            ts.assertValues(expected);
+            ts.assertNoErrors();
+            ts.assertComplete();
+        }
+    }
+
+    static final class InfiniteIterator implements Iterator<Integer>, Iterable<Integer> {
+
+        int count;
+
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public Integer next() {
+            return count++;
+        }
+
+        @Override
+        public void remove() {
+        }
+
+        @Override
+        public Iterator<Integer> iterator() {
+            return this;
+        }
+    }
+
+    @Test
+    public void concatMapDelayError() {
+        Flowable.just(Flowable.just(1), Flowable.just(2))
+        .concatMapDelayError(Functions.<Flowable<Integer>>identity(), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void concatMapDelayErrorJustSource() {
+        Flowable.just(0)
+        .concatMapDelayError(new Function<Object, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Object v) throws Exception {
+                return Flowable.just(1);
+            }
+        }, 16, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1);
+
+    }
+
+    @Test
+    public void concatMapJustSource() {
+        Flowable.just(0).hide()
+        .concatMap(new Function<Object, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Object v) throws Exception {
+                return Flowable.just(1);
+            }
+        }, 16, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void concatMapJustSourceDelayError() {
+        Flowable.just(0).hide()
+        .concatMapDelayError(new Function<Object, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Object v) throws Exception {
+                return Flowable.just(1);
+            }
+        }, 16, false, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void concatMapScalarBackpressured() {
+        Flowable.just(1).hide()
+        .concatMap(Functions.justFunction(Flowable.just(2)), 2, ImmediateThinScheduler.INSTANCE)
+        .test(1L)
+        .assertResult(2);
+    }
+
+    @Test
+    public void concatMapScalarBackpressuredDelayError() {
+        Flowable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(Flowable.just(2)), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test(1L)
+        .assertResult(2);
+    }
+
+    @Test
+    public void concatMapEmpty() {
+        Flowable.just(1).hide()
+        .concatMap(Functions.justFunction(Flowable.empty()), 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void concatMapEmptyDelayError() {
+        Flowable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(Flowable.empty()), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void ignoreBackpressure() {
+        new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                s.onSubscribe(new BooleanSubscription());
+                for (int i = 0; i < 10; i++) {
+                    s.onNext(i);
+                }
+            }
+        }
+        .concatMap(Functions.justFunction(Flowable.just(2)), 8, ImmediateThinScheduler.INSTANCE)
+        .test(0L)
+        .assertFailure(IllegalStateException.class);
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Flowable<Object> f) throws Exception {
+                return f.concatMap(Functions.justFunction(Flowable.just(2)), 2, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Integer>>() {
+            @Override
+            public Publisher<Integer> apply(Flowable<Object> f) throws Exception {
+                return f.concatMapDelayError(Functions.justFunction(Flowable.just(2)), 2, true, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+    }
+
+    @Test
+    public void immediateInnerNextOuterError() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onError(new TestException("First"));
+                }
+            }
+        };
+
+        pp.concatMap(Functions.justFunction(Flowable.just(1)), 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(ts);
+
+        pp.onNext(1);
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertFailureAndMessage(TestException.class, "First", 1);
+    }
+
+    @Test
+    public void immediateInnerNextOuterError2() {
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    pp.onError(new TestException("First"));
+                }
+            }
+        };
+
+        pp.concatMap(Functions.justFunction(Flowable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(ts);
+
+        pp.onNext(1);
+
+        assertFalse(pp.hasSubscribers());
+
+        ts.assertFailureAndMessage(TestException.class, "First", 1);
+    }
+
+    @Test
+    public void concatMapInnerError() {
+        Flowable.just(1).hide()
+        .concatMap(Functions.justFunction(Flowable.error(new TestException())), 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void concatMapInnerErrorDelayError() {
+        Flowable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(Flowable.error(new TestException())), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.concatMap(Functions.justFunction(Flowable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE);
+            }
+        }, true, 1, 1, 1);
+    }
+
+    @Test
+    public void badInnerSource() {
+        @SuppressWarnings("rawtypes")
+        final Subscriber[] ts0 = { null };
+        TestSubscriberEx<Integer> ts = Flowable.just(1).hide().concatMap(Functions.justFunction(new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                ts0[0] = s;
+                s.onSubscribe(new BooleanSubscription());
+                s.onError(new TestException("First"));
+            }
+        }), 2, ImmediateThinScheduler.INSTANCE)
+        .to(TestHelper.<Integer>testConsumer());
+
+        ts.assertFailureAndMessage(TestException.class, "First");
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            ts0[0].onError(new TestException("Second"));
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badInnerSourceDelayError() {
+        @SuppressWarnings("rawtypes")
+        final Subscriber[] ts0 = { null };
+        TestSubscriberEx<Integer> ts = Flowable.just(1).hide().concatMapDelayError(Functions.justFunction(new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                ts0[0] = s;
+                s.onSubscribe(new BooleanSubscription());
+                s.onError(new TestException("First"));
+            }
+        }), 2, true, ImmediateThinScheduler.INSTANCE)
+        .to(TestHelper.<Integer>testConsumer());
+
+        ts.assertFailureAndMessage(TestException.class, "First");
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            ts0[0].onError(new TestException("Second"));
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSourceDelayError() {
+        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
+            @Override
+            public Object apply(Flowable<Integer> f) throws Exception {
+                return f.concatMapDelayError(Functions.justFunction(Flowable.just(1).hide()), 2, true, ImmediateThinScheduler.INSTANCE);
+            }
+        }, true, 1, 1, 1);
+    }
+
+    @Test
+    public void fusedCrash() {
+        Flowable.range(1, 2)
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception { throw new TestException(); }
+        })
+        .concatMap(Functions.justFunction(Flowable.just(1)), 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void fusedCrashDelayError() {
+        Flowable.range(1, 2)
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception { throw new TestException(); }
+        })
+        .concatMapDelayError(Functions.justFunction(Flowable.just(1)), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void callableCrash() {
+        Flowable.just(1).hide()
+        .concatMap(Functions.justFunction(Flowable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new TestException();
+            }
+        })), 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void callableCrashDelayError() {
+        Flowable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(Flowable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new TestException();
+            }
+        })), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Flowable.range(1, 2)
+        .concatMap(Functions.justFunction(Flowable.just(1)), 2, ImmediateThinScheduler.INSTANCE));
+
+        TestHelper.checkDisposed(Flowable.range(1, 2)
+        .concatMapDelayError(Functions.justFunction(Flowable.just(1)), 2, true, ImmediateThinScheduler.INSTANCE));
+    }
+
+    @Test
+    public void notVeryEnd() {
+        Flowable.range(1, 2)
+        .concatMapDelayError(Functions.justFunction(Flowable.error(new TestException())), 16, false, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .concatMapDelayError(Functions.justFunction(Flowable.just(2)), 16, false, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapperThrows() {
+        Flowable.range(1, 2)
+        .concatMap(new Function<Integer, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        }, 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainErrors() {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        source.concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return Flowable.range(v, 2);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+
+        ts.assertValues(1, 2, 2, 3);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void innerErrors() {
+        final Flowable<Integer> inner = Flowable.range(1, 2)
+                .concatWith(Flowable.<Integer>error(new TestException()));
+
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.range(1, 3).concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return inner;
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertValues(1, 2, 1, 2, 1, 2);
+        ts.assertError(CompositeException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void singleInnerErrors() {
+        final Flowable<Integer> inner = Flowable.range(1, 2).concatWith(Flowable.<Integer>error(new TestException()));
+
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return inner;
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertValues(1, 2);
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void innerNull() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return null;
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertNoValues();
+        ts.assertError(NullPointerException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void innerThrows() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                throw new TestException();
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertNoValues();
+        ts.assertError(TestException.class);
+        ts.assertNotComplete();
+    }
+
+    @Test
+    public void innerWithEmpty() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.range(1, 3)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return v == 2 ? Flowable.<Integer>empty() : Flowable.range(1, 2);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertValues(1, 2, 1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void innerWithScalar() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+
+        Flowable.range(1, 3)
+        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return v == 2 ? Flowable.just(3) : Flowable.range(1, 2);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertValues(1, 2, 3, 1, 2);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void backpressure() {
+        TestSubscriber<Integer> ts = TestSubscriber.create(0);
+
+        Flowable.range(1, 3).concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Integer v) {
+                return Flowable.range(v, 2);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+
+        ts.assertNoValues();
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+
+        ts.request(1);
+        ts.assertValues(1);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+
+        ts.request(3);
+        ts.assertValues(1, 2, 2, 3);
+        ts.assertNoErrors();
+        ts.assertNotComplete();
+
+        ts.request(2);
+
+        ts.assertValues(1, 2, 2, 3, 3, 4);
+        ts.assertNoErrors();
+        ts.assertComplete();
+    }
+
+    @Test
+    public void mapperScheduledLong() {
+        TestSubscriber<String> ts = Flowable.range(1, 1000)
+        .hide()
+        .observeOn(Schedulers.computation())
+        .concatMap(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName())
+                        .repeat(1000)
+                        .observeOn(Schedulers.io());
+            }
+        }, 2, Schedulers.single())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayErrorScheduledLong() {
+        TestSubscriber<String> ts = Flowable.range(1, 1000)
+        .hide()
+        .observeOn(Schedulers.computation())
+        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName())
+                        .repeat(1000)
+                        .observeOn(Schedulers.io());
+            }
+        }, 2, false, Schedulers.single())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayError2ScheduledLong() {
+        TestSubscriber<String> ts = Flowable.range(1, 1000)
+        .hide()
+        .observeOn(Schedulers.computation())
+        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
+            @Override
+            public Flowable<String> apply(Integer t) throws Throwable {
+                return Flowable.just(Thread.currentThread().getName())
+                        .repeat(1000)
+                        .observeOn(Schedulers.io());
+            }
+        }, 2, true, Schedulers.single())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+}

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -1451,7 +1451,7 @@ public class FlowableConcatTest {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
             public Object apply(Flowable<Integer> f) throws Exception {
-                return f.concatMap(Functions.justFunction(Flowable.just(1).hide()));
+                return f.concatMapDelayError(Functions.justFunction(Flowable.just(1).hide()));
             }
         }, true, 1, 1, 1);
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -1,0 +1,1015 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.*;
+
+import io.reactivex.*;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.exceptions.*;
+import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.schedulers.ImmediateThinScheduler;
+import io.reactivex.observers.*;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.*;
+import io.reactivex.testsupport.*;
+
+public class ObservableConcatMapSchedulerTest {
+
+    @Test
+    public void boundaryFusion() {
+        Observable.range(1, 10000)
+        .observeOn(Schedulers.single())
+        .map(new Function<Integer, String>() {
+            @Override
+            public String apply(Integer t) throws Exception {
+                String name = Thread.currentThread().getName();
+                if (name.contains("RxSingleScheduler")) {
+                    return "RxSingleScheduler";
+                }
+                return name;
+            }
+        })
+        .concatMap(new Function<String, ObservableSource<? extends Object>>() {
+            @Override
+            public ObservableSource<? extends Object> apply(String v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        }, 2, ImmediateThinScheduler.INSTANCE)
+        .observeOn(Schedulers.computation())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult("RxSingleScheduler");
+    }
+
+    @Test
+    public void boundaryFusionDelayError() {
+        Observable.range(1, 10000)
+        .observeOn(Schedulers.single())
+        .map(new Function<Integer, String>() {
+            @Override
+            public String apply(Integer t) throws Exception {
+                String name = Thread.currentThread().getName();
+                if (name.contains("RxSingleScheduler")) {
+                    return "RxSingleScheduler";
+                }
+                return name;
+            }
+        })
+        .concatMapDelayError(new Function<String, ObservableSource<? extends Object>>() {
+            @Override
+            public ObservableSource<? extends Object> apply(String v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        .observeOn(Schedulers.computation())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult("RxSingleScheduler");
+    }
+
+    @Test
+    public void pollThrows() {
+        Observable.just(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .compose(TestHelper.<Integer>observableStripBoundary())
+        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        }, 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void pollThrowsDelayError() {
+        Observable.just(1)
+        .map(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        })
+        .compose(TestHelper.<Integer>observableStripBoundary())
+        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Integer v)
+                    throws Exception {
+                return Observable.just(v);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void noCancelPrevious() {
+        final AtomicInteger counter = new AtomicInteger();
+
+        Observable.range(1, 5)
+        .concatMap(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v) throws Exception {
+                return Observable.just(v).doOnDispose(new Action() {
+                    @Override
+                    public void run() throws Exception {
+                        counter.getAndIncrement();
+                    }
+                });
+            }
+        }, 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void delayErrorCallableTillTheEnd() {
+        Observable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
+        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+          @Override public Observable<Integer> apply(final Integer integer) throws Exception {
+            return Observable.fromCallable(new Callable<Integer>() {
+              @Override public Integer call() throws Exception {
+                if (integer >= 100) {
+                  throw new NullPointerException("test null exp");
+                }
+                return integer;
+              }
+            });
+          }
+        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
+    }
+
+    @Test
+    public void delayErrorCallableEager() {
+        Observable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
+        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+          @Override public Observable<Integer> apply(final Integer integer) throws Exception {
+            return Observable.fromCallable(new Callable<Integer>() {
+              @Override public Integer call() throws Exception {
+                if (integer >= 100) {
+                  throw new NullPointerException("test null exp");
+                }
+                return integer;
+              }
+            });
+          }
+        }, 2, false, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(NullPointerException.class, 1, 2, 3);
+    }
+
+    @Test
+    public void mapperScheduled() {
+        TestObserver<String> to = Observable.just(1)
+        .concatMap(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName());
+            }
+        }, 2, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperScheduledHidden() {
+        TestObserver<String> to = Observable.just(1)
+        .concatMap(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName()).hide();
+            }
+        }, 2, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayErrorScheduled() {
+        TestObserver<String> to = Observable.just(1)
+        .concatMapDelayError(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName());
+            }
+        }, 2, false, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayErrorScheduledHidden() {
+        TestObserver<String> to = Observable.just(1)
+        .concatMapDelayError(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName()).hide();
+            }
+        }, 2, false, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayError2Scheduled() {
+        TestObserver<String> to = Observable.just(1)
+        .concatMapDelayError(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName());
+            }
+        }, 2, true, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayError2ScheduledHidden() {
+        TestObserver<String> to = Observable.just(1)
+        .concatMapDelayError(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName()).hide();
+            }
+        }, 2, true, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test(timeout = 30000)
+    public void issue2890NoStackoverflow() throws InterruptedException {
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        final Scheduler sch = Schedulers.from(executor);
+
+        Function<Integer, Observable<Integer>> func = new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer t) {
+                Observable<Integer> flowable = Observable.just(t)
+                        .subscribeOn(sch)
+                ;
+                Subject<Integer> processor = UnicastSubject.create();
+                flowable.subscribe(processor);
+                return processor;
+            }
+        };
+
+        int n = 5000;
+        final AtomicInteger counter = new AtomicInteger();
+
+        Observable.range(1, n).concatMap(func, 2, ImmediateThinScheduler.INSTANCE).subscribe(new DefaultObserver<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                // Consume after sleep for 1 ms
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    // ignored
+                }
+                if (counter.getAndIncrement() % 100 == 0) {
+                    System.out.print("testIssue2890NoStackoverflow -> ");
+                    System.out.println(counter.get());
+                };
+            }
+
+            @Override
+            public void onComplete() {
+                executor.shutdown();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                executor.shutdown();
+            }
+        });
+
+        executor.awaitTermination(20000, TimeUnit.MILLISECONDS);
+
+        assertEquals(n, counter.get());
+    }
+
+    @Test//(timeout = 100000)
+    public void concatMapRangeAsyncLoopIssue2876() {
+        final long durationSeconds = 2;
+        final long startTime = System.currentTimeMillis();
+        for (int i = 0;; i++) {
+            //only run this for a max of ten seconds
+            if (System.currentTimeMillis() - startTime > TimeUnit.SECONDS.toMillis(durationSeconds)) {
+                return;
+            }
+            if (i % 1000 == 0) {
+                System.out.println("concatMapRangeAsyncLoop > " + i);
+            }
+            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            Observable.range(0, 1000)
+            .concatMap(new Function<Integer, Observable<Integer>>() {
+                @Override
+                public Observable<Integer> apply(Integer t) {
+                    return Observable.fromIterable(Arrays.asList(t));
+                }
+            }, 2, ImmediateThinScheduler.INSTANCE)
+            .observeOn(Schedulers.computation()).subscribe(to);
+
+            to.awaitDone(2500, TimeUnit.MILLISECONDS);
+            to.assertTerminated();
+            to.assertNoErrors();
+            assertEquals(1000, to.values().size());
+            assertEquals((Integer)999, to.values().get(999));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @Ignore("concat(a, b, ...) replaced by concatArray(T...)")
+    public void concatMany() throws Exception {
+        for (int i = 2; i < 10; i++) {
+            Class<?>[] clazz = new Class[i];
+            Arrays.fill(clazz, Observable.class);
+
+            Observable<Integer>[] obs = new Observable[i];
+            Arrays.fill(obs, Observable.just(1));
+
+            Integer[] expected = new Integer[i];
+            Arrays.fill(expected, 1);
+
+            Method m = Observable.class.getMethod("concat", clazz);
+
+            TestObserver<Integer> to = TestObserver.create();
+
+            ((Observable<Integer>)m.invoke(null, (Object[])obs)).subscribe(to);
+
+            to.assertValues(expected);
+            to.assertNoErrors();
+            to.assertComplete();
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void concatMapJustJust() {
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.just(Observable.just(1)).concatMap((Function)Functions.identity(), 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertComplete();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void concatMapJustRange() {
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.just(Observable.range(1, 5)).concatMap((Function)Functions.identity(), 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertValues(1, 2, 3, 4, 5);
+        to.assertNoErrors();
+        to.assertComplete();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void concatMapDelayErrorJustJust() {
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.just(Observable.just(1)).concatMapDelayError((Function)Functions.identity(), 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertValue(1);
+        to.assertNoErrors();
+        to.assertComplete();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void concatMapDelayErrorJustRange() {
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.just(Observable.range(1, 5)).concatMapDelayError((Function)Functions.identity(), 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertValues(1, 2, 3, 4, 5);
+        to.assertNoErrors();
+        to.assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @Ignore("startWith(a, b, ...) replaced by startWithArray(T...)")
+    public void startWith() throws Exception {
+        for (int i = 2; i < 10; i++) {
+            Class<?>[] clazz = new Class[i];
+            Arrays.fill(clazz, Object.class);
+
+            Object[] obs = new Object[i];
+            Arrays.fill(obs, 1);
+
+            Integer[] expected = new Integer[i];
+            Arrays.fill(expected, 1);
+
+            Method m = Observable.class.getMethod("startWith", clazz);
+
+            TestObserver<Integer> to = TestObserver.create();
+
+            ((Observable<Integer>)m.invoke(Observable.empty(), obs)).subscribe(to);
+
+            to.assertValues(expected);
+            to.assertNoErrors();
+            to.assertComplete();
+        }
+    }
+
+    static final class InfiniteIterator implements Iterator<Integer>, Iterable<Integer> {
+
+        int count;
+
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public Integer next() {
+            return count++;
+        }
+
+        @Override
+        public void remove() {
+        }
+
+        @Override
+        public Iterator<Integer> iterator() {
+            return this;
+        }
+    }
+
+    @Test
+    public void concatMapDelayError() {
+        Observable.just(Observable.just(1), Observable.just(2))
+        .concatMapDelayError(Functions.<Observable<Integer>>identity(), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void concatMapDelayErrorJustSource() {
+        Observable.just(0)
+        .concatMapDelayError(new Function<Object, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Object v) throws Exception {
+                return Observable.just(1);
+            }
+        }, 16, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1);
+
+    }
+
+    @Test
+    public void concatMapJustSource() {
+        Observable.just(0).hide()
+        .concatMap(new Function<Object, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Object v) throws Exception {
+                return Observable.just(1);
+            }
+        }, 16, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void concatMapJustSourceDelayError() {
+        Observable.just(0).hide()
+        .concatMapDelayError(new Function<Object, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Object v) throws Exception {
+                return Observable.just(1);
+            }
+        }, 16, false, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void concatMapEmpty() {
+        Observable.just(1).hide()
+        .concatMap(Functions.justFunction(Observable.empty()), 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void concatMapEmptyDelayError() {
+        Observable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(Observable.empty()), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Observable<Object> f) throws Exception {
+                return f.concatMap(Functions.justFunction(Observable.just(2)), 2, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Integer>>() {
+            @Override
+            public ObservableSource<Integer> apply(Observable<Object> f) throws Exception {
+                return f.concatMapDelayError(Functions.justFunction(Observable.just(2)), 2, true, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+    }
+
+    @Test
+    public void immediateInnerNextOuterError() {
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        final TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    ps.onError(new TestException("First"));
+                }
+            }
+        };
+
+        ps.concatMap(Functions.justFunction(Observable.just(1)), 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(to);
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasObservers());
+
+        to.assertFailureAndMessage(TestException.class, "First", 1);
+    }
+
+    @Test
+    public void immediateInnerNextOuterError2() {
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        final TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+            @Override
+            public void onNext(Integer t) {
+                super.onNext(t);
+                if (t == 1) {
+                    ps.onError(new TestException("First"));
+                }
+            }
+        };
+
+        ps.concatMap(Functions.justFunction(Observable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(to);
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasObservers());
+
+        to.assertFailureAndMessage(TestException.class, "First", 1);
+    }
+
+    @Test
+    public void concatMapInnerError() {
+        Observable.just(1).hide()
+        .concatMap(Functions.justFunction(Observable.error(new TestException())), 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void concatMapInnerErrorDelayError() {
+        Observable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(Observable.error(new TestException())), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void badSource() {
+        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
+            @Override
+            public Object apply(Observable<Integer> f) throws Exception {
+                return f.concatMap(Functions.justFunction(Observable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE);
+            }
+        }, true, 1, 1, 1);
+    }
+
+    @Test
+    public void badInnerSource() {
+        @SuppressWarnings("rawtypes")
+        final Observer[] ts0 = { null };
+        TestObserverEx<Integer> to = Observable.just(1).hide().concatMap(Functions.justFunction(new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> o) {
+                ts0[0] = o;
+                o.onSubscribe(Disposables.empty());
+                o.onError(new TestException("First"));
+            }
+        }), 2, ImmediateThinScheduler.INSTANCE)
+        .to(TestHelper.<Integer>testConsumer());
+
+        to.assertFailureAndMessage(TestException.class, "First");
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            ts0[0].onError(new TestException("Second"));
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badInnerSourceDelayError() {
+        @SuppressWarnings("rawtypes")
+        final Observer[] ts0 = { null };
+        TestObserverEx<Integer> to = Observable.just(1).hide().concatMapDelayError(Functions.justFunction(new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> o) {
+                ts0[0] = o;
+                o.onSubscribe(Disposables.empty());
+                o.onError(new TestException("First"));
+            }
+        }), 2, true, ImmediateThinScheduler.INSTANCE)
+        .to(TestHelper.<Integer>testConsumer());
+
+        to.assertFailureAndMessage(TestException.class, "First");
+
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            ts0[0].onError(new TestException("Second"));
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSourceDelayError() {
+        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
+            @Override
+            public Object apply(Observable<Integer> f) throws Exception {
+                return f.concatMapDelayError(Functions.justFunction(Observable.just(1).hide()), 2, true, ImmediateThinScheduler.INSTANCE);
+            }
+        }, true, 1, 1, 1);
+    }
+
+    @Test
+    public void fusedCrash() {
+        Observable.range(1, 2)
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception { throw new TestException(); }
+        })
+        .concatMap(Functions.justFunction(Observable.just(1)), 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void fusedCrashDelayError() {
+        Observable.range(1, 2)
+        .map(new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Exception { throw new TestException(); }
+        })
+        .concatMapDelayError(Functions.justFunction(Observable.just(1)), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void callableCrash() {
+        Observable.just(1).hide()
+        .concatMap(Functions.justFunction(Observable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new TestException();
+            }
+        })), 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void callableCrashDelayError() {
+        Observable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(Observable.fromCallable(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new TestException();
+            }
+        })), 2, true, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.range(1, 2)
+        .concatMap(Functions.justFunction(Observable.just(1)), 2, ImmediateThinScheduler.INSTANCE));
+
+        TestHelper.checkDisposed(Observable.range(1, 2)
+        .concatMapDelayError(Functions.justFunction(Observable.just(1)), 2, true, ImmediateThinScheduler.INSTANCE));
+    }
+
+    @Test
+    public void notVeryEnd() {
+        Observable.range(1, 2)
+        .concatMapDelayError(Functions.justFunction(Observable.error(new TestException())), 16, false, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .concatMapDelayError(Functions.justFunction(Observable.just(2)), 16, false, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapperThrows() {
+        Observable.range(1, 2)
+        .concatMap(new Function<Integer, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Integer v) throws Exception {
+                throw new TestException();
+            }
+        }, 2, ImmediateThinScheduler.INSTANCE)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mainErrors() {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        TestObserver<Integer> to = TestObserver.create();
+
+        source.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v) {
+                return Observable.range(v, 2);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onError(new TestException());
+
+        to.assertValues(1, 2, 2, 3);
+        to.assertError(TestException.class);
+        to.assertNotComplete();
+    }
+
+    @Test
+    public void innerErrors() {
+        final Observable<Integer> inner = Observable.range(1, 2)
+                .concatWith(Observable.<Integer>error(new TestException()));
+
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.range(1, 3).concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v) {
+                return inner;
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertValues(1, 2, 1, 2, 1, 2);
+        to.assertError(CompositeException.class);
+        to.assertNotComplete();
+    }
+
+    @Test
+    public void singleInnerErrors() {
+        final Observable<Integer> inner = Observable.range(1, 2).concatWith(Observable.<Integer>error(new TestException()));
+
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v) {
+                return inner;
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertValues(1, 2);
+        to.assertError(TestException.class);
+        to.assertNotComplete();
+    }
+
+    @Test
+    public void innerNull() {
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v) {
+                return null;
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertNoValues();
+        to.assertError(NullPointerException.class);
+        to.assertNotComplete();
+    }
+
+    @Test
+    public void innerThrows() {
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.just(1)
+        .hide() // prevent scalar optimization
+        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v) {
+                throw new TestException();
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertNoValues();
+        to.assertError(TestException.class);
+        to.assertNotComplete();
+    }
+
+    @Test
+    public void innerWithEmpty() {
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.range(1, 3)
+        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v) {
+                return v == 2 ? Observable.<Integer>empty() : Observable.range(1, 2);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertValues(1, 2, 1, 2);
+        to.assertNoErrors();
+        to.assertComplete();
+    }
+
+    @Test
+    public void innerWithScalar() {
+        TestObserver<Integer> to = TestObserver.create();
+
+        Observable.range(1, 3)
+        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Integer v) {
+                return v == 2 ? Observable.just(3) : Observable.range(1, 2);
+            }
+        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+
+        to.assertValues(1, 2, 3, 1, 2);
+        to.assertNoErrors();
+        to.assertComplete();
+    }
+
+    @Test
+    public void mapperScheduledLong() {
+        TestObserver<String> to = Observable.range(1, 1000)
+        .hide()
+        .observeOn(Schedulers.computation())
+        .concatMap(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName())
+                        .repeat(1000)
+                        .observeOn(Schedulers.io());
+            }
+        }, 2, Schedulers.single())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayErrorScheduledLong() {
+        TestObserver<String> to = Observable.range(1, 1000)
+        .hide()
+        .observeOn(Schedulers.computation())
+        .concatMapDelayError(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName())
+                        .repeat(1000)
+                        .observeOn(Schedulers.io());
+            }
+        }, 2, false, Schedulers.single())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+
+    @Test
+    public void mapperDelayError2ScheduledLong() {
+        TestObserver<String> to = Observable.range(1, 1000)
+        .hide()
+        .observeOn(Schedulers.computation())
+        .concatMapDelayError(new Function<Integer, Observable<String>>() {
+            @Override
+            public Observable<String> apply(Integer t) throws Throwable {
+                return Observable.just(Thread.currentThread().getName())
+                        .repeat(1000)
+                        .observeOn(Schedulers.io());
+            }
+        }, 2, true, Schedulers.single())
+        .distinct()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+    }
+}


### PR DESCRIPTION
…(#6538)

Back port `Add concatMap with Scheduler guaranteeing where the mapper runs` to 2.x branch.
see #6538

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
