### PR TITLE
3.x: widen throws on the XOnSubscribe interfaces

### DIFF
--- a/src/main/java/io/reactivex/CompletableOnSubscribe.java
+++ b/src/main/java/io/reactivex/CompletableOnSubscribe.java
@@ -24,8 +24,8 @@ public interface CompletableOnSubscribe {
     /**
      * Called for each CompletableObserver that subscribes.
      * @param emitter the safe emitter instance, never null
-     * @throws Exception on error
+     * @throws Throwable on error
      */
-    void subscribe(@NonNull CompletableEmitter emitter) throws Exception;
+    void subscribe(@NonNull CompletableEmitter emitter) throws Throwable;
 }
 

--- a/src/main/java/io/reactivex/FlowableOnSubscribe.java
+++ b/src/main/java/io/reactivex/FlowableOnSubscribe.java
@@ -26,8 +26,8 @@ public interface FlowableOnSubscribe<T> {
     /**
      * Called for each Subscriber that subscribes.
      * @param emitter the safe emitter instance, never null
-     * @throws Exception on error
+     * @throws Throwable on error
      */
-    void subscribe(@NonNull FlowableEmitter<T> emitter) throws Exception;
+    void subscribe(@NonNull FlowableEmitter<T> emitter) throws Throwable;
 }
 

--- a/src/main/java/io/reactivex/MaybeOnSubscribe.java
+++ b/src/main/java/io/reactivex/MaybeOnSubscribe.java
@@ -26,8 +26,8 @@ public interface MaybeOnSubscribe<T> {
     /**
      * Called for each MaybeObserver that subscribes.
      * @param emitter the safe emitter instance, never null
-     * @throws Exception on error
+     * @throws Throwable on error
      */
-    void subscribe(@NonNull MaybeEmitter<T> emitter) throws Exception;
+    void subscribe(@NonNull MaybeEmitter<T> emitter) throws Throwable;
 }
 

--- a/src/main/java/io/reactivex/ObservableOnSubscribe.java
+++ b/src/main/java/io/reactivex/ObservableOnSubscribe.java
@@ -26,8 +26,8 @@ public interface ObservableOnSubscribe<T> {
     /**
      * Called for each Observer that subscribes.
      * @param emitter the safe emitter instance, never null
-     * @throws Exception on error
+     * @throws Throwable on error
      */
-    void subscribe(@NonNull ObservableEmitter<T> emitter) throws Exception;
+    void subscribe(@NonNull ObservableEmitter<T> emitter) throws Throwable;
 }
 

--- a/src/main/java/io/reactivex/SingleOnSubscribe.java
+++ b/src/main/java/io/reactivex/SingleOnSubscribe.java
@@ -26,8 +26,8 @@ public interface SingleOnSubscribe<T> {
     /**
      * Called for each SingleObserver that subscribes.
      * @param emitter the safe emitter instance, never null
-     * @throws Exception on error
+     * @throws Throwable on error
      */
-    void subscribe(@NonNull SingleEmitter<T> emitter) throws Exception;
+    void subscribe(@NonNull SingleEmitter<T> emitter) throws Throwable;
 }
 


### PR DESCRIPTION
This PR widens the `throws Exception` to `throws Throwable` on the callback interfaces of the `create` methods: `{Flowable|Observable|Maybe|Single|Completable}OnSubscribe`.