### PR TITLE
Upgrade Gradle & Build-Time dependencies to allow building with JDK 11, fix #6585

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ buildscript {
   }
 }
 
+plugins {
+	id 'ru.vyarus.animalsniffer' version '1.5.0'
+}
+
 group = "io.reactivex.rxjava3"
 ext.githubProjectName = "rxjava"
 
@@ -36,7 +40,6 @@ description = "RxJava: Reactive Extensions for the JVM – a library for composi
 apply plugin: "java-library"
 apply plugin: "checkstyle"
 apply plugin: "jacoco"
-apply plugin: "ru.vyarus.animalsniffer"
 apply plugin: "maven"
 apply plugin: "osgi"
 apply plugin: "me.champeau.gradle.jmh"
@@ -57,7 +60,7 @@ def mockitoVersion = "2.1.0"
 def jmhLibVersion = "1.20"
 def testNgVersion = "6.11"
 def guavaVersion = "24.0-jre"
-def jacocoVersion = "0.8.0"
+def jacocoVersion = "0.8.4"
 // --------------------------------------
 
 repositories {
@@ -106,6 +109,7 @@ javadoc {
 
 animalsniffer {
     annotation = "io.reactivex.internal.util.SuppressAnimalSniffer"
+    toolVersion = '1.18'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip


### PR DESCRIPTION
These updates to build-time dependencies allow building with JDK 11, fixing #6585. I tested it with OpenJDK 8 and 11.