### PR TITLE
3.x: Fix many operators swallowing undeliverable exceptions

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeArray.java
@@ -32,7 +32,7 @@ public final class CompletableMergeArray extends Completable {
         final AtomicBoolean once = new AtomicBoolean();
 
         InnerCompletableObserver shared = new InnerCompletableObserver(observer, once, set, sources.length + 1);
-        observer.onSubscribe(set);
+        observer.onSubscribe(shared);
 
         for (CompletableSource c : sources) {
             if (set.isDisposed()) {
@@ -52,7 +52,7 @@ public final class CompletableMergeArray extends Completable {
         shared.onComplete();
     }
 
-    static final class InnerCompletableObserver extends AtomicInteger implements CompletableObserver {
+    static final class InnerCompletableObserver extends AtomicInteger implements CompletableObserver, Disposable {
         private static final long serialVersionUID = -8360547806504310570L;
 
         final CompletableObserver downstream;
@@ -90,6 +90,17 @@ public final class CompletableMergeArray extends Completable {
                     downstream.onComplete();
                 }
             }
+        }
+
+        @Override
+        public void dispose() {
+            set.dispose();
+            once.set(true);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return set.isDisposed();
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorArray.java
@@ -34,6 +34,7 @@ public final class CompletableMergeDelayErrorArray extends Completable {
         final AtomicInteger wip = new AtomicInteger(sources.length + 1);
 
         final AtomicThrowable error = new AtomicThrowable();
+        set.add(new TryTerminateAndReportDisposable(error));
 
         observer.onSubscribe(set);
 
@@ -54,6 +55,23 @@ public final class CompletableMergeDelayErrorArray extends Completable {
 
         if (wip.decrementAndGet() == 0) {
             error.tryTerminateConsumer(observer);
+        }
+    }
+
+    static final class TryTerminateAndReportDisposable implements Disposable {
+        final AtomicThrowable errors;
+        TryTerminateAndReportDisposable(AtomicThrowable errors) {
+            this.errors = errors;
+        }
+
+        @Override
+        public void dispose() {
+            errors.tryTerminateAndReport();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return errors.isTerminated();
         }
     }
 

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorArray.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorArray.java
@@ -53,12 +53,7 @@ public final class CompletableMergeDelayErrorArray extends Completable {
         }
 
         if (wip.decrementAndGet() == 0) {
-            Throwable ex = error.terminate();
-            if (ex == null) {
-                observer.onComplete();
-            } else {
-                observer.onError(ex);
-            }
+            error.tryTerminateConsumer(observer);
         }
     }
 
@@ -98,12 +93,7 @@ public final class CompletableMergeDelayErrorArray extends Completable {
 
         void tryTerminate() {
             if (wip.decrementAndGet() == 0) {
-                Throwable ex = error.terminate();
-                if (ex == null) {
-                    downstream.onComplete();
-                } else {
-                    downstream.onError(ex);
-                }
+                error.tryTerminateConsumer(downstream);
             }
         }
     }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
@@ -93,12 +93,7 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
         }
 
         if (wip.decrementAndGet() == 0) {
-            Throwable ex = error.terminate();
-            if (ex == null) {
-                observer.onComplete();
-            } else {
-                observer.onError(ex);
-            }
+            error.tryTerminateConsumer(observer);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
+++ b/src/main/java/io/reactivex/internal/operators/completable/CompletableMergeDelayErrorIterable.java
@@ -20,7 +20,7 @@ import io.reactivex.*;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.operators.completable.CompletableMergeDelayErrorArray.MergeInnerCompletableObserver;
+import io.reactivex.internal.operators.completable.CompletableMergeDelayErrorArray.*;
 import io.reactivex.internal.util.AtomicThrowable;
 
 public final class CompletableMergeDelayErrorIterable extends Completable {
@@ -50,6 +50,7 @@ public final class CompletableMergeDelayErrorIterable extends Completable {
         final AtomicInteger wip = new AtomicInteger(1);
 
         final AtomicThrowable error = new AtomicThrowable();
+        set.add(new TryTerminateAndReportDisposable(error));
 
         for (;;) {
             if (set.isDisposed()) {

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEager.java
@@ -163,6 +163,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
             }
             cancelled = true;
             upstream.cancel();
+            errors.tryTerminateAndReport();
 
             drainAndCancel();
         }
@@ -247,7 +248,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                         if (ex != null) {
                             cancelAll();
 
-                            a.onError(errors.terminate());
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -257,12 +258,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                     inner = subscribers.poll();
 
                     if (outerDone && inner == null) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            a.onError(ex);
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
 
@@ -289,7 +285,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                                     inner.cancel();
                                     cancelAll();
 
-                                    a.onError(errors.terminate());
+                                    errors.tryTerminateConsumer(downstream);
                                     return;
                                 }
                             }
@@ -343,7 +339,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                                     inner.cancel();
                                     cancelAll();
 
-                                    a.onError(errors.terminate());
+                                    errors.tryTerminateConsumer(downstream);
                                     return;
                                 }
                             }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableConcatMapScheduler.java
@@ -199,7 +199,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                 inner.cancel();
 
                 if (getAndIncrement() == 0) {
-                    downstream.onError(errors.terminate());
+                    errors.tryTerminateConsumer(downstream);
                     worker.dispose();
                 }
             } else {
@@ -214,7 +214,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                 if (compareAndSet(1, 0)) {
                     return;
                 }
-                downstream.onError(errors.terminate());
+                errors.tryTerminateConsumer(downstream);
                 worker.dispose();
             }
         }
@@ -225,7 +225,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                 upstream.cancel();
 
                 if (getAndIncrement() == 0) {
-                    downstream.onError(errors.terminate());
+                    errors.tryTerminateConsumer(downstream);
                     worker.dispose();
                 }
             } else {
@@ -246,6 +246,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                 inner.cancel();
                 upstream.cancel();
                 worker.dispose();
+                errors.tryTerminateAndReport();
             }
         }
 
@@ -274,7 +275,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                         Exceptions.throwIfFatal(e);
                         upstream.cancel();
                         errors.addThrowable(e);
-                        downstream.onError(errors.terminate());
+                        errors.tryTerminateConsumer(downstream);
                         worker.dispose();
                         return;
                     }
@@ -297,7 +298,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
 
                             upstream.cancel();
                             errors.addThrowable(e);
-                            downstream.onError(errors.terminate());
+                            errors.tryTerminateConsumer(downstream);
                             worker.dispose();
                             return;
                         }
@@ -324,7 +325,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                                 Exceptions.throwIfFatal(e);
                                 upstream.cancel();
                                 errors.addThrowable(e);
-                                downstream.onError(errors.terminate());
+                                errors.tryTerminateConsumer(downstream);
                                 worker.dispose();
                                 return;
                             }
@@ -337,7 +338,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                                 if (get() == 0 && compareAndSet(0, 1)) {
                                     downstream.onNext(vr);
                                     if (!compareAndSet(1, 0)) {
-                                        downstream.onError(errors.terminate());
+                                        errors.tryTerminateConsumer(downstream);
                                         worker.dispose();
                                         return;
                                     }
@@ -425,6 +426,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                 inner.cancel();
                 upstream.cancel();
                 worker.dispose();
+                errors.tryTerminateAndReport();
             }
         }
 
