### PR TITLE
Fixing version tag on Schedulers.from(Executor, boolean)

### DIFF
--- a/src/main/java/io/reactivex/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/schedulers/Schedulers.java
@@ -400,7 +400,7 @@ public final class Schedulers {
      * @param interruptibleWorker if {@code true} the tasks submitted to the {@link io.reactivex.Scheduler.Worker Scheduler.Worker} will
      * be interrupted when the task is disposed.
      * @return the new Scheduler wrapping the Executor
-     * @since 2.2.6 - experimental
+     * @since 3.0.0
      */
     @NonNull
     public static Scheduler from(@NonNull Executor executor, boolean interruptibleWorker) {


### PR DESCRIPTION
Resolves #6543 

Updating the version tag on `Schedulers.from(Executor, boolean)` since it was promoted.
