### PR TITLE
3.x: Remove vararg overloads for combineLatest in Observable + Flowable

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -129,9 +129,9 @@ import io.reactivex.rxjava3.subscribers.*;
  * }, BackpressureStrategy.BUFFER);
  *
  * System.out.println("Subscribe!");
- * 
+ *
  * source.subscribe(System.out::println);
- * 
+ *
  * System.out.println("Done!");
  * </code></pre>
  * <p>
@@ -274,50 +274,6 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     public static <T, R> Flowable<R> combineLatest(Publisher<? extends T>[] sources, Function<? super Object[], ? extends R> combiner) {
-        return combineLatest(sources, combiner, bufferSize());
-    }
-
-    /**
-     * Combines a collection of source Publishers by emitting an item that aggregates the latest values of each of
-     * the source Publishers each time an item is received from any of the source Publishers, where this
-     * aggregation is defined by a specified function.
-     * <p>
-     * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
-     * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
-     * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
-     * <p>
-     * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
-     * If that input source is also synchronous, other sources after it will not be subscribed to.
-     * <p>
-     * If there are no source Publishers provided, the resulting sequence completes immediately without emitting
-     * any items and without any calls to the combiner function.
-     *
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Publisher} honors backpressure from downstream. The source {@code Publisher}s
-     *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
-     *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T>
-     *            the common base type of source values
-     * @param <R>
-     *            the result type
-     * @param sources
-     *            the collection of source Publishers
-     * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
-     * @return a Flowable that emits items that are the result of combining the items emitted by the source
-     *         Publishers by means of the given aggregation function
-     * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatest(Function<? super Object[], ? extends R> combiner, Publisher<? extends T>... sources) {
         return combineLatest(sources, combiner, bufferSize());
     }
 
@@ -529,100 +485,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
-     * If there are no source Publishers provided, the resulting sequence completes immediately without emitting
-     * any items and without any calls to the combiner function.
-     *
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Publisher} honors backpressure from downstream. The source {@code Publisher}s
-     *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
-     *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T>
-     *            the common base type of source values
-     * @param <R>
-     *            the result type
-     * @param sources
-     *            the collection of source Publishers
-     * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
-     * @return a Flowable that emits items that are the result of combining the items emitted by the source
-     *         Publishers by means of the given aggregation function
-     * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatestDelayError(Function<? super Object[], ? extends R> combiner,
-            Publisher<? extends T>... sources) {
-        return combineLatestDelayError(sources, combiner, bufferSize());
-    }
-
-    /**
-     * Combines a collection of source Publishers by emitting an item that aggregates the latest values of each of
-     * the source Publishers each time an item is received from any of the source Publisher, where this
-     * aggregation is defined by a specified function and delays any error from the sources until
-     * all source Publishers terminate.
-     * <p>
-     * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
-     * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
-     * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
-     * <p>
-     * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
-     * If that input source is also synchronous, other sources after it will not be subscribed to.
-     * <p>
-     * If there are no source Publishers provided, the resulting sequence completes immediately without emitting
-     * any items and without any calls to the combiner function.
-     *
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Publisher} honors backpressure from downstream. The source {@code Publisher}s
-     *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
-     *   {@code MissingBackpressureException}) and may lead to {@code OutOfMemoryError} due to internal buffer bloat.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T>
-     *            the common base type of source values
-     * @param <R>
-     *            the result type
-     * @param sources
-     *            the collection of source Publishers
-     * @param combiner
-     *            the aggregation function used to combine the items emitted by the source Publishers
-     * @param bufferSize
-     *            the internal buffer size and prefetch amount applied to every source Publisher
-     * @return a Flowable that emits items that are the result of combining the items emitted by the source
-     *         Publishers by means of the given aggregation function
-     * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
-     */
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatestDelayError(Function<? super Object[], ? extends R> combiner,
-            int bufferSize, Publisher<? extends T>... sources) {
-        return combineLatestDelayError(sources, combiner, bufferSize);
-    }
-
-    /**
-     * Combines a collection of source Publishers by emitting an item that aggregates the latest values of each of
-     * the source Publishers each time an item is received from any of the source Publishers, where this
-     * aggregation is defined by a specified function and delays any error from the sources until
-     * all source Publishers terminate.
-     * <p>
-     * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
-     * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
-     * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
-     * <p>
-     * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated until that point).
-     * If that input source is also synchronous, other sources after it will not be subscribed to.
-     * <p>
      * If the provided array of source Publishers is empty, the resulting sequence completes immediately without emitting
      * any items and without any calls to the combiner function.
      *
@@ -802,8 +664,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             BiFunction<? super T1, ? super T2, ? extends R> combiner) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
-        Function<Object[], R> f = Functions.toFunction(combiner);
-        return combineLatest(f, source1, source2);
+        return combineLatest(new Publisher[] { source1, source2 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -853,7 +714,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(source3, "source3 is null");
-        return combineLatest(Functions.toFunction(combiner), source1, source2, source3);
+        return combineLatest(new Publisher[] { source1, source2, source3 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -907,7 +768,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(source3, "source3 is null");
         ObjectHelper.requireNonNull(source4, "source4 is null");
-        return combineLatest(Functions.toFunction(combiner), source1, source2, source3, source4);
+        return combineLatest(new Publisher[] { source1, source2, source3, source4 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -966,7 +827,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(source3, "source3 is null");
         ObjectHelper.requireNonNull(source4, "source4 is null");
         ObjectHelper.requireNonNull(source5, "source5 is null");
-        return combineLatest(Functions.toFunction(combiner), source1, source2, source3, source4, source5);
+        return combineLatest(new Publisher[] { source1, source2, source3, source4, source5 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -1029,7 +890,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(source4, "source4 is null");
         ObjectHelper.requireNonNull(source5, "source5 is null");
         ObjectHelper.requireNonNull(source6, "source6 is null");
-        return combineLatest(Functions.toFunction(combiner), source1, source2, source3, source4, source5, source6);
+        return combineLatest(new Publisher[] { source1, source2, source3, source4, source5, source6 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -1097,7 +958,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(source5, "source5 is null");
         ObjectHelper.requireNonNull(source6, "source6 is null");
         ObjectHelper.requireNonNull(source7, "source7 is null");
-        return combineLatest(Functions.toFunction(combiner), source1, source2, source3, source4, source5, source6, source7);
+        return combineLatest(new Publisher[] { source1, source2, source3, source4, source5, source6, source7 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -1169,7 +1030,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(source6, "source6 is null");
         ObjectHelper.requireNonNull(source7, "source7 is null");
         ObjectHelper.requireNonNull(source8, "source8 is null");
-        return combineLatest(Functions.toFunction(combiner), source1, source2, source3, source4, source5, source6, source7, source8);
+        return combineLatest(new Publisher[] { source1, source2, source3, source4, source5, source6, source7, source8 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -1246,7 +1107,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.requireNonNull(source7, "source7 is null");
         ObjectHelper.requireNonNull(source8, "source8 is null");
         ObjectHelper.requireNonNull(source9, "source9 is null");
-        return combineLatest(Functions.toFunction(combiner), source1, source2, source3, source4, source5, source6, source7, source8, source9);
+        return combineLatest(new Publisher[] { source1, source2, source3, source4, source5, source6, source7, source8, source9 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -10870,15 +10731,15 @@ public abstract class Flowable<T> implements Publisher<T> {
      * map has been evicted. The next source emission will bring about the completion of the evicted
      * {@link GroupedFlowable}s and the arrival of an item with the same key as a completed {@link GroupedFlowable}
      * will prompt the creation and emission of a new {@link GroupedFlowable} with that key.
-     * 
+     *
      * <p>A use case for specifying an {@code evictingMapFactory} is where the source is infinite and fast and
      * over time the number of keys grows enough to be a concern in terms of the memory footprint of the
      * internal hash map containing the {@link GroupedFlowable}s.
-     * 
+     *
      * <p>The map created by an {@code evictingMapFactory} must be thread-safe.
-     * 
+     *
      * <p>An example of an {@code evictingMapFactory} using <a href="https://google.github.io/guava/releases/24.0-jre/api/docs/com/google/common/cache/CacheBuilder.html">CacheBuilder</a> from the Guava library is below:
-     * 
+     *
      * <pre><code>
      * Function&lt;Consumer&lt;Object&gt;, Map&lt;Integer, Object&gt;&gt; evictingMapFactory =
      *   notify -&gt;
@@ -10905,7 +10766,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   .flatMap(g -&gt; g)
      *   .forEach(System.out::println);
      * </code></pre>
-     * 
+     *
      * <p>
      * <img width="640" height="360" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/groupBy.png" alt="">
      * <p>
@@ -11238,7 +11099,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Example:
      * <pre><code>
      * // Step 1: Create the consumer type that will be returned by the FlowableOperator.apply():
-     * 
+     *
      * public final class CustomSubscriber&lt;T&gt; implements FlowableSubscriber&lt;T&gt;, Subscription {
      *
      *     // The downstream's Subscriber that will receive the onXXX events

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -181,49 +181,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
      * If that input source is also synchronous, other sources after it will not be subscribed to.
      * <p>
-     * If there are no ObservableSources provided, the resulting sequence completes immediately without emitting
-     * any items and without any calls to the combiner function.
-     *
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatest.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatest} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T>
-     *            the common base type of source values
-     * @param <R>
-     *            the result type
-     * @param sources
-     *            the collection of source ObservableSources
-     * @param combiner
-     *            the aggregation function used to combine the items emitted by the source ObservableSources
-     * @param bufferSize
-     *            the internal buffer size and prefetch amount applied to every source Observable
-     * @return an Observable that emits items that are the result of combining the items emitted by the source
-     *         ObservableSources by means of the given aggregation function
-     * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(Function<? super Object[], ? extends R> combiner, int bufferSize, ObservableSource<? extends T>... sources) {
-        return combineLatest(sources, combiner, bufferSize);
-    }
-
-    /**
-     * Combines a collection of source ObservableSources by emitting an item that aggregates the latest values of each of
-     * the source ObservableSources each time an item is received from any of the source ObservableSources, where this
-     * aggregation is defined by a specified function.
-     * <p>
-     * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
-     * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
-     * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
-     * <p>
-     * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
-     * If that input source is also synchronous, other sources after it will not be subscribed to.
-     * <p>
      * If the provided iterable of ObservableSources is empty, the resulting sequence completes immediately without emitting
      * any items and without any calls to the combiner function.
      *
@@ -437,7 +394,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             BiFunction<? super T1, ? super T2, ? extends R> combiner) {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
-        return combineLatest(Functions.toFunction(combiner), bufferSize(), source1, source2);
+        return combineLatest(new ObservableSource[] { source1, source2 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -482,7 +439,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source1, "source1 is null");
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(source3, "source3 is null");
-        return combineLatest(Functions.toFunction(combiner), bufferSize(), source1, source2, source3);
+        return combineLatest(new ObservableSource[] { source1, source2, source3 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -531,7 +488,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source2, "source2 is null");
         ObjectHelper.requireNonNull(source3, "source3 is null");
         ObjectHelper.requireNonNull(source4, "source4 is null");
-        return combineLatest(Functions.toFunction(combiner), bufferSize(), source1, source2, source3, source4);
+        return combineLatest(new ObservableSource[] { source1, source2, source3, source4 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -585,7 +542,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source3, "source3 is null");
         ObjectHelper.requireNonNull(source4, "source4 is null");
         ObjectHelper.requireNonNull(source5, "source5 is null");
-        return combineLatest(Functions.toFunction(combiner), bufferSize(), source1, source2, source3, source4, source5);
+        return combineLatest(new ObservableSource[] { source1, source2, source3, source4, source5 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -643,7 +600,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source4, "source4 is null");
         ObjectHelper.requireNonNull(source5, "source5 is null");
         ObjectHelper.requireNonNull(source6, "source6 is null");
-        return combineLatest(Functions.toFunction(combiner), bufferSize(), source1, source2, source3, source4, source5, source6);
+        return combineLatest(new ObservableSource[] { source1, source2, source3, source4, source5, source6 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -706,7 +663,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source5, "source5 is null");
         ObjectHelper.requireNonNull(source6, "source6 is null");
         ObjectHelper.requireNonNull(source7, "source7 is null");
-        return combineLatest(Functions.toFunction(combiner), bufferSize(), source1, source2, source3, source4, source5, source6, source7);
+        return combineLatest(new ObservableSource[] { source1, source2, source3, source4, source5, source6, source7 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -773,7 +730,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source6, "source6 is null");
         ObjectHelper.requireNonNull(source7, "source7 is null");
         ObjectHelper.requireNonNull(source8, "source8 is null");
-        return combineLatest(Functions.toFunction(combiner), bufferSize(), source1, source2, source3, source4, source5, source6, source7, source8);
+        return combineLatest(new ObservableSource[] { source1, source2, source3, source4, source5, source6, source7, source8 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -845,7 +802,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(source7, "source7 is null");
         ObjectHelper.requireNonNull(source8, "source8 is null");
         ObjectHelper.requireNonNull(source9, "source9 is null");
-        return combineLatest(Functions.toFunction(combiner), bufferSize(), source1, source2, source3, source4, source5, source6, source7, source8, source9);
+        return combineLatest(new ObservableSource[] { source1, source2, source3, source4, source5, source6, source7, source8, source9 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -888,51 +845,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T, R> Observable<R> combineLatestDelayError(ObservableSource<? extends T>[] sources,
             Function<? super Object[], ? extends R> combiner) {
         return combineLatestDelayError(sources, combiner, bufferSize());
-    }
-
-    /**
-     * Combines a collection of source ObservableSources by emitting an item that aggregates the latest values of each of
-     * the source ObservableSources each time an item is received from any of the source ObservableSources, where this
-     * aggregation is defined by a specified function and delays any error from the sources until
-     * all source ObservableSources terminate.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatestDelayError.png" alt="">
-     * <p>
-     * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
-     * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
-     * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
-     * <p>
-     * If any of the sources never produces an item but only terminates (normally or with an error), the
-     * resulting sequence terminates immediately (normally or with all the errors accumulated till that point).
-     * If that input source is also synchronous, other sources after it will not be subscribed to.
-     * <p>
-     * If there are no ObservableSources provided, the resulting sequence completes immediately without emitting
-     * any items and without any calls to the combiner function.
-     *
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T>
-     *            the common base type of source values
-     * @param <R>
-     *            the result type
-     * @param sources
-     *            the collection of source ObservableSources
-     * @param combiner
-     *            the aggregation function used to combine the items emitted by the source ObservableSources
-     * @param bufferSize
-     *            the internal buffer size and prefetch amount applied to every source Observable
-     * @return an Observable that emits items that are the result of combining the items emitted by the source
-     *         ObservableSources by means of the given aggregation function
-     * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatestDelayError(Function<? super Object[], ? extends R> combiner,
-            int bufferSize, ObservableSource<? extends T>... sources) {
-        return combineLatestDelayError(sources, combiner, bufferSize);
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
@@ -77,27 +77,6 @@ public class FlowableNullTests extends RxJavaTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void combineLatestVarargsNull() {
-        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, (Publisher<Object>[])null);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestVarargsOneIsNull() {
-        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, Flowable.never(), null).blockingLast();
-    }
-
-    @Test(expected = NullPointerException.class)
     public void combineLatestIterableNull() {
         Flowable.combineLatestDelayError((Iterable<Publisher<Object>>)null, new Function<Object[], Object>() {
             @Override
@@ -131,23 +110,6 @@ public class FlowableNullTests extends RxJavaTest {
                 return 1;
             }
         }).blockingLast();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestVarargsFunctionNull() {
-        Flowable.combineLatestDelayError(null, Flowable.never());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestVarargsFunctionReturnsNull() {
-        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return null;
-            }
-        }, just1).blockingLast();
     }
 
     @SuppressWarnings("unchecked")
@@ -2759,12 +2721,6 @@ public class FlowableNullTests extends RxJavaTest {
         Flowable.combineLatestDelayError(Arrays.asList(just1), null, 128);
     }
 
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestDelayErrorVarargsFunctionNull() {
-        Flowable.combineLatestDelayError(null, 128, Flowable.never());
-    }
-
     @Test(expected = NullPointerException.class)
     public void zipFlowableNull() {
         Flowable.zip((Flowable<Flowable<Object>>)null, new Function<Object[], Object>() {
@@ -2793,27 +2749,6 @@ public class FlowableNullTests extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void concatFlowableNull() {
         Flowable.concat((Flowable<Flowable<Object>>)null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void combineLatestDelayErrorVarargsNull() {
-        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, 128, (Flowable<Object>[])null);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestDelayErrorVarargsOneIsNull() {
-        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, 128, Flowable.never(), null).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
@@ -2875,16 +2810,5 @@ public class FlowableNullTests extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void sampleFlowableNull() {
         just1.sample(null);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestDelayErrorVarargsFunctionReturnsNull() {
-        Flowable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return null;
-            }
-        }, 128, just1).blockingLast();
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1305,15 +1305,14 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @Test
     public void errorDelayed() {
         Flowable.combineLatestDelayError(
+                new Publisher[] { Flowable.error(new TestException()), Flowable.just(1) },
                 new Function<Object[], Object>() {
                     @Override
                     public Object apply(Object[] a) throws Exception {
                         return a;
                     }
                 },
-                128,
-                Flowable.error(new TestException()),
-                Flowable.just(1)
+                128
         )
         .test()
         .assertFailure(TestException.class);
@@ -1323,15 +1322,14 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @Test
     public void errorDelayed2() {
         Flowable.combineLatestDelayError(
+                new Publisher[] { Flowable.error(new TestException()).startWithItem(1), Flowable.empty() },
                 new Function<Object[], Object>() {
                     @Override
                     public Object apply(Object[] a) throws Exception {
                         return a;
                     }
                 },
-                128,
-                Flowable.error(new TestException()).startWithItem(1),
-                Flowable.empty()
+                128
         )
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
@@ -926,15 +926,14 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @Test
     public void errorDelayed() {
         Observable.combineLatestDelayError(
+                new ObservableSource[] { Observable.error(new TestException()), Observable.just(1) },
                 new Function<Object[], Object>() {
                     @Override
                     public Object apply(Object[] a) throws Exception {
                         return a;
                     }
                 },
-                128,
-                Observable.error(new TestException()),
-                Observable.just(1)
+                128
         )
         .test()
         .assertFailure(TestException.class);
@@ -944,15 +943,14 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @Test
     public void errorDelayed2() {
         Observable.combineLatestDelayError(
+                new ObservableSource[] { Observable.error(new TestException()).startWithItem(1), Observable.empty() },
                 new Function<Object[], Object>() {
                     @Override
                     public Object apply(Object[] a) throws Exception {
                         return a;
                     }
                 },
-                128,
-                Observable.error(new TestException()).startWithItem(1),
-                Observable.empty()
+                128
         )
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
@@ -75,27 +75,6 @@ public class ObservableNullTests extends RxJavaTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void combineLatestVarargsNull() {
-        Observable.combineLatest(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, 128, (Observable<Object>[])null);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestVarargsOneIsNull() {
-        Observable.combineLatest(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, 128, Observable.never(), null).blockingLast();
-    }
-
-    @Test(expected = NullPointerException.class)
     public void combineLatestIterableNull() {
         Observable.combineLatest((Iterable<Observable<Object>>)null, new Function<Object[], Object>() {
             @Override
@@ -133,23 +112,6 @@ public class ObservableNullTests extends RxJavaTest {
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
-    public void combineLatestVarargsFunctionNull() {
-        Observable.combineLatest(null, 128, Observable.never());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestVarargsFunctionReturnsNull() {
-        Observable.combineLatest(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return null;
-            }
-        }, 128, just1).blockingLast();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionNull() {
         Observable.combineLatest(Arrays.asList(just1), null, 128);
     }
@@ -163,27 +125,6 @@ public class ObservableNullTests extends RxJavaTest {
                 return null;
             }
         }, 128).blockingLast();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void combineLatestDelayErrorVarargsNull() {
-        Observable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, 128, (Observable<Object>[])null);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestDelayErrorVarargsOneIsNull() {
-        Observable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, 128, Observable.never(), null).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
@@ -220,23 +161,6 @@ public class ObservableNullTests extends RxJavaTest {
                 return 1;
             }
         }, 128).blockingLast();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestDelayErrorVarargsFunctionNull() {
-        Observable.combineLatestDelayError(null, 128, Observable.never());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
-    public void combineLatestDelayErrorVarargsFunctionReturnsNull() {
-        Observable.combineLatestDelayError(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return null;
-            }
-        }, 128, just1).blockingLast();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/rxjava3/tck/CombineLatestArrayDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/CombineLatestArrayDelayErrorTckTest.java
@@ -27,14 +27,13 @@ public class CombineLatestArrayDelayErrorTckTest extends BaseTck<Long> {
     public Publisher<Long> createPublisher(long elements) {
         return
             Flowable.combineLatestDelayError(
+                new Publisher[] { Flowable.just(1L), Flowable.fromIterable(iterate(elements)) },
                 new Function<Object[], Long>() {
                     @Override
                     public Long apply(Object[] a) throws Exception {
                         return (Long)a[0];
                     }
-                },
-                Flowable.just(1L),
-                Flowable.fromIterable(iterate(elements))
+                }
             )
         ;
     }

--- a/src/test/java/io/reactivex/rxjava3/tck/CombineLatestArrayTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/CombineLatestArrayTckTest.java
@@ -27,14 +27,13 @@ public class CombineLatestArrayTckTest extends BaseTck<Long> {
     public Publisher<Long> createPublisher(long elements) {
         return
             Flowable.combineLatest(
+                new Publisher[] { Flowable.just(1L), Flowable.fromIterable(iterate(elements)) },
                 new Function<Object[], Long>() {
                     @Override
                     public Long apply(Object[] a) throws Exception {
                         return (Long)a[0];
                     }
-                },
-                Flowable.just(1L),
-                Flowable.fromIterable(iterate(elements))
+                }
             )
         ;
     }


### PR DESCRIPTION
Started removing the vararg function from #6634