@@ -450,7 +452,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                     if (d && !veryEnd) {
                         Throwable ex = errors.get();
                         if (ex != null) {
-                            downstream.onError(errors.terminate());
+                            errors.tryTerminateConsumer(downstream);
                             worker.dispose();
                             return;
                         }
@@ -464,7 +466,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                         Exceptions.throwIfFatal(e);
                         upstream.cancel();
                         errors.addThrowable(e);
-                        downstream.onError(errors.terminate());
+                        errors.tryTerminateConsumer(downstream);
                         worker.dispose();
                         return;
                     }
@@ -472,12 +474,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                     boolean empty = v == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            downstream.onError(ex);
-                        } else {
-                            downstream.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         worker.dispose();
                         return;
                     }
@@ -492,7 +489,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
 
                             upstream.cancel();
                             errors.addThrowable(e);
-                            downstream.onError(errors.terminate());
+                            errors.tryTerminateConsumer(downstream);
                             worker.dispose();
                             return;
                         }
@@ -520,7 +517,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                                 errors.addThrowable(e);
                                 if (!veryEnd) {
                                     upstream.cancel();
-                                    downstream.onError(errors.terminate());
+                                    errors.tryTerminateConsumer(downstream);
                                     worker.dispose();
                                     return;
                                 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -157,6 +157,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
             cancelled = true;
             upstream.cancel();
             set.dispose();
+            errors.tryTerminateAndReport();
         }
 
         @Override
@@ -177,12 +178,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                     SpscLinkedArrayQueue<R> q = queue.get();
 
                     if (d && (q == null || q.isEmpty())) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            downstream.onError(ex);
-                        } else {
-                            downstream.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
                     BackpressureHelper.produced(requested, 1);
@@ -250,12 +246,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                 SpscLinkedArrayQueue<R> q = queue.get();
 
                 if (d && (q == null || q.isEmpty())) {
-                    Throwable ex = errors.terminate();
-                    if (ex != null) {
-                        downstream.onError(ex);
-                    } else {
-                        downstream.onComplete();
-                    }
+                    errors.tryTerminateConsumer(downstream);
                     return;
                 }
 
@@ -307,9 +298,8 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                     if (!delayErrors) {
                         Throwable ex = errors.get();
                         if (ex != null) {
-                            ex = errors.terminate();
                             clear();
-                            a.onError(ex);
+                            errors.tryTerminateConsumer(a);
                             return;
                         }
                     }
@@ -320,12 +310,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                     boolean empty = v == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            a.onError(ex);
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(a);
                         return;
                     }
 
@@ -347,9 +332,8 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                     if (!delayErrors) {
                         Throwable ex = errors.get();
                         if (ex != null) {
-                            ex = errors.terminate();
                             clear();
-                            a.onError(ex);
+                            errors.tryTerminateConsumer(a);
                             return;
                         }
                     }
@@ -359,12 +343,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                     boolean empty = q == null || q.isEmpty();
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            a.onError(ex);
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(a);
                         return;
                     }
                 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -157,6 +157,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
             cancelled = true;
             upstream.cancel();
             set.dispose();
+            errors.tryTerminateAndReport();
         }
 
         @Override
@@ -177,12 +178,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                     SpscLinkedArrayQueue<R> q = queue.get();
 
                     if (d && (q == null || q.isEmpty())) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            downstream.onError(ex);
-                        } else {
-                            downstream.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
                     BackpressureHelper.produced(requested, 1);
@@ -274,9 +270,8 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                     if (!delayErrors) {
                         Throwable ex = errors.get();
                         if (ex != null) {
-                            ex = errors.terminate();
                             clear();
-                            a.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -287,12 +282,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                     boolean empty = v == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            a.onError(ex);
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(a);
                         return;
                     }
 
@@ -314,9 +304,8 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                     if (!delayErrors) {
                         Throwable ex = errors.get();
                         if (ex != null) {
-                            ex = errors.terminate();
                             clear();
-                            a.onError(ex);
+                            errors.tryTerminateConsumer(a);
                             return;
                         }
                     }
@@ -326,12 +315,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                     boolean empty = q == null || q.isEmpty();
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            a.onError(ex);
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(a);
                         return;
                     }
                 }

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -61,7 +61,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
 
         final OtherObserver<T> otherObserver;
 
-        final AtomicThrowable error;
+        final AtomicThrowable errors;
 
         final AtomicLong requested;
 
@@ -91,7 +91,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
             this.downstream = downstream;
             this.mainSubscription = new AtomicReference<Subscription>();
             this.otherObserver = new OtherObserver<T>(this);
-            this.error = new AtomicThrowable();
+            this.errors = new AtomicThrowable();
             this.requested = new AtomicLong();
             this.prefetch = bufferSize();
             this.limit = prefetch - (prefetch >> 2);
