### PR TITLE
Fix issue #6576 - ObservableBlockingSubscribe compares BlockingObserver.TERMINATED with wrong object

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBlockingSubscribe.java
@@ -61,7 +61,7 @@ public final class ObservableBlockingSubscribe {
                 }
             }
             if (bs.isDisposed()
-                    || o == BlockingObserver.TERMINATED
+                    || v == BlockingObserver.TERMINATED
                     || NotificationLite.acceptFull(v, observer)) {
                 break;
             }


### PR DESCRIPTION
Fix #6576 , compare with `v` instead of `o`.