### PR TITLE
2.x: ObservableBlockingSubscribe compares with wrong object

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableBlockingSubscribe.java
@@ -61,7 +61,7 @@ public final class ObservableBlockingSubscribe {
                 }
             }
             if (bs.isDisposed()
-                    || o == BlockingObserver.TERMINATED
+                    || v == BlockingObserver.TERMINATED
                     || NotificationLite.acceptFull(v, observer)) {
                 break;
             }


### PR DESCRIPTION
It should compare the TERMINATED instance with the value received from the blocking queue.

Fixes: #6576 
Related: #6577