@@ -142,7 +142,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
 
         @Override
         public void onError(Throwable ex) {
-            if (error.addThrowable(ex)) {
+            if (errors.addThrowable(ex)) {
                 DisposableHelper.dispose(otherObserver);
                 drain();
             } else {
@@ -167,6 +167,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
             cancelled = true;
             SubscriptionHelper.cancel(mainSubscription);
             DisposableHelper.dispose(otherObserver);
+            errors.tryTerminateAndReport();
             if (getAndIncrement() == 0) {
                 queue = null;
                 singleItem = null;
@@ -199,7 +200,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
         }
 
         void otherError(Throwable ex) {
-            if (error.addThrowable(ex)) {
+            if (errors.addThrowable(ex)) {
                 SubscriptionHelper.cancel(mainSubscription);
                 drain();
             } else {
@@ -244,10 +245,10 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
                         return;
                     }
 
-                    if (error.get() != null) {
+                    if (errors.get() != null) {
                         singleItem = null;
                         queue = null;
-                        actual.onError(error.terminate());
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
 
@@ -295,10 +296,10 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
                         return;
                     }
 
-                    if (error.get() != null) {
+                    if (errors.get() != null) {
                         singleItem = null;
                         queue = null;
-                        actual.onError(error.terminate());
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayDelayError.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeConcatArrayDelayError.java
@@ -87,6 +87,7 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
         @Override
         public void cancel() {
             disposables.dispose();
+            errors.tryTerminateAndReport();
         }
 
         @Override
@@ -155,12 +156,7 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
                     if (goNextSource && !cancelled.isDisposed()) {
                         int i = index;
                         if (i == sources.length) {
-                            Throwable ex = errors.get();
-                            if (ex != null) {
-                                a.onError(errors.terminate());
-                            } else {
-                                a.onComplete();
-                            }
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                         index = i + 1;

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeMergeArray.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeMergeArray.java
@@ -201,7 +201,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
                     Throwable ex = error.get();
                     if (ex != null) {
                         q.clear();
-                        a.onError(error.terminate());
+                        error.tryTerminateConsumer(downstream);
                         return;
                     }
 
@@ -227,7 +227,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
                     Throwable ex = error.get();
                     if (ex != null) {
                         q.clear();
-                        a.onError(error.terminate());
+                        error.tryTerminateConsumer(downstream);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybe.java
@@ -167,6 +167,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
             cancelled = true;
             upstream.cancel();
             inner.dispose();
+            errors.tryTerminateAndReport();
             if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
@@ -225,8 +226,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
                                 || (errorMode == ErrorMode.BOUNDARY && s == STATE_INACTIVE)) {
                             queue.clear();
                             item = null;
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -237,12 +237,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
                         boolean empty = v == null;
 
                         if (d && empty) {
-                            Throwable ex = errors.terminate();
-                            if (ex == null) {
-                                downstream.onComplete();
-                            } else {
-                                downstream.onError(ex);
-                            }
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 
@@ -267,8 +262,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
                             upstream.cancel();
                             queue.clear();
                             errors.addThrowable(ex);
-                            ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -167,6 +167,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
             cancelled = true;
             upstream.cancel();
             inner.dispose();
+            errors.tryTerminateAndReport();
             if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
@@ -220,8 +221,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
                                 || (errorMode == ErrorMode.BOUNDARY && s == STATE_INACTIVE)) {
                             queue.clear();
                             item = null;
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -232,12 +232,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
                         boolean empty = v == null;
 
                         if (d && empty) {
-                            Throwable ex = errors.terminate();
-                            if (ex == null) {
-                                downstream.onComplete();
-                            } else {
-                                downstream.onError(ex);
-                            }
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 
@@ -262,8 +257,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
                             upstream.cancel();
                             queue.clear();
                             errors.addThrowable(ex);
-                            ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletable.java
@@ -128,10 +128,7 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
                     onComplete();
                 } else {
                     disposeInner();
-                    Throwable ex = errors.terminate();
-                    if (ex != ExceptionHelper.TERMINATED) {
-                        downstream.onError(ex);
-                    }
+                    errors.tryTerminateConsumer(downstream);
                 }
             } else {
                 RxJavaPlugins.onError(t);
@@ -142,12 +139,7 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
         public void onComplete() {
             done = true;
             if (inner.get() == null) {
-                Throwable ex = errors.terminate();
-                if (ex == null) {
-                    downstream.onComplete();
-                } else {
-                    downstream.onError(ex);
-                }
+                errors.tryTerminateConsumer(downstream);
             }
         }
 
@@ -175,16 +167,12 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
                 if (errors.addThrowable(error)) {
                     if (delayErrors) {
                         if (done) {
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                         }
                     } else {
                         upstream.cancel();
                         disposeInner();
-                        Throwable ex = errors.terminate();
-                        if (ex != ExceptionHelper.TERMINATED) {
-                            downstream.onError(ex);
-                        }
+                        errors.tryTerminateConsumer(downstream);
                     }
                     return;
                 }
@@ -195,12 +183,7 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
         void innerComplete(SwitchMapInnerObserver sender) {
             if (inner.compareAndSet(sender, null)) {
                 if (done) {
-                    Throwable ex = errors.terminate();
-                    if (ex == null) {
-                        downstream.onComplete();
-                    } else {
-                        downstream.onError(ex);
-                    }
+                    errors.tryTerminateConsumer(downstream);
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybe.java
@@ -221,8 +221,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
 
                     if (errors.get() != null) {
                         if (!delayErrors) {
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -232,12 +231,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
                     boolean empty = current == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            downstream.onError(ex);
-                        } else {
-                            downstream.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingle.java
@@ -215,8 +215,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
 
                     if (errors.get() != null) {
                         if (!delayErrors) {
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -226,12 +225,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
                     boolean empty = current == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            downstream.onError(ex);
-                        } else {
-                            downstream.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybe.java
@@ -145,6 +145,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
             cancelled = true;
             upstream.dispose();
             inner.dispose();
+            errors.tryTerminateAndReport();
             if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
@@ -206,8 +207,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
                                 || (errorMode == ErrorMode.BOUNDARY && s == STATE_INACTIVE)) {
                             queue.clear();
                             item = null;
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -218,12 +218,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
                         boolean empty = v == null;
 
                         if (d && empty) {
-                            Throwable ex = errors.terminate();
-                            if (ex == null) {
-                                downstream.onComplete();
-                            } else {
-                                downstream.onError(ex);
-                            }
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 
@@ -240,8 +235,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
                             upstream.dispose();
                             queue.clear();
                             errors.addThrowable(ex);
-                            ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -145,6 +145,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
             cancelled = true;
             upstream.dispose();
             inner.dispose();
+            errors.tryTerminateAndReport();
             if (getAndIncrement() == 0) {
                 queue.clear();
                 item = null;
@@ -201,8 +202,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
                                 || (errorMode == ErrorMode.BOUNDARY && s == STATE_INACTIVE)) {
                             queue.clear();
                             item = null;
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -213,12 +213,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
                         boolean empty = v == null;
 
                         if (d && empty) {
-                            Throwable ex = errors.terminate();
-                            if (ex == null) {
-                                downstream.onComplete();
-                            } else {
-                                downstream.onError(ex);
-                            }
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 
@@ -235,8 +230,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
                             upstream.dispose();
                             queue.clear();
                             errors.addThrowable(ex);
-                            ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletable.java
@@ -126,10 +126,7 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
                     onComplete();
                 } else {
                     disposeInner();
-                    Throwable ex = errors.terminate();
-                    if (ex != ExceptionHelper.TERMINATED) {
-                        downstream.onError(ex);
-                    }
+                    errors.tryTerminateConsumer(downstream);
                 }
             } else {
                 RxJavaPlugins.onError(t);
@@ -140,12 +137,7 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
         public void onComplete() {
             done = true;
             if (inner.get() == null) {
-                Throwable ex = errors.terminate();
-                if (ex == null) {
-                    downstream.onComplete();
-                } else {
-                    downstream.onError(ex);
-                }
+                errors.tryTerminateConsumer(downstream);
             }
         }
 
@@ -173,16 +165,12 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
                 if (errors.addThrowable(error)) {
                     if (delayErrors) {
                         if (done) {
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                         }
                     } else {
                         upstream.dispose();
                         disposeInner();
-                        Throwable ex = errors.terminate();
-                        if (ex != ExceptionHelper.TERMINATED) {
-                            downstream.onError(ex);
-                        }
+                        errors.tryTerminateConsumer(downstream);
                     }
                     return;
                 }
@@ -193,12 +181,7 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
         void innerComplete(SwitchMapInnerObserver sender) {
             if (inner.compareAndSet(sender, null)) {
                 if (done) {
-                    Throwable ex = errors.terminate();
-                    if (ex == null) {
-                        downstream.onComplete();
-                    } else {
-                        downstream.onError(ex);
-                    }
+                    errors.tryTerminateConsumer(downstream);
                 }
             }
         }

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybe.java
@@ -211,8 +211,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
 
                     if (errors.get() != null) {
                         if (!delayErrors) {
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -222,12 +221,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
                     boolean empty = current == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            downstream.onError(ex);
-                        } else {
-                            downstream.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingle.java
@@ -205,8 +205,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
 
                     if (errors.get() != null) {
                         if (!delayErrors) {
-                            Throwable ex = errors.terminate();
-                            downstream.onError(ex);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
                     }
@@ -216,12 +215,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
                     boolean empty = current == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            downstream.onError(ex);
-                        } else {
-                            downstream.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -361,14 +361,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 }
 
                 if (d && (svq == null || svq.isEmpty()) && n == 0 && nSources == 0) {
-                    Throwable ex = errors.terminate();
-                    if (ex != ExceptionHelper.TERMINATED) {
-                        if (ex == null) {
-                            child.onComplete();
-                        } else {
-                            child.onError(ex);
-                        }
-                    }
+                    errors.tryTerminateConsumer(downstream);
                     return;
                 }
 
@@ -487,10 +480,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             Throwable e = errors.get();
             if (!delayErrors && (e != null)) {
                 disposeAll();
-                e = errors.terminate();
-                if (e != ExceptionHelper.TERMINATED) {
-                    downstream.onError(e);
-                }
+                errors.tryTerminateConsumer(downstream);
                 return true;
             }
             return false;

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -138,6 +138,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
             cancelled = true;
             upstream.dispose();
             set.dispose();
+            errors.tryTerminateAndReport();
         }
 
         @Override
@@ -154,12 +155,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
                 SpscLinkedArrayQueue<R> q = queue.get();
 
                 if (d && (q == null || q.isEmpty())) {
-                    Throwable ex = errors.terminate();
-                    if (ex != null) {
-                        downstream.onError(ex);
-                    } else {
-                        downstream.onComplete();
-                    }
+                    errors.tryTerminateConsumer(downstream);
                     return;
                 }
                 if (decrementAndGet() == 0) {
@@ -213,12 +209,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
                 SpscLinkedArrayQueue<R> q = queue.get();
 
                 if (d && (q == null || q.isEmpty())) {
-                    Throwable ex = errors.terminate();
-                    if (ex != null) {
-                        downstream.onError(ex);
-                    } else {
-                        downstream.onComplete();
-                    }
+                    errors.tryTerminateConsumer(downstream);
                     return;
                 }
                 if (decrementAndGet() == 0) {
@@ -260,9 +251,8 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
                     if (!delayErrors) {
                         Throwable ex = errors.get();
                         if (ex != null) {
-                            ex = errors.terminate();
                             clear();
-                            a.onError(ex);
+                            errors.tryTerminateConsumer(a);
                             return;
                         }
                     }
@@ -273,12 +263,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
                     boolean empty = v == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            a.onError(ex);
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(a);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingle.java
@@ -138,6 +138,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
             cancelled = true;
             upstream.dispose();
             set.dispose();
+            errors.tryTerminateAndReport();
         }
 
         @Override
@@ -154,12 +155,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
                 SpscLinkedArrayQueue<R> q = queue.get();
 
                 if (d && (q == null || q.isEmpty())) {
-                    Throwable ex = errors.terminate();
-                    if (ex != null) {
-                        downstream.onError(ex);
-                    } else {
-                        downstream.onComplete();
-                    }
+                    errors.tryTerminateConsumer(downstream);
                     return;
                 }
                 if (decrementAndGet() == 0) {
@@ -234,9 +230,8 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
                     if (!delayErrors) {
                         Throwable ex = errors.get();
                         if (ex != null) {
-                            ex = errors.terminate();
                             clear();
-                            a.onError(ex);
+                            errors.tryTerminateConsumer(a);
                             return;
                         }
                     }
@@ -247,12 +242,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
                     boolean empty = v == null;
 
                     if (d && empty) {
-                        Throwable ex = errors.terminate();
-                        if (ex != null) {
-                            a.onError(ex);
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(downstream);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingle.java
@@ -58,7 +58,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
 
         final OtherObserver<T> otherObserver;
 
-        final AtomicThrowable error;
+        final AtomicThrowable errors;
 
         volatile SimplePlainQueue<T> queue;
 
@@ -78,7 +78,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
             this.downstream = downstream;
             this.mainDisposable = new AtomicReference<Disposable>();
             this.otherObserver = new OtherObserver<T>(this);
-            this.error = new AtomicThrowable();
+            this.errors = new AtomicThrowable();
         }
 
         @Override
@@ -105,7 +105,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
 
         @Override
         public void onError(Throwable ex) {
-            if (error.addThrowable(ex)) {
+            if (errors.addThrowable(ex)) {
                 DisposableHelper.dispose(otherObserver);
                 drain();
             } else {
@@ -129,6 +129,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
             disposed = true;
             DisposableHelper.dispose(mainDisposable);
             DisposableHelper.dispose(otherObserver);
+            errors.tryTerminateAndReport();
             if (getAndIncrement() == 0) {
                 queue = null;
                 singleItem = null;
@@ -150,7 +151,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
         }
 
         void otherError(Throwable ex) {
-            if (error.addThrowable(ex)) {
+            if (errors.addThrowable(ex)) {
                 DisposableHelper.dispose(mainDisposable);
                 drain();
             } else {
@@ -185,10 +186,10 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
                         return;
                     }
 
-                    if (error.get() != null) {
+                    if (errors.get() != null) {
                         singleItem = null;
                         queue = null;
-                        actual.onError(error.terminate());
+                        errors.tryTerminateConsumer(actual);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -210,7 +210,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                     } else {
                         Throwable ex = errors.get();
                         if (ex != null) {
-                            a.onError(errors.terminate());
+                            errors.tryTerminateConsumer(a);
                             return;
                         }
                         if (empty) {
@@ -236,7 +236,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                             } else {
                                 Throwable ex = errors.get();
                                 if (ex != null) {
-                                    a.onError(errors.terminate());
+                                    errors.tryTerminateConsumer(a);
                                     return;
                                 }
                                 if (empty) {
@@ -260,7 +260,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                             if (!delayErrors) {
                                 Throwable ex = errors.get();
                                 if (ex != null) {
-                                    a.onError(errors.terminate());
+                                    errors.tryTerminateConsumer(a);
                                     return;
                                 }
                             }

--- a/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/internal/operators/parallel/ParallelJoin.java
@@ -428,12 +428,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
                     }
 
                     if (d && empty) {
-                        Throwable ex = errors.get();
-                        if (ex != null) {
-                            a.onError(errors.terminate());
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(a);
                         return;
                     }
 
@@ -463,12 +458,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
                     }
 
                     if (d && empty) {
-                        Throwable ex = errors.get();
-                        if (ex != null) {
-                            a.onError(errors.terminate());
-                        } else {
-                            a.onComplete();
-                        }
+                        errors.tryTerminateConsumer(a);
                         return;
                     }
                 }

--- a/src/main/java/io/reactivex/internal/util/AtomicThrowable.java
+++ b/src/main/java/io/reactivex/internal/util/AtomicThrowable.java
@@ -15,6 +15,9 @@ package io.reactivex.internal.util;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.*;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -59,6 +62,84 @@ public final class AtomicThrowable extends AtomicReference<Throwable> {
         Throwable ex = terminate();
         if (ex != null && ex != ExceptionHelper.TERMINATED) {
             RxJavaPlugins.onError(ex);
+        }
+    }
+
+    /**
+     * Tries to terminate this atomic throwable (by swapping in the TERMINATED indicator)
+     * and notifies the consumer if there was no error (onComplete) or there was a
+     * non-null, non-indicator exception contained before (onError).
+     * If there was a terminated indicator, the consumer is not signaled.
+     * @param consumer the consumer to notify
+     */
+    public void tryTerminateConsumer(Subscriber<?> consumer) {
+        Throwable ex = terminate();
+        if (ex == null) {
+            consumer.onComplete();
+        } else if (ex != ExceptionHelper.TERMINATED) {
+            consumer.onError(ex);
+        }
+    }
+
+    /**
+     * Tries to terminate this atomic throwable (by swapping in the TERMINATED indicator)
+     * and notifies the consumer if there was no error (onComplete) or there was a
+     * non-null, non-indicator exception contained before (onError).
+     * If there was a terminated indicator, the consumer is not signaled.
+     * @param consumer the consumer to notify
+     */
+    public void tryTerminateConsumer(Observer<?> consumer) {
+        Throwable ex = terminate();
+        if (ex == null) {
+            consumer.onComplete();
+        } else if (ex != ExceptionHelper.TERMINATED) {
+            consumer.onError(ex);
+        }
+    }
+
+    /**
+     * Tries to terminate this atomic throwable (by swapping in the TERMINATED indicator)
+     * and notifies the consumer if there was no error (onComplete) or there was a
+     * non-null, non-indicator exception contained before (onError).
+     * If there was a terminated indicator, the consumer is not signaled.
+     * @param consumer the consumer to notify
+     */
+    public void tryTerminateConsumer(MaybeObserver<?> consumer) {
+        Throwable ex = terminate();
+        if (ex == null) {
+            consumer.onComplete();
+        } else if (ex != ExceptionHelper.TERMINATED) {
+            consumer.onError(ex);
+        }
+    }
+
+    /**
+     * Tries to terminate this atomic throwable (by swapping in the TERMINATED indicator)
+     * and notifies the consumer if there was no error (onComplete) or there was a
+     * non-null, non-indicator exception contained before (onError).
+     * If there was a terminated indicator, the consumer is not signaled.
+     * @param consumer the consumer to notify
+     */
+    public void tryTerminateConsumer(SingleObserver<?> consumer) {
+        Throwable ex = terminate();
+        if (ex != null && ex != ExceptionHelper.TERMINATED) {
+            consumer.onError(ex);
+        }
+    }
+
+    /**
+     * Tries to terminate this atomic throwable (by swapping in the TERMINATED indicator)
+     * and notifies the consumer if there was no error (onComplete) or there was a
+     * non-null, non-indicator exception contained before (onError).
+     * If there was a terminated indicator, the consumer is not signaled.
+     * @param consumer the consumer to notify
+     */
+    public void tryTerminateConsumer(CompletableObserver consumer) {
+        Throwable ex = terminate();
+        if (ex == null) {
+            consumer.onComplete();
+        } else if (ex != ExceptionHelper.TERMINATED) {
+            consumer.onError(ex);
         }
     }
 }

--- a/src/main/java/io/reactivex/internal/util/HalfSerializer.java
+++ b/src/main/java/io/reactivex/internal/util/HalfSerializer.java
@@ -44,12 +44,7 @@ public final class HalfSerializer {
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
             subscriber.onNext(value);
             if (wip.decrementAndGet() != 0) {
-                Throwable ex = error.terminate();
-                if (ex != null) {
-                    subscriber.onError(ex);
-                } else {
-                    subscriber.onComplete();
-                }
+                error.tryTerminateConsumer(subscriber);
             }
         }
     }
@@ -67,7 +62,7 @@ public final class HalfSerializer {
             AtomicInteger wip, AtomicThrowable error) {
         if (error.addThrowable(ex)) {
             if (wip.getAndIncrement() == 0) {
-                subscriber.onError(error.terminate());
+                error.tryTerminateConsumer(subscriber);
             }
         } else {
             RxJavaPlugins.onError(ex);
@@ -83,12 +78,7 @@ public final class HalfSerializer {
      */
     public static void onComplete(Subscriber<?> subscriber, AtomicInteger wip, AtomicThrowable error) {
         if (wip.getAndIncrement() == 0) {
-            Throwable ex = error.terminate();
-            if (ex != null) {
-                subscriber.onError(ex);
-            } else {
-                subscriber.onComplete();
-            }
+            error.tryTerminateConsumer(subscriber);
         }
     }
 
@@ -106,12 +96,7 @@ public final class HalfSerializer {
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
             observer.onNext(value);
             if (wip.decrementAndGet() != 0) {
-                Throwable ex = error.terminate();
-                if (ex != null) {
-                    observer.onError(ex);
-                } else {
-                    observer.onComplete();
-                }
+                error.tryTerminateConsumer(observer);
             }
         }
     }
@@ -129,7 +114,7 @@ public final class HalfSerializer {
             AtomicInteger wip, AtomicThrowable error) {
         if (error.addThrowable(ex)) {
             if (wip.getAndIncrement() == 0) {
-                observer.onError(error.terminate());
+                error.tryTerminateConsumer(observer);
             }
         } else {
             RxJavaPlugins.onError(ex);
@@ -145,12 +130,7 @@ public final class HalfSerializer {
      */
     public static void onComplete(Observer<?> observer, AtomicInteger wip, AtomicThrowable error) {
         if (wip.getAndIncrement() == 0) {
-            Throwable ex = error.terminate();
-            if (ex != null) {
-                observer.onError(ex);
-            } else {
-                observer.onComplete();
-            }
+            error.tryTerminateConsumer(observer);
         }
     }
 

--- a/src/main/java/io/reactivex/observers/SerializedObserver.java
+++ b/src/main/java/io/reactivex/observers/SerializedObserver.java
@@ -74,6 +74,7 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
 
     @Override
     public void dispose() {
+        done = true;
         upstream.dispose();
     }
 

--- a/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/flowable/FlowableSubscriberTest.java
@@ -16,7 +16,6 @@ package io.reactivex.flowable;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;

--- a/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/completable/CompletableMergeTest.java
@@ -553,4 +553,44 @@ public class CompletableMergeTest extends RxJavaTest {
 
         to.assertEmpty();
     }
+
+    @Test
+    public void arrayUndeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return Completable.mergeArray(upstream.ignoreElements(), Completable.complete().hide());
+            }
+        });
+    }
+
+    @Test
+    public void iterableUndeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return Completable.merge(Arrays.asList(upstream.ignoreElements(), Completable.complete().hide()));
+            }
+        });
+    }
+
+    @Test
+    public void arrayUndeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return Completable.mergeArrayDelayError(upstream.ignoreElements(), Completable.complete().hide());
+            }
+        });
+    }
+
+    @Test
+    public void iterableUndeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return Completable.mergeDelayError(Arrays.asList(upstream.ignoreElements(), Completable.complete().hide()));
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecentTest.java
@@ -24,7 +24,6 @@ import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.processors.*;
 import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.testsupport.TestHelper;
 
 public class BlockingFlowableMostRecentTest extends RxJavaTest {
     @Test

--- a/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.*;
 import java.util.*;
 import java.util.concurrent.*;
 
-import io.reactivex.testsupport.TestHelper;
 import org.junit.*;
 import org.reactivestreams.*;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAllTest.java
@@ -28,7 +28,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
-import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAmbTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableAnyTest.java
@@ -28,7 +28,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
-import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -15,16 +15,14 @@ package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
 
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
@@ -1326,5 +1324,50 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         ts.cancel();
 
         assertFalse(pp1.hasSubscribers());
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapEager(new Function<Integer, Flowable<Integer>>() {
+                    @Override
+                    public Flowable<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapEagerDelayError(new Function<Integer, Flowable<Integer>>() {
+                    @Override
+                    public Flowable<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                }, false);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapEagerDelayError(new Function<Integer, Flowable<Integer>>() {
+                    @Override
+                    public Flowable<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                }, true);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -1043,4 +1043,49 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
         assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMap(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                }, 2, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                }, 2, false, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                }, 2, true, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
@@ -207,4 +207,49 @@ public class FlowableConcatMapTest extends RxJavaTest {
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMap(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                }, 2, false);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                }, 2, true);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
@@ -20,8 +20,6 @@ import org.junit.*;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.Flowable;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.subscribers.DefaultSubscriber;
 import io.reactivex.testsupport.*;
 
 public class FlowableDefaultIfEmptyTest extends RxJavaTest {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -540,4 +540,34 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
             }
         }
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return upstream.flatMapCompletable(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return upstream.flatMapCompletable(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                }, true, 2);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -610,5 +611,35 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
 
             TestHelper.race(r1, r2);
         }
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                }, true, 2);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
+import io.reactivex.Flowable;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Function;
@@ -510,5 +511,35 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(CompositeException.class);
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.flatMapSingle(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.flatMapSingle(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                }, true, 2);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -20,11 +20,10 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.RxJavaTest;
 import org.junit.*;
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
@@ -1085,5 +1084,35 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
         assertFalse(pp3.hasSubscribers());
         assertFalse(pp4.hasSubscribers());
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.flatMap(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.flatMap(new Function<Integer, Publisher<Integer>>() {
+                    @Override
+                    public Publisher<Integer> apply(Integer v) throws Throwable {
+                        return Flowable.just(v).hide();
+                    }
+                }, true);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -16,13 +16,11 @@ package io.reactivex.internal.operators.flowable;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.*;
 
 import io.reactivex.RxJavaTest;
 import org.junit.*;
-import org.mockito.InOrder;
 import org.reactivestreams.*;
 
 import io.reactivex.Flowable;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeTest.java
@@ -17,7 +17,6 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.TestException;
-import io.reactivex.functions.Action;
+import io.reactivex.functions.*;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subscribers.TestSubscriber;
@@ -172,5 +172,15 @@ public class FlowableMergeWithCompletableTest extends RxJavaTest {
 
         assertFalse("main has observers!", pp.hasSubscribers());
         assertFalse("other has observers", cs.hasObservers());
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.mergeWith(Completable.complete().hide());
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithMaybeTest.java
@@ -438,4 +438,14 @@ public class FlowableMergeWithMaybeTest extends RxJavaTest {
         assertFalse("main has observers!", pp.hasSubscribers());
         assertFalse("other has observers", ms.hasObservers());
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.mergeWith(Maybe.just(1).hide());
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -434,4 +434,14 @@ public class FlowableMergeWithSingleTest extends RxJavaTest {
         assertFalse("main has observers!", pp.hasSubscribers());
         assertFalse("other has observers", ss.hasObservers());
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.mergeWith(Single.just(1).hide());
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.*;
 import org.mockito.InOrder;
-import org.reactivestreams.Subscriber;
+import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
@@ -549,5 +549,45 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Single<Boolean>>() {
+            @Override
+            public Single<Boolean> apply(Flowable<Integer> upstream) {
+                return Flowable.sequenceEqual(Flowable.just(1).hide(), upstream);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelAsFlowable() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Boolean>>() {
+            @Override
+            public Flowable<Boolean> apply(Flowable<Integer> upstream) {
+                return Flowable.sequenceEqual(Flowable.just(1).hide(), upstream).toFlowable();
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancel2() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Single<Boolean>>() {
+            @Override
+            public Single<Boolean> apply(Flowable<Integer> upstream) {
+                return Flowable.sequenceEqual(upstream, Flowable.just(1).hide());
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelAsFlowable2() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Boolean>>() {
+            @Override
+            public Flowable<Boolean> apply(Flowable<Integer> upstream) {
+                return Flowable.sequenceEqual(upstream, Flowable.just(1).hide()).toFlowable();
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -32,7 +32,7 @@ import io.reactivex.schedulers.*;
 import io.reactivex.subscribers.*;
 import io.reactivex.testsupport.*;
 
-public class FlowableSubscribeOnTest extends RxJavaTest{
+public class FlowableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void issue813() throws InterruptedException {

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTimeoutTests.java
@@ -17,7 +17,6 @@ import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.*;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToListTest.java
@@ -27,7 +27,6 @@ import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableToSortedListTest.java
@@ -24,9 +24,6 @@ import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.*;
-import io.reactivex.observers.TestObserver;
-import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.*;
 

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapCompletableTest.java
@@ -386,4 +386,49 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
 
         to.assertResult();
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return upstream.concatMapCompletable(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return upstream.concatMapCompletableDelayError(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                }, false, 2);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return upstream.concatMapCompletableDelayError(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                }, true, 2);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -420,4 +420,48 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
         }
     }
 
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                }, false, 2);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                }, true, 2);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
-import org.reactivestreams.Subscriber;
+import org.reactivestreams.*;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposables;
@@ -336,5 +336,50 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
 
             ts.assertNoErrors();
         }
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapSingle(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapSingleDelayError(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                }, false, 2);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.concatMapSingleDelayError(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                }, true, 2);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
@@ -390,31 +390,31 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return upstream.switchMapCompletable(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                });
+            }
+        });
+    }
 
-            Flowable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    to.dispose();
-                    throw new TestException();
-                }
-            })
-            .switchMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Throwable {
-                    return Completable.complete().hide();
-                }
-            })
-            .subscribe(to);
-
-            to.assertEmpty();
-
-            TestHelper.assertUndeliverable(errors, 0, TestException.class);
-        } finally {
-            RxJavaPlugins.reset();
-        }
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Flowable<Integer> upstream) {
+                return upstream.switchMapCompletableDelayError(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                });
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
@@ -649,31 +649,31 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
 
-            Flowable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    ts.cancel();
-                    throw new TestException();
-                }
-            })
-            .switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer v) throws Throwable {
-                    return Maybe.just(v).hide();
-                }
-            })
-            .subscribe(ts);
-
-            ts.assertEmpty();
-
-            TestHelper.assertUndeliverable(errors, 0, TestException.class);
-        } finally {
-            RxJavaPlugins.reset();
-        }
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.switchMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                });
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -606,31 +606,31 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.switchMapSingle(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
 
-            Flowable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    ts.cancel();
-                    throw new TestException();
-                }
-            })
-            .switchMapSingle(new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer v) throws Throwable {
-                    return Single.just(v).hide();
-                }
-            })
-            .subscribe(ts);
-
-            ts.assertEmpty();
-
-            TestHelper.assertUndeliverable(errors, 0, TestException.class);
-        } finally {
-            RxJavaPlugins.reset();
-        }
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
+            @Override
+            public Flowable<Integer> apply(Flowable<Integer> upstream) {
+                return upstream.switchMapSingleDelayError(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                });
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapCompletableTest.java
@@ -429,4 +429,49 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
 
         to.assertResult();
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Observable<Integer> upstream) {
+                return upstream.concatMapCompletable(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Observable<Integer> upstream) {
+                return upstream.concatMapCompletableDelayError(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                }, false, 2);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Observable<Integer> upstream) {
+                return upstream.concatMapCompletableDelayError(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                }, true, 2);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -441,4 +441,49 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
             to.assertNoErrors();
         }
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                }, false, 2);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                }, true, 2);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -382,4 +382,48 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
         }
     }
 
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapSingle(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapSingleDelayError(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                }, false, 2);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapSingleDelayError(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                }, true, 2);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
@@ -27,7 +27,7 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.*;
-import io.reactivex.testsupport.*;
+import io.reactivex.testsupport.TestHelper;
 
 public class ObservableSwitchMapCompletableTest extends RxJavaTest {
 
@@ -432,31 +432,31 @@ public class ObservableSwitchMapCompletableTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Observable<Integer> upstream) {
+                return upstream.switchMapCompletable(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                });
+            }
+        });
+    }
 
