### PR TITLE
3.x: Have unit tests extends `RxJavaTest` - 5

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/maybe/AbstractMaybeWithUpstreamTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/AbstractMaybeWithUpstreamTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -20,7 +21,7 @@ import io.reactivex.Maybe;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 
-public class AbstractMaybeWithUpstreamTest {
+public class AbstractMaybeWithUpstreamTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeAmbTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeAmbTest {
+public class MaybeAmbTest extends RxJavaTest {
 
     @Test
     public void ambLots() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCacheTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeCacheTest {
+public class MaybeCacheTest extends RxJavaTest {
 
     @Test
     public void offlineSuccess() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import io.reactivex.RxJavaTest;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
@@ -26,7 +27,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-public class MaybeCallbackObserverTest {
+public class MaybeCallbackObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeConcatArrayTest {
+public class MaybeConcatArrayTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeConcatIterableTest {
+public class MaybeConcatIterableTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeConcatPublisherTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 
-public class MaybeConcatPublisherTest {
+public class MaybeConcatPublisherTest extends RxJavaTest {
 
     @Test
     public void scalar() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeContainsTest.java
@@ -25,7 +25,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeContainsTest {
+public class MaybeContainsTest extends RxJavaTest {
 
     @Test
     public void doesContain() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCountTest.java
@@ -25,7 +25,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeCountTest {
+public class MaybeCountTest extends RxJavaTest {
 
     @Test
     public void one() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCreateTest.java
@@ -26,7 +26,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeCreateTest {
+public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void callbackThrows() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayOtherTest.java
@@ -28,7 +28,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.*;
 
-public class MaybeDelayOtherTest {
+public class MaybeDelayOtherTest extends RxJavaTest {
 
     @Test
     public void justWithOnNext() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -31,7 +31,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeDelaySubscriptionTest {
+public class MaybeDelaySubscriptionTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDelayTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeDelayTest {
+public class MaybeDelayTest extends RxJavaTest {
 
     @Test
     public void success() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDetachTest.java
@@ -28,7 +28,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeDetachTest {
+public class MaybeDetachTest extends RxJavaTest {
 
     @Test
     public void doubleSubscribe() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoAfterSuccessTest.java
@@ -28,7 +28,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeDoAfterSuccessTest {
+public class MaybeDoAfterSuccessTest extends RxJavaTest {
 
     final List<Integer> values = new ArrayList<Integer>();
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoFinallyTest.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeDoFinallyTest implements Action {
+public class MaybeDoFinallyTest extends RxJavaTest implements Action {
 
     int calls;
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnEventTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnEventTest.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeDoOnEventTest {
+public class MaybeDoOnEventTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeDoOnTerminateTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
@@ -25,7 +26,7 @@ import io.reactivex.exceptions.*;
 import io.reactivex.functions.Action;
 import io.reactivex.testsupport.*;
 
-public class MaybeDoOnTerminateTest {
+public class MaybeDoOnTerminateTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void doOnTerminate() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeEmptyTest.java
@@ -15,12 +15,13 @@ package io.reactivex.internal.operators.maybe;
 
 import static org.junit.Assert.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
 import io.reactivex.internal.fuseable.ScalarSupplier;
 
-public class MaybeEmptyTest {
+public class MaybeEmptyTest extends RxJavaTest {
 
     @Test
     public void scalarSupplier() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeEqualTest.java
@@ -20,7 +20,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.BiPredicate;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeEqualTest {
+public class MaybeEqualTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeErrorTest.java
@@ -13,13 +13,14 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Supplier;
 
-public class MaybeErrorTest {
+public class MaybeErrorTest extends RxJavaTest {
 
     @Test
     public void errorSupplierThrows() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFilterSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFilterSingleTest.java
@@ -22,7 +22,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFilterSingleTest {
+public class MaybeFilterSingleTest extends RxJavaTest {
 
     @Test
     public void error() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapBiSelectorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapBiSelectorTest.java
@@ -24,7 +24,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFlatMapBiSelectorTest {
+public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
 
     BiFunction<Integer, Integer, String> stringCombine() {
         return new BiFunction<Integer, Integer, String>() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapCompletableTest.java
@@ -20,7 +20,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFlatMapCompletableTest {
+public class MaybeFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -31,7 +31,7 @@ import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class MaybeFlatMapIterableFlowableTest {
+public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
@@ -30,7 +30,7 @@ import io.reactivex.internal.util.CrashingIterable;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.*;
 
-public class MaybeFlatMapIterableObservableTest {
+public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapNotificationTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapNotificationTest.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.testsupport.*;
 
-public class MaybeFlatMapNotificationTest {
+public class MaybeFlatMapNotificationTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapSingleElementTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapSingleElementTest.java
@@ -20,7 +20,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFlatMapSingleElementTest {
+public class MaybeFlatMapSingleElementTest extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void flatMapSingleElementNull() {
         Maybe.just(1)

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlatMapSingleTest.java
@@ -22,7 +22,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFlatMapSingleTest {
+public class MaybeFlatMapSingleTest extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void flatMapSingleNull() {
         Maybe.just(1)

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlattenTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFlattenTest.java
@@ -20,7 +20,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFlattenTest {
+public class MaybeFlattenTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFromActionTest {
+public class MaybeFromActionTest extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void fromActionNull() {
         Maybe.fromAction(null);

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
@@ -32,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFromCallableTest {
+public class MaybeFromCallableTest extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void fromCallableNull() {
         Maybe.fromCallable(null);

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCompletableTest.java
@@ -22,7 +22,7 @@ import io.reactivex.testsupport.TestHelper;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
-public class MaybeFromCompletableTest {
+public class MaybeFromCompletableTest extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void fromCompletableNull() {
         Maybe.fromCompletable(null);

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromFutureTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
@@ -25,7 +26,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 
-public class MaybeFromFutureTest {
+public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void cancelImmediately() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFromRunnableTest {
+public class MaybeFromRunnableTest extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void fromRunnableNull() {
         Maybe.fromRunnable(null);

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromSingleTest.java
@@ -23,7 +23,7 @@ import io.reactivex.internal.fuseable.HasUpstreamSingleSource;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFromSingleTest {
+public class MaybeFromSingleTest extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void fromSingleNull() {
         Maybe.fromSingle(null);

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromSupplierTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromSupplierTest.java
@@ -32,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFromSupplierTest {
+public class MaybeFromSupplierTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromSupplierNull() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeHideTest.java
@@ -24,7 +24,7 @@ import io.reactivex.internal.fuseable.ScalarSupplier;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeHideTest {
+public class MaybeHideTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeIgnoreElementTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeIgnoreElementTest.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeIgnoreElementTest {
+public class MaybeIgnoreElementTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptySingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptySingleTest.java
@@ -14,12 +14,14 @@
 package io.reactivex.internal.operators.maybe;
 
 import static org.junit.Assert.*;
+
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 
-public class MaybeIsEmptySingleTest {
+public class MaybeIsEmptySingleTest extends RxJavaTest {
 
     @Test
     public void source() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeIsEmptyTest.java
@@ -22,7 +22,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeIsEmptyTest {
+public class MaybeIsEmptyTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeJustTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeJustTest.java
@@ -15,12 +15,13 @@ package io.reactivex.internal.operators.maybe;
 
 import static org.junit.Assert.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
 import io.reactivex.internal.fuseable.ScalarSupplier;
 
-public class MaybeJustTest {
+public class MaybeJustTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMapTest.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeMapTest {
+public class MaybeMapTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMaterializeTest.java
@@ -21,7 +21,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeMaterializeTest {
+public class MaybeMaterializeTest extends RxJavaTest {
 
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -30,7 +30,7 @@ import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class MaybeMergeArrayTest {
+public class MaybeMergeArrayTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeTest.java
@@ -23,7 +23,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeMergeTest {
+public class MaybeMergeTest extends RxJavaTest {
 
     @Test
     public void delayErrorWithMaxConcurrency() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeWithTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeMergeWithTest.java
@@ -13,11 +13,12 @@
 
 package io.reactivex.internal.operators.maybe;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
 
-public class MaybeMergeWithTest {
+public class MaybeMergeWithTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeOfTypeTest.java
@@ -22,7 +22,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeOfTypeTest {
+public class MaybeOfTypeTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeOnErrorXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeOnErrorXTest.java
@@ -24,7 +24,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeOnErrorXTest {
+public class MaybeOnErrorXTest extends RxJavaTest {
 
     @Test
     public void onErrorReturnConst() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybePeekTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybePeekTest.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.*;
 
-public class MaybePeekTest {
+public class MaybePeekTest extends RxJavaTest {
 
     @Test
     public void disposed() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSubscribeOnTest.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeSubscribeOnTest {
+public class MaybeSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
@@ -25,7 +25,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeSwitchIfEmptySingleTest {
+public class MaybeSwitchIfEmptySingleTest extends RxJavaTest {
 
     @Test
     public void nonEmpty() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
@@ -24,7 +24,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeSwitchIfEmptyTest {
+public class MaybeSwitchIfEmptyTest extends RxJavaTest {
 
     @Test
     public void nonEmpty() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeTakeUntilPublisherTest {
+public class MaybeTakeUntilPublisherTest extends RxJavaTest {
 
     @Test
     public void disposed() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTakeUntilTest.java
@@ -28,7 +28,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeTakeUntilTest {
+public class MaybeTakeUntilTest extends RxJavaTest {
 
     @Test
     public void normalPublisher() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutPublisherTest.java
@@ -27,7 +27,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.*;
 
-public class MaybeTimeoutPublisherTest {
+public class MaybeTimeoutPublisherTest extends RxJavaTest {
 
     @Test
     public void mainError() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimeoutTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.*;
 
-public class MaybeTimeoutTest {
+public class MaybeTimeoutTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeTimerTest.java
@@ -26,7 +26,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeTimerTest {
+public class MaybeTimerTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeToCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeToCompletableTest.java
@@ -21,7 +21,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeToCompletableTest {
+public class MaybeToCompletableTest extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeToFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeToFlowableTest.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeToFlowableTest {
+public class MaybeToFlowableTest extends RxJavaTest {
 
     @Test
     public void source() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeToObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeToObservableTest.java
@@ -21,7 +21,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeToObservableTest {
+public class MaybeToObservableTest extends RxJavaTest {
 
     @Test
     public void source() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeToSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeToSingleTest.java
@@ -22,7 +22,7 @@ import io.reactivex.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeToSingleTest {
+public class MaybeToSingleTest extends RxJavaTest {
 
     @Test
     public void source() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUnsubscribeOnTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeUnsubscribeOnTest {
+public class MaybeUnsubscribeOnTest extends RxJavaTest {
 
     @Test
     public void normal() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeUsingTest.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.*;
 
-public class MaybeUsingTest {
+public class MaybeUsingTest extends RxJavaTest {
 
     @Test
     public void resourceSupplierThrows() {

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipArrayTest.java
@@ -28,7 +28,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeZipArrayTest {
+public class MaybeZipArrayTest extends RxJavaTest {
 
     final BiFunction<Object, Object, Object> addString = new BiFunction<Object, Object, Object>() {
         @Override

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeZipIterableTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Maybe;
@@ -29,7 +30,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeZipIterableTest {
+public class MaybeZipIterableTest extends RxJavaTest {
 
     final Function<Object[], Object> addString = new Function<Object[], Object>() {
         @Override

--- a/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenObservableTest.java
@@ -23,7 +23,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class CompletableAndThenObservableTest {
+public class CompletableAndThenObservableTest extends RxJavaTest {
 
     @Test
     public void cancelMain() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/CompletableAndThenPublisherTest.java
@@ -25,7 +25,7 @@ import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class CompletableAndThenPublisherTest {
+public class CompletableAndThenPublisherTest extends RxJavaTest {
 
     @Test
     public void cancelMain() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletableTest.java
@@ -32,7 +32,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.testsupport.*;
 
-public class FlowableConcatMapCompletableTest {
+public class FlowableConcatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void simple() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -37,7 +37,7 @@ import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableConcatMapMaybeTest {
+public class FlowableConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void simple() {
@@ -366,7 +366,7 @@ public class FlowableConcatMapMaybeTest {
         assertFalse(pp.hasSubscribers());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void cancelNoConcurrentClean() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ConcatMapMaybeSubscriber<Integer, Integer> operator =

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -35,7 +35,7 @@ import io.reactivex.subjects.SingleSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableConcatMapSingleTest {
+public class FlowableConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void simple() {
@@ -284,7 +284,7 @@ public class FlowableConcatMapSingleTest {
         assertFalse(pp.hasSubscribers());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void cancelNoConcurrentClean() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
         ConcatMapSingleSubscriber<Integer, Integer> operator =

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
@@ -31,7 +31,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.testsupport.*;
 
-public class FlowableSwitchMapCompletableTest {
+public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
@@ -33,7 +33,7 @@ import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableSwitchMapMaybeTest {
+public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void simple() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -33,7 +33,7 @@ import io.reactivex.subjects.SingleSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class FlowableSwitchMapSingleTest {
+public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void simple() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/MaybeFlatMapObservableTest.java
@@ -25,7 +25,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFlatMapObservableTest {
+public class MaybeFlatMapObservableTest extends RxJavaTest {
 
     @Test
     public void cancelMain() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/MaybeFlatMapPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/MaybeFlatMapPublisherTest.java
@@ -27,7 +27,7 @@ import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
-public class MaybeFlatMapPublisherTest {
+public class MaybeFlatMapPublisherTest extends RxJavaTest {
 
     @Test
     public void cancelMain() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletableTest.java
@@ -30,7 +30,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.*;
 
-public class ObservableConcatMapCompletableTest {
+public class ObservableConcatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void simple() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -34,7 +34,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.*;
 
-public class ObservableConcatMapMaybeTest {
+public class ObservableConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void simple() {
@@ -371,7 +371,7 @@ public class ObservableConcatMapMaybeTest {
         assertFalse(ms.hasObservers());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void cancelNoConcurrentClean() {
         TestObserver<Integer> to = new TestObserver<Integer>();
         ConcatMapMaybeMainObserver<Integer, Integer> operator =

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -32,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.*;
 
-public class ObservableConcatMapSingleTest {
+public class ObservableConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void simple() {
@@ -311,7 +311,7 @@ public class ObservableConcatMapSingleTest {
         assertFalse(ss.hasObservers());
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void cancelNoConcurrentClean() {
         TestObserver<Integer> to = new TestObserver<Integer>();
         ConcatMapSingleMainObserver<Integer, Integer> operator =

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.*;
 
-public class ObservableSwitchMapCompletableTest {
+public class ObservableSwitchMapCompletableTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -30,7 +30,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.*;
 
-public class ObservableSwitchMapMaybeTest {
+public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void simple() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -30,7 +30,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.*;
 
-public class ObservableSwitchMapSingleTest {
+public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void simple() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/ScalarXMapZHelperTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ScalarXMapZHelperTest.java
@@ -13,11 +13,12 @@
 
 package io.reactivex.internal.operators.mixed;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.testsupport.TestHelper;
 
-public class ScalarXMapZHelperTest {
+public class ScalarXMapZHelperTest extends RxJavaTest {
 
     @Test
     public void utilityClass() {

--- a/src/test/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/SingleFlatMapObservableTest.java
@@ -25,7 +25,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleFlatMapObservableTest {
+public class SingleFlatMapObservableTest extends RxJavaTest {
 
     @Test
     public void cancelMain() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleAmbTest.java
@@ -31,7 +31,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleAmbTest {
+public class SingleAmbTest extends RxJavaTest {
     @Test
     public void ambWithFirstFires() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -72,7 +72,7 @@ public class SingleAmbTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Test(timeout = 1000)
+    @Test
     public void ambIterableWithFirstFires() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
@@ -94,7 +94,7 @@ public class SingleAmbTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Test(timeout = 1000)
+    @Test
     public void ambIterableWithSecondFires() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCacheTest.java
@@ -21,7 +21,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleCacheTest {
+public class SingleCacheTest extends RxJavaTest {
 
     @Test
     public void cancelImmediately() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleConcatPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleConcatPublisherTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 
-public class SingleConcatPublisherTest {
+public class SingleConcatPublisherTest extends RxJavaTest {
 
     @Test
     public void scalar() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleConcatTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 
-public class SingleConcatTest {
+public class SingleConcatTest extends RxJavaTest {
     @Test
     public void concatWith() {
         Single.just(1).concatWith(Single.just(2))

--- a/src/test/java/io/reactivex/internal/operators/single/SingleContainstTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleContainstTest.java
@@ -13,13 +13,14 @@
 
 package io.reactivex.internal.operators.single;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Single;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.BiPredicate;
 
-public class SingleContainstTest {
+public class SingleContainstTest extends RxJavaTest {
 
     @Test
     public void comparerThrows() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleCreateTest.java
@@ -27,7 +27,7 @@ import io.reactivex.functions.Cancellable;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleCreateTest {
+public class SingleCreateTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullArgument() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDeferTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDeferTest.java
@@ -13,12 +13,13 @@
 
 package io.reactivex.internal.operators.single;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Single;
 import io.reactivex.functions.Supplier;
 
-public class SingleDeferTest {
+public class SingleDeferTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDelayTest.java
@@ -33,7 +33,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleDelayTest {
+public class SingleDelayTest extends RxJavaTest {
     @Test
     public void delayOnSuccess() {
         final TestScheduler scheduler = new TestScheduler();

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDematerializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDematerializeTest.java
@@ -22,7 +22,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.subjects.SingleSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleDematerializeTest {
+public class SingleDematerializeTest extends RxJavaTest {
 
     @Test
     public void success() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDetachTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDetachTest.java
@@ -28,7 +28,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleDetachTest {
+public class SingleDetachTest extends RxJavaTest {
 
     @Test
     public void doubleSubscribe() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterSuccessTest.java
@@ -28,7 +28,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleDoAfterSuccessTest {
+public class SingleDoAfterSuccessTest extends RxJavaTest {
 
     final List<Integer> values = new ArrayList<Integer>();
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoAfterTerminateTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public class SingleDoAfterTerminateTest {
+public class SingleDoAfterTerminateTest extends RxJavaTest {
 
     private final int[] call = { 0 };
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoFinallyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoFinallyTest.java
@@ -26,7 +26,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleDoFinallyTest implements Action {
+public class SingleDoFinallyTest extends RxJavaTest implements Action {
 
     int calls;
 

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTerminateTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTerminateTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Single;
@@ -25,7 +26,7 @@ import io.reactivex.exceptions.*;
 import io.reactivex.functions.Action;
 import io.reactivex.testsupport.*;
 
-public class SingleDoOnTerminateTest {
+public class SingleDoOnTerminateTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void doOnTerminate() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleDoOnTest.java
@@ -28,7 +28,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.*;
 
-public class SingleDoOnTest {
+public class SingleDoOnTest extends RxJavaTest {
 
     @Test
     public void doOnDispose() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleEqualsTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleEqualsTest.java
@@ -22,7 +22,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleEqualsTest {
+public class SingleEqualsTest extends RxJavaTest {
 
     @Test
     public void bothError() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleErrorTest.java
@@ -13,13 +13,14 @@
 
 package io.reactivex.internal.operators.single;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Single;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Supplier;
 
-public class SingleErrorTest {
+public class SingleErrorTest extends RxJavaTest {
 
     @Test
     public void errorSupplierThrows() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapCompletableTest.java
@@ -19,7 +19,7 @@ import io.reactivex.*;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleFlatMapCompletableTest {
+public class SingleFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -31,7 +31,7 @@ import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 
-public class SingleFlatMapIterableFlowableTest {
+public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapIterableObservableTest.java
@@ -30,7 +30,7 @@ import io.reactivex.internal.util.CrashingIterable;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.*;
 
-public class SingleFlatMapIterableObservableTest {
+public class SingleFlatMapIterableObservableTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapMaybeTest.java
@@ -20,7 +20,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleFlatMapMaybeTest {
+public class SingleFlatMapMaybeTest extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void flatMapMaybeNull() {
         Single.just(1)

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFlatMapTest.java
@@ -25,7 +25,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.testsupport.*;
 
-public class SingleFlatMapTest {
+public class SingleFlatMapTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromCallableTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
-public class SingleFromCallableTest {
+public class SingleFromCallableTest extends RxJavaTest {
 
     @Test
     public void fromCallableValue() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromPublisherTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromPublisherTest.java
@@ -28,7 +28,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleFromPublisherTest {
+public class SingleFromPublisherTest extends RxJavaTest {
 
     @Test
     public void just() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromSupplierTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromSupplierTest.java
@@ -32,7 +32,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleFromSupplierTest {
+public class SingleFromSupplierTest extends RxJavaTest {
 
     @Test
     public void fromSupplierValue() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleFromTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleFromTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.schedulers.Schedulers;
 
-public class SingleFromTest {
+public class SingleFromTest extends RxJavaTest {
 
     @Test
     public void fromFuture() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleHideTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleHideTest.java
@@ -21,7 +21,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleHideTest {
+public class SingleHideTest extends RxJavaTest {
 
     @Test
     public void error() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleInternalHelperTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleInternalHelperTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleInternalHelperTest {
+public class SingleInternalHelperTest extends RxJavaTest {
 
     @Test
     public void utilityClass() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleLiftTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleLiftTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
 
-public class SingleLiftTest {
+public class SingleLiftTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMapTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.single;
 
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Single;
@@ -20,7 +21,7 @@ import io.reactivex.SingleSource;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleMapTest {
+public class SingleMapTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void mapNull() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMaterializeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMaterializeTest.java
@@ -21,7 +21,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.subjects.SingleSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleMaterializeTest {
+public class SingleMaterializeTest extends RxJavaTest {
 
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMergeTest.java
@@ -24,7 +24,7 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleMergeTest {
+public class SingleMergeTest extends RxJavaTest {
 
     @Test
     public void mergeSingleSingle() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleMiscTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.single;
 
+import io.reactivex.RxJavaTest;
 import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.SingleSource;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
-public class SingleMiscTest {
+public class SingleMiscTest extends RxJavaTest {
     @Test
     public void never() {
         Single.never()

--- a/src/test/java/io/reactivex/internal/operators/single/SingleObserveOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleObserveOnTest.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleObserveOnTest {
+public class SingleObserveOnTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleOnErrorXTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleOnErrorXTest.java
@@ -22,7 +22,7 @@ import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
 import io.reactivex.testsupport.*;
 
-public class SingleOnErrorXTest {
+public class SingleOnErrorXTest extends RxJavaTest {
 
     @Test
     public void returnSuccess() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleSubscribeOnTest.java
@@ -28,7 +28,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleSubscribeOnTest {
+public class SingleSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void normal() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTakeUntilTest.java
@@ -30,7 +30,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleTakeUntilTest {
+public class SingleTakeUntilTest extends RxJavaTest {
 
     @Test
     public void mainSuccessPublisher() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimeoutTest.java
@@ -31,7 +31,7 @@ import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleTimeoutTest {
+public class SingleTimeoutTest extends RxJavaTest {
 
     @Test
     public void shouldUnsubscribeFromUnderlyingSubscriptionOnDispose() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleTimerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleTimerTest.java
@@ -26,7 +26,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.*;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleTimerTest {
+public class SingleTimerTest extends RxJavaTest {
 
     @Test
     public void disposed() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleToFlowableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleToFlowableTest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.internal.operators.single;
 
+import io.reactivex.RxJavaTest;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.PublishSubject;
@@ -21,7 +22,7 @@ import io.reactivex.testsupport.TestHelper;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 
-public class SingleToFlowableTest {
+public class SingleToFlowableTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleToObservableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleToObservableTest.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleToObservableTest {
+public class SingleToObservableTest extends RxJavaTest {
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUnsubscribeOnTest.java
@@ -27,7 +27,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleUnsubscribeOnTest {
+public class SingleUnsubscribeOnTest extends RxJavaTest {
 
     @Test
     public void normal() throws Exception {

--- a/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleUsingTest.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.*;
 
-public class SingleUsingTest {
+public class SingleUsingTest extends RxJavaTest {
 
     Function<Disposable, Single<Integer>> mapper = new Function<Disposable, Single<Integer>>() {
         @Override

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipArrayTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipArrayTest.java
@@ -28,7 +28,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleZipArrayTest {
+public class SingleZipArrayTest extends RxJavaTest {
 
     final BiFunction<Object, Object, Object> addString = new BiFunction<Object, Object, Object>() {
         @Override

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipIterableTest.java
@@ -29,7 +29,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.testsupport.TestHelper;
 
-public class SingleZipIterableTest {
+public class SingleZipIterableTest extends RxJavaTest {
 
     final Function<Object[], Object> addString = new Function<Object[], Object>() {
         @Override

--- a/src/test/java/io/reactivex/internal/operators/single/SingleZipTest.java
+++ b/src/test/java/io/reactivex/internal/operators/single/SingleZipTest.java
@@ -17,12 +17,14 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
+
+import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
 import io.reactivex.Single;
 import io.reactivex.functions.*;
 
-public class SingleZipTest {
+public class SingleZipTest extends RxJavaTest {
 
     @Test
     public void zip2() {


### PR DESCRIPTION
This commit updates the unit tests of the following operators:
* internal.operators.maybe
* internal.operator.mixed
* internal.operator.single

Related: #6583