### PR TITLE
3.x: Add more time for GC in RefCountTest.publishNoLeak

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -738,8 +738,6 @@ public class FlowableRefCountTest {
         System.gc();
         Thread.sleep(GC_SLEEP_TIME);
 
-        long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
-
         source = Flowable.fromCallable(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
@@ -748,6 +746,8 @@ public class FlowableRefCountTest {
         })
         .publish()
         .refCount();
+
+        long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
         source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer());
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -731,11 +731,12 @@ public class FlowableRefCountTest {
         }
     }
 
+    static final int GC_SLEEP_TIME = 250;
+
     @Test
     public void publishNoLeak() throws Exception {
-        Thread.sleep(100);
         System.gc();
-        Thread.sleep(100);
+        Thread.sleep(GC_SLEEP_TIME);
 
         long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
@@ -750,9 +751,8 @@ public class FlowableRefCountTest {
 
         source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer());
 
-        Thread.sleep(100);
         System.gc();
-        Thread.sleep(200);
+        Thread.sleep(GC_SLEEP_TIME);
 
         long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
@@ -764,7 +764,7 @@ public class FlowableRefCountTest {
     @Test
     public void publishNoLeak2() throws Exception {
         System.gc();
-        Thread.sleep(100);
+        Thread.sleep(GC_SLEEP_TIME);
 
         long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
@@ -787,7 +787,7 @@ public class FlowableRefCountTest {
         d2 = null;
 
         System.gc();
-        Thread.sleep(100);
+        Thread.sleep(GC_SLEEP_TIME);
 
         long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -704,10 +704,12 @@ public class ObservableRefCountTest {
         }
     }
 
+    static final int GC_SLEEP_TIME = 250;
+
     @Test
     public void publishNoLeak() throws Exception {
         System.gc();
-        Thread.sleep(100);
+        Thread.sleep(GC_SLEEP_TIME);
 
         long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
@@ -723,7 +725,7 @@ public class ObservableRefCountTest {
         source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer());
 
         System.gc();
-        Thread.sleep(100);
+        Thread.sleep(GC_SLEEP_TIME);
 
         long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
@@ -734,7 +736,7 @@ public class ObservableRefCountTest {
     @Test
     public void publishNoLeak2() throws Exception {
         System.gc();
-        Thread.sleep(100);
+        Thread.sleep(GC_SLEEP_TIME);
 
         long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
@@ -757,7 +759,7 @@ public class ObservableRefCountTest {
         d2 = null;
 
         System.gc();
-        Thread.sleep(100);
+        Thread.sleep(GC_SLEEP_TIME);
 
         long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 


### PR DESCRIPTION
Few of the recent merges failed the `publishNoLeak` test because the GC apparently didn't finish in time. This PR increases the GC time to 250 milliseconds in those tests.