-            Observable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    to.dispose();
-                    throw new TestException();
-                }
-            })
-            .switchMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Throwable {
-                    return Completable.complete().hide();
-                }
-            })
-            .subscribe(to);
-
-            to.assertEmpty();
-
-            TestHelper.assertUndeliverable(errors, 0, TestException.class);
-        } finally {
-            RxJavaPlugins.reset();
-        }
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Observable<Integer> upstream) {
+                return upstream.switchMapCompletableDelayError(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                });
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -689,31 +689,31 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
 
-            Observable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    to.dispose();
-                    throw new TestException();
-                }
-            })
-            .switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer v) throws Throwable {
-                    return Maybe.just(v).hide();
-                }
-            })
-            .subscribe(to);
-
-            to.assertEmpty();
-
-            TestHelper.assertUndeliverable(errors, 0, TestException.class);
-        } finally {
-            RxJavaPlugins.reset();
-        }
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.switchMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                });
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -657,31 +657,31 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.switchMapSingle(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
 
-            Observable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    to.dispose();
-                    throw new TestException();
-                }
-            })
-            .switchMapSingle(new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer v) throws Throwable {
-                    return Single.just(v).hide();
-                }
-            })
-            .subscribe(to);
-
-            to.assertEmpty();
-
-            TestHelper.assertUndeliverable(errors, 0, TestException.class);
-        } finally {
-            RxJavaPlugins.reset();
-        }
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.switchMapSingleDelayError(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                });
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -20,11 +20,10 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.RxJavaTest;
 import org.junit.*;
 
