### PR TITLE
3.x: Fix blockingIterable not unblocking when force-disposed

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
@@ -182,7 +182,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
         @Override
         public void dispose() {
             SubscriptionHelper.cancel(this);
-            signalConsumer(); // just in case it is currently blocking in hasNext
+            signalConsumer(); // Just in case it is currently blocking in hasNext.
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
@@ -21,7 +21,7 @@ import org.reactivestreams.Subscription;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
@@ -62,7 +62,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
         long produced;
 
         volatile boolean done;
-        Throwable error;
+        volatile Throwable error;
 
         BlockingFlowableIterator(int batchSize) {
             this.queue = new SpscArrayQueue<T>(batchSize);
@@ -75,6 +75,13 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
         @Override
         public boolean hasNext() {
             for (;;) {
+                if (isDisposed()) {
+                    Throwable e = error;
+                    if (e != null) {
+                        throw ExceptionHelper.wrapOrThrow(e);
+                    }
+                    return false;
+                }
                 boolean d = done;
                 boolean empty = queue.isEmpty();
                 if (d) {
@@ -90,7 +97,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
                     BlockingHelper.verifyNonBlocking();
                     lock.lock();
                     try {
-                        while (!done && queue.isEmpty()) {
+                        while (!done && queue.isEmpty() && !isDisposed()) {
                             condition.await();
                         }
                     } catch (InterruptedException ex) {
@@ -175,6 +182,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
         @Override
         public void dispose() {
             SubscriptionHelper.cancel(this);
+            signalConsumer(); // just in case it is currently blocking in hasNext
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableIterable.java
@@ -53,7 +53,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
         final Condition condition;
 
         volatile boolean done;
-        Throwable error;
+        volatile Throwable error;
 
         BlockingObservableIterator(int batchSize) {
             this.queue = new SpscLinkedArrayQueue<T>(batchSize);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableIterable.java
@@ -153,7 +153,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
         @Override
         public void dispose() {
             DisposableHelper.dispose(this);
-            signalConsumer(); // just in case it is currently blocking in hasNext
+            signalConsumer(); // Just in case it is currently blocking in hasNext.
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableIterable.java
@@ -64,6 +64,13 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
         @Override
         public boolean hasNext() {
             for (;;) {
+                if (isDisposed()) {
+                    Throwable e = error;
+                    if (e != null) {
+                        throw ExceptionHelper.wrapOrThrow(e);
+                    }
+                    return false;
+                }
                 boolean d = done;
                 boolean empty = queue.isEmpty();
                 if (d) {
@@ -80,7 +87,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
                         BlockingHelper.verifyNonBlocking();
                         lock.lock();
                         try {
-                            while (!done && queue.isEmpty()) {
+                            while (!done && queue.isEmpty() && !isDisposed()) {
                                 condition.await();
                             }
                         } finally {
@@ -146,6 +153,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
         @Override
         public void dispose() {
             DisposableHelper.dispose(this);
+            signalConsumer(); // just in case it is currently blocking in hasNext
         }
 
         @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNextTest.java
@@ -28,7 +28,6 @@ import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.internal.operators.observable.BlockingObservableNext.NextObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
-import io.reactivex.rxjava3.processors.BehaviorProcessor;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.TestHelper;
@@ -333,9 +332,9 @@ public class BlockingObservableNextTest extends RxJavaTest {
 
     @Test
     public void synchronousNext() {
-        assertEquals(1, BehaviorProcessor.createDefault(1).take(1).blockingSingle().intValue());
-        assertEquals(2, BehaviorProcessor.createDefault(2).blockingIterable().iterator().next().intValue());
-        assertEquals(3, BehaviorProcessor.createDefault(3).blockingNext().iterator().next().intValue());
+        assertEquals(1, BehaviorSubject.createDefault(1).take(1).blockingSingle().intValue());
+        assertEquals(2, BehaviorSubject.createDefault(2).blockingIterable().iterator().next().intValue());
+        assertEquals(3, BehaviorSubject.createDefault(3).blockingNext().iterator().next().intValue());
     }
 
     @Test


### PR DESCRIPTION
When the iterator was cast to `Disposable` and disposed, the subsequent `hasNext` would block indefinitely. That interface is not intended to be part of the public API and `Iterator` in general does not support any form of official cancellation (unlike Stream). This PR makes sure that if that dispose is called, it unblocks the iterator.

A separate PR will be posted for 2.x.

Related #6625 