### PR TITLE
3.x: fix switchMaps inconsistency swallowing errors when cancelled

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMap.java
@@ -585,10 +585,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                     for (InnerSubscriber<?, ?> inner : a) {
                         inner.dispose();
                     }
-                    Throwable ex = errs.terminate();
-                    if (ex != null && ex != ExceptionHelper.TERMINATED) {
-                        RxJavaPlugins.onError(ex);
-                    }
+                    errs.tryTerminateAndReport();
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableSwitchMap.java
@@ -173,6 +173,8 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
                 upstream.cancel();
 
                 disposeInner();
+
+                error.tryTerminateAndReport();
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
@@ -162,6 +162,7 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
         public void dispose() {
             upstream.cancel();
             disposeInner();
+            errors.tryTerminateAndReport();
         }
 
         @Override
@@ -178,7 +179,8 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
                             downstream.onError(ex);
                         }
                     } else {
-                        dispose();
+                        upstream.cancel();
+                        disposeInner();
                         Throwable ex = errors.terminate();
                         if (ex != ExceptionHelper.TERMINATED) {
                             downstream.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybe.java
@@ -177,6 +177,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
             cancelled = true;
             upstream.cancel();
             disposeInner();
+            errors.tryTerminateAndReport();
         }
 
         void innerError(SwitchMapMaybeObserver<R> sender, Throwable ex) {

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingle.java
@@ -177,6 +177,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
             cancelled = true;
             upstream.cancel();
             disposeInner();
+            errors.tryTerminateAndReport();
         }
 
         void innerError(SwitchMapSingleObserver<R> sender, Throwable ex) {

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletable.java
@@ -160,6 +160,7 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
         public void dispose() {
             upstream.dispose();
             disposeInner();
+            errors.tryTerminateAndReport();
         }
 
         @Override
@@ -176,7 +177,8 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
                             downstream.onError(ex);
                         }
                     } else {
-                        dispose();
+                        upstream.dispose();
+                        disposeInner();
                         Throwable ex = errors.terminate();
                         if (ex != ExceptionHelper.TERMINATED) {
                             downstream.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybe.java
@@ -164,6 +164,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
             cancelled = true;
             upstream.dispose();
             disposeInner();
+            errors.tryTerminateAndReport();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingle.java
@@ -164,6 +164,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
             cancelled = true;
             upstream.dispose();
             disposeInner();
+            errors.tryTerminateAndReport();
         }
 
         @Override

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -307,10 +307,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             if (!cancelled) {
                 cancelled = true;
                 if (disposeAll()) {
-                    Throwable ex = errors.terminate();
-                    if (ex != null && ex != ExceptionHelper.TERMINATED) {
-                        RxJavaPlugins.onError(ex);
-                    }
+                    errors.tryTerminateAndReport();
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -157,6 +157,8 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                 cancelled = true;
                 upstream.dispose();
                 disposeInner();
+
+                errors.tryTerminateAndReport();
             }
         }
 

--- a/src/main/java/io/reactivex/internal/util/AtomicThrowable.java
+++ b/src/main/java/io/reactivex/internal/util/AtomicThrowable.java
@@ -15,6 +15,8 @@ package io.reactivex.internal.util;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.plugins.RxJavaPlugins;
+
 /**
  * Atomic container for Throwables including combining and having a
  * terminal state via ExceptionHelper.
@@ -45,5 +47,18 @@ public final class AtomicThrowable extends AtomicReference<Throwable> {
 
     public boolean isTerminated() {
         return get() == ExceptionHelper.TERMINATED;
+    }
+
+    /**
+     * Tries to terminate this atomic throwable (by swapping in the TERMINATED indicator)
+     * and calls {@link RxJavaPlugins#onError(Throwable)} if there was a non-null, non-indicator
+     * exception contained within before.
+     * @since 3.0.0
+     */
+    public void tryTerminateAndReport() {
+        Throwable ex = terminate();
+        if (ex != null && ex != ExceptionHelper.TERMINATED) {
+            RxJavaPlugins.onError(ex);
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
@@ -27,7 +27,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.*;
-import io.reactivex.testsupport.TestHelper;
+import io.reactivex.testsupport.*;
 
 public class ObservableSwitchMapCompletableTest {
 
@@ -428,5 +428,35 @@ public class ObservableSwitchMapCompletableTest {
         cs.onComplete();
 
         to.assertResult();
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+
+            Observable.just(1)
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Throwable {
+                    to.dispose();
+                    throw new TestException();
+                }
+            })
+            .switchMapCompletable(new Function<Integer, Completable>() {
+                @Override
+                public Completable apply(Integer v) throws Throwable {
+                    return Completable.complete().hide();
+                }
+            })
+            .subscribe(to);
+
+            to.assertEmpty();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -654,4 +654,34 @@ public class ObservableSwitchMapSingleTest {
 
         to.assertResult(2);
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+
+            Observable.just(1)
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Throwable {
+                    to.dispose();
+                    throw new TestException();
+                }
+            })
+            .switchMapSingle(new Function<Integer, Single<Integer>>() {
+                @Override
+                public Single<Integer> apply(Integer v) throws Throwable {
+                    return Single.just(v).hide();
+                }
+            })
+            .subscribe(to);
+
+            to.assertEmpty();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
 }


### PR DESCRIPTION
The various `switchMap` operators did not report any accumulated exceptions to the global error handler when the sequence was cancelled (and thus the errors would never be delivered through the regular channels).