+import io.reactivex.*;
 import io.reactivex.Observable;
-import io.reactivex.ObservableSource;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
@@ -1005,5 +1004,50 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.dispose();
 
         assertFalse(ps1.hasObservers());
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapEager(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapEagerDelayError(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                }, false);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapEagerDelayError(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                }, true);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -1004,4 +1004,49 @@ public class ObservableConcatMapSchedulerTest {
 
         assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMap(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                }, 2, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                }, 2, false, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                }, 2, true, ImmediateThinScheduler.INSTANCE);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableConcatMapTest.java
@@ -522,4 +522,49 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
         assertEquals(0, counter.get());
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMap(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                }, 2, false);
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayErrorTillEnd() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                }, 2, true);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableDefaultIfEmptyTest.java
@@ -18,8 +18,6 @@ import static org.mockito.Mockito.*;
 import org.junit.*;
 
 import io.reactivex.*;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.observers.DefaultObserver;
 import io.reactivex.testsupport.TestHelper;
 
 public class ObservableDefaultIfEmptyTest extends RxJavaTest {

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -476,4 +476,34 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
             }
         }, false, 1, null);
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Observable<Integer> upstream) {
+                return upstream.flatMapCompletable(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
+            @Override
+            public Completable apply(Observable<Integer> upstream) {
+                return upstream.flatMapCompletable(new Function<Integer, Completable>() {
+                    @Override
+                    public Completable apply(Integer v) throws Throwable {
+                        return Completable.complete().hide();
+                    }
+                }, true);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -455,4 +455,34 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         to
         .assertEmpty();
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> apply(Integer v) throws Throwable {
+                        return Maybe.just(v).hide();
+                    }
+                }, true);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -370,4 +370,34 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         to
         .assertEmpty();
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.flatMapSingle(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.flatMapSingle(new Function<Integer, Single<Integer>>() {
+                    @Override
+                    public Single<Integer> apply(Integer v) throws Throwable {
+                        return Single.just(v).hide();
+                    }
+                }, true);
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -14,17 +14,17 @@
 package io.reactivex.internal.operators.observable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.RxJavaTest;
 import org.junit.*;
 
+import io.reactivex.*;
 import io.reactivex.Observable;
-import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
@@ -1046,5 +1046,35 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
         assertFalse(ps3.hasObservers());
         assertFalse(ps4.hasObservers());
+    }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.flatMap(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Test
+    public void undeliverableUponCancelDelayError() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.flatMap(new Function<Integer, Observable<Integer>>() {
+                    @Override
+                    public Observable<Integer> apply(Integer v) throws Throwable {
+                        return Observable.just(v).hide();
+                    }
+                }, true);
+            }
+        });
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.*;
 
 import io.reactivex.RxJavaTest;
 import org.junit.*;
