### PR TITLE
3.x: elementAt, first - constrain upstream requests 

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -9494,8 +9494,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/elementAt.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
+     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in a bounded manner.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code elementAt} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9523,8 +9522,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/elementAtOrDefault.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
+     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in a bounded manner.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code elementAt} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9558,8 +9556,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/elementAtOrDefault.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an unbounded manner
-     *  (i.e., no backpressure applied to it).</dd>
+     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in a bounded manner.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code elementAtOrError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9573,7 +9570,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/elementat.html">ReactiveX operators documentation: ElementAt</a>
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> elementAtOrError(long index) {
         if (index < 0) {
@@ -9617,8 +9614,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="237" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstElement.m.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
-     *  unbounded manner (i.e., without applying backpressure).</dd>
+     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in a bounded manner.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code firstElement} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9640,8 +9636,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/first.s.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
-     *  unbounded manner (i.e., without applying backpressure).</dd>
+     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in a bounded manner.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code first} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -9666,8 +9661,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="237" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstOrError.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in an
-     *  unbounded manner (i.e., without applying backpressure).</dd>
+     *  <dd>The operator honors backpressure from downstream and consumes the source {@code Publisher} in a bounded manner.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code firstOrError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -9627,7 +9627,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.SPECIAL) // take may trigger UNBOUNDED_IN
+    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> firstElement() {
         return elementAt(0);
@@ -9653,7 +9653,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.SPECIAL) // take may trigger UNBOUNDED_IN
+    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> first(T defaultItem) {
         return elementAt(0, defaultItem);

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -9507,7 +9507,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/elementat.html">ReactiveX operators documentation: ElementAt</a>
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> elementAt(long index) {
         if (index < 0) {

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -9541,7 +9541,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @CheckReturnValue
     @NonNull
-    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> elementAt(long index, T defaultItem) {
         if (index < 0) {

--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -9676,7 +9676,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/first.html">ReactiveX operators documentation: First</a>
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.SPECIAL) // take may trigger UNBOUNDED_IN
+    @BackpressureSupport(BackpressureKind.FULL) // take may trigger UNBOUNDED_IN
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> firstOrError() {
         return elementAtOrError(0);

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtMaybe.java
@@ -63,7 +63,7 @@ public final class FlowableElementAtMaybe<T> extends Maybe<T> implements FuseToF
             if (SubscriptionHelper.validate(this.upstream, s)) {
                 this.upstream = s;
                 downstream.onSubscribe(this);
-                s.request(Long.MAX_VALUE);
+                s.request(index + 1);
             }
         }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableElementAtSingle.java
@@ -70,7 +70,7 @@ public final class FlowableElementAtSingle<T> extends Single<T> implements FuseT
             if (SubscriptionHelper.validate(this.upstream, s)) {
                 this.upstream = s;
                 downstream.onSubscribe(this);
-                s.request(Long.MAX_VALUE);
+                s.request(index + 1);
             }
         }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -26,6 +26,7 @@ import io.reactivex.Observer;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.TestException;
 import io.reactivex.functions.Function;
+import io.reactivex.functions.LongConsumer;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
@@ -68,6 +69,22 @@ public class FlowableElementAtTest extends RxJavaTest {
     public void elementAt() {
         assertEquals(2, Flowable.fromArray(1, 2).elementAt(1).blockingGet()
                 .intValue());
+    }
+    
+    @Test
+    public void elementAtConstrainsUpstreamRequests() {
+        final List<Long> requests = new ArrayList<Long>();
+        Flowable.fromArray(1, 2, 3, 4)
+            .doOnRequest(new LongConsumer() {
+                @Override
+                public void accept(long n) throws Throwable {
+                    requests.add(n);
+                }
+            })
+            .elementAt(2)
+            .blockingGet()
+                .intValue();
+        assertEquals(Arrays.asList(3L), requests);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableElementAtTest.java
@@ -86,6 +86,22 @@ public class FlowableElementAtTest extends RxJavaTest {
                 .intValue();
         assertEquals(Arrays.asList(3L), requests);
     }
+    
+    @Test
+    public void elementAtWithDefaultConstrainsUpstreamRequests() {
+        final List<Long> requests = new ArrayList<Long>();
+        Flowable.fromArray(1, 2, 3, 4)
+            .doOnRequest(new LongConsumer() {
+                @Override
+                public void accept(long n) throws Throwable {
+                    requests.add(n);
+                }
+            })
+            .elementAt(2, 100)
+            .blockingGet()
+                .intValue();
+        assertEquals(Arrays.asList(3L), requests);
+    }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void elementAtWithMinusIndex() {


### PR DESCRIPTION
As discussed in #6569 this PR constrains upstream requests for the `elementAt` and `first` overloads. Other operators will be covered in other PRs.