### PR TITLE
Fix #6587

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -172,6 +172,8 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                 do {
                     cancelAll();
                 } while (decrementAndGet() != 0);
+
+                errors.tryTerminateAndReport();
             }
         }
 
@@ -279,6 +281,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                         while (e != r) {
                             if (cancelled) {
                                 cancelAll();
+                                errors.tryTerminateAndReport();
                                 return;
                             }
 
@@ -305,6 +308,8 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                                 current = null;
                                 inner.cancel();
                                 cancelAll();
+                                errors.addThrowable(ex);
+                                ex = errors.terminate();
                                 a.onError(ex);
                                 return;
                             }
@@ -333,6 +338,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                         if (e == r) {
                             if (cancelled) {
                                 cancelAll();
+                                errors.tryTerminateAndReport();
                                 return;
                             }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletable.java
@@ -156,6 +156,7 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
             inner.dispose();
             if (getAndIncrement() == 0) {
                 queue.clear();
+                errors.tryTerminateAndReport();
             }
         }
 
@@ -197,6 +198,7 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
             do {
                 if (disposed) {
                     queue.clear();
+                    errors.tryTerminateAndReport();
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
@@ -170,6 +170,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
             if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
+                errors.tryTerminateAndReport();
             }
         }
 
@@ -215,7 +216,8 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
                     if (cancelled) {
                         queue.clear();
                         item = null;
-                        break;
+                        errors.tryTerminateAndReport();
+                        return;
                     }
 
                     int s = state;

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -170,6 +170,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
             if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
+                errors.tryTerminateAndReport();
             }
         }
 
@@ -210,7 +211,8 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
                     if (cancelled) {
                         queue.clear();
                         item = null;
-                        break;
+                        errors.tryTerminateAndReport();
+                        return;
                     }
 
                     int s = state;

--- a/src/main/java/io/reactivex/observers/SerializedObserver.java
+++ b/src/main/java/io/reactivex/observers/SerializedObserver.java
@@ -197,4 +197,8 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
             }
         }
     }
+
+    public void finish () {
+        done = true;
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -223,8 +223,7 @@ public class ObservableConcatMapSingleTest {
             TestObserverEx<Integer> to = ps.concatMapSingle(
                     new Function<Integer, SingleSource<Integer>>() {
                         @Override
-                        public SingleSource<Integer> apply(Integer v)
-                                throws Exception {
+                        public SingleSource<Integer> apply(Integer v) {
                             return new Single<Integer>() {
                                 @Override
                                 protected void subscribeActual(


### PR DESCRIPTION
In `ObservableConcatMapSingle`, if `dispose` is called before `innerError`, forward errors to `RxJavaPlugins.onError` instead of swallowing them. Since `dispose` and `innerError` can run on different threads, there can be various concurrency situations. Depending on which one executes faster, `dispose` or `innerError` will call `RxJavaPlugins.onError` via `errors.terminate`. If the `drain` loop is running while `dispose` is called, it will call `RxJavaPlugins.onError` instead.