-import org.mockito.InOrder;
 
 import io.reactivex.Observable;
 import io.reactivex.ObservableSource;

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithCompletableTest.java
@@ -172,4 +172,14 @@ public class ObservableMergeWithCompletableTest extends RxJavaTest {
         assertFalse("main has observers!", ps.hasObservers());
         assertFalse("other has observers", cs.hasObservers());
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.mergeWith(Completable.complete().hide());
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithMaybeTest.java
@@ -308,4 +308,14 @@ public class ObservableMergeWithMaybeTest extends RxJavaTest {
         assertFalse("main has observers!", ps.hasObservers());
         assertFalse("other has observers", ms.hasObservers());
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.mergeWith(Maybe.just(1).hide());
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -300,4 +300,14 @@ public class ObservableMergeWithSingleTest extends RxJavaTest {
         assertFalse("main has observers!", ps.hasObservers());
         assertFalse("other has observers", ss.hasObservers());
     }
+
+    @Test
+    public void undeliverableUponCancel() {
+        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> upstream) {
+                return upstream.mergeWith(Single.just(1).hide());
+            }
+        });
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTimeoutTests.java
@@ -17,7 +17,6 @@ import static io.reactivex.internal.util.ExceptionHelper.timeoutMessage;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.*;
 

--- a/src/test/java/io/reactivex/internal/util/AtomicThrowableTest.java
+++ b/src/test/java/io/reactivex/internal/util/AtomicThrowableTest.java
@@ -17,11 +17,15 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
-import io.reactivex.RxJavaTest;
 import org.junit.Test;
 
