### PR TITLE
3.x: Fix mergeWith not cancelling the other source if the main errors

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletable.java
@@ -86,7 +86,7 @@ public final class FlowableMergeWithCompletable<T> extends AbstractFlowableWithU
 
         @Override
         public void onError(Throwable ex) {
-            SubscriptionHelper.cancel(mainSubscription);
+            DisposableHelper.dispose(otherObserver);
             HalfSerializer.onError(downstream, ex, this, error);
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -143,7 +143,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
         @Override
         public void onError(Throwable ex) {
             if (error.addThrowable(ex)) {
-                SubscriptionHelper.cancel(mainSubscription);
+                DisposableHelper.dispose(otherObserver);
                 drain();
             } else {
                 RxJavaPlugins.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingle.java
@@ -143,7 +143,7 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
         @Override
         public void onError(Throwable ex) {
             if (error.addThrowable(ex)) {
-                SubscriptionHelper.cancel(mainSubscription);
+                DisposableHelper.dispose(otherObserver);
                 drain();
             } else {
                 RxJavaPlugins.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletable.java
@@ -80,7 +80,7 @@ public final class ObservableMergeWithCompletable<T> extends AbstractObservableW
 
         @Override
         public void onError(Throwable ex) {
-            DisposableHelper.dispose(mainDisposable);
+            DisposableHelper.dispose(otherObserver);
             HalfSerializer.onError(downstream, ex, this, error);
         }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybe.java
@@ -106,7 +106,7 @@ public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUps
         @Override
         public void onError(Throwable ex) {
             if (error.addThrowable(ex)) {
-                DisposableHelper.dispose(mainDisposable);
+                DisposableHelper.dispose(otherObserver);
                 drain();
             } else {
                 RxJavaPlugins.onError(ex);

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
@@ -106,7 +106,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
         @Override
         public void onError(Throwable ex) {
             if (error.addThrowable(ex)) {
-                DisposableHelper.dispose(mainDisposable);
+                DisposableHelper.dispose(otherObserver);
                 drain();
             } else {
                 RxJavaPlugins.onError(ex);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -157,7 +157,7 @@ public class FlowableMergeWithCompletableTest {
     }
 
     @Test
-    public void cancelMainOnOhterError() {
+    public void cancelMainOnOtherError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         CompletableSubject cs = CompletableSubject.create();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -13,9 +13,9 @@
 
 package io.reactivex.internal.operators.flowable;
 
-import org.junit.Test;
-
 import static org.junit.Assert.*;
+
+import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
@@ -136,5 +136,41 @@ public class FlowableMergeWithCompletableTest {
 
             ts.assertResult(1);
         }
+    }
+
+    @Test
+    public void cancelOtherOnMainError() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        CompletableSubject cs = CompletableSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+        assertTrue(pp.hasSubscribers());
+        assertTrue(cs.hasObservers());
+
+        pp.onError(new TestException());
+
+        ts.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", pp.hasSubscribers());
+        assertFalse("other has observers", cs.hasObservers());
+    }
+
+    @Test
+    public void cancelMainOnOhterError() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        CompletableSubject cs = CompletableSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+        assertTrue(pp.hasSubscribers());
+        assertTrue(cs.hasObservers());
+
+        cs.onError(new TestException());
+
+        ts.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", pp.hasSubscribers());
+        assertFalse("other has observers", cs.hasObservers());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
@@ -422,7 +422,7 @@ public class FlowableMergeWithMaybeTest {
     }
 
     @Test
-    public void cancelMainOnOhterError() {
+    public void cancelMainOnOtherError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         MaybeSubject<Integer> ms = MaybeSubject.create();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -398,4 +398,40 @@ public class FlowableMergeWithSingleTest {
         ts.assertValueCount(Flowable.bufferSize());
         ts.assertComplete();
     }
+
+    @Test
+    public void cancelOtherOnMainError() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(ss).test();
+
+        assertTrue(pp.hasSubscribers());
+        assertTrue(ss.hasObservers());
+
+        pp.onError(new TestException());
+
+        ts.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", pp.hasSubscribers());
+        assertFalse("other has observers", ss.hasObservers());
+    }
+
+    @Test
+    public void cancelMainOnOhterError() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        TestSubscriber<Integer> ts = pp.mergeWith(ss).test();
+
+        assertTrue(pp.hasSubscribers());
+        assertTrue(ss.hasObservers());
+
+        ss.onError(new TestException());
+
+        ts.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", pp.hasSubscribers());
+        assertFalse("other has observers", ss.hasObservers());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -418,7 +418,7 @@ public class FlowableMergeWithSingleTest {
     }
 
     @Test
-    public void cancelMainOnOhterError() {
+    public void cancelMainOnOtherError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         SingleSubject<Integer> ss = SingleSubject.create();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
@@ -136,4 +136,40 @@ public class ObservableMergeWithCompletableTest {
         .test()
         .assertResult(1);
     }
+
+    @Test
+    public void cancelOtherOnMainError() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        CompletableSubject cs = CompletableSubject.create();
+
+        TestObserver<Integer> to = ps.mergeWith(cs).test();
+
+        assertTrue(ps.hasObservers());
+        assertTrue(cs.hasObservers());
+
+        ps.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", ps.hasObservers());
+        assertFalse("other has observers", cs.hasObservers());
+    }
+
+    @Test
+    public void cancelMainOnOhterError() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        CompletableSubject cs = CompletableSubject.create();
+
+        TestObserver<Integer> to = ps.mergeWith(cs).test();
+
+        assertTrue(ps.hasObservers());
+        assertTrue(cs.hasObservers());
+
+        cs.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", ps.hasObservers());
+        assertFalse("other has observers", cs.hasObservers());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
@@ -156,7 +156,7 @@ public class ObservableMergeWithCompletableTest {
     }
 
     @Test
-    public void cancelMainOnOhterError() {
+    public void cancelMainOnOtherError() {
         PublishSubject<Integer> ps = PublishSubject.create();
         CompletableSubject cs = CompletableSubject.create();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
@@ -273,4 +273,39 @@ public class ObservableMergeWithMaybeTest {
         to.assertResult(0, 1, 2, 3, 4);
     }
 
+    @Test
+    public void cancelOtherOnMainError() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        TestObserver<Integer> to = ps.mergeWith(ms).test();
+
+        assertTrue(ps.hasObservers());
+        assertTrue(ms.hasObservers());
+
+        ps.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", ps.hasObservers());
+        assertFalse("other has observers", ms.hasObservers());
+    }
+
+    @Test
+    public void cancelMainOnOhterError() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        TestObserver<Integer> to = ps.mergeWith(ms).test();
+
+        assertTrue(ps.hasObservers());
+        assertTrue(ms.hasObservers());
+
+        ms.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", ps.hasObservers());
+        assertFalse("other has observers", ms.hasObservers());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
@@ -292,7 +292,7 @@ public class ObservableMergeWithMaybeTest {
     }
 
     @Test
-    public void cancelMainOnOhterError() {
+    public void cancelMainOnOtherError() {
         PublishSubject<Integer> ps = PublishSubject.create();
         MaybeSubject<Integer> ms = MaybeSubject.create();
 

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -264,4 +264,40 @@ public class ObservableMergeWithSingleTest {
 
         to.assertResult(0, 1, 2, 3, 4);
     }
+
+    @Test
+    public void cancelOtherOnMainError() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        TestObserver<Integer> to = ps.mergeWith(ss).test();
+
+        assertTrue(ps.hasObservers());
+        assertTrue(ss.hasObservers());
+
+        ps.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", ps.hasObservers());
+        assertFalse("other has observers", ss.hasObservers());
+    }
+
+    @Test
+    public void cancelMainOnOhterError() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        TestObserver<Integer> to = ps.mergeWith(ss).test();
+
+        assertTrue(ps.hasObservers());
+        assertTrue(ss.hasObservers());
+
+        ss.onError(new TestException());
+
+        to.assertFailure(TestException.class);
+
+        assertFalse("main has observers!", ps.hasObservers());
+        assertFalse("other has observers", ss.hasObservers());
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -284,7 +284,7 @@ public class ObservableMergeWithSingleTest {
     }
 
     @Test
-    public void cancelMainOnOhterError() {
+    public void cancelMainOnOtherError() {
         PublishSubject<Integer> ps = PublishSubject.create();
         SingleSubject<Integer> ss = SingleSubject.create();
 


### PR DESCRIPTION
The `mergeWith` implementations' `onError` (called by the main source) cancelled the main source instead of cancelling the other source. This mistake affects all 2 x 3 overloads of the operator.

Fixes #6597