### PR TITLE
3.x: travis use openjdk8 as oraclejdk8 stopped working?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
-
-# force upgrade Java8 as per https://github.com/travis-ci/travis-ci/issues/4042 (fixes compilation issue)
-#addons:
-#  apt:
-#    packages:
-#      - oracle-java8-installer
+- openjdk8
 
 # prevent travis running gradle assemble; let the build script do it anyway
 install: true


### PR DESCRIPTION
The last [merge failed](https://travis-ci.org/ReactiveX/RxJava/builds/559419743#L166) and looks like oraclejdk8 target is broken?