+import io.reactivex.*;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
+import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
 import io.reactivex.testsupport.TestHelper;
 
 public class AtomicThrowableTest extends RxJavaTest {
@@ -83,5 +87,165 @@ public class AtomicThrowableTest extends RxJavaTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @Test
+    public void tryTerminateConsumerSubscriberNoError() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        ts.onSubscribe(new BooleanSubscription());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.tryTerminateConsumer(ts);
+        ts.assertResult();
+    }
+
+    @Test
+    public void tryTerminateConsumerSubscriberError() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        ts.onSubscribe(new BooleanSubscription());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.set(new TestException());
+        ex.tryTerminateConsumer(ts);
+        ts.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void tryTerminateConsumerSubscriberTerminated() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        ts.onSubscribe(new BooleanSubscription());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.terminate();
+        ex.tryTerminateConsumer(ts);
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void tryTerminateConsumerObserverNoError() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.tryTerminateConsumer((Observer<Object>)to);
+        to.assertResult();
+    }
+
+    @Test
+    public void tryTerminateConsumerObserverError() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.set(new TestException());
+        ex.tryTerminateConsumer((Observer<Object>)to);
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void tryTerminateConsumerObserverTerminated() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.terminate();
+        ex.tryTerminateConsumer((Observer<Object>)to);
+        to.assertEmpty();
+    }
+
+    @Test
+    public void tryTerminateConsumerMaybeObserverNoError() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.tryTerminateConsumer((MaybeObserver<Object>)to);
+        to.assertResult();
+    }
+
+    @Test
+    public void tryTerminateConsumerMaybeObserverError() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.set(new TestException());
+        ex.tryTerminateConsumer((MaybeObserver<Object>)to);
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void tryTerminateConsumerMaybeObserverTerminated() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.terminate();
+        ex.tryTerminateConsumer((MaybeObserver<Object>)to);
+        to.assertEmpty();
+    }
+
+    @Test
+    public void tryTerminateConsumerSingleNoError() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.tryTerminateConsumer((SingleObserver<Object>)to);
+        to.assertEmpty();
+    }
+
+    @Test
+    public void tryTerminateConsumerSingleError() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.set(new TestException());
+        ex.tryTerminateConsumer((SingleObserver<Object>)to);
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void tryTerminateConsumerSingleTerminated() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.terminate();
+        ex.tryTerminateConsumer((SingleObserver<Object>)to);
+        to.assertEmpty();
+    }
+
+    @Test
+    public void tryTerminateConsumerCompletableObserverNoError() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.tryTerminateConsumer((CompletableObserver)to);
+        to.assertResult();
+    }
+
+    @Test
+    public void tryTerminateConsumerCompletableObserverError() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.set(new TestException());
+        ex.tryTerminateConsumer((CompletableObserver)to);
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void tryTerminateConsumerCompletableObserverTerminated() {
+        TestObserver<Object> to = new TestObserver<Object>();
+        to.onSubscribe(Disposables.empty());
+
+        AtomicThrowable ex = new AtomicThrowable();
+        ex.terminate();
+        ex.tryTerminateConsumer((CompletableObserver)to);
+        to.assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/testsupport/TestHelper.java
@@ -3255,4 +3255,140 @@ public enum TestHelper {
 
         return f;
     }
+
+    /**
+     * Cancels a flow before notifying a transformation and checks if an undeliverable exception
+     * has been signaled due to the cancellation.
+     * @param transform the operator to test
+     * @param <T> the output type of the transformation
+     */
+    public static <T> void checkUndeliverableUponCancel(FlowableConverter<Integer, T> transform) {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+
+            final SerialDisposable disposable = new SerialDisposable();
+
+            T result = Flowable.just(1)
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Throwable {
+                    disposable.dispose();
+                    throw new TestException();
+                }
+            })
+            .to(transform);
+
+            if (result instanceof MaybeSource) {
+                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                disposable.set(to);
+
+                ((MaybeSource<?>)result)
+                .subscribe(to);
+                to.assertEmpty();
+            } else if (result instanceof SingleSource) {
+                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                disposable.set(to);
+
+                ((SingleSource<?>)result)
+                .subscribe(to);
+                to.assertEmpty();
+            } else if (result instanceof CompletableSource) {
+                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                disposable.set(to);
+
+                ((CompletableSource)result)
+                .subscribe(to);
+                to.assertEmpty();
+            } else if (result instanceof ObservableSource) {
+                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                disposable.set(to);
+
+                ((ObservableSource<?>)result)
+                .subscribe(to);
+                to.assertEmpty();
+            } else if (result instanceof Publisher) {
+                TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+                disposable.set(Disposables.fromSubscription(ts));
+
+                ((Publisher<?>)result)
+                .subscribe(ts);
+                ts.assertEmpty();
+            } else {
+                fail("Unsupported transformation output: " + result + " of class " + (result != null ? result.getClass() : " <null>"));
+            }
+
+            assertFalse("No undeliverable errors received", errors.isEmpty());
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    /**
+     * Cancels a flow before notifying a transformation and checks if an undeliverable exception
+     * has been signaled due to the cancellation.
+     * @param transform the operator to test
+     * @param <T> the output type of the transformation
+     */
+    public static <T> void checkUndeliverableUponCancel(ObservableConverter<Integer, T> transform) {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+
+            final SerialDisposable disposable = new SerialDisposable();
+
+            T result = Observable.just(1)
+            .map(new Function<Integer, Integer>() {
+                @Override
+                public Integer apply(Integer v) throws Throwable {
+                    disposable.dispose();
+                    throw new TestException();
+                }
+            })
+            .to(transform);
+
+            if (result instanceof MaybeSource) {
+                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                disposable.set(to);
+
+                ((MaybeSource<?>)result)
+                .subscribe(to);
+                to.assertEmpty();
+            } else if (result instanceof SingleSource) {
+                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                disposable.set(to);
+
+                ((SingleSource<?>)result)
+                .subscribe(to);
+                to.assertEmpty();
+            } else if (result instanceof CompletableSource) {
+                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                disposable.set(to);
+
+                ((CompletableSource)result)
+                .subscribe(to);
+                to.assertEmpty();
+            } else if (result instanceof ObservableSource) {
+                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                disposable.set(to);
+
+                ((ObservableSource<?>)result)
+                .subscribe(to);
+                to.assertEmpty();
+            } else if (result instanceof Publisher) {
+                TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+                disposable.set(Disposables.fromSubscription(ts));
+
+                ((Publisher<?>)result)
+                .subscribe(ts);
+                ts.assertEmpty();
+            } else {
+                fail("Unsupported transformation output: " + result + " of class " + (result != null ? result.getClass() : " <null>"));
+            }
+
+            assertFalse("No undeliverable errors received", errors.isEmpty());
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
 }


### PR DESCRIPTION
Fix many operators to emit the collected exception in case of a cancel/dispose call to the plugin error handler (i.e., becoming undeliverable excptions).

In addition, the terminal event/error delivery has been unified in many other operators so that the terminal-indicator exception is never leaked.

There will be a separate PR about cleaning up the `addThrowable` usage cases (#6611).

Fixes: #6587