### PR TITLE
2.x Fix NPE when debouncing empty source

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableDebounce.java
@@ -119,7 +119,9 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
             if (!DisposableHelper.isDisposed(d)) {
                 @SuppressWarnings("unchecked")
                 DebounceInnerSubscriber<T, U> dis = (DebounceInnerSubscriber<T, U>)d;
-                dis.emit();
+                if (dis != null) {
+                    dis.emit();
+                }
                 DisposableHelper.dispose(debouncer);
                 downstream.onComplete();
             }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableDebounce.java
@@ -112,7 +112,9 @@ public final class ObservableDebounce<T, U> extends AbstractObservableWithUpstre
             if (d != DisposableHelper.DISPOSED) {
                 @SuppressWarnings("unchecked")
                 DebounceInnerObserver<T, U> dis = (DebounceInnerObserver<T, U>)d;
-                dis.emit();
+                if (dis != null) {
+                    dis.emit();
+                }
                 DisposableHelper.dispose(debouncer);
                 downstream.onComplete();
             }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -546,4 +546,14 @@ public class FlowableDebounceTest {
         .test()
         .assertFailure(TestException.class);
     }
+
+    @Test
+    public void debounceOnEmpty() {
+        Flowable.empty().debounce(new Function<Object, Publisher<Object>>() {
+            @Override
+            public Publisher<Object> apply(Object o) {
+                return Flowable.just(new Object());
+            }
+        }).subscribe();
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDebounceTest.java
@@ -504,4 +504,14 @@ public class ObservableDebounceTest {
         .test()
         .assertFailure(TestException.class);
     }
+
+    @Test
+    public void debounceOnEmpty() {
+        Observable.empty().debounce(new Function<Object, ObservableSource<Object>>() {
+            @Override
+            public ObservableSource<Object> apply(Object o) {
+                return Observable.just(new Object());
+            }
+        }).subscribe();
+    }
 }


### PR DESCRIPTION
**Background** Related issue #6558 
Cherry pick of #6559 for 2.x version

Debounce with selector on the empty `Observable` leads to NPE.

It happens because of `DebounceObserver#debouncer` field is set up only when `onNext` is called. When `onNext` isn't called at all, like when debouncing `Observable.empty()`, we get a null reference from `debouncer` and call `emit` on `null` which actually leads to NPE.

**Change**
Wrap `emit` call with null check both in `ObservableDebounce` and `FlowableDebounce`

**Test plan**
To check `Observable`:
```
./gradlew test --tests "io.reactivex.internal.operators.observable.ObservableDebounceTest.debounceOnEmpty"`
```
To check `Flowable`:
```
./gradlew test --tests "io.reactivex.internal.operators.flowable.FlowableDebounceTest.debounceOnEmpty"`
```