### PR TITLE
3.x: Code verification fixes for javac's generated switchmap classes

### DIFF
--- a/src/test/java/io/reactivex/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/testsupport/TestHelper.java
@@ -17,7 +17,9 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
+import java.io.File;
 import java.lang.reflect.*;
+import java.net.URL;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -3217,5 +3219,40 @@ public enum TestHelper {
             }
         }
         return to;
+    }
+
+    /**
+     * Given a base reactive type name, try to find its source in the current runtime
+     * path and return a file to it or null if not found.
+     * @param baseClassName the class name such as {@code Maybe}
+     * @return the File pointing to the source
+     * @throws Exception on error
+     */
+    public static File findSource(String baseClassName) throws Exception {
+        URL u = TestHelper.class.getResource(TestHelper.class.getSimpleName() + ".class");
+
+        String path = new File(u.toURI()).toString().replace('\\', '/');
+
+//        System.out.println(path);
+
+        int i = path.toLowerCase().indexOf("/rxjava");
+        if (i < 0) {
+            System.out.println("Can't find the base RxJava directory");
+            return null;
+        }
+
+        // find end of any potential postfix to /RxJava
+        int j = path.indexOf("/", i + 6);
+
+        String p = path.substring(0, j + 1) + "src/main/java/io/reactivex/" + baseClassName + ".java";
+
+        File f = new File(p);
+
+        if (!f.canRead()) {
+            System.out.println("Can't read " + p);
+            return null;
+        }
+
+        return f;
     }
 }

--- a/src/test/java/io/reactivex/validators/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/validators/CheckLocalVariablesInTests.java
@@ -19,6 +19,8 @@ import java.util.regex.Pattern;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 /**
  * Checks for commonly copy-pasted but not-renamed local variables in unit tests.
  * <ul>
@@ -41,7 +43,7 @@ public class CheckLocalVariablesInTests {
     }
 
     static void findPattern(String pattern, boolean checkMain) throws Exception {
-        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        File f = TestHelper.findSource("Flowable");
         if (f == null) {
             System.out.println("Unable to find sources of RxJava");
             return;

--- a/src/test/java/io/reactivex/validators/FixLicenseHeaders.java
+++ b/src/test/java/io/reactivex/validators/FixLicenseHeaders.java
@@ -18,6 +18,8 @@ import java.util.*;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 /**
  * Adds license header to java files.
  */
@@ -45,7 +47,7 @@ public class FixLicenseHeaders {
             // no point in changing the files in CI
             return;
         }
-        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        File f = TestHelper.findSource("Flowable");
         if (f == null) {
             return;
         }

