### PR TITLE
Fix JavaDocs of Single.doOnTerminate refer to onComplete notification

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -2501,13 +2501,13 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnTerminate.png" alt="">
      * <p>
-     * This differs from {@code doAfterTerminate} in that this happens <em>before</em> the {@code onComplete} or
+     * This differs from {@code doAfterTerminate} in that this happens <em>before</em> the {@code onSuccess} or
      * {@code onError} notification.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code doOnTerminate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param onTerminate the action to invoke when the consumer calls {@code onComplete} or {@code onError}
+     * @param onTerminate the action to invoke when the consumer calls {@code onSuccess} or {@code onError}
      * @return the new Single instance
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      * @see #doOnTerminate(Action)


### PR DESCRIPTION
As mentioned in JavaDocs of this class that Single does not have "onComplete" notification.
This newly introduced method refer to that notification, which looks to me it should be onSuccess instead.