### PR TITLE
3.x: Have `internal.operator.flowable` unit tests extends `RxJavaTest` - 4

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstreamTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/AbstractFlowableWithUpstreamTest.java
@@ -15,13 +15,14 @@ package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.assertSame;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.HasUpstreamPublisher;
 
-public class AbstractFlowableWithUpstreamTest {
+public class AbstractFlowableWithUpstreamTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableLatestTest.java
@@ -28,8 +28,8 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.testsupport.TestHelper;
 
-public class BlockingFlowableLatestTest {
-    @Test(timeout = 1000)
+public class BlockingFlowableLatestTest extends RxJavaTest {
+    @Test
     public void simple() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -53,7 +53,7 @@ public class BlockingFlowableLatestTest {
         Assert.assertFalse(it.hasNext());
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void sameSourceMultipleIterators() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -79,7 +79,7 @@ public class BlockingFlowableLatestTest {
         }
     }
 
-    @Test(timeout = 1000, expected = NoSuchElementException.class)
+    @Test(expected = NoSuchElementException.class)
     public void empty() {
         Flowable<Long> source = Flowable.<Long> empty();
 
@@ -92,7 +92,7 @@ public class BlockingFlowableLatestTest {
         it.next();
     }
 
-    @Test(timeout = 1000, expected = NoSuchElementException.class)
+    @Test(expected = NoSuchElementException.class)
     public void simpleJustNext() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -111,7 +111,7 @@ public class BlockingFlowableLatestTest {
         }
     }
 
-    @Test(/* timeout = 1000, */expected = RuntimeException.class)
+    @Test(expected = RuntimeException.class)
     public void hasNextThrows() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -126,7 +126,7 @@ public class BlockingFlowableLatestTest {
         it.hasNext();
     }
 
-    @Test(timeout = 1000, expected = RuntimeException.class)
+    @Test(expected = RuntimeException.class)
     public void nextThrows() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -140,7 +140,7 @@ public class BlockingFlowableLatestTest {
         it.next();
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void fasterSource() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         Flowable<Integer> blocker = source;
@@ -167,12 +167,6 @@ public class BlockingFlowableLatestTest {
         source.onComplete();
 
         Assert.assertFalse(it.hasNext());
-    }
-
-    @Ignore("THe target is an enum")
-    @Test
-    public void constructorshouldbeprivate() {
-        TestHelper.checkUtilityClass(BlockingFlowableLatest.class);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
@@ -26,7 +26,7 @@ import io.reactivex.processors.*;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.testsupport.TestHelper;
 
-public class BlockingFlowableMostRecentTest {
+public class BlockingFlowableMostRecentTest extends RxJavaTest {
     @Test
     public void mostRecentNull() {
         assertNull(Flowable.<Void>never().blockingMostRecent(null).iterator().next());
@@ -73,7 +73,7 @@ public class BlockingFlowableMostRecentTest {
         it.next();
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void singleSourceManyIterators() {
         TestScheduler scheduler = new TestScheduler();
         Flowable<Long> source = Flowable.interval(1, TimeUnit.SECONDS, scheduler).take(10);
@@ -96,12 +96,6 @@ public class BlockingFlowableMostRecentTest {
             Assert.assertFalse(it.hasNext());
         }
 
-    }
-
-    @Ignore("The target is an enum")
-    @Test
-    public void constructorshouldbeprivate() {
-        TestHelper.checkUtilityClass(BlockingFlowableMostRecent.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -32,7 +32,7 @@ import io.reactivex.processors.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class BlockingFlowableNextTest {
+public class BlockingFlowableNextTest extends RxJavaTest {
 
     private void fireOnNextInNewThread(final FlowableProcessor<String> o, final String value) {
         new Thread() {
@@ -307,7 +307,7 @@ public class BlockingFlowableNextTest {
         }
     }
 
-    @Test /* (timeout = 8000) */
+    @Test
     public void singleSourceManyIterators() throws InterruptedException {
         Flowable<Long> f = Flowable.interval(250, TimeUnit.MILLISECONDS);
         PublishProcessor<Integer> terminal = PublishProcessor.create();
@@ -331,12 +331,6 @@ public class BlockingFlowableNextTest {
         assertEquals(1, BehaviorProcessor.createDefault(1).take(1).blockingSingle().intValue());
         assertEquals(2, BehaviorProcessor.createDefault(2).blockingIterable().iterator().next().intValue());
         assertEquals(3, BehaviorProcessor.createDefault(3).blockingNext().iterator().next().intValue());
-    }
-
-    @Ignore("THe target is an enum")
-    @Test
-    public void constructorshouldbeprivate() {
-        TestHelper.checkUtilityClass(BlockingFlowableNext.class);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 import java.util.*;
 import java.util.concurrent.*;
 
+import io.reactivex.testsupport.TestHelper;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -28,11 +29,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 
 public class BlockingFlowableToFutureTest {
-    @Ignore("No separate file")
-    @Test
-    public void constructorShouldBePrivate() {
-//        TestHelper.checkUtilityClass(FlowableToFuture.class);
-    }
 
     @Test
     public void toFuture() throws InterruptedException, ExecutionException {
@@ -50,7 +46,7 @@ public class BlockingFlowableToFutureTest {
         assertEquals("three", f.get().get(2));
     }
 
-    @Test(/* timeout = 5000, */expected = IndexOutOfBoundsException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
     public void exceptionWithMoreThanOneElement() throws Throwable {
         Flowable<String> obs = Flowable.just("one", "two");
         Future<String> f = obs.toFuture();
@@ -113,13 +109,5 @@ public class BlockingFlowableToFutureTest {
         catch (ExecutionException e) {
             throw e.getCause();
         }
-    }
-
-    @Ignore("null value is not allowed")
-    @Test
-    public void getWithASingleNullItem() throws Exception {
-        Flowable<String> obs = Flowable.just((String)null);
-        Future<String> f = obs.toFuture();
-        assertNull(f.get());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToIteratorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToIteratorTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -25,7 +26,7 @@ import io.reactivex.exceptions.*;
 import io.reactivex.internal.operators.flowable.BlockingFlowableIterable.BlockingFlowableIterator;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 
-public class BlockingFlowableToIteratorTest {
+public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test
     public void toIterator() {
@@ -65,28 +66,6 @@ public class BlockingFlowableToIteratorTest {
 
         assertTrue(it.hasNext());
         it.next();
-    }
-
-    @Ignore("subscribe() should not throw")
-    @Test(expected = TestException.class)
-    public void exceptionThrownFromOnSubscribe() {
-        Iterable<String> strings = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                throw new TestException("intentional");
-            }
-        }).blockingIterable();
-
-        for (String string : strings) {
-            // never reaches here
-            System.out.println(string);
-        }
-    }
-
-    @Ignore("This is not a separate class anymore")
-    @Test
-    public void constructorShouldBePrivate() {
-        // TestHelper.checkUtilityClass(BlockingOperatorToIterator.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/BufferUntilSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BufferUntilSubscriberTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.Publisher;
 
@@ -25,7 +26,7 @@ import io.reactivex.functions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 
-public class BufferUntilSubscriberTest {
+public class BufferUntilSubscriberTest extends RxJavaTest {
 
     @Test
     public void issue1677() throws InterruptedException {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -33,7 +33,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableAllTest {
+public class FlowableAllTest extends RxJavaTest {
 
     @Test
     public void all() {
@@ -125,7 +125,7 @@ public class FlowableAllTest {
         assertFalse(allOdd.blockingGet());
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void issue1935NoUnsubscribeDownstream() {
         Flowable<Integer> source = Flowable.just(1)
             .all(new Predicate<Integer>() {
@@ -142,22 +142,6 @@ public class FlowableAllTest {
             });
 
         assertEquals((Object)2, source.blockingFirst());
-    }
-
-    @Test
-    @Ignore("No backpressure in Single")
-    public void backpressureIfNoneRequestedNoneShouldBeDelivered() {
-        TestObserver<Boolean> to = new TestObserver<Boolean>();
-        Flowable.empty().all(new Predicate<Object>() {
-            @Override
-            public boolean test(Object t1) {
-                return false;
-            }
-        }).subscribe(to);
-
-        to.assertNoValues();
-        to.assertNoErrors();
-        to.assertNotComplete();
     }
 
     @Test
@@ -299,7 +283,7 @@ public class FlowableAllTest {
         assertFalse(allOdd.blockingFirst());
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void issue1935NoUnsubscribeDownstreamFlowable() {
         Flowable<Integer> source = Flowable.just(1)
             .all(new Predicate<Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -38,7 +38,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableAmbTest {
+public class FlowableAmbTest extends RxJavaTest {
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
@@ -326,7 +326,7 @@ public class FlowableAmbTest {
 
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void multipleUse() {
         TestSubscriber<Long> ts1 = new TestSubscriber<Long>();
         TestSubscriber<Long> ts2 = new TestSubscriber<Long>();
@@ -392,132 +392,6 @@ public class FlowableAmbTest {
         ts.assertValue(2);
         ts.assertNoErrors();
         ts.assertComplete();
-    }
-
-    @Ignore("No 2-9 arg overloads")
-    @SuppressWarnings("unchecked")
-    @Test
-    public void ambMany() throws Exception {
-        for (int i = 2; i < 10; i++) {
-            Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Publisher.class);
-
-            PublishProcessor<Integer>[] ps = new PublishProcessor[i];
-
-            for (int j = 0; j < i; j++) {
-
-                for (int k = 0; k < i; k++) {
-                    ps[k] = PublishProcessor.create();
-                }
-
-                Method m = Flowable.class.getMethod("amb", clazz);
-
-                Flowable<Integer> obs = (Flowable<Integer>)m.invoke(null, (Object[])ps);
-
-                TestSubscriber<Integer> ts = TestSubscriber.create();
-
-                obs.subscribe(ts);
-
-                for (int k = 0; k < i; k++) {
-                    assertTrue("@" + i + "/" + k + " has no observers?", ps[k].hasSubscribers());
-                }
-
-                ps[j].onNext(j);
-                ps[j].onComplete();
-
-                for (int k = 0; k < i; k++) {
-                    assertFalse("@" + i + "/" + k + " has observers?", ps[k].hasSubscribers());
-                }
-
-                ts.assertValue(j);
-                ts.assertNoErrors();
-                ts.assertComplete();
-            }
-        }
-    }
-
-    @Ignore("No 2-9 arg overloads")
-    @SuppressWarnings("unchecked")
-    @Test
-    public void ambManyError() throws Exception {
-        for (int i = 2; i < 10; i++) {
-            Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Publisher.class);
-
-            PublishProcessor<Integer>[] ps = new PublishProcessor[i];
-
-            for (int j = 0; j < i; j++) {
-
-                for (int k = 0; k < i; k++) {
-                    ps[k] = PublishProcessor.create();
-                }
-
-                Method m = Flowable.class.getMethod("amb", clazz);
-
-                Flowable<Integer> obs = (Flowable<Integer>)m.invoke(null, (Object[])ps);
-
-                TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
-
-                obs.subscribe(ts);
-
-                for (int k = 0; k < i; k++) {
-                    assertTrue("@" + i + "/" + k + " has no observers?", ps[k].hasSubscribers());
-                }
-
-                ps[j].onError(new TestException(Integer.toString(j)));
-
-                for (int k = 0; k < i; k++) {
-                    assertFalse("@" + i + "/" + k + " has observers?", ps[k].hasSubscribers());
-                }
-
-                ts.assertNoValues();
-                ts.assertError(TestException.class);
-                ts.assertNotComplete();
-
-                assertEquals(Integer.toString(j), ts.errors().get(0).getMessage());
-            }
-        }
-    }
-
-    @Ignore("No 2-9 arg overloads")
-    @SuppressWarnings("unchecked")
-    @Test
-    public void ambManyComplete() throws Exception {
-        for (int i = 2; i < 10; i++) {
-            Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Publisher.class);
-
-            PublishProcessor<Integer>[] ps = new PublishProcessor[i];
-
-            for (int j = 0; j < i; j++) {
-
-                for (int k = 0; k < i; k++) {
-                    ps[k] = PublishProcessor.create();
-                }
-
-                Method m = Flowable.class.getMethod("amb", clazz);
-
-                Flowable<Integer> obs = (Flowable<Integer>)m.invoke(null, (Object[])ps);
-
-                TestSubscriber<Integer> ts = TestSubscriber.create();
-
-                obs.subscribe(ts);
-
-                for (int k = 0; k < i; k++) {
-                    assertTrue("@" + i + "/" + k + " has no observers?", ps[k].hasSubscribers());
-                }
-
-                ps[j].onComplete();
-
-                for (int k = 0; k < i; k++) {
-                    assertFalse("@" + i + "/" + k + " has observers?", ps[k].hasSubscribers());
-                }
-
-                ts.assertNoValues();
-                ts.assertNoErrors();
-                ts.assertComplete();
-            }
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -33,7 +33,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableAnyTest {
+public class FlowableAnyTest extends RxJavaTest {
 
     @Test
     public void anyWithTwoItems() {
@@ -224,7 +224,7 @@ public class FlowableAnyTest {
         assertTrue(anyEven.blockingGet());
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void issue1935NoUnsubscribeDownstream() {
         Flowable<Integer> source = Flowable.just(1).isEmpty()
             .flatMapPublisher(new Function<Boolean, Publisher<Integer>>() {
@@ -235,24 +235,6 @@ public class FlowableAnyTest {
             });
 
         assertEquals((Object)2, source.blockingFirst());
-    }
-
-    @Test
-    @Ignore("Single doesn't do backpressure")
-    public void backpressureIfNoneRequestedNoneShouldBeDelivered() {
-        TestObserver<Boolean> to = new TestObserver<Boolean>();
-
-        Flowable.just(1).any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t) {
-                return true;
-            }
-        })
-        .subscribe(to);
-
-        to.assertNoValues();
-        to.assertNoErrors();
-        to.assertNotComplete();
     }
 
     @Test
@@ -491,7 +473,7 @@ public class FlowableAnyTest {
         assertTrue(anyEven.blockingFirst());
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void issue1935NoUnsubscribeDownstreamFlowable() {
         Flowable<Integer> source = Flowable.just(1).isEmpty()
             .flatMapPublisher(new Function<Boolean, Publisher<Integer>>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAsObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAsObservableTest.java
@@ -25,7 +25,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableAsObservableTest {
+public class FlowableAsObservableTest extends RxJavaTest {
     @Test
     public void hiding() {
         PublishProcessor<Integer> src = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAutoConnectTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAutoConnectTest.java
@@ -15,11 +15,12 @@ package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.assertTrue;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.processors.PublishProcessor;
 
-public class FlowableAutoConnectTest {
+public class FlowableAutoConnectTest extends RxJavaTest {
 
     @Test
     public void autoConnectImmediately() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBlockingTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableBlockingTest {
+public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingFirst() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableBufferTest.java
@@ -39,7 +39,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableBufferTest {
+public class FlowableBufferTest extends RxJavaTest {
 
     private Subscriber<List<String>> subscriber;
     private TestScheduler scheduler;
@@ -452,7 +452,7 @@ public class FlowableBufferTest {
         verify(subscriber, never()).onNext(any());
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void bufferWithSizeTake1() {
         Flowable<Integer> source = Flowable.just(1).repeat();
 
@@ -467,7 +467,7 @@ public class FlowableBufferTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void bufferWithSizeSkipTake1() {
         Flowable<Integer> source = Flowable.just(1).repeat();
 
@@ -482,7 +482,7 @@ public class FlowableBufferTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void bufferWithTimeTake1() {
         Flowable<Long> source = Flowable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
 
@@ -499,7 +499,7 @@ public class FlowableBufferTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void bufferWithTimeSkipTake2() {
         Flowable<Long> source = Flowable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
 
@@ -518,7 +518,7 @@ public class FlowableBufferTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void bufferWithBoundaryTake2() {
         Flowable<Long> boundary = Flowable.interval(60, 60, TimeUnit.MILLISECONDS, scheduler);
         Flowable<Long> source = Flowable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
@@ -539,7 +539,7 @@ public class FlowableBufferTest {
 
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void bufferWithStartEndBoundaryTake2() {
         Flowable<Long> start = Flowable.interval(61, 61, TimeUnit.MILLISECONDS, scheduler);
         Function<Long, Flowable<Long>> end = new Function<Long, Flowable<Long>>() {
@@ -953,7 +953,7 @@ public class FlowableBufferTest {
         assertEquals(Long.MAX_VALUE - 1, requested.get());
     }
 
-    @Test(timeout = 3000)
+    @Test
     public void bufferWithTimeDoesntUnsubscribeDownstream() throws InterruptedException {
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCacheTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -32,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableCacheTest {
+public class FlowableCacheTest extends RxJavaTest {
     @Test
     public void coldReplayNoBackpressure() {
         FlowableCache<Integer> source = new FlowableCache<Integer>(Flowable.range(0, 1000), 16);
@@ -260,36 +261,6 @@ public class FlowableCacheTest {
         ts2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ts2.assertNotComplete();
         ts2.assertError(TestException.class);
-    }
-
-    @Test
-    @Ignore("RS subscribers should not throw")
-    public void unsafeChildThrows() {
-        final AtomicInteger count = new AtomicInteger();
-
-        Flowable<Integer> source = Flowable.range(1, 100)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        })
-        .cache();
-
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
-            @Override
-            public void onNext(Integer t) {
-                throw new TestException();
-            }
-        };
-
-        source.subscribe(ts);
-
-        Assert.assertEquals(100, count.get());
-
-        ts.assertNoValues();
-        ts.assertNotComplete();
-        ts.assertError(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCastTest.java
@@ -23,7 +23,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableCastTest {
+public class FlowableCastTest extends RxJavaTest {
 
     @Test
     public void cast() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -37,7 +37,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableCombineLatestTest {
+public class FlowableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void combineLatestWithFunctionThatThrowsAnException() {
@@ -455,7 +455,7 @@ public class FlowableCombineLatestTest {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void oneToNSourcesScheduled() throws InterruptedException {
         int n = 10;
         Function<Object[], List<Object>> func = new Function<Object[], List<Object>>() {
@@ -743,7 +743,7 @@ public class FlowableCombineLatestTest {
         }
     }
 
-    @Test//(timeout = 2000)
+    @Test
     public void backpressure() {
         BiFunction<String, Integer, String> combineLatestFunction = getConcatStringIntegerCombineLatestFunction();
 
@@ -799,7 +799,7 @@ public class FlowableCombineLatestTest {
         assertEquals(SIZE, count.get());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void combineLatestRequestOverflow() throws InterruptedException {
         @SuppressWarnings("unchecked")
         List<Flowable<Integer>> sources = Arrays.asList(Flowable.fromArray(1, 2, 3, 4),
@@ -861,39 +861,6 @@ public class FlowableCombineLatestTest {
           .combineLatest(Collections.singletonList(source), THROW_NON_FATAL)
           .subscribe(ts);
         assertFalse(errorOccurred.get());
-    }
-
-    @Ignore("Nulls are not allowed")
-    @Test
-    public void combineManyNulls() {
-        int n = Flowable.bufferSize() * 3;
-
-        Flowable<Integer> source = Flowable.just((Integer)null);
-
-        List<Flowable<Integer>> sources = new ArrayList<Flowable<Integer>>();
-
-        for (int i = 0; i < n; i++) {
-            sources.add(source);
-        }
-
-        TestSubscriber<Integer> ts = TestSubscriber.create();
-
-        Flowable.combineLatest(sources, new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] args) {
-                int sum = 0;
-                for (Object o : args) {
-                    if (o == null) {
-                        sum ++;
-                    }
-                }
-                return sum;
-            }
-        }).subscribe(ts);
-
-        ts.assertValue(n);
-        ts.assertNoErrors();
-        ts.assertComplete();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
@@ -26,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestSubscriberEx;
 
-public class FlowableConcatDelayErrorTest {
+public class FlowableConcatDelayErrorTest extends RxJavaTest {
 
     @Test
     public void mainCompletes() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -34,7 +35,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableConcatMapEagerTest {
+public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void normal() {
@@ -642,21 +643,6 @@ public class FlowableConcatMapEagerTest {
     }
 
     @Test
-    @Ignore("Null values are not allowed in RS")
-    public void innerNull() {
-        Flowable.just(1).concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                return Flowable.just(null);
-            }
-        }).subscribe(ts);
-
-        ts.assertNoErrors();
-        ts.assertComplete();
-        ts.assertValue(null);
-    }
-
-    @Test
     public void maxConcurrent5() {
         final List<Long> requests = new ArrayList<Long>();
         Flowable.range(1, 100).doOnRequest(new LongConsumer() {
@@ -676,32 +662,6 @@ public class FlowableConcatMapEagerTest {
         Assert.assertEquals(1, (long) requests.get(3));
         Assert.assertEquals(1, (long) requests.get(4));
         Assert.assertEquals(1, (long) requests.get(5));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    @Ignore("Currently there are no 2-9 argument variants, use concatArrayEager()")
-    public void many() throws Exception {
-        for (int i = 2; i < 10; i++) {
-            Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Flowable.class);
-
-            Flowable<Integer>[] obs = new Flowable[i];
-            Arrays.fill(obs, Flowable.just(1));
-
-            Integer[] expected = new Integer[i];
-            Arrays.fill(expected, 1);
-
-            Method m = Flowable.class.getMethod("concatEager", clazz);
-
-            TestSubscriber<Integer> ts = TestSubscriber.create();
-
-            ((Flowable<Integer>)m.invoke(null, (Object[])obs)).subscribe(ts);
-
-            ts.assertValues(expected);
-            ts.assertNoErrors();
-            ts.assertComplete();
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -35,7 +35,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableConcatMapSchedulerTest {
+public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
     @Test
     public void boundaryFusion() {
@@ -303,7 +303,7 @@ public class FlowableConcatMapSchedulerTest {
         assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
     }
 
-    @Test(timeout = 30000)
+    @Test
     public void issue2890NoStackoverflow() throws InterruptedException {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
@@ -354,7 +354,7 @@ public class FlowableConcatMapSchedulerTest {
         assertEquals(n, counter.get());
     }
 
-    @Test//(timeout = 100000)
+    @Test
     public void concatMapRangeAsyncLoopIssue2876() {
         final long durationSeconds = 2;
         final long startTime = System.currentTimeMillis();
@@ -386,23 +386,19 @@ public class FlowableConcatMapSchedulerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    @Ignore("concat(a, b, ...) replaced by concatArray(T...)")
-    public void concatMany() throws Exception {
+    public void concatArray() throws Exception {
         for (int i = 2; i < 10; i++) {
-            Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Flowable.class);
-
             Flowable<Integer>[] obs = new Flowable[i];
             Arrays.fill(obs, Flowable.just(1));
 
             Integer[] expected = new Integer[i];
             Arrays.fill(expected, 1);
 
-            Method m = Flowable.class.getMethod("concat", clazz);
+            Method m = Flowable.class.getMethod("concatArray",  Publisher[].class);
 
             TestSubscriber<Integer> ts = TestSubscriber.create();
 
-            ((Flowable<Integer>)m.invoke(null, (Object[])obs)).subscribe(ts);
+            ((Flowable<Integer>)m.invoke(null, new Object[]{obs})).subscribe(ts);
 
             ts.assertValues(expected);
             ts.assertNoErrors();
@@ -460,51 +456,23 @@ public class FlowableConcatMapSchedulerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    @Ignore("startWith(a, b, ...) replaced by startWithArray(T...)")
-    public void startWith() throws Exception {
+    public void startWithArray() throws Exception {
         for (int i = 2; i < 10; i++) {
-            Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Object.class);
-
             Object[] obs = new Object[i];
             Arrays.fill(obs, 1);
 
             Integer[] expected = new Integer[i];
             Arrays.fill(expected, 1);
 
-            Method m = Flowable.class.getMethod("startWith", clazz);
+            Method m = Flowable.class.getMethod("startWithArray", Object[].class);
 
             TestSubscriber<Integer> ts = TestSubscriber.create();
 
-            ((Flowable<Integer>)m.invoke(Flowable.empty(), obs)).subscribe(ts);
+            ((Flowable<Integer>)m.invoke(Flowable.empty(), new Object[]{obs})).subscribe(ts);
 
             ts.assertValues(expected);
             ts.assertNoErrors();
             ts.assertComplete();
-        }
-    }
-
-    static final class InfiniteIterator implements Iterator<Integer>, Iterable<Integer> {
-
-        int count;
-
-        @Override
-        public boolean hasNext() {
-            return true;
-        }
-
-        @Override
-        public Integer next() {
-            return count++;
-        }
-
-        @Override
-        public void remove() {
-        }
-
-        @Override
-        public Iterator<Integer> iterator() {
-            return this;
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
@@ -29,7 +29,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableConcatMapTest {
+public class FlowableConcatMapTest extends RxJavaTest {
 
     @Test
     public void weakSubscriptionRequest() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatTest.java
@@ -726,7 +726,7 @@ public class FlowableConcatTest {
         ts.assertValues("hello", "hello");
     }
 
-    @Test(timeout = 30000)
+    @Test
     public void issue2890NoStackoverflow() throws InterruptedException {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
@@ -802,7 +802,7 @@ public class FlowableConcatTest {
         assertTrue(completed.get());
     }
 
-    @Test//(timeout = 100000)
+    @Test
     public void concatMapRangeAsyncLoopIssue2876() {
         final long durationSeconds = 2;
         final long startTime = System.currentTimeMillis();
@@ -915,23 +915,19 @@ public class FlowableConcatTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    @Ignore("concat(a, b, ...) replaced by concatArray(T...)")
-    public void concatMany() throws Exception {
+    public void concatArray() throws Exception {
         for (int i = 2; i < 10; i++) {
-            Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Flowable.class);
-
             Flowable<Integer>[] obs = new Flowable[i];
             Arrays.fill(obs, Flowable.just(1));
 
             Integer[] expected = new Integer[i];
             Arrays.fill(expected, 1);
 
-            Method m = Flowable.class.getMethod("concat", clazz);
+            Method m = Flowable.class.getMethod("concatArray", Publisher[].class);
 
             TestSubscriber<Integer> ts = TestSubscriber.create();
 
-            ((Flowable<Integer>)m.invoke(null, (Object[])obs)).subscribe(ts);
+            ((Flowable<Integer>)m.invoke(null, new Object[]{obs})).subscribe(ts);
 
             ts.assertValues(expected);
             ts.assertNoErrors();
@@ -989,23 +985,19 @@ public class FlowableConcatTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    @Ignore("startWith(a, b, ...) replaced by startWithArray(T...)")
-    public void startWith() throws Exception {
+    public void startWithArray() throws Exception {
         for (int i = 2; i < 10; i++) {
-            Class<?>[] clazz = new Class[i];
-            Arrays.fill(clazz, Object.class);
-
             Object[] obs = new Object[i];
             Arrays.fill(obs, 1);
 
             Integer[] expected = new Integer[i];
             Arrays.fill(expected, 1);
 
-            Method m = Flowable.class.getMethod("startWith", clazz);
+            Method m = Flowable.class.getMethod("startWithArray", Object[].class);
 
             TestSubscriber<Integer> ts = TestSubscriber.create();
 
-            ((Flowable<Integer>)m.invoke(Flowable.empty(), obs)).subscribe(ts);
+            ((Flowable<Integer>)m.invoke(Flowable.empty(), new Object[]{obs})).subscribe(ts);
 
             ts.assertValues(expected);
             ts.assertNoErrors();
@@ -1037,7 +1029,7 @@ public class FlowableConcatTest {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void veryLongTake() {
         Flowable.fromIterable(new InfiniteIterator()).concatWith(Flowable.<Integer>empty()).take(10)
         .test()

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithCompletableTest.java
@@ -29,7 +29,7 @@ import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableConcatWithCompletableTest {
+public class FlowableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithMaybeTest.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.Action;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 
-public class FlowableConcatWithMaybeTest {
+public class FlowableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void normalEmpty() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatWithSingleTest.java
@@ -22,7 +22,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.subjects.SingleSubject;
 import io.reactivex.subscribers.TestSubscriber;
 
-public class FlowableConcatWithSingleTest {
+public class FlowableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCountTest.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableCountTest {
+public class FlowableCountTest extends RxJavaTest {
     @Test
     public void simpleFlowable() {
         Assert.assertEquals(0, Flowable.empty().count().toFlowable().blockingLast().intValue());

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableCreateTest.java
@@ -29,7 +29,7 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.testsupport.*;
 
-public class FlowableCreateTest {
+public class FlowableCreateTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void sourceNull() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDebounceTest.java
@@ -37,7 +37,7 @@ import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableDebounceTest {
+public class FlowableDebounceTest extends RxJavaTest {
 
     private TestScheduler scheduler;
     private Subscriber<String> Subscriber;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import static org.mockito.Mockito.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.Subscriber;
 
@@ -23,7 +24,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableDefaultIfEmptyTest {
+public class FlowableDefaultIfEmptyTest extends RxJavaTest {
 
     @Test
     public void defaultIfEmpty() {
@@ -54,33 +55,6 @@ public class FlowableDefaultIfEmptyTest {
         verify(subscriber).onNext(10);
         verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    @Ignore("Subscribers should not throw")
-    public void emptyButClientThrows() {
-        final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-
-        Flowable.<Integer>empty().defaultIfEmpty(1).subscribe(new DefaultSubscriber<Integer>() {
-            @Override
-            public void onNext(Integer t) {
-                throw new TestException();
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                subscriber.onError(e);
-            }
-
-            @Override
-            public void onComplete() {
-                subscriber.onComplete();
-            }
-        });
-
-        verify(subscriber).onError(any(TestException.class));
-        verify(subscriber, never()).onNext(any(Integer.class));
-        verify(subscriber, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDeferTest.java
@@ -24,7 +24,7 @@ import io.reactivex.functions.Supplier;
 import io.reactivex.testsupport.TestHelper;
 
 @SuppressWarnings("unchecked")
-public class FlowableDeferTest {
+public class FlowableDeferTest extends RxJavaTest {
 
     @Test
     public void defer() throws Throwable {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -26,7 +26,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableDelaySubscriptionOtherTest {
+public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
     @Test
     public void noPrematureSubscription() {
         PublishProcessor<Object> other = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDelayTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableDelayTest {
+public class FlowableDelayTest extends RxJavaTest {
     private Subscriber<Long> subscriber;
     private Subscriber<Long> subscriber2;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDematerializeTest.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.testsupport.*;
 
-public class FlowableDematerializeTest {
+public class FlowableDematerializeTest extends RxJavaTest {
 
     @Test
     public void simpleSelector() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDetachTest.java
@@ -27,7 +27,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableDetachTest {
+public class FlowableDetachTest extends RxJavaTest {
 
     Object o;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctTest.java
@@ -32,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.testsupport.*;
 
-public class FlowableDistinctTest {
+public class FlowableDistinctTest extends RxJavaTest {
 
     Subscriber<String> w;
 
@@ -100,35 +100,6 @@ public class FlowableDistinctTest {
         inOrder.verify(w, times(1)).onComplete();
         inOrder.verify(w, never()).onNext(anyString());
         verify(w, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    @Ignore("Null values no longer allowed")
-    public void distinctOfSourceWithNulls() {
-        Flowable<String> src = Flowable.just(null, "a", "a", null, null, "b", null);
-        src.distinct().subscribe(w);
-
-        InOrder inOrder = inOrder(w);
-        inOrder.verify(w, times(1)).onNext(null);
-        inOrder.verify(w, times(1)).onNext("a");
-        inOrder.verify(w, times(1)).onNext("b");
-        inOrder.verify(w, times(1)).onComplete();
-        inOrder.verify(w, never()).onNext(anyString());
-        verify(w, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    @Ignore("Null values no longer allowed")
-    public void distinctOfSourceWithExceptionsFromKeySelector() {
-        Flowable<String> src = Flowable.just("a", "b", null, "c");
-        src.distinct(TO_UPPER_WITH_EXCEPTION).subscribe(w);
-
-        InOrder inOrder = inOrder(w);
-        inOrder.verify(w, times(1)).onNext("a");
-        inOrder.verify(w, times(1)).onNext("b");
-        inOrder.verify(w, times(1)).onError(any(NullPointerException.class));
-        inOrder.verify(w, never()).onNext(anyString());
-        inOrder.verify(w, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
@@ -34,7 +35,7 @@ import io.reactivex.processors.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableDistinctUntilChangedTest {
+public class FlowableDistinctUntilChangedTest extends RxJavaTest {
 
     Subscriber<String> w;
     Subscriber<String> w2;
@@ -108,37 +109,6 @@ public class FlowableDistinctUntilChangedTest {
         inOrder.verify(w, times(1)).onComplete();
         inOrder.verify(w, never()).onNext(anyString());
         verify(w, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    @Ignore("Null values no longer allowed")
-    public void distinctUntilChangedOfSourceWithNulls() {
-        Flowable<String> src = Flowable.just(null, "a", "a", null, null, "b", null, null);
-        src.distinctUntilChanged().subscribe(w);
-
-        InOrder inOrder = inOrder(w);
-        inOrder.verify(w, times(1)).onNext(null);
-        inOrder.verify(w, times(1)).onNext("a");
-        inOrder.verify(w, times(1)).onNext(null);
-        inOrder.verify(w, times(1)).onNext("b");
-        inOrder.verify(w, times(1)).onNext(null);
-        inOrder.verify(w, times(1)).onComplete();
-        inOrder.verify(w, never()).onNext(anyString());
-        verify(w, never()).onError(any(Throwable.class));
-    }
-
-    @Test
-    @Ignore("Null values no longer allowed")
-    public void distinctUntilChangedOfSourceWithExceptionsFromKeySelector() {
-        Flowable<String> src = Flowable.just("a", "b", null, "c");
-        src.distinctUntilChanged(TO_UPPER_WITH_EXCEPTION).subscribe(w);
-
-        InOrder inOrder = inOrder(w);
-        inOrder.verify(w, times(1)).onNext("a");
-        inOrder.verify(w, times(1)).onNext("b");
-        verify(w, times(1)).onError(any(NullPointerException.class));
-        inOrder.verify(w, never()).onNext(anyString());
-        inOrder.verify(w, never()).onComplete();
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterNextTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
@@ -28,7 +29,7 @@ import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableDoAfterNextTest {
+public class FlowableDoAfterNextTest extends RxJavaTest {
 
     final List<Integer> values = new ArrayList<Integer>();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoAfterTerminateTest.java
@@ -31,7 +31,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableDoAfterTerminateTest {
+public class FlowableDoAfterTerminateTest extends RxJavaTest {
 
     private Action aAction0;
     private Subscriber<String> subscriber;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoFinallyTest.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.testsupport.*;
 
-public class FlowableDoFinallyTest implements Action {
+public class FlowableDoFinallyTest extends RxJavaTest implements Action {
 
     int calls;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -35,7 +35,7 @@ import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableDoOnEachTest {
+public class FlowableDoOnEachTest extends RxJavaTest {
 
     Subscriber<String> subscribedSubscriber;
     Subscriber<String> sideEffectSubscriber;
@@ -168,37 +168,6 @@ public class FlowableDoOnEachTest {
                     .subscribe();
         }
         assertEquals(expectedCount, count.get());
-    }
-
-    @Test
-    @Ignore("crashing publisher can't propagate to a subscriber")
-    public void fatalError() {
-//        try {
-//            Flowable.just(1, 2, 3)
-//                    .flatMap(new Function<Integer, Flowable<?>>() {
-//                        @Override
-//                        public Flowable<?> apply(Integer integer) {
-//                            return Flowable.create(new Publisher<Object>() {
-//                                @Override
-//                                public void subscribe(Subscriber<Object> subscriber) {
-//                                    throw new NullPointerException("Test NPE");
-//                                }
-//                            });
-//                        }
-//                    })
-//                    .doOnNext(new Consumer<Object>() {
-//                        @Override
-//                        public void accept(Object o) {
-//                            System.out.println("Won't come here");
-//                        }
-//                    })
-//                    .subscribe();
-//            fail("should have thrown an exception");
-//        } catch (OnErrorNotImplementedException e) {
-//            assertTrue(e.getCause() instanceof NullPointerException);
-//            assertEquals(e.getCause().getMessage(), "Test NPE");
-//            System.out.println("Received exception: " + e);
-//        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnLifecycleTest.java
@@ -28,7 +28,7 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableDoOnLifecycleTest {
+public class FlowableDoOnLifecycleTest extends RxJavaTest {
 
     @Test
     public void onSubscribeCrashed() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnRequestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnRequestTest.java
@@ -18,13 +18,14 @@ import static org.junit.Assert.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.functions.*;
 import io.reactivex.subscribers.DefaultSubscriber;
 
-public class FlowableDoOnRequestTest {
+public class FlowableDoOnRequestTest extends RxJavaTest {
 
     @Test
     public void unsubscribeHappensAgainstParent() {
@@ -84,57 +85,5 @@ public class FlowableDoOnRequestTest {
                     }
                 });
         assertEquals(Arrays.asList(3L, 1L, 2L, 3L, 4L, 5L), requests);
-    }
-
-    @Test
-    @Ignore("This is a 1.x architecture-specific test")
-    public void dontRequestIfDownstreamRequestsLate() {
-//        final List<Long> requested = new ArrayList<Long>();
-//
-//        Action1<Long> empty = Actions.empty();
-//
-//        final AtomicReference<Producer> producer = new AtomicReference<Producer>();
-//
-//        Observable.create(new OnSubscribe<Integer>() {
-//            @Override
-//            public void call(Subscriber<? super Integer> t) {
-//                t.setProducer(new Producer() {
-//                    @Override
-//                    public void request(long n) {
-//                        requested.add(n);
-//                    }
-//                });
-//            }
-//        }).doOnRequest(empty).subscribe(new FlowableSubscriber<Object>() {
-//            @Override
-//            public void onNext(Object t) {
-//
-//            }
-//
-//            @Override
-//            public void onError(Throwable e) {
-//
-//            }
-//
-//            @Override
-//            public void onComplete() {
-//
-//            }
-//
-//            @Override
-//            public void setProducer(Producer p) {
-//                producer.set(p);
-//            }
-//        });
-//
-//        producer.get().request(1);
-//
-//        int s = requested.size();
-//        if (s == 1) {
-//            // this allows for an implementation that itself doesn't request
-//            Assert.assertEquals(Arrays.asList(1L), requested);
-//        } else {
-//            Assert.assertEquals(Arrays.asList(0L, 1L), requested);
-//        }
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnSubscribeTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -24,7 +25,7 @@ import io.reactivex.Flowable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 
-public class FlowableDoOnSubscribeTest {
+public class FlowableDoOnSubscribeTest extends RxJavaTest {
 
     @Test
     public void doOnSubscribe() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
@@ -27,7 +28,7 @@ import io.reactivex.functions.*;
 import io.reactivex.processors.BehaviorProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 
-public class FlowableDoOnUnsubscribeTest {
+public class FlowableDoOnUnsubscribeTest extends RxJavaTest {
 
     @Test
     public void doOnUnsubscribe() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -31,7 +31,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableElementAtTest {
+public class FlowableElementAtTest extends RxJavaTest {
 
     @Test
     public void elementAtFlowable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFilterTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFilterTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
@@ -34,7 +35,7 @@ import io.reactivex.processors.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableFilterTest {
+public class FlowableFilterTest extends RxJavaTest {
 
     @Test
     public void filter() {
@@ -63,7 +64,7 @@ public class FlowableFilterTest {
      * @throws InterruptedException if the test is interrupted
      * @throws InterruptedException if the test is interrupted
      */
-    @Test(timeout = 500)
+    @Test
     public void withBackpressure() throws InterruptedException {
         Flowable<String> w = Flowable.just("one", "two", "three");
         Flowable<String> f = w.filter(new Predicate<String>() {
@@ -110,7 +111,7 @@ public class FlowableFilterTest {
      * Make sure we are adjusting subscriber.request() for filtered items.
      * @throws InterruptedException if the test is interrupted
      */
-    @Test(timeout = 500000)
+    @Test
     public void withBackpressure2() throws InterruptedException {
         Flowable<Integer> w = Flowable.range(1, Flowable.bufferSize() * 2);
         Flowable<Integer> f = w.filter(new Predicate<Integer>() {
@@ -150,32 +151,6 @@ public class FlowableFilterTest {
 
         // this will wait forever unless OperatorTake handles the request(n) on filtered items
         latch.await();
-    }
-
-    @Test
-    @Ignore("subscribers are not allowed to throw")
-    public void fatalError() {
-//        try {
-//            Flowable.just(1)
-//            .filter(new Predicate<Integer>() {
-//                @Override
-//                public boolean test(Integer t) {
-//                    return true;
-//                }
-//            })
-//            .first()
-//            .subscribe(new Consumer<Integer>() {
-//                @Override
-//                public void accept(Integer t) {
-//                    throw new TestException();
-//                }
-//            });
-//            Assert.fail("No exception was thrown");
-//        } catch (OnErrorNotImplementedException ex) {
-//            if (!(ex.getCause() instanceof TestException)) {
-//                Assert.fail("Failed to report the original exception, instead: " + ex.getCause());
-//            }
-//        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFirstTest.java
@@ -25,7 +25,7 @@ import io.reactivex.*;
 import io.reactivex.functions.Predicate;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableFirstTest {
+public class FlowableFirstTest extends RxJavaTest {
 
     Subscriber<String> w;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableFlatMapCompletableTest {
+public class FlowableFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void normalFlowable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableFlatMapMaybeTest {
+public class FlowableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableFlatMapSingleTest {
+public class FlowableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -33,7 +34,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableFlatMapTest {
+public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void normal() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -440,46 +441,7 @@ public class FlowableFlatMapTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    @Ignore("Don't care for any reordering")
-    @Test(timeout = 10000)
-    public void flatMapRangeAsyncLoop() {
-        for (int i = 0; i < 2000; i++) {
-            if (i % 10 == 0) {
-                System.out.println("flatMapRangeAsyncLoop > " + i);
-            }
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
-            Flowable.range(0, 1000)
-            .flatMap(new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer t) {
-                    return Flowable.just(t);
-                }
-            })
-            .observeOn(Schedulers.computation())
-            .subscribe(ts);
-
-            ts.awaitDone(2500, TimeUnit.MILLISECONDS);
-            if (ts.completions() == 0) {
-                System.out.println(ts.values().size());
-            }
-            ts.assertTerminated();
-            ts.assertNoErrors();
-            List<Integer> list = ts.values();
-            assertEquals(1000, list.size());
-            boolean f = false;
-            for (int j = 0; j < list.size(); j++) {
-                if (list.get(j) != j) {
-                    System.out.println(j + " " + list.get(j));
-                    f = true;
-                }
-            }
-            if (f) {
-                Assert.fail("Results are out of order!");
-            }
-        }
-    }
-
-    @Test(timeout = 30000)
+    @Test
     public void flatMapRangeMixedAsyncLoop() {
         for (int i = 0; i < 2000; i++) {
             if (i % 10 == 0) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -35,7 +35,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableFlattenIterableTest {
+public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void normal0() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableForEachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableForEachTest.java
@@ -17,13 +17,14 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 
-public class FlowableForEachTest {
+public class FlowableForEachTest extends RxJavaTest {
 
     @Test
     public void forEachWile() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromArrayTest.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.fuseable.ScalarSupplier;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableFromArrayTest {
+public class FlowableFromArrayTest extends RxJavaTest {
 
     Flowable<Integer> create(int n) {
         Integer[] array = new Integer[n];

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromCallableTest.java
@@ -35,7 +35,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableFromCallableTest {
+public class FlowableFromCallableTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test
@@ -243,7 +243,7 @@ public class FlowableFromCallableTest {
         .assertFailure(NullPointerException.class);
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void undeliverableUponCancellation() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromIterableTest.java
@@ -35,7 +35,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableFromIterableTest {
+public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullValue() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromObservableTest.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableFromObservableTest {
+public class FlowableFromObservableTest extends RxJavaTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Observable.just(1).toFlowable(BackpressureStrategy.MISSING));

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSourceTest.java
@@ -26,7 +26,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableFromSourceTest {
+public class FlowableFromSourceTest extends RxJavaTest {
 
     PublishAsyncEmitter source;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFromSupplierTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -35,7 +36,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableFromSupplierTest {
+public class FlowableFromSupplierTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test
@@ -243,7 +244,7 @@ public class FlowableFromSupplierTest {
         .assertFailure(NullPointerException.class);
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void undeliverableUponCancellation() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGenerateTest.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableGenerateTest {
+public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void statefulBiconsumer() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupByTest.java
@@ -41,7 +41,7 @@ import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableGroupByTest {
+public class FlowableGroupByTest extends RxJavaTest {
 
     final Function<String, Integer> length = new Function<String, Integer>() {
         @Override
@@ -506,7 +506,7 @@ public class FlowableGroupByTest {
         assertEquals(100, eventCounter.get());
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void completionIfInnerNotSubscribed() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger eventCounter = new AtomicInteger();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -34,7 +34,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableGroupJoinTest {
+public class FlowableGroupJoinTest extends RxJavaTest {
 
     Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableHideTest.java
@@ -25,7 +25,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableHideTest {
+public class FlowableHideTest extends RxJavaTest {
     @Test
     public void hiding() {
         PublishProcessor<Integer> src = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -29,7 +29,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableIgnoreElementsTest {
+public class FlowableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void withEmptyFlowable() {
@@ -95,7 +95,7 @@ public class FlowableIgnoreElementsTest {
         assertTrue(unsub.get());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void doesNotHangAndProcessesAllUsingBackpressureFlowable() {
         final AtomicInteger upstreamCount = new AtomicInteger();
         final AtomicInteger count = new AtomicInteger(0);
@@ -145,12 +145,12 @@ public class FlowableIgnoreElementsTest {
         assertEquals(0, count.get());
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void withEmpty() {
         Flowable.empty().ignoreElements().blockingAwait();
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void withNonEmpty() {
         Flowable.just(1, 2, 3).ignoreElements().blockingAwait();
     }
@@ -206,7 +206,7 @@ public class FlowableIgnoreElementsTest {
         assertTrue(unsub.get());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void doesNotHangAndProcessesAllUsingBackpressure() {
         final AtomicInteger upstreamCount = new AtomicInteger();
         final AtomicInteger count = new AtomicInteger(0);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableInternalHelperTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableInternalHelperTest.java
@@ -12,11 +12,12 @@
  */
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableInternalHelperTest {
+public class FlowableInternalHelperTest extends RxJavaTest {
 
     @Test
     public void utilityClass() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalRangeTest.java
@@ -27,7 +27,7 @@ import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableIntervalRangeTest {
+public class FlowableIntervalRangeTest extends RxJavaTest {
     @Test
     public void simple() throws Exception {
         Flowable.intervalRange(5, 5, 50, 50, TimeUnit.MILLISECONDS)
@@ -111,7 +111,7 @@ public class FlowableIntervalRangeTest {
         .assertResult(1L);
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void cancel() {
         Flowable.intervalRange(0, 20, 1, 1, TimeUnit.MILLISECONDS, Schedulers.trampoline())
         .take(10)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableIntervalTest.java
@@ -23,9 +23,9 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableIntervalTest {
+public class FlowableIntervalTest extends RxJavaTest {
 
-    @Test(timeout = 2000)
+    @Test
     public void cancel() {
         Flowable.interval(1, TimeUnit.MILLISECONDS, Schedulers.trampoline())
         .take(10)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableJoinTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.mockito.MockitoAnnotations;
 import org.reactivestreams.Subscriber;
@@ -33,7 +34,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableJoinTest {
+public class FlowableJoinTest extends RxJavaTest {
     Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
     BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLastTest.java
@@ -26,7 +26,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableLastTest {
+public class FlowableLastTest extends RxJavaTest {
 
     @Test
     public void lastWithElements() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLiftTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLiftTest.java
@@ -25,7 +25,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableLiftTest {
+public class FlowableLiftTest extends RxJavaTest {
 
     @Test
     public void callbackCrash() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableLimitTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableLimitTest.java
@@ -29,7 +29,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableLimitTest implements LongConsumer, Action {
+public class FlowableLimitTest extends RxJavaTest implements LongConsumer, Action {
 
     final List<Long> requests = new ArrayList<Long>();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapNotificationTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.flowable;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -26,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableMapNotificationTest {
+public class FlowableMapNotificationTest extends RxJavaTest {
     @Test
     public void just() {
         TestSubscriber<Object> ts = new TestSubscriber<Object>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMapTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.util.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -34,7 +35,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableMapTest {
+public class FlowableMapTest extends RxJavaTest {
 
     Subscriber<String> stringSubscriber;
     Subscriber<String> stringSubscriber2;
@@ -264,79 +265,6 @@ public class FlowableMapTest {
         m.put("firstName", prefix + "First");
         m.put("lastName", prefix + "Last");
         return m;
-    }
-
-    @Test//(expected = OnErrorNotImplementedException.class)
-    @Ignore("RS subscribers can't throw")
-    public void shouldNotSwallowOnErrorNotImplementedException() {
-//        Flowable.just("a", "b").flatMap(new Function<String, Flowable<String>>() {
-//            @Override
-//            public Flowable<String> apply(String s) {
-//                return Flowable.just(s + "1", s + "2");
-//            }
-//        }).flatMap(new Function<String, Flowable<String>>() {
-//            @Override
-//            public Flowable<String> apply(String s) {
-//                return Flowable.error(new Exception("test"));
-//            }
-//        }).forEach(new Consumer<String>() {
-//            @Override
-//            public void accept(String s) {
-//                System.out.println(s);
-//            }
-//        });
-    }
-
-    @Test//(expected = OnErrorNotImplementedException.class)
-    @Ignore("RS subscribers can't throw")
-    public void verifyExceptionIsThrownIfThereIsNoExceptionHandler() {
-//
-//        Flowable.OnSubscribe<Object> creator = new Flowable.OnSubscribe<Object>() {
-//
-//            @Override
-//            public void call(Subscriber<? super Object> subscriber) {
-//                subscriber.onNext("a");
-//                subscriber.onNext("b");
-//                subscriber.onNext("c");
-//                subscriber.onComplete();
-//            }
-//        };
-//
-//        Func1<Object, Flowable<Object>> manyMapper = new Func1<Object, Flowable<Object>>() {
-//
-//            @Override
-//            public Flowable<Object> call(Object object) {
-//                return Flowable.just(object);
-//            }
-//        };
-//
-//        Func1<Object, Object> mapper = new Func1<Object, Object>() {
-//            private int count = 0;
-//
-//            @Override
-//            public Object call(Object object) {
-//                ++count;
-//                if (count > 2) {
-//                    throw new RuntimeException();
-//                }
-//                return object;
-//            }
-//        };
-//
-//        Action1<Object> onNext = new Action1<Object>() {
-//
-//            @Override
-//            public void call(Object object) {
-//                System.out.println(object.toString());
-//            }
-//        };
-//
-//        try {
-//            Flowable.create(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
-//        } catch (RuntimeException e) {
-//            e.printStackTrace();
-//            throw e;
-//        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMaterializeTest.java
@@ -28,7 +28,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableMaterializeTest {
+public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void materialize1() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -29,7 +30,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestSubscriberEx;
 
-public class FlowableMergeMaxConcurrentTest {
+public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
 
     @Test
     public void whenMaxConcurrentIsOne() {
@@ -185,7 +186,7 @@ public class FlowableMergeMaxConcurrentTest {
         }
     }
 
-    @Test//(timeout = 20000)
+    @Test
     public void simpleAsyncLoop() {
         IoScheduler ios = (IoScheduler)Schedulers.io();
         int c = ios.size();
@@ -198,7 +199,7 @@ public class FlowableMergeMaxConcurrentTest {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void simpleAsync() {
         for (int i = 1; i < 50; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
@@ -219,14 +220,14 @@ public class FlowableMergeMaxConcurrentTest {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void simpleOneLessAsyncLoop() {
         for (int i = 0; i < 200; i++) {
             simpleOneLessAsync();
         }
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void simpleOneLessAsync() {
         long t = System.currentTimeMillis();
         for (int i = 2; i < 50; i++) {
@@ -251,7 +252,7 @@ public class FlowableMergeMaxConcurrentTest {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void backpressureHonored() throws Exception {
         List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(3);
 
@@ -282,7 +283,7 @@ public class FlowableMergeMaxConcurrentTest {
         ts.cancel();
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void take() throws Exception {
         List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(3);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -25,7 +25,7 @@ import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableMergeWithCompletableTest {
+public class FlowableMergeWithCompletableTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
@@ -32,7 +32,7 @@ import io.reactivex.subjects.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableMergeWithMaybeTest {
+public class FlowableMergeWithMaybeTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -32,7 +32,7 @@ import io.reactivex.subjects.SingleSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableMergeWithSingleTest {
+public class FlowableMergeWithSingleTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableObserveOnTest.java
@@ -40,7 +40,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableObserveOnTest {
+public class FlowableObserveOnTest extends RxJavaTest {
 
     /**
      * This is testing a no-op path since it uses Schedulers.immediate() which will not do scheduling.
@@ -58,8 +58,6 @@ public class FlowableObserveOnTest {
 
     @Test
     public void ordering() throws InterruptedException {
-//        Flowable<String> obs = Flowable.just("one", null, "two", "three", "four");
-        // FIXME null values not allowed
         Flowable<String> obs = Flowable.just("one", "null", "two", "three", "four");
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
@@ -89,8 +87,6 @@ public class FlowableObserveOnTest {
     @Test
     public void threadName() throws InterruptedException {
         System.out.println("Main Thread: " + Thread.currentThread().getName());
-        // FIXME null values not allowed
-//        Flowable<String> obs = Flowable.just("one", null, "two", "three", "four");
         Flowable<String> obs = Flowable.just("one", "null", "two", "three", "four");
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferStrategyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferStrategyTest.java
@@ -31,9 +31,9 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableOnBackpressureBufferStrategyTest {
+public class FlowableOnBackpressureBufferStrategyTest extends RxJavaTest {
 
-    @Test(timeout = 2000)
+    @Test
     public void backpressureWithBufferDropOldest() throws InterruptedException {
         int bufferSize = 3;
         final AtomicInteger droppedCount = new AtomicInteger(0);
@@ -79,7 +79,7 @@ public class FlowableOnBackpressureBufferStrategyTest {
         }, 0L);
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void backpressureWithBufferDropLatest() throws InterruptedException {
         int bufferSize = 3;
         final AtomicInteger droppedCount = new AtomicInteger(0);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -30,7 +31,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestSubscriberEx;
 
-public class FlowableOnBackpressureBufferTest {
+public class FlowableOnBackpressureBufferTest extends RxJavaTest {
 
     @Test
     public void noBackpressureSupport() {
@@ -44,7 +45,7 @@ public class FlowableOnBackpressureBufferTest {
         ts.assertNoErrors();
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void fixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -28,7 +29,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableOnBackpressureDropTest {
+public class FlowableOnBackpressureDropTest extends RxJavaTest {
 
     @Test
     public void noBackpressureSupport() {
@@ -42,14 +43,14 @@ public class FlowableOnBackpressureDropTest {
         ts.assertNoErrors();
     }
 
-    @Test(timeout = 500)
+    @Test
     public void withObserveOn() throws InterruptedException {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Flowable.range(0, Flowable.bufferSize() * 10).onBackpressureDrop().observeOn(Schedulers.io()).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void fixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureErrorTest.java
@@ -20,7 +20,7 @@ import io.reactivex.*;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableOnBackpressureErrorTest {
+public class FlowableOnBackpressureErrorTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.Publisher;
 
@@ -27,7 +28,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableOnBackpressureLatestTest {
+public class FlowableOnBackpressureLatestTest extends RxJavaTest {
     @Test
     public void simple() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
@@ -30,7 +31,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableOnErrorResumeNextViaFlowableTest {
+public class FlowableOnErrorResumeNextViaFlowableTest extends RxJavaTest {
 
     @Test
     public void resumeNext() {
@@ -100,53 +101,6 @@ public class FlowableOnErrorResumeNextViaFlowableTest {
         verify(subscriber, Mockito.never()).onNext("three");
         verify(subscriber, times(1)).onNext("twoResume");
         verify(subscriber, times(1)).onNext("threeResume");
-    }
-
-    @Test
-    @Ignore("Publishers should not throw")
-    public void resumeNextWithFailureOnSubscribe() {
-        Flowable<String> testObservable = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> t1) {
-                throw new RuntimeException("force failure");
-            }
-
-        });
-        Flowable<String> resume = Flowable.just("resume");
-        Flowable<String> flowable = testObservable.onErrorResumeWith(resume);
-
-        Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        flowable.subscribe(subscriber);
-
-        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
-        verify(subscriber, times(1)).onComplete();
-        verify(subscriber, times(1)).onNext("resume");
-    }
-
-    @Test
-    @Ignore("Publishers should not throw")
-    public void resumeNextWithFailureOnSubscribeAsync() {
-        Flowable<String> testObservable = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> t1) {
-                throw new RuntimeException("force failure");
-            }
-
-        });
-        Flowable<String> resume = Flowable.just("resume");
-        Flowable<String> flowable = testObservable.subscribeOn(Schedulers.io()).onErrorResumeWith(resume);
-
-        Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
-        flowable.subscribe(ts);
-
-        ts.awaitDone(5, TimeUnit.SECONDS);
-
-        verify(subscriber, Mockito.never()).onError(any(Throwable.class));
-        verify(subscriber, times(1)).onComplete();
-        verify(subscriber, times(1)).onNext("resume");
     }
 
     static final class TestObservable implements Publisher<String> {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
@@ -32,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableOnErrorReturnTest {
+public class FlowableOnErrorReturnTest extends RxJavaTest {
 
     @Test
     public void resumeNext() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -34,7 +35,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowablePublishFunctionTest {
+public class FlowablePublishFunctionTest extends RxJavaTest {
     @Test
     public void concatTakeFirstLastCompletes() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishMulticastTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.internal.fuseable.QueueSubscription;
@@ -27,7 +28,7 @@ import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowablePublishMulticastTest {
+public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void asyncFusedInput() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowablePublishTest.java
@@ -38,7 +38,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowablePublishTest {
+public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void publish() throws InterruptedException {
@@ -189,7 +189,7 @@ public class FlowablePublishTest {
         System.out.println(ts.values());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void backpressureTwoConsumers() {
         final AtomicInteger sourceEmission = new AtomicInteger();
         final AtomicBoolean sourceUnsubscribed = new AtomicBoolean();
@@ -730,7 +730,7 @@ public class FlowablePublishTest {
         assertFalse(pp.hasSubscribers());
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void selectorLatecommer() {
         Flowable.range(1, 5)
         .publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
@@ -981,7 +981,6 @@ public class FlowablePublishTest {
     }
 
     @Test
-    @Ignore("publish() keeps consuming the upstream if there are no subscribers, 3.x should change this")
     public void subscriberSwap() {
         final ConnectableFlowable<Integer> cf = Flowable.range(1, 5).publish();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeLongTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
@@ -29,7 +30,7 @@ import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableRangeLongTest {
+public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void rangeStartAt2Count3() {
@@ -254,7 +255,7 @@ public class FlowableRangeLongTest {
         assertTrue(completed.get());
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void nearMaxValueWithoutBackpressure() {
         TestSubscriber<Long> ts = new TestSubscriber<Long>();
         Flowable.rangeLong(Long.MAX_VALUE - 1L, 2L).subscribe(ts);
@@ -264,7 +265,7 @@ public class FlowableRangeLongTest {
         ts.assertValues(Long.MAX_VALUE - 1L, Long.MAX_VALUE);
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void nearMaxValueWithBackpressure() {
         TestSubscriber<Long> ts = new TestSubscriber<Long>(3L);
         Flowable.rangeLong(Long.MAX_VALUE - 1L, 2L).subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRangeTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
@@ -29,7 +30,7 @@ import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableRangeTest {
+public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void rangeStartAt2Count3() {
@@ -254,7 +255,7 @@ public class FlowableRangeTest {
         assertTrue(completed.get());
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void nearMaxValueWithoutBackpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         Flowable.range(Integer.MAX_VALUE - 1, 2).subscribe(ts);
@@ -264,7 +265,7 @@ public class FlowableRangeTest {
         ts.assertValues(Integer.MAX_VALUE - 1, Integer.MAX_VALUE);
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void nearMaxValueWithBackpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(3L);
         Flowable.range(Integer.MAX_VALUE - 1, 2).subscribe(ts);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableReduceTest {
+public class FlowableReduceTest extends RxJavaTest {
     Subscriber<Object> subscriber;
 
     SingleObserver<Object> singleObserver;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReduceWithSingleTest.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.BiFunction;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableReduceWithSingleTest {
+public class FlowableReduceWithSingleTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -41,7 +41,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableRefCountTest {
+public class FlowableRefCountTest extends RxJavaTest {
 
     @Test
     public void refCountAsync() {
@@ -531,7 +531,7 @@ public class FlowableRefCountTest {
         ts2.assertValue(30);
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void upstreamErrorAllowsRetry() throws InterruptedException {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -1020,7 +1020,7 @@ public class FlowableRefCountTest {
         }
     }
 
-    @Test(timeout = 7500)
+    @Test
     public void blockingSourceAsnycCancel() throws Exception {
         BehaviorProcessor<Integer> bp = BehaviorProcessor.createDefault(1);
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRepeatTest.java
@@ -36,7 +36,7 @@ import io.reactivex.testsupport.*;
 
 public class FlowableRepeatTest {
 
-    @Test(timeout = 2000)
+    @Test
     public void repetition() {
         int num = 10;
         final AtomicInteger count = new AtomicInteger();
@@ -53,14 +53,14 @@ public class FlowableRepeatTest {
         assertEquals(num, value);
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void repeatTake() {
         Flowable<Integer> xs = Flowable.just(1, 2);
         Object[] ys = xs.repeat().subscribeOn(Schedulers.newThread()).take(4).toList().blockingGet().toArray();
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);
     }
 
-    @Test(timeout = 20000)
+    @Test
     public void noStackOverFlow() {
         Flowable.just(1).repeat().subscribeOn(Schedulers.newThread()).take(100000).blockingLast();
     }
@@ -99,7 +99,7 @@ public class FlowableRepeatTest {
         assertArrayEquals(new Object[] { 1, 2, 1, 2 }, ys);
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void repeatAndTake() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -110,7 +110,7 @@ public class FlowableRepeatTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void repeatLimited() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -121,7 +121,7 @@ public class FlowableRepeatTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void repeatError() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -133,7 +133,7 @@ public class FlowableRepeatTest {
 
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void repeatZero() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -144,7 +144,7 @@ public class FlowableRepeatTest {
         verify(subscriber, never()).onError(any(Throwable.class));
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void repeatOne() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -173,7 +173,7 @@ public class FlowableRepeatTest {
     }
 
     /** Issue #2844: wrong target of request. */
-    @Test(timeout = 3000)
+    @Test
     public void repeatRetarget() {
         final List<Integer> concatBase = new ArrayList<Integer>();
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -42,7 +42,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableReplayEagerTruncateTest {
+public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void bufferedReplay() {
         PublishProcessor<Integer> source = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableReplayTest.java
@@ -42,7 +42,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableReplayTest {
+public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void bufferedReplay() {
         PublishProcessor<Integer> source = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.mockito.*;
 import org.reactivestreams.*;
@@ -37,7 +38,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableRetryTest {
+public class FlowableRetryTest extends RxJavaTest {
 
     @Test
     public void iterativeBackoff() {
@@ -664,7 +665,7 @@ public class FlowableRetryTest {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void unsubscribeAfterError() {
 
         Subscriber<Long> subscriber = TestHelper.mockSubscriber();
@@ -688,7 +689,7 @@ public class FlowableRetryTest {
         assertEquals("Only 1 active subscription", 1, so.maxActive.get());
     }
 
-    @Test//(timeout = 10000)
+    @Test
     public void timeoutWithRetry() {
 
         Subscriber<Long> subscriber = TestHelper.mockSubscriber();
@@ -711,7 +712,7 @@ public class FlowableRetryTest {
         assertEquals("Start 6 threads, retry 5 then fail on 6", 6, sf.efforts.get());
     }
 
-    @Test//(timeout = 15000)
+    @Test
     public void retryWithBackpressure() throws InterruptedException {
         final int NUM_LOOPS = 1;
         for (int j = 0; j < NUM_LOOPS; j++) {
@@ -737,7 +738,7 @@ public class FlowableRetryTest {
         }
     }
 
-    @Test//(timeout = 15000)
+    @Test
     public void retryWithBackpressureParallel() throws InterruptedException {
         final int NUM_LOOPS = 1;
         final int numRetries = Flowable.bufferSize() * 2;
@@ -837,7 +838,7 @@ public class FlowableRetryTest {
         return sb;
     }
 
-    @Test//(timeout = 3000)
+    @Test
     public void issue1900() throws InterruptedException {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         final int NUM_MSG = 1034;
@@ -878,7 +879,7 @@ public class FlowableRetryTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    @Test//(timeout = 3000)
+    @Test
     public void issue1900SourceNotSupportingBackpressure() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         final int NUM_MSG = 1034;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
@@ -36,7 +37,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableRetryWithPredicateTest {
+public class FlowableRetryWithPredicateTest extends RxJavaTest {
     BiPredicate<Integer, Throwable> retryTwice = new BiPredicate<Integer, Throwable>() {
         @Override
         public boolean test(Integer t1, Throwable t2) {
@@ -224,7 +225,7 @@ public class FlowableRetryWithPredicateTest {
         assertEquals(1, count.get());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void unsubscribeAfterError() {
 
         Subscriber<Long> subscriber = TestHelper.mockSubscriber();
@@ -250,7 +251,7 @@ public class FlowableRetryWithPredicateTest {
         assertEquals("Only 1 active subscription", 1, so.maxActive.get());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void timeoutWithRetry() {
 
         Subscriber<Long> subscriber = TestHelper.mockSubscriber();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSampleTest.java
@@ -31,7 +31,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSampleTest {
+public class FlowableSampleTest extends RxJavaTest {
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
     private Subscriber<Long> subscriber;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScalarXMapTest.java
@@ -25,7 +25,7 @@ import io.reactivex.internal.subscriptions.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableScalarXMapTest {
+public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void utilityClass() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableScanTest.java
@@ -33,7 +33,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableScanTest {
+public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void scanIntegersWithInitialValue() {
@@ -366,44 +366,6 @@ public class FlowableScanTest {
 
         verify(producer.get(), never()).request(0);
         verify(producer.get(), times(1)).request(Flowable.bufferSize() - 1);
-    }
-
-    @Test
-    @Ignore("scanSeed no longer emits without upstream signal")
-    public void initialValueEmittedNoProducer() {
-        PublishProcessor<Integer> source = PublishProcessor.create();
-
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        source.scan(0, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        }).subscribe(ts);
-
-        ts.assertNoErrors();
-        ts.assertNotComplete();
-        ts.assertValue(0);
-    }
-
-    @Test
-    @Ignore("scanSeed no longer emits without upstream signal")
-    public void initialValueEmittedWithProducer() {
-        Flowable<Integer> source = Flowable.never();
-
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-
-        source.scan(0, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        }).subscribe(ts);
-
-        ts.assertNoErrors();
-        ts.assertNotComplete();
-        ts.assertValue(0);
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSequenceEqualTest {
+public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void flowable1() {
@@ -107,22 +107,6 @@ public class FlowableSequenceEqualTest {
     public void withEmpty3Flowable() {
         Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.<String> empty(), Flowable.<String> empty()).toFlowable();
-        verifyResult(flowable, true);
-    }
-
-    @Test
-    @Ignore("Null values not allowed")
-    public void withNull1Flowable() {
-        Flowable<Boolean> flowable = Flowable.sequenceEqual(
-                Flowable.just((String) null), Flowable.just("one")).toFlowable();
-        verifyResult(flowable, false);
-    }
-
-    @Test
-    @Ignore("Null values not allowed")
-    public void withNull2Flowable() {
-        Flowable<Boolean> flowable = Flowable.sequenceEqual(
-                Flowable.just((String) null), Flowable.just((String) null)).toFlowable();
         verifyResult(flowable, true);
     }
 
@@ -211,22 +195,6 @@ public class FlowableSequenceEqualTest {
     public void withEmpty3() {
         Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.<String> empty(), Flowable.<String> empty());
-        verifyResult(single, true);
-    }
-
-    @Test
-    @Ignore("Null values not allowed")
-    public void withNull1() {
-        Single<Boolean> single = Flowable.sequenceEqual(
-                Flowable.just((String) null), Flowable.just("one"));
-        verifyResult(single, false);
-    }
-
-    @Test
-    @Ignore("Null values not allowed")
-    public void withNull2() {
-        Single<Boolean> single = Flowable.sequenceEqual(
-                Flowable.just((String) null), Flowable.just((String) null));
         verifyResult(single, true);
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSerializeTest.java
@@ -27,7 +27,7 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSerializeTest {
+public class FlowableSerializeTest extends RxJavaTest {
 
     Subscriber<String> subscriber;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSingleTest.java
@@ -30,7 +30,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSingleTest {
+public class FlowableSingleTest extends RxJavaTest {
 
     @Test
     public void singleFlowable() {
@@ -634,7 +634,7 @@ public class FlowableSingleTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    @Test(timeout = 30000)
+    @Test
     public void issue1527() throws InterruptedException {
         //https://github.com/ReactiveX/RxJava/pull/1527
         Flowable<Integer> source = Flowable.just(1, 2, 3, 4, 5, 6);
@@ -686,7 +686,7 @@ public class FlowableSingleTest {
             .assertError(RuntimeException.class);
     }
 
-    @Test(timeout = 30000)
+    @Test
     public void issue1527Flowable() throws InterruptedException {
         //https://github.com/ReactiveX/RxJava/pull/1527
         Flowable<Integer> source = Flowable.just(1, 2, 3, 4, 5, 6);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
@@ -30,7 +31,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSkipLastTest {
+public class FlowableSkipLastTest extends RxJavaTest {
 
     @Test
     public void skipLastEmpty() {
@@ -81,21 +82,6 @@ public class FlowableSkipLastTest {
 
         verify(subscriber, times(1)).onNext("one");
         verify(subscriber, times(1)).onNext("two");
-        verify(subscriber, never()).onError(any(Throwable.class));
-        verify(subscriber, times(1)).onComplete();
-    }
-
-    @Test
-    @Ignore("Null values not allowed")
-    public void skipLastWithNull() {
-        Flowable<String> flowable = Flowable.fromIterable(Arrays.asList("one", null, "two")).skipLast(1);
-
-        Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        flowable.subscribe(subscriber);
-
-        verify(subscriber, times(1)).onNext("one");
-        verify(subscriber, times(1)).onNext(null);
-        verify(subscriber, never()).onNext("two");
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber, times(1)).onComplete();
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -29,7 +29,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSkipLastTimedTest {
+public class FlowableSkipLastTimedTest extends RxJavaTest {
 
     @Test
     public void skipLastTimed() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
@@ -28,7 +29,7 @@ import io.reactivex.functions.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableSkipTest {
+public class FlowableSkipTest extends RxJavaTest {
 
     @Test
     public void skipNegativeElements() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipTimedTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSkipTimedTest {
+public class FlowableSkipTimedTest extends RxJavaTest {
 
     @Test
     public void skipTimed() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipUntilTest.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSkipUntilTest {
+public class FlowableSkipUntilTest extends RxJavaTest {
     Subscriber<Object> subscriber;
 
     @Before

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSkipWhileTest.java
@@ -26,7 +26,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableSkipWhileTest {
+public class FlowableSkipWhileTest extends RxJavaTest {
 
     Subscriber<Integer> w = TestHelper.mockSubscriber();
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -32,9 +32,9 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableSubscribeOnTest {
+public class FlowableSubscribeOnTest extends RxJavaTest{
 
-    @Test(timeout = 2000)
+    @Test
     public void issue813() throws InterruptedException {
         // https://github.com/ReactiveX/RxJava/issues/813
         final CountDownLatch scheduled = new CountDownLatch(1);
@@ -75,22 +75,6 @@ public class FlowableSubscribeOnTest {
         doneLatch.await();
         ts.assertNoErrors();
         ts.assertComplete();
-    }
-
-    @Test
-    @Ignore("Publisher.subscribe can't throw")
-    public void thrownErrorHandling() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
-        Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> s) {
-                throw new RuntimeException("fail");
-            }
-
-        }).subscribeOn(Schedulers.computation()).subscribe(ts);
-        ts.awaitDone(1000, TimeUnit.MILLISECONDS);
-        ts.assertTerminated();
     }
 
     @Test
@@ -166,7 +150,7 @@ public class FlowableSubscribeOnTest {
 
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void unsubscribeInfiniteStream() throws InterruptedException {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         final AtomicInteger count = new AtomicInteger();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -29,7 +30,7 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 
-public class FlowableSwitchIfEmptyTest {
+public class FlowableSwitchIfEmptyTest extends RxJavaTest {
 
     @Test
     public void switchWhenNotEmpty() throws Exception {
@@ -172,7 +173,7 @@ public class FlowableSwitchIfEmptyTest {
         ts.assertNoValues();
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void requestsNotLost() throws InterruptedException {
         final TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.unsafeCreate(new Publisher<Long>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -37,7 +37,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableSwitchTest {
+public class FlowableSwitchTest extends RxJavaTest {
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
@@ -547,7 +547,7 @@ public class FlowableSwitchTest {
         Assert.assertEquals(250, ts.values().size());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void initialRequestsAreAdditive() {
         TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.switchOnNext(
@@ -566,7 +566,7 @@ public class FlowableSwitchTest {
         ts.awaitDone(5, TimeUnit.SECONDS);
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void initialRequestsDontOverflow() {
         TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.switchOnNext(
@@ -583,7 +583,7 @@ public class FlowableSwitchTest {
         assertTrue(ts.values().size() > 0);
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void secondaryRequestsDontOverflow() throws InterruptedException {
         TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
         Flowable.switchOnNext(
@@ -601,38 +601,6 @@ public class FlowableSwitchTest {
         ts.request(Long.MAX_VALUE - 1);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertValueCount(7);
-    }
-
-    @Test(timeout = 10000)
-    @Ignore("Request pattern changed and I can't decide if this is okay or not")
-    public void secondaryRequestsAdditivelyAreMoreThanLongMaxValueInducesMaxValueRequestFromUpstream()
-            throws InterruptedException {
-        final List<Long> requests = new CopyOnWriteArrayList<Long>();
-
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L);
-        Flowable.switchOnNext(
-                Flowable.interval(100, TimeUnit.MILLISECONDS)
-                        .map(new Function<Long, Flowable<Long>>() {
-                            @Override
-                            public Flowable<Long> apply(Long t) {
-                                return Flowable.fromIterable(Arrays.asList(1L, 2L, 3L))
-                                        .doOnRequest(new LongConsumer() {
-                                            @Override
-                                            public void accept(long v) {
-                                                requests.add(v);
-                                            }
-                                        });
-                            }
-                        }).take(3)).subscribe(ts);
-        // we will miss two of the first observables
-        Thread.sleep(250);
-        ts.request(Long.MAX_VALUE - 1);
-        ts.request(Long.MAX_VALUE - 1);
-        ts.awaitDone(5, TimeUnit.SECONDS);
-        assertTrue(ts.values().size() > 0);
-        System.out.println(requests);
-        assertEquals(5, requests.size());
-        assertEquals(Long.MAX_VALUE, (long) requests.get(requests.size() - 1));
     }
 
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastOneTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
@@ -26,7 +27,7 @@ import io.reactivex.functions.*;
 import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableTakeLastOneTest {
+public class FlowableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void lastOfManyReturnsLast() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
@@ -31,7 +32,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableTakeLastTest {
+public class FlowableTakeLastTest extends RxJavaTest {
 
     @Test
     public void takeLastEmpty() {
@@ -84,22 +85,6 @@ public class FlowableTakeLastTest {
         take.subscribe(subscriber);
 
         verify(subscriber, never()).onNext("one");
-        verify(subscriber, never()).onError(any(Throwable.class));
-        verify(subscriber, times(1)).onComplete();
-    }
-
-    @Test
-    @Ignore("Null values no longer allowed")
-    public void takeLastWithNull() {
-        Flowable<String> w = Flowable.just("one", null, "three");
-        Flowable<String> take = w.takeLast(2);
-
-        Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        take.subscribe(subscriber);
-
-        verify(subscriber, never()).onNext("one");
-        verify(subscriber, times(1)).onNext(null);
-        verify(subscriber, times(1)).onNext("three");
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber, times(1)).onComplete();
     }
@@ -216,7 +201,7 @@ public class FlowableTakeLastTest {
         });
     }
 
-    @Test(timeout = 30000)
+    @Test
     public void ignoreRequest3() {
         // If `takeLast` does not ignore `request` properly, it will enter an infinite loop.
         Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
@@ -296,7 +281,7 @@ public class FlowableTakeLastTest {
         assertEquals(1, count.get());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void requestOverflow() {
         final List<Integer> list = new ArrayList<Integer>();
         Flowable.range(1, 100).takeLast(50).subscribe(new DefaultSubscriber<Integer>() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -29,7 +29,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableTakeLastTimedTest {
+public class FlowableTakeLastTimedTest extends RxJavaTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void takeLastTimedWithNegativeCount() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTest.java
@@ -34,7 +34,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableTakeTest {
+public class FlowableTakeTest extends RxJavaTest {
 
     @Test
     public void take1() {
@@ -143,34 +143,6 @@ public class FlowableTakeTest {
     }
 
     @Test
-    @Ignore("take(0) is now empty() and doesn't even subscribe to the original source")
-    public void takeZeroDoesntLeakError() {
-        final AtomicBoolean subscribed = new AtomicBoolean(false);
-        final BooleanSubscription bs = new BooleanSubscription();
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscribed.set(true);
-                subscriber.onSubscribe(bs);
-                subscriber.onError(new Throwable("test failed"));
-            }
-        });
-
-        Subscriber<String> subscriber = TestHelper.mockSubscriber();
-
-        source.take(0).subscribe(subscriber);
-
-        assertTrue("source subscribed", subscribed.get());
-        assertTrue("source unsubscribed", bs.isCancelled());
-
-        verify(subscriber, never()).onNext(anyString());
-        // even though onError is called we take(0) so shouldn't see it
-        verify(subscriber, never()).onError(any(Throwable.class));
-        verify(subscriber, times(1)).onComplete();
-        verifyNoMoreInteractions(subscriber);
-    }
-
-    @Test
     public void unsubscribeAfterTake() {
         TestFlowableFunc f = new TestFlowableFunc("one", "two", "three");
         Flowable<String> w = Flowable.unsafeCreate(f);
@@ -199,7 +171,7 @@ public class FlowableTakeTest {
         verifyNoMoreInteractions(subscriber);
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void unsubscribeFromSynchronousInfiniteFlowable() {
         final AtomicLong count = new AtomicLong();
         INFINITE_OBSERVABLE.take(10).subscribe(new Consumer<Long>() {
@@ -213,7 +185,7 @@ public class FlowableTakeTest {
         assertEquals(10, count.get());
     }
 
-    @Test(timeout = 2000)
+    @Test
     public void multiTake() {
         final AtomicInteger count = new AtomicInteger();
         Flowable.unsafeCreate(new Publisher<Integer>() {
@@ -293,7 +265,7 @@ public class FlowableTakeTest {
 
     });
 
-    @Test(timeout = 2000)
+    @Test
     public void takeObserveOn() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeTimedTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableTakeTimedTest {
+public class FlowableTakeTimedTest extends RxJavaTest {
 
     @Test
     public void takeTimed() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
@@ -29,9 +30,8 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
-;
 
-public class FlowableTakeUntilPredicateTest {
+public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     @Test
     public void takeEmpty() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -16,6 +16,7 @@ package io.reactivex.internal.operators.flowable;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -26,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableTakeUntilTest {
+public class FlowableTakeUntilTest extends RxJavaTest {
 
     @Test
     public void takeUntil() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
@@ -31,7 +32,7 @@ import io.reactivex.processors.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableTakeWhileTest {
+public class FlowableTakeWhileTest extends RxJavaTest {
 
     @Test
     public void takeWhile1() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -30,7 +30,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableThrottleFirstTest {
+public class FlowableThrottleFirstTest extends RxJavaTest {
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -28,7 +28,7 @@ import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableThrottleLatestTest {
+public class FlowableThrottleLatestTest extends RxJavaTest {
 
     @Test
     public void just() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeIntervalTest.java
@@ -29,7 +29,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableTimeIntervalTest {
+public class FlowableTimeIntervalTest extends RxJavaTest {
 
     private static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
@@ -38,8 +39,8 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableTimeoutWithSelectorTest {
-    @Test(timeout = 2000)
+public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
+    @Test
     public void timeoutSelectorNormal1() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimerTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableTimerTest {
+public class FlowableTimerTest extends RxJavaTest {
     @Mock
     Subscriber<Object> subscriber;
     @Mock

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimestampTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimestampTest.java
@@ -28,7 +28,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableTimestampTest {
+public class FlowableTimestampTest extends RxJavaTest {
     Subscriber<Object> subscriber;
 
     @Before

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToCompletableTest.java
@@ -26,7 +26,7 @@ import io.reactivex.functions.Action;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestSubscriberEx;
 
-public class FlowableToCompletableTest {
+public class FlowableToCompletableTest extends RxJavaTest {
 
     @Test
     public void justSingleItemObservable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToFutureTest.java
@@ -26,7 +26,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableToFutureTest {
+public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void success() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMapTest.java
@@ -24,7 +24,7 @@ import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableToMapTest {
+public class FlowableToMapTest extends RxJavaTest {
     Subscriber<Object> objectSubscriber;
     SingleObserver<Object> singleObserver;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToMultimapTest.java
@@ -24,7 +24,7 @@ import io.reactivex.*;
 import io.reactivex.functions.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableToMultimapTest {
+public class FlowableToMultimapTest extends RxJavaTest {
     Subscriber<Object> objectSubscriber;
 
     SingleObserver<Object> singleObserver;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSingleTest.java
@@ -21,7 +21,7 @@ import io.reactivex.*;
 import io.reactivex.functions.Action;
 import io.reactivex.subscribers.TestSubscriber;
 
-public class FlowableToSingleTest {
+public class FlowableToSingleTest extends RxJavaTest {
 
     @Test
     public void justSingleItemObservable() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -31,9 +31,9 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.*;
 
-public class FlowableUnsubscribeOnTest {
+public class FlowableUnsubscribeOnTest extends RxJavaTest {
 
-    @Test(timeout = 5000)
+    @Test
     public void unsubscribeWhenSubscribeOnAndUnsubscribeOnAreOnSameThread() throws InterruptedException {
         UIEventLoopScheduler uiEventLoop = new UIEventLoopScheduler();
         try {
@@ -82,7 +82,7 @@ public class FlowableUnsubscribeOnTest {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void unsubscribeWhenSubscribeOnAndUnsubscribeOnAreOnDifferentThreads() throws InterruptedException {
         UIEventLoopScheduler uiEventLoop = new UIEventLoopScheduler();
         try {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableUsingTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
@@ -33,7 +34,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableUsingTest {
+public class FlowableUsingTest extends RxJavaTest {
 
     private interface Resource {
         String getTextFromWeb();
@@ -223,52 +224,6 @@ public class FlowableUsingTest {
 
         try {
             Flowable.using(resourceFactory, observableFactory, disposeSubscription).blockingLast();
-            fail("Should throw a TestException when the observableFactory throws it");
-        } catch (TestException e) {
-            // Make sure that unsubscribe is called so that users can close
-            // the resource if some error happens.
-            verify(unsubscribe, times(1)).run();
-        }
-    }
-
-    @Test
-    @Ignore("subscribe() can't throw")
-    public void usingWithFlowableFactoryErrorInOnSubscribe() {
-        performTestUsingWithFlowableFactoryErrorInOnSubscribe(false);
-    }
-
-    @Test
-    @Ignore("subscribe() can't throw")
-    public void usingWithFlowableFactoryErrorInOnSubscribeDisposeEagerly() {
-        performTestUsingWithFlowableFactoryErrorInOnSubscribe(true);
-    }
-
-    private void performTestUsingWithFlowableFactoryErrorInOnSubscribe(boolean disposeEagerly) {
-        final Runnable unsubscribe = mock(Runnable.class);
-        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
-            @Override
-            public Disposable get() {
-                return Disposables.fromRunnable(unsubscribe);
-            }
-        };
-
-        Function<Disposable, Flowable<Integer>> observableFactory = new Function<Disposable, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Disposable subscription) {
-                return Flowable.unsafeCreate(new Publisher<Integer>() {
-                    @Override
-                    public void subscribe(Subscriber<? super Integer> t1) {
-                        throw new TestException();
-                    }
-                });
-            }
-        };
-
-        try {
-            Flowable
-            .using(resourceFactory, observableFactory, disposeSubscription, disposeEagerly)
-            .blockingLast();
-
             fail("Should throw a TestException when the observableFactory throws it");
         } catch (TestException e) {
             // Make sure that unsubscribe is called so that users can close

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -33,7 +34,7 @@ import io.reactivex.processors.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableWindowWithFlowableTest {
+public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
     @Test
     public void windowViaFlowableNormal1() {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.reactivestreams.*;
 
@@ -32,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableWindowWithSizeTest {
+public class FlowableWindowWithSizeTest extends RxJavaTest {
 
     private static <T> List<List<T>> toLists(Flowable<Flowable<T>> observables) {
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableWindowWithStartEndFlowableTest {
+public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableWindowWithTimeTest {
+public class FlowableWindowWithTimeTest extends RxJavaTest {
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
@@ -33,7 +34,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableWithLatestFromTest {
+public class FlowableWithLatestFromTest extends RxJavaTest {
     static final BiFunction<Integer, Integer, Integer> COMBINER = new BiFunction<Integer, Integer, Integer>() {
         @Override
         public Integer apply(Integer t1, Integer t2) {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipCompletionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipCompletionTest.java
@@ -29,7 +29,7 @@ import io.reactivex.testsupport.TestHelper;
  * the resulting Observable is finite.
  *
  */
-public class FlowableZipCompletionTest {
+public class FlowableZipCompletionTest extends RxJavaTest {
     BiFunction<String, String, String> concat2Strings;
 
     PublishProcessor<String> s1;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipIterableTest.java
@@ -32,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class FlowableZipIterableTest {
+public class FlowableZipIterableTest extends RxJavaTest {
     BiFunction<String, String, String> concat2Strings;
     PublishProcessor<String> s1;
     PublishProcessor<String> s2;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableZipTest.java
@@ -37,7 +37,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableZipTest {
+public class FlowableZipTest extends RxJavaTest {
     BiFunction<String, String, String> concat2Strings;
     PublishProcessor<String> s1;
     PublishProcessor<String> s2;
@@ -853,36 +853,6 @@ public class FlowableZipTest {
         assertEquals("5-5", list.get(4));
     }
 
-    @Test
-    @Ignore("Null values not allowed")
-    public void emitNull() {
-        Flowable<Integer> oi = Flowable.just(1, null, 3);
-        Flowable<String> os = Flowable.just("a", "b", null);
-        Flowable<String> f = Flowable.zip(oi, os, new BiFunction<Integer, String, String>() {
-
-            @Override
-            public String apply(Integer t1, String t2) {
-                return t1 + "-" + t2;
-            }
-
-        });
-
-        final ArrayList<String> list = new ArrayList<String>();
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                System.out.println(s);
-                list.add(s);
-            }
-        });
-
-        assertEquals(3, list.size());
-        assertEquals("1-a", list.get(0));
-        assertEquals("null-b", list.get(1));
-        assertEquals("3-null", list.get(2));
-    }
-
     @SuppressWarnings("rawtypes")
     static String kind(Notification notification) {
         if (notification.isOnError()) {
@@ -1199,7 +1169,7 @@ public class FlowableZipTest {
         });
     }
 
-    @Test(timeout = 30000)
+    @Test
     public void issue1812() {
         // https://github.com/ReactiveX/RxJava/issues/1812
         Flowable<Integer> zip1 = Flowable.zip(Flowable.range(0, 1026), Flowable.range(0, 1026),
@@ -1249,7 +1219,7 @@ public class FlowableZipTest {
         ts.assertValues(11, 22);
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void zipRace() {
         long startTime = System.currentTimeMillis();
         Flowable<Integer> src = Flowable.just(1).subscribeOn(Schedulers.computation());

--- a/src/test/java/io/reactivex/internal/operators/flowable/NotificationLiteTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/NotificationLiteTest.java
@@ -15,6 +15,7 @@ package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.disposables.Disposables;
@@ -23,7 +24,7 @@ import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.internal.util.NotificationLite;
 import io.reactivex.testsupport.TestHelper;
 
-public class NotificationLiteTest {
+public class NotificationLiteTest extends RxJavaTest {
 
     @Test
     public void complete() {


### PR DESCRIPTION
This commit updates the unit tests for `internal.operator.flowable`

Related: #6583
