### PR TITLE
3.x: Fix refCount not resetting when termination triggers cross-cancel

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -115,14 +115,15 @@ public final class FlowableRefCount<T> extends Flowable<T> {
 
     void terminated(RefConnection rc) {
         synchronized (this) {
-            if (connection != null && connection == rc) {
-                connection = null;
+            if (connection == rc) {
                 if (rc.timer != null) {
                     rc.timer.dispose();
+                    rc.timer = null;
                 }
-            }
-            if (--rc.subscriberCount == 0) {
-                source.reset();
+                if (--rc.subscriberCount == 0) {
+                    connection = null;
+                    source.reset();
+                }
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableRefCount.java
@@ -112,14 +112,15 @@ public final class ObservableRefCount<T> extends Observable<T> {
 
     void terminated(RefConnection rc) {
         synchronized (this) {
-            if (connection != null && connection == rc) {
-                connection = null;
+            if (connection == rc) {
                 if (rc.timer != null) {
                     rc.timer.dispose();
+                    rc.timer = null;
                 }
-            }
-            if (--rc.subscriberCount == 0) {
-                source.reset();
+                if (--rc.subscriberCount == 0) {
+                    connection = null;
+                    source.reset();
+                }
             }
         }
     }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -1454,4 +1455,22 @@ public class FlowableRefCountTest extends RxJavaTest {
             .assertComplete();
         }
     }
-}
+
+    @Test
+    public void upstreamTerminationTriggersAnotherCancel() throws Exception {
+        ReplayProcessor<Integer> rp = ReplayProcessor.create();
+        rp.onNext(1);
+        rp.onComplete();
+
+        Flowable<Integer> shared = rp.share();
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+    }}

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -22,7 +23,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.*;
@@ -1267,8 +1268,6 @@ public class ObservableRefCountTest {
         .publish()
         .refCount();
 
-        o.cancel(null);
-
         o.cancel(new RefConnection(o));
 
         RefConnection rc = new RefConnection(o);
@@ -1411,5 +1410,24 @@ public class ObservableRefCountTest {
             .assertNoErrors()
             .assertComplete();
         }
+    }
+
+    @Test
+    public void upstreamTerminationTriggersAnotherCancel() throws Exception {
+        ReplaySubject<Integer> rs = ReplaySubject.create();
+        rs.onNext(1);
+        rs.onComplete();
+
+        Observable<Integer> shared = rs.share();
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
     }
 }


### PR DESCRIPTION
This PR fixes both `refCount` implementation to properly reset the source when the source terminates multiple consumers.

In the original, when the source terminated multiple sources, the first termination handler cleared the connection but since the `--subscriberCount` wasn't zero, the source was not reset. If this termination triggered a cancel on the second consumer, that path would not get the source reset either due to losing the connection object. Unfortunately, one can't just take the first termination handler and reset there immediately either because that could disrupt the termination of the rest of the consumers. It has to wait for the source to terminate all consumers or have the consumers cancel all.

This affects 2.x and will be backported in a separate PR.

Fixes #6608