### PR TITLE
3.x: Fix truncation bugs in replay() and ReplaySubject/Processor

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableReplay.java
@@ -633,6 +633,11 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
             }
 
             setFirst(head);
+            // correct the tail if all items have been removed
+            head = get();
+            if (head.get() == null) {
+                tail = head;
+            }
         }
         /**
          * Arranges the given node is the new head from now on.
@@ -641,11 +646,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         final void setFirst(Node n) {
             if (eagerTruncate) {
                 Node m = new Node(null);
-                Node nextNode = n.get();
-                if (nextNode == null) {
-                    tail = m;
-                }
-                m.lazySet(nextNode);
+                m.lazySet(n.get());
                 n = m;
             }
             set(n);
@@ -845,7 +846,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
 
             int e = 0;
             for (;;) {
-                if (next != null) {
+                if (next != null && size > 1) { // never truncate the very last item just added
                     if (size > limit) {
                         e++;
                         size--;

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -1070,6 +1070,10 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
             TimedNode<T> h = head;
 
             for (;;) {
+                if (size <= 1) {
+                    head = h;
+                    break;
+                }
                 TimedNode<T> next = h.get();
                 if (next == null) {
                     head = h;
@@ -1082,6 +1086,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
                 }
 
                 h = next;
+                size--;
             }
 
         }

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -1074,8 +1074,12 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
                     head = h;
                     break;
                 }
-
                 TimedNode<T> next = h.get();
+                if (next == null) {
+                    head = h;
+                    break;
+                }
+
                 if (next.time > limit) {
                     head = h;
                     break;

--- a/src/main/java/io/reactivex/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/processors/ReplayProcessor.java
@@ -1074,12 +1074,8 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
                     head = h;
                     break;
                 }
-                TimedNode<T> next = h.get();
-                if (next == null) {
-                    head = h;
-                    break;
-                }
 
+                TimedNode<T> next = h.get();
                 if (next.time > limit) {
                     head = h;
                     break;

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -1071,6 +1071,10 @@ public final class ReplaySubject<T> extends Subject<T> {
             TimedNode<Object> h = head;
 
             for (;;) {
+                if (size <= 1) {
+                    head = h;
+                    break;
+                }
                 TimedNode<Object> next = h.get();
                 if (next == null) {
                     head = h;
@@ -1083,6 +1087,7 @@ public final class ReplaySubject<T> extends Subject<T> {
                 }
 
                 h = next;
+                size--;
             }
 
         }

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -1075,12 +1075,8 @@ public final class ReplaySubject<T> extends Subject<T> {
                     head = h;
                     break;
                 }
-                TimedNode<Object> next = h.get();
-                if (next == null) {
-                    head = h;
-                    break;
-                }
 
+                TimedNode<Object> next = h.get();
                 if (next.time > limit) {
                     head = h;
                     break;

--- a/src/main/java/io/reactivex/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/subjects/ReplaySubject.java
@@ -1075,8 +1075,12 @@ public final class ReplaySubject<T> extends Subject<T> {
                     head = h;
                     break;
                 }
-
                 TimedNode<Object> next = h.get();
+                if (next == null) {
+                    head = h;
+                    break;
+                }
+
                 if (next.time > limit) {
                     head = h;
                     break;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -28,7 +28,7 @@ import org.reactivestreams.*;
 import io.reactivex.*;
 import io.reactivex.Scheduler.Worker;
 import io.reactivex.annotations.NonNull;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.*;
@@ -2257,5 +2257,14 @@ public class FlowableReplayEagerTruncateTest {
             Assert.fail("Bounded Replay Leak check: Memory leak detected: " + (initial / 1024.0 / 1024.0)
                     + " -> " + after / 1024.0 / 1024.0);
         }
+    }
+
+    @Test
+    public void timeAndSizeNoTerminalTruncationOnTimechange() {
+        Flowable.just(1).replay(1, 1, TimeUnit.SECONDS, new TimesteppingScheduler(), true)
+        .autoConnect()
+        .test()
+        .assertComplete()
+        .assertNoErrors();
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.management.*;
@@ -1997,4 +1998,12 @@ public class ObservableReplayEagerTruncateTest {
         }
     }
 
+    @Test
+    public void timeAndSizeNoTerminalTruncationOnTimechange() {
+        Observable.just(1).replay(1, 1, TimeUnit.SECONDS, new TimesteppingScheduler(), true)
+        .autoConnect()
+        .test()
+        .assertComplete()
+        .assertNoErrors();
+    }
 }

--- a/src/test/java/io/reactivex/testsupport/TimesteppingScheduler.java
+++ b/src/test/java/io/reactivex/testsupport/TimesteppingScheduler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.testsupport;
+
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.Scheduler;
+import io.reactivex.disposables.*;
+
+/**
+ * Basic scheduler that produces an ever increasing {@link #now(TimeUnit)} value.
+ * Use this scheduler only as a time source!
+ */
+public class TimesteppingScheduler extends Scheduler {
+
+    final class TimesteppingWorker extends Worker {
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return false;
+        }
+
+        @Override
+        public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
+            run.run();
+            return Disposables.disposed();
+        }
+
+        @Override
+        public long now(TimeUnit unit) {
+            return time++;
+        }
+    }
+
+    long time;
+
+    @Override
+    public Worker createWorker() {
+        return new TimesteppingWorker();
+    }
+
+    @Override
+    public long now(TimeUnit unit) {
+        return time++;
+    }
+}


### PR DESCRIPTION
This PR fixes several truncation bugs with the time and size-bound replay() operators and their hot class versions:

- Unexpected removal of the last item just added due to becoming out-of-date at the lowest time resolution, creating a hole in the linked chain and hanging the consumer. [Related failure](https://travis-ci.org/akarnokd/RxJava3_BuildMatrix/jobs/562038485#L791).
- Incorrect size accounting upon removing old entries leading to more items dropped than expected.

*Sidenote: The operators and classes would benefit from a rewrite to improve on allocation and indirection. I wanted first to get the bugfixes and related tests done to have a known good baseline.*