### PR TITLE
2.x: Fix refCount() not resetting when cross-canceled

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableRefCount.java
@@ -115,19 +115,39 @@ public final class FlowableRefCount<T> extends Flowable<T> {
 
     void terminated(RefConnection rc) {
         synchronized (this) {
-            if (connection != null && connection == rc) {
-                connection = null;
-                if (rc.timer != null) {
-                    rc.timer.dispose();
+            if (source instanceof FlowablePublishClassic) {
+                if (connection != null && connection == rc) {
+                    connection = null;
+                    clearTimer(rc);
+                }
+
+                if (--rc.subscriberCount == 0) {
+                    reset(rc);
+                }
+            } else {
+                if (connection != null && connection == rc) {
+                    clearTimer(rc);
+                    if (--rc.subscriberCount == 0) {
+                        connection = null;
+                        reset(rc);
+                    }
                 }
             }
-            if (--rc.subscriberCount == 0) {
-                if (source instanceof Disposable) {
-                    ((Disposable)source).dispose();
-                } else if (source instanceof ResettableConnectable) {
-                    ((ResettableConnectable)source).resetIf(rc.get());
-                }
-            }
+        }
+    }
+
+    void clearTimer(RefConnection rc) {
+        if (rc.timer != null) {
+            rc.timer.dispose();
+            rc.timer = null;
+        }
+    }
+
+    void reset(RefConnection rc) {
+        if (source instanceof Disposable) {
+            ((Disposable)source).dispose();
+        } else if (source instanceof ResettableConnectable) {
+            ((ResettableConnectable)source).resetIf(rc.get());
         }
     }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountAltTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountAltTest.java
@@ -1443,4 +1443,23 @@ public class FlowableRefCountAltTest {
             .assertComplete();
         }
     }
+
+    @Test
+    public void upstreamTerminationTriggersAnotherCancel() throws Exception {
+        ReplayProcessor<Integer> rp = ReplayProcessor.create();
+        rp.onNext(1);
+        rp.onComplete();
+
+        Flowable<Integer> shared = rp.share();
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableRefCountTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.internal.operators.flowable;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -1435,5 +1436,24 @@ public class FlowableRefCountTest {
         processor.onNext(2);
 
         flowable.take(1).test().assertResult(2);
+    }
+
+    @Test
+    public void upstreamTerminationTriggersAnotherCancel() throws Exception {
+        ReplayProcessor<Integer> rp = ReplayProcessor.create();
+        rp.onNext(1);
+        rp.onComplete();
+
+        Flowable<Integer> shared = rp.share();
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountAltTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountAltTest.java
@@ -1399,4 +1399,23 @@ public class ObservableRefCountAltTest {
             .assertComplete();
         }
     }
+
+    @Test
+    public void upstreamTerminationTriggersAnotherCancel() throws Exception {
+        ReplaySubject<Integer> rs = ReplaySubject.create();
+        rs.onNext(1);
+        rs.onComplete();
+
+        Observable<Integer> shared = rs.share();
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -532,7 +532,7 @@ public class ObservableRefCountTest {
         to2.assertValue(30);
     }
 
-    @Test(timeout = 10000)
+    @Test//(timeout = 10000)
     public void testUpstreamErrorAllowsRetry() throws InterruptedException {
         final AtomicInteger intervalSubscribed = new AtomicInteger();
         Observable<String> interval =
@@ -1379,5 +1379,24 @@ public class ObservableRefCountTest {
         subject.onNext(2);
 
         observable.take(1).test().assertResult(2);
+    }
+
+    @Test
+    public void upstreamTerminationTriggersAnotherCancel() throws Exception {
+        ReplaySubject<Integer> rs = ReplaySubject.create();
+        rs.onNext(1);
+        rs.onComplete();
+
+        Observable<Integer> shared = rs.share();
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
+
+        shared
+        .buffer(shared.debounce(5, TimeUnit.SECONDS))
+        .test()
+        .assertValueCount(2);
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableRefCountTest.java
@@ -532,7 +532,7 @@ public class ObservableRefCountTest {
         to2.assertValue(30);
     }
 
-    @Test//(timeout = 10000)
+    @Test(timeout = 10000)
     public void testUpstreamErrorAllowsRetry() throws InterruptedException {
         final AtomicInteger intervalSubscribed = new AtomicInteger();
         Observable<String> interval =


### PR DESCRIPTION
This PR fixes the issue with `refCount` not resetting the connection when the termination triggers cross-cancellation over it.

Fixes #6608

The fix is more involved than #6609 because how 2.x uses two `publish()` implementation internally due to bugfix #6505. The old/classic implementation does not fail #6608 but the newer implementation fails #6608. If the fix is applied unconditionally, the old/classic implementation fails an older unit test verifying an error allows reconnection. Therefore, the PR checks and applies the new code path only if `refCount` isn't talking to the classic publish implementation.

As a reminder #6609 for 3.x has a redesigned `Connectable` with a much more clearer reset semantics and thus the restructuring of the termination handling had no trouble passing the aforementioned error-allows-reconnect unit test.