--- a/src/test/java/io/reactivex/validators/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/validators/InternalWrongNaming.java
@@ -18,13 +18,15 @@ import java.util.*;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 /**
  * Adds license header to java files.
  */
 public class InternalWrongNaming {
 
     static void checkInternalOperatorNaming(String baseClassName, String consumerClassName, String... ignore) throws Exception {
-        File f = MaybeNo2Dot0Since.findSource(baseClassName);
+        File f = TestHelper.findSource(baseClassName);
         if (f == null) {
             return;
         }

--- a/src/test/java/io/reactivex/validators/JavadocFindUnescapedAngleBrackets.java
+++ b/src/test/java/io/reactivex/validators/JavadocFindUnescapedAngleBrackets.java
@@ -17,11 +17,13 @@ import java.util.*;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 public class JavadocFindUnescapedAngleBrackets {
 
     @Test
     public void find() throws Exception {
-        File base = MaybeNo2Dot0Since.findSource("Flowable");
+        File base = TestHelper.findSource("Flowable");
 
         if (base == null) {
             return;

--- a/src/test/java/io/reactivex/validators/JavadocForAnnotations.java
+++ b/src/test/java/io/reactivex/validators/JavadocForAnnotations.java
@@ -20,6 +20,7 @@ import java.io.*;
 import org.junit.*;
 
 import io.reactivex.*;
+import io.reactivex.testsupport.TestHelper;
 
 /**
  * Checks the source code of the base reactive types and locates missing
@@ -28,7 +29,7 @@ import io.reactivex.*;
 public class JavadocForAnnotations {
 
     static void checkSource(String baseClassName, boolean scheduler) throws Exception {
-        File f = MaybeNo2Dot0Since.findSource(baseClassName);
+        File f = TestHelper.findSource(baseClassName);
         if (f == null) {
             return;
         }
@@ -173,7 +174,7 @@ public class JavadocForAnnotations {
     }
 
     static void checkSchedulerBadMethod(String baseClassName) throws Exception {
-        File f = MaybeNo2Dot0Since.findSource(baseClassName);
+        File f = TestHelper.findSource(baseClassName);
         if (f == null) {
             return;
         }

--- a/src/test/java/io/reactivex/validators/JavadocWording.java
+++ b/src/test/java/io/reactivex/validators/JavadocWording.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
 import io.reactivex.validators.BaseTypeParser.RxMethod;
 
 /**
@@ -38,7 +39,7 @@ public class JavadocWording {
 
     @Test
     public void maybeDocRefersToMaybeTypes() throws Exception {
-        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Maybe"), "Maybe");
+        List<RxMethod> list = BaseTypeParser.parse(TestHelper.findSource("Maybe"), "Maybe");
 
         assertFalse(list.isEmpty());
 
@@ -214,7 +215,7 @@ public class JavadocWording {
 
     @Test
     public void flowableDocRefersToFlowableTypes() throws Exception {
-        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Flowable"), "Flowable");
+        List<RxMethod> list = BaseTypeParser.parse(TestHelper.findSource("Flowable"), "Flowable");
 
         assertFalse(list.isEmpty());
 
@@ -323,7 +324,7 @@ public class JavadocWording {
 
     @Test
     public void observableDocRefersToObservableTypes() throws Exception {
-        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Observable"), "Observable");
+        List<RxMethod> list = BaseTypeParser.parse(TestHelper.findSource("Observable"), "Observable");
 
         assertFalse(list.isEmpty());
 
@@ -424,7 +425,7 @@ public class JavadocWording {
 
     @Test
     public void singleDocRefersToSingleTypes() throws Exception {
-        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Single"), "Single");
+        List<RxMethod> list = BaseTypeParser.parse(TestHelper.findSource("Single"), "Single");
 
         assertFalse(list.isEmpty());
 
@@ -598,7 +599,7 @@ public class JavadocWording {
 
     @Test
     public void completableDocRefersToCompletableTypes() throws Exception {
-        List<RxMethod> list = BaseTypeParser.parse(MaybeNo2Dot0Since.findSource("Completable"), "Completable");
+        List<RxMethod> list = BaseTypeParser.parse(TestHelper.findSource("Completable"), "Completable");
 
         assertFalse(list.isEmpty());
 

--- a/src/test/java/io/reactivex/validators/MaybeNo2Dot0Since.java
+++ b/src/test/java/io/reactivex/validators/MaybeNo2Dot0Since.java
@@ -16,11 +16,11 @@ package io.reactivex.validators;
 import static org.junit.Assert.fail;
 
 import java.io.*;
-import java.net.URL;
 
 import org.junit.Test;
 
 import io.reactivex.Maybe;
+import io.reactivex.testsupport.TestHelper;
 
 /**
  * Checks the source code of Maybe and finds unnecessary since 2.0 annotations in the
@@ -28,45 +28,10 @@ import io.reactivex.Maybe;
  */
 public class MaybeNo2Dot0Since {
 
-    /**
-     * Given a base reactive type name, try to find its source in the current runtime
-     * path and return a file to it or null if not found.
-     * @param baseClassName the class name such as {@code Maybe}
-     * @return the File pointing to the source
-     * @throws Exception on error
-     */
-    public static File findSource(String baseClassName) throws Exception {
-        URL u = MaybeNo2Dot0Since.class.getResource(MaybeNo2Dot0Since.class.getSimpleName() + ".class");
-
-        String path = new File(u.toURI()).toString().replace('\\', '/');
-
-//        System.out.println(path);
-
-        int i = path.indexOf("/RxJava");
-        if (i < 0) {
-            System.out.println("Can't find the base RxJava directory");
-            return null;
-        }
-
-        // find end of any potential postfix to /RxJava
-        int j = path.indexOf("/", i + 6);
-
-        String p = path.substring(0, j + 1) + "src/main/java/io/reactivex/" + baseClassName + ".java";
-
-        File f = new File(p);
-
-        if (!f.canRead()) {
-            System.out.println("Can't read " + p);
-            return null;
-        }
-
-        return f;
-    }
-
     @Test
     public void noSince20InMaybe() throws Exception {
 
-        File f = findSource(Maybe.class.getSimpleName());
+        File f = TestHelper.findSource(Maybe.class.getSimpleName());
 
         String line;
 

--- a/src/test/java/io/reactivex/validators/NewLinesBeforeAnnotation.java
+++ b/src/test/java/io/reactivex/validators/NewLinesBeforeAnnotation.java
@@ -18,6 +18,8 @@ import java.util.*;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 /**
  * These tests verify the code style that a typical closing curly brace
  * and the next annotation &#64; indicator
@@ -64,7 +66,7 @@ public class NewLinesBeforeAnnotation {
     }
 
     static void findPattern(int newLines) throws Exception {
-        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        File f = TestHelper.findSource("Flowable");
         if (f == null) {
             System.out.println("Unable to find sources of RxJava");
             return;

--- a/src/test/java/io/reactivex/validators/NoAnonymousInnerClassesTest.java
+++ b/src/test/java/io/reactivex/validators/NoAnonymousInnerClassesTest.java
@@ -26,9 +26,13 @@ public class NoAnonymousInnerClassesTest {
         URL u = NoAnonymousInnerClassesTest.class.getResource("/");
         File f = new File(u.toURI());
 
+        String fs = f.toString().toLowerCase().replace("\\", "/");
+
+        System.out.println("Found " + fs);
+
         // running this particular test from IntelliJ will have the wrong class directory
-        String fs = f.toString();
-        int idx = fs.toLowerCase().replace("\\", "/").indexOf("/out/test");
+        // gradle will generate test classes into a separate directory too
+        int idx = fs.indexOf("/test");
         if (idx >= 0) {
             f = new File(fs.substring(0, idx));
         }
@@ -66,7 +70,7 @@ public class NoAnonymousInnerClassesTest {
                                 n = n.substring(1);
                             }
 
-                            // javac 13+ generates switch-map anonymous classes with the same $x.class pattern
+                            // javac generates switch-map anonymous classes with the same $x.class pattern
                             // we have to look into the file and search for $SwitchMap$
 
                             boolean found = false;

--- a/src/test/java/io/reactivex/validators/OperatorsAreFinal.java
+++ b/src/test/java/io/reactivex/validators/OperatorsAreFinal.java
@@ -18,10 +18,12 @@ import java.lang.reflect.Modifier;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 public class OperatorsAreFinal {
 
     File directoryOf(String baseClassName) throws Exception {
-        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        File f = TestHelper.findSource("Flowable");
         if (f == null) {
             return null;
         }

--- a/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
+++ b/src/test/java/io/reactivex/validators/TestPrefixInMethodName.java
@@ -15,6 +15,8 @@ package io.reactivex.validators;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 import java.io.*;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -33,7 +35,7 @@ public class TestPrefixInMethodName {
 
     @Test
     public void checkAndUpdateTestMethodNames() throws Exception {
-        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        File f = TestHelper.findSource("Flowable");
         if (f == null) {
             System.out.println("Unable to find sources of RxJava");
             return;

--- a/src/test/java/io/reactivex/validators/TextualAorAn.java
+++ b/src/test/java/io/reactivex/validators/TextualAorAn.java
@@ -18,6 +18,8 @@ import java.util.*;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 /**
  * Adds license header to java files.
  */
@@ -25,7 +27,7 @@ public class TextualAorAn {
 
     @Test
     public void checkFiles() throws Exception {
-        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        File f = TestHelper.findSource("Flowable");
         if (f == null) {
             return;
         }

--- a/src/test/java/io/reactivex/validators/TooManyEmptyNewLines.java
+++ b/src/test/java/io/reactivex/validators/TooManyEmptyNewLines.java
@@ -18,6 +18,8 @@ import java.util.*;
 
 import org.junit.Test;
 
+import io.reactivex.testsupport.TestHelper;
+
 /**
  * Test verifying there are no 2..5 empty newlines in the code.
  */
@@ -44,7 +46,7 @@ public class TooManyEmptyNewLines {
     }
 
     static void findPattern(int newLines) throws Exception {
-        File f = MaybeNo2Dot0Since.findSource("Flowable");
+        File f = TestHelper.findSource("Flowable");
         if (f == null) {
             System.out.println("Unable to find sources of TestHelper.findSourceDir()");
             return;


### PR DESCRIPTION
Java 13+ compilers generate a synthetic class for switch statements over enumerables now, so `Observable.class` (and a few others) now receive an `Observable$1.class` companion, which trips the no anonymous inner classes heuristic verification. This PR changes the respective unit test to filter out such classes in a heuristic manner too.

In addition, the `findSource` method has been moved into `TestHelper` for clarity and changed so that any capitalization of the "rxjava" host directory is accepted.