### PR TITLE
3.x: better leak detection via GC/sleep loop

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRefCountTest.java
@@ -676,11 +676,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         source.subscribe();
 
-        Thread.sleep(100);
-        System.gc();
-        Thread.sleep(100);
-
-        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;
         assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
@@ -712,11 +708,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         d1 = null;
         d2 = null;
 
-        Thread.sleep(100);
-        System.gc();
-        Thread.sleep(100);
-
-        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;
         assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
@@ -752,10 +744,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer());
 
-        System.gc();
-        Thread.sleep(GC_SLEEP_TIME);
-
-        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;
 
@@ -790,7 +779,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         System.gc();
         Thread.sleep(GC_SLEEP_TIME);
 
-        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;
         assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRefCountTest.java
@@ -776,9 +776,6 @@ public class FlowableRefCountTest extends RxJavaTest {
         d1 = null;
         d2 = null;
 
-        System.gc();
-        Thread.sleep(GC_SLEEP_TIME);
-
         long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
@@ -652,10 +652,7 @@ public class ObservableRefCountTest extends RxJavaTest {
 
         source.subscribe();
 
-        System.gc();
-        Thread.sleep(100);
-
-        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;
         assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
@@ -689,7 +686,7 @@ public class ObservableRefCountTest extends RxJavaTest {
         System.gc();
         Thread.sleep(100);
 
-        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;
         assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
@@ -725,19 +722,7 @@ public class ObservableRefCountTest extends RxJavaTest {
 
         source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer());
 
-        long after = 0L;
-
-        for (int i = 0; i < 10; i++) {
-            System.gc();
-
-            after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
-
-            if (start + 20 * 1000 * 1000 > after) {
-                break;
-            }
-
-            Thread.sleep(GC_SLEEP_TIME);
-        }
+        long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;
         assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);
@@ -768,10 +753,7 @@ public class ObservableRefCountTest extends RxJavaTest {
         d1 = null;
         d2 = null;
 
-        System.gc();
-        Thread.sleep(GC_SLEEP_TIME);
-
-        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;
         assertTrue(String.format("%,3d -> %,3d%n", start, after), start + 20 * 1000 * 1000 > after);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
@@ -683,9 +683,6 @@ public class ObservableRefCountTest extends RxJavaTest {
         d1 = null;
         d2 = null;
 
-        System.gc();
-        Thread.sleep(100);
-
         long after = TestHelper.awaitGC(GC_SLEEP_TIME, 20, start + 20 * 1000 * 1000);
 
         source = null;


### PR DESCRIPTION
The `publishNoLeak` and `replayNoLeak` tests tend to fail because the GC/sleep time is not enough sometimes to cleanup memory. This PR adds a main test helper that loops at most a number of times and quits when the GC has apparently done its job.