### PR TITLE
3.x rename on error resume next methods to disambiguate when calling from kotlin (#6551)

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -12197,9 +12197,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * By default, when a Publisher encounters an error that prevents it from emitting the expected item to
      * its {@link Subscriber}, the Publisher invokes its Subscriber's {@code onError} method, and then quits
-     * without invoking any more of its Subscriber's methods. The {@code onErrorResumeNext} method changes this
+     * without invoking any more of its Subscriber's methods. The {@code onErrorResumeWith} method changes this
      * behavior. If you pass another Publisher ({@code resumeSequence}) to a Publisher's
-     * {@code onErrorResumeNext} method, if the original Publisher encounters an error, instead of invoking its
+     * {@code onErrorResumeWith} method, if the original Publisher encounters an error, instead of invoking its
      * Subscriber's {@code onError} method, it will instead relinquish control to {@code resumeSequence} which
      * will invoke the Subscriber's {@link Subscriber#onNext onNext} method if it is able to do so. In such a case,
      * because no Publisher necessarily invokes {@code onError}, the Subscriber may never know that an error
@@ -12215,7 +12215,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  {@code IllegalStateException} when the source {@code Publisher} completes or
      *  {@code MissingBackpressureException} is signaled somewhere downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code onErrorResumeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param next
@@ -12228,7 +12228,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> onErrorResumeNext(final Publisher<? extends T> next) {
+    public final Flowable<T> onErrorResumeWith(final Publisher<? extends T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
         return onErrorResumeNext(Functions.justFunction(next));
     }

--- a/src/main/java/io/reactivex/Maybe.java
+++ b/src/main/java/io/reactivex/Maybe.java
@@ -3732,7 +3732,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * encountered.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code onErrorResumeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param next
@@ -3744,7 +3744,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorResumeNext(final MaybeSource<? extends T> next) {
+    public final Maybe<T> onErrorResumeWith(final MaybeSource<? extends T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
         return onErrorResumeNext(Functions.justFunction(next));
     }

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -10126,10 +10126,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * By default, when an ObservableSource encounters an error that prevents it from emitting the expected item to
      * its {@link Observer}, the ObservableSource invokes its Observer's {@code onError} method, and then quits
-     * without invoking any more of its Observer's methods. The {@code onErrorResumeNext} method changes this
-     * behavior. If you pass another ObservableSource ({@code resumeSequence}) to an ObservableSource's
-     * {@code onErrorResumeNext} method, if the original ObservableSource encounters an error, instead of invoking its
-     * Observer's {@code onError} method, it will instead relinquish control to {@code resumeSequence} which
+     * without invoking any more of its Observer's methods. The {@code onErrorResumeWith} method changes this
+     * behavior. If you pass another ObservableSource ({@code next}) to an ObservableSource's
+     * {@code onErrorResumeWith} method, if the original ObservableSource encounters an error, instead of invoking its
+     * Observer's {@code onError} method, it will instead relinquish control to {@code next} which
      * will invoke the Observer's {@link Observer#onNext onNext} method if it is able to do so. In such a case,
      * because no ObservableSource necessarily invokes {@code onError}, the Observer may never know that an error
      * happened.
@@ -10138,7 +10138,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * encountered.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code onErrorResumeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param next
@@ -10149,7 +10149,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> onErrorResumeNext(final ObservableSource<? extends T> next) {
+    public final Observable<T> onErrorResumeWith(final ObservableSource<? extends T> next) {
         ObjectHelper.requireNonNull(next, "next is null");
         return onErrorResumeNext(Functions.justFunction(next));
     }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3207,9 +3207,9 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * By default, when a Single encounters an error that prevents it from emitting the expected item to
      * its {@link SingleObserver}, the Single invokes its SingleObserver's {@code onError} method, and then quits
-     * without invoking any more of its SingleObserver's methods. The {@code onErrorResumeNext} method changes this
+     * without invoking any more of its SingleObserver's methods. The {@code onErrorResumeWith} method changes this
      * behavior. If you pass another Single ({@code resumeSingleInCaseOfError}) to a Single's
-     * {@code onErrorResumeNext} method, if the original Single encounters an error, instead of invoking its
+     * {@code onErrorResumeWith} method, if the original Single encounters an error, instead of invoking its
      * SingleObserver's {@code onError} method, it will instead relinquish control to {@code resumeSingleInCaseOfError} which
      * will invoke the SingleObserver's {@link SingleObserver#onSuccess onSuccess} method if it is able to do so. In such a case,
      * because no Single necessarily invokes {@code onError}, the SingleObserver may never know that an error
@@ -3219,7 +3219,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * encountered.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code onErrorResumeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param resumeSingleInCaseOfError a Single that will take control if source Single encounters an error.
@@ -3229,7 +3229,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> onErrorResumeNext(final Single<? extends T> resumeSingleInCaseOfError) {
+    public final Single<T> onErrorResumeWith(final Single<? extends T> resumeSingleInCaseOfError) {
         ObjectHelper.requireNonNull(resumeSingleInCaseOfError, "resumeSingleInCaseOfError is null");
         return onErrorResumeNext(Functions.justFunction(resumeSingleInCaseOfError));
     }

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -3229,7 +3229,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> onErrorResumeWith(final Single<? extends T> resumeSingleInCaseOfError) {
+    public final Single<T> onErrorResumeWith(final SingleSource<? extends T> resumeSingleInCaseOfError) {
         ObjectHelper.requireNonNull(resumeSingleInCaseOfError, "resumeSingleInCaseOfError is null");
         return onErrorResumeNext(Functions.justFunction(resumeSingleInCaseOfError));
     }

--- a/src/test/java/io/reactivex/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/flowable/FlowableNullTests.java
@@ -1646,8 +1646,8 @@ public class FlowableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void onErrorResumeNextFunctionNull() {
-        just1.onErrorResumeNext((Function<Throwable, Publisher<Integer>>)null);
+    public void onErrorResumeNextNull() {
+        just1.onErrorResumeNext(null);
     }
 
     @Test
@@ -1669,8 +1669,8 @@ public class FlowableNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void onErrorResumeNextPublisherNull() {
-        just1.onErrorResumeNext((Publisher<Integer>)null);
+    public void onErrorResumeWithNull() {
+        just1.onErrorResumeWith(null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -2956,11 +2956,6 @@ public class FlowableNullTests {
     @Test(expected = NullPointerException.class)
     public void sampleFlowableNull() {
         just1.sample(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void onErrorResumeNextFlowableNull() {
-        just1.onErrorResumeNext((Flowable<Integer>)null);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
@@ -928,7 +928,7 @@ public class FlowableDelayTest {
                         latch.countDown();
                     }
                 })
-                .onErrorResumeNext(Flowable.<String>empty())
+                .onErrorResumeWith(Flowable.<String>empty())
                 .subscribe();
 
         latch.await();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
@@ -39,7 +39,7 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
         TestObservable f = new TestObservable(s, "one", "fail", "two", "three");
         Flowable<String> w = Flowable.unsafeCreate(f);
         Flowable<String> resume = Flowable.just("twoResume", "threeResume");
-        Flowable<String> flowable = w.onErrorResumeNext(resume);
+        Flowable<String> flowable = w.onErrorResumeWith(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         flowable.subscribe(subscriber);
@@ -81,7 +81,7 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
             }
         });
 
-        Flowable<String> flowable = w.onErrorResumeNext(resume);
+        Flowable<String> flowable = w.onErrorResumeWith(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -114,7 +114,7 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
 
         });
         Flowable<String> resume = Flowable.just("resume");
-        Flowable<String> flowable = testObservable.onErrorResumeNext(resume);
+        Flowable<String> flowable = testObservable.onErrorResumeWith(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         flowable.subscribe(subscriber);
@@ -136,7 +136,7 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
 
         });
         Flowable<String> resume = Flowable.just("resume");
-        Flowable<String> flowable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
+        Flowable<String> flowable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeWith(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
@@ -196,7 +196,7 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
     public void backpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Flowable.range(0, 100000)
-                .onErrorResumeNext(Flowable.just(1))
+                .onErrorResumeWith(Flowable.just(1))
                 .observeOn(Schedulers.computation())
                 .map(new Function<Integer, Integer>() {
                     int c;
@@ -226,7 +226,7 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        pp.onErrorResumeNext(Flowable.range(3, 2)).subscribe(ts);
+        pp.onErrorResumeWith(Flowable.range(3, 2)).subscribe(ts);
 
         ts.request(2);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -326,7 +326,7 @@ public class FlowablePublishFunctionTest {
         .publish(new Function<Flowable<Object>, Publisher<Object>>() {
             @Override
             public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                return f.onErrorResumeNext(f);
+                return f.onErrorResumeWith(f);
             }
         })
         .test()

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeOnErrorXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeOnErrorXTest.java
@@ -193,7 +193,7 @@ public class MaybeOnErrorXTest {
 
     @Test
     public void onErrorNextDispose() {
-        TestHelper.checkDisposed(PublishProcessor.create().singleElement().onErrorResumeNext(Maybe.just(1)));
+        TestHelper.checkDisposed(PublishProcessor.create().singleElement().onErrorResumeWith(Maybe.just(1)));
     }
 
     @Test
@@ -201,7 +201,7 @@ public class MaybeOnErrorXTest {
         TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
             @Override
             public MaybeSource<Object> apply(Maybe<Object> v) throws Exception {
-                return v.onErrorResumeNext(Maybe.just(1));
+                return v.onErrorResumeWith(Maybe.just(1));
             }
         });
     }
@@ -209,7 +209,7 @@ public class MaybeOnErrorXTest {
     @Test
     public void onErrorNextIsAlsoError() {
         Maybe.error(new TestException("Main"))
-        .onErrorResumeNext(Maybe.error(new TestException("Secondary")))
+        .onErrorResumeWith(Maybe.error(new TestException("Secondary")))
         .to(TestHelper.testConsumer())
         .assertFailureAndMessage(TestException.class, "Secondary");
     }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDelayTest.java
@@ -876,7 +876,7 @@ public class ObservableDelayTest {
                         latch.countDown();
                     }
                 })
-                .onErrorResumeNext(Observable.<String>empty())
+                .onErrorResumeWith(Observable.<String>empty())
                 .subscribe();
 
         latch.await();

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeNextTest.java
@@ -32,7 +32,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.*;
 
-public class ObservableOnErrorResumeNextViaFunctionTest {
+public class ObservableOnErrorResumeNextTest {
 
     @Test
     public void resumeNextWithSynchronousExecution() {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeWithTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableOnErrorResumeWithTest.java
@@ -28,7 +28,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class ObservableOnErrorResumeNextViaObservableTest {
+public class ObservableOnErrorResumeWithTest {
 
     @Test
     public void resumeNext() {
@@ -37,7 +37,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
         TestObservable f = new TestObservable(upstream, "one", "fail", "two", "three");
         Observable<String> w = Observable.unsafeCreate(f);
         Observable<String> resume = Observable.just("twoResume", "threeResume");
-        Observable<String> observable = w.onErrorResumeNext(resume);
+        Observable<String> observable = w.onErrorResumeWith(resume);
 
         Observer<String> observer = TestHelper.mockObserver();
         observable.subscribe(observer);
@@ -79,7 +79,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
             }
         });
 
-        Observable<String> observable = w.onErrorResumeNext(resume);
+        Observable<String> observable = w.onErrorResumeWith(resume);
 
         Observer<String> observer = TestHelper.mockObserver();
 
@@ -112,7 +112,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
 
         });
         Observable<String> resume = Observable.just("resume");
-        Observable<String> observable = testObservable.onErrorResumeNext(resume);
+        Observable<String> observable = testObservable.onErrorResumeWith(resume);
 
         Observer<String> observer = TestHelper.mockObserver();
         observable.subscribe(observer);
@@ -134,7 +134,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
 
         });
         Observable<String> resume = Observable.just("resume");
-        Observable<String> observable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeNext(resume);
+        Observable<String> observable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeWith(resume);
 
         Observer<String> observer = TestHelper.mockObserver();
         TestObserver<String> to = new TestObserver<String>(observer);
@@ -194,7 +194,7 @@ public class ObservableOnErrorResumeNextViaObservableTest {
     public void backpressure() {
         TestObserver<Integer> to = new TestObserver<Integer>();
         Observable.range(0, 100000)
-                .onErrorResumeNext(Observable.just(1))
+                .onErrorResumeWith(Observable.just(1))
                 .observeOn(Schedulers.computation())
                 .map(new Function<Integer, Integer>() {
                     int c;

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
@@ -149,7 +149,7 @@ public class SingleDelayTest {
                         latch.countDown();
                     }
                 })
-                .onErrorResumeNext(Single.just(""))
+                .onErrorResumeWith(Single.just(""))
                 .subscribe();
 
         latch.await();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
@@ -106,9 +106,9 @@ public class SingleMiscTest {
     }
 
     @Test
-    public void onErrorResumeNext() {
+    public void onErrorResumeWith() {
         Single.<Integer>error(new TestException())
-        .onErrorResumeNext(Single.just(1))
+        .onErrorResumeWith(Single.just(1))
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/internal/operators/single/SingleOnErrorXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleOnErrorXTest.java
@@ -53,7 +53,7 @@ public class SingleOnErrorXTest {
     @Test
     public void resumeErrors() {
         Single.error(new TestException("Main"))
-        .onErrorResumeNext(Single.error(new TestException("Resume")))
+        .onErrorResumeWith(Single.error(new TestException("Resume")))
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "Resume");
     }
@@ -61,7 +61,7 @@ public class SingleOnErrorXTest {
     @Test
     public void resumeDispose() {
         TestHelper.checkDisposed(Single.error(new TestException("Main"))
-        .onErrorResumeNext(Single.just(1)));
+        .onErrorResumeWith(Single.just(1)));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class SingleOnErrorXTest {
         TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
             @Override
             public SingleSource<Object> apply(Single<Object> s) throws Exception {
-                return s.onErrorResumeNext(Single.just(1));
+                return s.onErrorResumeWith(Single.just(1));
             }
         });
     }
@@ -77,7 +77,7 @@ public class SingleOnErrorXTest {
     @Test
     public void resumeSuccess() {
         Single.just(1)
-        .onErrorResumeNext(Single.just(2))
+        .onErrorResumeWith(Single.just(2))
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/maybe/MaybeTest.java
@@ -3199,9 +3199,9 @@ public class MaybeTest {
     }
 
     @Test
-    public void onErrorResumeNextEmpty() {
+    public void onErrorResumeWithEmpty() {
         Maybe.empty()
-            .onErrorResumeNext(Maybe.just(1))
+            .onErrorResumeWith(Maybe.just(1))
             .test()
             .assertNoValues()
             .assertNoErrors()
@@ -3209,18 +3209,18 @@ public class MaybeTest {
     }
 
     @Test
-    public void onErrorResumeNextValue() {
+    public void onErrorResumeWithValue() {
         Maybe.just(1)
-            .onErrorResumeNext(Maybe.<Integer>empty())
+            .onErrorResumeWith(Maybe.<Integer>empty())
             .test()
             .assertNoErrors()
             .assertValue(1);
     }
 
     @Test
-    public void onErrorResumeNextError() {
+    public void onErrorResumeWithError() {
         Maybe.error(new RuntimeException("some error"))
-            .onErrorResumeNext(Maybe.empty())
+            .onErrorResumeWith(Maybe.empty())
             .test()
             .assertNoValues()
             .assertNoErrors()

--- a/src/test/java/io/reactivex/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/observable/ObservableNullTests.java
@@ -1700,7 +1700,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void onErrorResumeNextFunctionNull() {
-        just1.onErrorResumeNext((Function<Throwable, Observable<Integer>>)null);
+        just1.onErrorResumeNext(null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -1715,7 +1715,7 @@ public class ObservableNullTests {
 
     @Test(expected = NullPointerException.class)
     public void onErrorResumeNextObservableNull() {
-        just1.onErrorResumeNext((Observable<Integer>)null);
+        just1.onErrorResumeWith(null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/single/SingleNullTests.java
@@ -709,13 +709,13 @@ public class SingleNullTests {
     }
 
     @Test(expected = NullPointerException.class)
-    public void onErrorResumeNextSingleNull() {
-        error.onErrorResumeNext((Single<Integer>)null);
+    public void onErrorResumeWithSingleNull() {
+        error.onErrorResumeWith(null);
     }
 
     @Test(expected = NullPointerException.class)
-    public void onErrorResumeNextFunctionNull() {
-        error.onErrorResumeNext((Function<Throwable, Single<Integer>>)null);
+    public void onErrorResumeNextNull() {
+        error.onErrorResumeNext(null);
     }
 
     @Test

--- a/src/test/java/io/reactivex/tck/OnErrorResumeWithTckTest.java
+++ b/src/test/java/io/reactivex/tck/OnErrorResumeWithTckTest.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 
 @Test
-public class OnErrorResumeNextTckTest extends BaseTck<Integer> {
+public class OnErrorResumeWithTckTest extends BaseTck<Integer> {
 
     @Override
     public Publisher<Integer> createPublisher(long elements) {
         return
-                Flowable.range(0, (int)elements).onErrorResumeNext(Flowable.<Integer>never())
+                Flowable.range(0, (int)elements).onErrorResumeWith(Flowable.<Integer>never())
         ;
     }
 }


### PR DESCRIPTION
Resolves #6551 

- Renamed `onErrorResumeNext(Source)` to `onErrorResumeWith(Source)` for `Observable`, `Maybe`, `Single`, and `Flowable`
- Renamed some unit tests and their classes to reflect the method name change
- Changed parameter type of `Single.onErrorResumeWith` from `Single` to `SingleSource`  
- Updated JavaDocs for all renamed methods
- Removed redundant casts for unit tests
- Deleted duplicate unit test that arose from no longer needing to cast arguments 