### PR TITLE
3.x: Rename zipIterable, remove zip(O(O)), adjust concatMapX arg order

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -1014,7 +1014,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concat(Iterable<? extends ObservableSource<? extends T>> sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return fromIterable(sources).concatMapDelayError((Function)Functions.identity(), bufferSize(), false);
+        return fromIterable(sources).concatMapDelayError((Function)Functions.identity(), false, bufferSize());
     }
 
     /**
@@ -1271,7 +1271,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatArrayEager(int maxConcurrency, int prefetch, ObservableSource<? extends T>... sources) {
-        return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(), maxConcurrency, prefetch, false);
+        return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(), false, maxConcurrency, prefetch);
     }
 
     /**
@@ -1323,7 +1323,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatArrayEagerDelayError(int maxConcurrency, int prefetch, ObservableSource<? extends T>... sources) {
-        return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(), maxConcurrency, prefetch, true);
+        return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(), true, maxConcurrency, prefetch);
     }
 
     /**
@@ -1492,7 +1492,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concatEager(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
-        return fromIterable(sources).concatMapEagerDelayError((Function)Functions.identity(), maxConcurrency, prefetch, false);
+        return fromIterable(sources).concatMapEagerDelayError((Function)Functions.identity(), false, maxConcurrency, prefetch);
     }
 
     /**
@@ -4102,12 +4102,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     /**
      * Returns an Observable that emits the results of a specified combiner function applied to combinations of
-     * <i>n</i> items emitted, in sequence, by the <i>n</i> ObservableSources emitted by a specified ObservableSource.
+     * items emitted, in sequence, by an Iterable of other ObservableSources.
      * <p>
      * {@code zip} applies this function in strict sequence, so the first item emitted by the new ObservableSource
-     * will be the result of the function applied to the first item emitted by each of the ObservableSources emitted
-     * by the source ObservableSource; the second item emitted by the new ObservableSource will be the result of the
-     * function applied to the second item emitted by each of those ObservableSources; and so forth.
+     * will be the result of the function applied to the first item emitted by each of the source ObservableSources;
+     * the second item emitted by the new ObservableSource will be the result of the function applied to the second
+     * item emitted by each of those ObservableSources; and so forth.
      * <p>
      * The resulting {@code ObservableSource<R>} returned from {@code zip} will invoke {@code onNext} as many times as
      * the number of {@code onNext} invocations of the source ObservableSource that emits the fewest items.
@@ -4118,7 +4118,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
      * source A completes and B has been consumed and is about to complete, the operator detects A won't
      * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(just(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
+     * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
      * {@code action1} will be called but {@code action2} won't.
      * <br>To work around this termination property,
      * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
@@ -4129,30 +4129,36 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
      *
      * <p>
-     * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.o.png" alt="">
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zipIterable.o.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <T> the value type of the inner ObservableSources
-     * @param <R> the zipped result type
+     *
      * @param sources
-     *            an ObservableSource of source ObservableSources
+     *            an Iterable of source ObservableSources
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the ObservableSources emitted by
-     *            {@code ws}, results in an item that will be emitted by the resulting ObservableSource
+     *            a function that, when applied to an item emitted by each of the source ObservableSources, results in
+     *            an item that will be emitted by the resulting ObservableSource
+     * @param delayError
+     *            delay errors signalled by any of the source ObservableSource until all ObservableSources terminate
+     * @param bufferSize
+     *            the number of elements to prefetch from each source ObservableSource
+     * @param <T> the common source value type
+     * @param <R> the zipped result type
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> zip(ObservableSource<? extends ObservableSource<? extends T>> sources, final Function<? super Object[], ? extends R> zipper) {
+    public static <T, R> Observable<R> zip(Iterable<? extends ObservableSource<? extends T>> sources,
+            Function<? super Object[], ? extends R> zipper, boolean delayError,
+            int bufferSize) {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         ObjectHelper.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new ObservableToList(sources, 16)
-                .flatMap(ObservableInternalHelper.zipIterable(zipper)));
+        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
+        return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(null, sources, zipper, bufferSize, delayError));
     }
 
     /**
@@ -4892,67 +4898,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.requireNonNull(zipper, "zipper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(sources, null, zipper, bufferSize, delayError));
-    }
-
-    /**
-     * Returns an Observable that emits the results of a specified combiner function applied to combinations of
-     * items emitted, in sequence, by an Iterable of other ObservableSources.
-     * <p>
-     * {@code zip} applies this function in strict sequence, so the first item emitted by the new ObservableSource
-     * will be the result of the function applied to the first item emitted by each of the source ObservableSources;
-     * the second item emitted by the new ObservableSource will be the result of the function applied to the second
-     * item emitted by each of those ObservableSources; and so forth.
-     * <p>
-     * The resulting {@code ObservableSource<R>} returned from {@code zip} will invoke {@code onNext} as many times as
-     * the number of {@code onNext} invocations of the source ObservableSource that emits the fewest items.
-     * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
-     * is possible those other sources will never be able to run to completion (and thus not calling
-     * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
-     * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(Arrays.asList(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2)), (a) -&gt; a)</code></pre>
-     * {@code action1} will be called but {@code action2} won't.
-     * <br>To work around this termination property,
-     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
-     * or a dispose() call.
-     * <p>
-     * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
-     * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
-     * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
-     *
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zipIterable.o.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code zipIterable} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     *
-     * @param sources
-     *            an Iterable of source ObservableSources
-     * @param zipper
-     *            a function that, when applied to an item emitted by each of the source ObservableSources, results in
-     *            an item that will be emitted by the resulting ObservableSource
-     * @param delayError
-     *            delay errors signalled by any of the source ObservableSource until all ObservableSources terminate
-     * @param bufferSize
-     *            the number of elements to prefetch from each source ObservableSource
-     * @param <T> the common source value type
-     * @param <R> the zipped result type
-     * @return an Observable that emits the zipped results
-     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> zipIterable(Iterable<? extends ObservableSource<? extends T>> sources,
-            Function<? super Object[], ? extends R> zipper, boolean delayError,
-            int bufferSize) {
-        ObjectHelper.requireNonNull(zipper, "zipper is null");
-        ObjectHelper.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(null, sources, zipper, bufferSize, delayError));
     }
 
     // ***************************************************************************************************
@@ -6407,7 +6352,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
      * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
-     * the {@code mapper} function is confined to a known thread, use the {@link #concatMapDelayError(Function, int, boolean, Scheduler)} overload.
+     * the {@code mapper} function is confined to a known thread, use the {@link #concatMapDelayError(Function, boolean, int, Scheduler)} overload.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -6416,12 +6361,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <R> the result value type
      * @param mapper the function that maps the items of this ObservableSource into the inner ObservableSources.
      * @return the new ObservableSource instance with the concatenation behavior
-     * @see #concatMapDelayError(Function, int, boolean, Scheduler)
+     * @see #concatMapDelayError(Function, boolean, int, Scheduler)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return concatMapDelayError(mapper, bufferSize(), true);
+        return concatMapDelayError(mapper, true, bufferSize());
     }
 
     /**
@@ -6434,7 +6379,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <p>
      * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
      * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
-     * the {@code mapper} function is confined to a known thread, use the {@link #concatMapDelayError(Function, int, boolean, Scheduler)} overload.
+     * the {@code mapper} function is confined to a known thread, use the {@link #concatMapDelayError(Function, boolean, int, Scheduler)} overload.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -6442,18 +6387,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <R> the result value type
      * @param mapper the function that maps the items of this ObservableSource into the inner ObservableSources.
-     * @param prefetch
-     *            the number of elements to prefetch from the current Observable
      * @param tillTheEnd
      *            if true, all errors from the outer and inner ObservableSource sources are delayed until the end,
      *            if false, an error from the main source is signalled when the current ObservableSource source terminates
+     * @param prefetch
+     *            the number of elements to prefetch from the current Observable
      * @return the new ObservableSource instance with the concatenation behavior
-     * @see #concatMapDelayError(Function, int, boolean, Scheduler)
+     * @see #concatMapDelayError(Function, boolean, int, Scheduler)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            int prefetch, boolean tillTheEnd) {
+            boolean tillTheEnd, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         if (this instanceof ScalarSupplier) {
@@ -6481,21 +6426,21 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * @param <R> the result value type
      * @param mapper the function that maps the items of this ObservableSource into the inner ObservableSources.
-     * @param prefetch
-     *            the number of elements to prefetch from the current Observable
      * @param tillTheEnd
      *            if true, all errors from the outer and inner ObservableSource sources are delayed until the end,
      *            if false, an error from the main source is signalled when the current ObservableSource source terminates
+     * @param prefetch
+     *            the number of elements to prefetch from the current Observable
      * @param scheduler
      *            the scheduler where the {@code mapper} function will be executed
      * @return the new ObservableSource instance with the concatenation behavior
-     * @see #concatMapDelayError(Function, int, boolean)
+     * @see #concatMapDelayError(Function, boolean, int)
      * @since 3.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final <R> Observable<R> concatMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            int prefetch, boolean tillTheEnd, Scheduler scheduler) {
+            boolean tillTheEnd, int prefetch, Scheduler scheduler) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         ObjectHelper.requireNonNull(scheduler, "scheduler is null");
@@ -6584,7 +6529,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
             boolean tillTheEnd) {
-        return concatMapEagerDelayError(mapper, Integer.MAX_VALUE, bufferSize(), tillTheEnd);
+        return concatMapEagerDelayError(mapper, tillTheEnd, Integer.MAX_VALUE, bufferSize());
     }
 
     /**
@@ -6603,20 +6548,20 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <R> the value type
      * @param mapper the function that maps a sequence of values into a sequence of ObservableSources that will be
      *               eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrent subscribed ObservableSources
-     * @param prefetch
-     *               the number of elements to prefetch from each source ObservableSource
      * @param tillTheEnd
      *               if true, exceptions from the current Observable and all the inner ObservableSources are delayed until
      *               all of them terminate, if false, exception from the current Observable is delayed until the
      *               currently running ObservableSource terminates
+     * @param maxConcurrency the maximum number of concurrent subscribed ObservableSources
+     * @param prefetch
+     *               the number of elements to prefetch from each source ObservableSource
      * @return the new ObservableSource instance with the specified concatenation behavior
      * @since 2.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            int maxConcurrency, int prefetch, boolean tillTheEnd) {
+            boolean tillTheEnd, int maxConcurrency, int prefetch) {
         ObjectHelper.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableInternalHelper.java
@@ -12,7 +12,6 @@
  */
 package io.reactivex.rxjava3.internal.operators.flowable;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.reactivestreams.*;
@@ -215,24 +214,6 @@ public final class FlowableInternalHelper {
         public void accept(Subscription t) throws Exception {
             t.request(Long.MAX_VALUE);
         }
-    }
-
-    static final class ZipIterableFunction<T, R>
-    implements Function<List<Publisher<? extends T>>, Publisher<? extends R>> {
-        private final Function<? super Object[], ? extends R> zipper;
-
-        ZipIterableFunction(Function<? super Object[], ? extends R> zipper) {
-            this.zipper = zipper;
-        }
-
-        @Override
-        public Publisher<? extends R> apply(List<Publisher<? extends T>> list) {
-            return Flowable.zipIterable(list, zipper, false, Flowable.bufferSize());
-        }
-    }
-
-    public static <T, R> Function<List<Publisher<? extends T>>, Publisher<? extends R>> zipIterable(final Function<? super Object[], ? extends R> zipper) {
-        return new ZipIterableFunction<T, R>(zipper);
     }
 
     static final class ReplaySupplier<T> implements Supplier<ConnectableFlowable<T>> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableInternalHelper.java
@@ -12,7 +12,6 @@
  */
 package io.reactivex.rxjava3.internal.operators.observable;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.core.*;
@@ -212,24 +211,6 @@ public final class ObservableInternalHelper {
 
     public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
         return new TimedReplayCallable<T>(parent, time, unit, scheduler, eagerTruncate);
-    }
-
-    static final class ZipIterableFunction<T, R>
-    implements Function<List<ObservableSource<? extends T>>, ObservableSource<? extends R>> {
-        private final Function<? super Object[], ? extends R> zipper;
-
-        ZipIterableFunction(Function<? super Object[], ? extends R> zipper) {
-            this.zipper = zipper;
-        }
-
-        @Override
-        public ObservableSource<? extends R> apply(List<ObservableSource<? extends T>> list) {
-            return Observable.zipIterable(list, zipper, false, Observable.bufferSize());
-        }
-    }
-
-    public static <T, R> Function<List<ObservableSource<? extends T>>, ObservableSource<? extends R>> zipIterable(final Function<? super Object[], ? extends R> zipper) {
-        return new ZipIterableFunction<T, R>(zipper);
     }
 
     static final class ReplaySupplier<T> implements Supplier<ConnectableObservable<T>> {

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
@@ -652,33 +652,8 @@ public class FlowableNullTests extends RxJavaTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void zipPublisherNull() {
-        Flowable.zip((Publisher<Publisher<Object>>)null, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return 1;
-            }
-        });
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void zipPublisherFunctionNull() {
-        Flowable.zip((Flowable.just(just1)), null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void zipPublisherFunctionReturnsNull() {
-        Flowable.zip((Flowable.just(just1)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return null;
-            }
-        }).blockingLast();
-    }
-
-    @Test(expected = NullPointerException.class)
     public void zipIterable2Null() {
-        Flowable.zipIterable((Iterable<Publisher<Object>>)null, new Function<Object[], Object>() {
+        Flowable.zip((Iterable<Publisher<Object>>)null, new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] a) {
                 return 1;
@@ -688,7 +663,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2IteratorNull() {
-        Flowable.zipIterable(new Iterable<Publisher<Object>>() {
+        Flowable.zip(new Iterable<Publisher<Object>>() {
             @Override
             public Iterator<Publisher<Object>> iterator() {
                 return null;
@@ -704,13 +679,13 @@ public class FlowableNullTests extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionNull() {
-        Flowable.zipIterable(Arrays.asList(just1, just1), null, true, 128);
+        Flowable.zip(Arrays.asList(just1, just1), null, true, 128);
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionReturnsNull() {
-        Flowable.zipIterable(Arrays.asList(just1, just1), new Function<Object[], Object>() {
+        Flowable.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] a) {
                 return null;
@@ -2719,31 +2694,6 @@ public class FlowableNullTests extends RxJavaTest {
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableFunctionNull() {
         Flowable.combineLatestDelayError(Arrays.asList(just1), null, 128);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void zipFlowableNull() {
-        Flowable.zip((Flowable<Flowable<Object>>)null, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return 1;
-            }
-        });
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void zipFlowableFunctionNull() {
-        Flowable.zip((Flowable.just(just1)), null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void zipFlowableFunctionReturnsNull() {
-        Flowable.zip((Flowable.just(just1)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return null;
-            }
-        }).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -85,7 +85,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
                     throws Exception {
                 return Flowable.just(v);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        }, true, 2, ImmediateThinScheduler.INSTANCE)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -130,7 +130,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
                     throws Exception {
                 return Flowable.just(v);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        }, true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -171,7 +171,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
               }
             });
           }
-        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        }, true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
     }
@@ -190,7 +190,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
               }
             });
           }
-        }, 2, false, ImmediateThinScheduler.INSTANCE)
+        }, false, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);
     }
@@ -239,7 +239,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<String> apply(Integer t) throws Throwable {
                 return Flowable.just(Thread.currentThread().getName());
             }
-        }, 2, false, Schedulers.single())
+        }, false, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -257,7 +257,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<String> apply(Integer t) throws Throwable {
                 return Flowable.just(Thread.currentThread().getName()).hide();
             }
-        }, 2, false, Schedulers.single())
+        }, false, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -275,7 +275,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<String> apply(Integer t) throws Throwable {
                 return Flowable.just(Thread.currentThread().getName());
             }
-        }, 2, true, Schedulers.single())
+        }, true, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -293,7 +293,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<String> apply(Integer t) throws Throwable {
                 return Flowable.just(Thread.currentThread().getName()).hide();
             }
-        }, 2, true, Schedulers.single())
+        }, true, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -435,7 +435,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void concatMapDelayErrorJustJust() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        Flowable.just(Flowable.just(1)).concatMapDelayError((Function)Functions.identity(), 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        Flowable.just(Flowable.just(1)).concatMapDelayError((Function)Functions.identity(), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertValue(1);
         ts.assertNoErrors();
@@ -447,7 +447,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void concatMapDelayErrorJustRange() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        Flowable.just(Flowable.range(1, 5)).concatMapDelayError((Function)Functions.identity(), 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        Flowable.just(Flowable.range(1, 5)).concatMapDelayError((Function)Functions.identity(), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertValues(1, 2, 3, 4, 5);
         ts.assertNoErrors();
@@ -479,7 +479,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void concatMapDelayError() {
         Flowable.just(Flowable.just(1), Flowable.just(2))
-        .concatMapDelayError(Functions.<Flowable<Integer>>identity(), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.<Flowable<Integer>>identity(), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1, 2);
     }
@@ -492,7 +492,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Object v) throws Exception {
                 return Flowable.just(1);
             }
-        }, 16, true, ImmediateThinScheduler.INSTANCE)
+        }, true, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
 
@@ -519,7 +519,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Object v) throws Exception {
                 return Flowable.just(1);
             }
-        }, 16, false, ImmediateThinScheduler.INSTANCE)
+        }, false, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
     }
@@ -535,7 +535,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void concatMapScalarBackpressuredDelayError() {
         Flowable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Flowable.just(2)), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Flowable.just(2)), true, 2, ImmediateThinScheduler.INSTANCE)
         .test(1L)
         .assertResult(2);
     }
@@ -551,7 +551,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void concatMapEmptyDelayError() {
         Flowable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Flowable.empty()), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Flowable.empty()), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult();
     }
@@ -583,7 +583,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Flowable<Object> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Flowable.just(2)), 2, true, ImmediateThinScheduler.INSTANCE);
+                return f.concatMapDelayError(Functions.justFunction(Flowable.just(2)), true, 2, ImmediateThinScheduler.INSTANCE);
             }
         });
     }
@@ -647,7 +647,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void concatMapInnerErrorDelayError() {
         Flowable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Flowable.error(new TestException())), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Flowable.error(new TestException())), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -699,7 +699,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
                 s.onSubscribe(new BooleanSubscription());
                 s.onError(new TestException("First"));
             }
-        }), 2, true, ImmediateThinScheduler.INSTANCE)
+        }), true, 2, ImmediateThinScheduler.INSTANCE)
         .to(TestHelper.<Integer>testConsumer());
 
         ts.assertFailureAndMessage(TestException.class, "First");
@@ -719,7 +719,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
             public Object apply(Flowable<Integer> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Flowable.just(1).hide()), 2, true, ImmediateThinScheduler.INSTANCE);
+                return f.concatMapDelayError(Functions.justFunction(Flowable.just(1).hide()), true, 2, ImmediateThinScheduler.INSTANCE);
             }
         }, true, 1, 1, 1);
     }
@@ -743,7 +743,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             @Override
             public Object apply(Integer v) throws Exception { throw new TestException(); }
         })
-        .concatMapDelayError(Functions.justFunction(Flowable.just(1)), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Flowable.just(1)), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -769,7 +769,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Object call() throws Exception {
                 throw new TestException();
             }
-        })), 2, true, ImmediateThinScheduler.INSTANCE)
+        })), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -780,13 +780,13 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .concatMap(Functions.justFunction(Flowable.just(1)), 2, ImmediateThinScheduler.INSTANCE));
 
         TestHelper.checkDisposed(Flowable.range(1, 2)
-        .concatMapDelayError(Functions.justFunction(Flowable.just(1)), 2, true, ImmediateThinScheduler.INSTANCE));
+        .concatMapDelayError(Functions.justFunction(Flowable.just(1)), true, 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test
     public void notVeryEnd() {
         Flowable.range(1, 2)
-        .concatMapDelayError(Functions.justFunction(Flowable.error(new TestException())), 16, false, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Flowable.error(new TestException())), false, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -794,7 +794,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void error() {
         Flowable.error(new TestException())
-        .concatMapDelayError(Functions.justFunction(Flowable.just(2)), 16, false, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Flowable.just(2)), false, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -823,7 +823,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer v) {
                 return Flowable.range(v, 2);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -846,7 +846,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer v) {
                 return inner;
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertValues(1, 2, 1, 2, 1, 2);
         ts.assertError(CompositeException.class);
@@ -866,7 +866,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer v) {
                 return inner;
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertValues(1, 2);
         ts.assertError(TestException.class);
@@ -884,7 +884,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer v) {
                 return null;
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertNoValues();
         ts.assertError(NullPointerException.class);
@@ -902,7 +902,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer v) {
                 throw new TestException();
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertNoValues();
         ts.assertError(TestException.class);
@@ -919,7 +919,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer v) {
                 return v == 2 ? Flowable.<Integer>empty() : Flowable.range(1, 2);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertValues(1, 2, 1, 2);
         ts.assertNoErrors();
@@ -936,7 +936,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer v) {
                 return v == 2 ? Flowable.just(3) : Flowable.range(1, 2);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertValues(1, 2, 3, 1, 2);
         ts.assertNoErrors();
@@ -952,7 +952,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer v) {
                 return Flowable.range(v, 2);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertNoValues();
         ts.assertNoErrors();
@@ -1010,7 +1010,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
                         .repeat(1000)
                         .observeOn(Schedulers.io());
             }
-        }, 2, false, Schedulers.single())
+        }, false, 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1033,7 +1033,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
                         .repeat(1000)
                         .observeOn(Schedulers.io());
             }
-        }, 2, true, Schedulers.single())
+        }, true, 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1069,7 +1069,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
                     public Publisher<Integer> apply(Integer v) throws Throwable {
                         return Flowable.just(v).hide();
                     }
-                }, 2, false, ImmediateThinScheduler.INSTANCE);
+                }, false, 2, ImmediateThinScheduler.INSTANCE);
             }
         });
     }
@@ -1084,7 +1084,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
                     public Publisher<Integer> apply(Integer v) throws Throwable {
                         return Flowable.just(v).hide();
                     }
-                }, 2, true, ImmediateThinScheduler.INSTANCE);
+                }, true, 2, ImmediateThinScheduler.INSTANCE);
             }
         });
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapTest.java
@@ -203,7 +203,7 @@ public class FlowableConcatMapTest extends RxJavaTest {
               }
             });
           }
-        }, 2, false)
+        }, false, 2)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);
     }
@@ -233,7 +233,7 @@ public class FlowableConcatMapTest extends RxJavaTest {
                     public Publisher<Integer> apply(Integer v) throws Throwable {
                         return Flowable.just(v).hide();
                     }
-                }, 2, false);
+                }, false, 2);
             }
         });
     }
@@ -248,7 +248,7 @@ public class FlowableConcatMapTest extends RxJavaTest {
                     public Publisher<Integer> apply(Integer v) throws Throwable {
                         return Flowable.just(v).hide();
                     }
-                }, 2, true);
+                }, true, 2);
             }
         });
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
@@ -1183,7 +1183,7 @@ public class FlowableConcatTest {
                     public Flowable<Integer> apply(Object v) throws Exception {
                         return Flowable.just(1);
                     }
-                }, 16, true));
+                }, true, 16));
     }
 
     @Test
@@ -1194,7 +1194,7 @@ public class FlowableConcatTest {
             public Flowable<Integer> apply(Object v) throws Exception {
                 return Flowable.just(1);
             }
-        }, 16, true)
+        }, true, 16)
         .test()
         .assertResult(1);
 
@@ -1244,7 +1244,7 @@ public class FlowableConcatTest {
             public Flowable<Integer> apply(Object v) throws Exception {
                 return Flowable.just(1);
             }
-        }, 16, false)
+        }, false, 16)
         .test()
         .assertResult(1);
     }
@@ -1511,7 +1511,7 @@ public class FlowableConcatTest {
     @Test
     public void notVeryEnd() {
         Flowable.range(1, 2)
-        .concatMapDelayError(Functions.justFunction(Flowable.error(new TestException())), 16, false)
+        .concatMapDelayError(Functions.justFunction(Flowable.error(new TestException())), false, 16)
         .test()
         .assertFailure(TestException.class);
     }
@@ -1519,7 +1519,7 @@ public class FlowableConcatTest {
     @Test
     public void error() {
         Flowable.error(new TestException())
-        .concatMapDelayError(Functions.justFunction(Flowable.just(2)), 16, false)
+        .concatMapDelayError(Functions.justFunction(Flowable.just(2)), false, 16)
         .test()
         .assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -86,7 +86,7 @@ public class ObservableConcatMapSchedulerTest {
                     throws Exception {
                 return Observable.just(v);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        }, true, 2, ImmediateThinScheduler.INSTANCE)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -131,7 +131,7 @@ public class ObservableConcatMapSchedulerTest {
                     throws Exception {
                 return Observable.just(v);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        }, true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -172,7 +172,7 @@ public class ObservableConcatMapSchedulerTest {
               }
             });
           }
-        }, 2, true, ImmediateThinScheduler.INSTANCE)
+        }, true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
     }
@@ -191,7 +191,7 @@ public class ObservableConcatMapSchedulerTest {
               }
             });
           }
-        }, 2, false, ImmediateThinScheduler.INSTANCE)
+        }, false, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);
     }
@@ -240,7 +240,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<String> apply(Integer t) throws Throwable {
                 return Observable.just(Thread.currentThread().getName());
             }
-        }, 2, false, Schedulers.single())
+        }, false, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -258,7 +258,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<String> apply(Integer t) throws Throwable {
                 return Observable.just(Thread.currentThread().getName()).hide();
             }
-        }, 2, false, Schedulers.single())
+        }, false, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -276,7 +276,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<String> apply(Integer t) throws Throwable {
                 return Observable.just(Thread.currentThread().getName());
             }
-        }, 2, true, Schedulers.single())
+        }, true, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -294,7 +294,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<String> apply(Integer t) throws Throwable {
                 return Observable.just(Thread.currentThread().getName()).hide();
             }
-        }, 2, true, Schedulers.single())
+        }, true, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -436,7 +436,7 @@ public class ObservableConcatMapSchedulerTest {
     public void concatMapDelayErrorJustJust() {
         TestObserver<Integer> to = TestObserver.create();
 
-        Observable.just(Observable.just(1)).concatMapDelayError((Function)Functions.identity(), 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        Observable.just(Observable.just(1)).concatMapDelayError((Function)Functions.identity(), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValue(1);
         to.assertNoErrors();
@@ -448,7 +448,7 @@ public class ObservableConcatMapSchedulerTest {
     public void concatMapDelayErrorJustRange() {
         TestObserver<Integer> to = TestObserver.create();
 
-        Observable.just(Observable.range(1, 5)).concatMapDelayError((Function)Functions.identity(), 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        Observable.just(Observable.range(1, 5)).concatMapDelayError((Function)Functions.identity(), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValues(1, 2, 3, 4, 5);
         to.assertNoErrors();
@@ -504,7 +504,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapDelayError() {
         Observable.just(Observable.just(1), Observable.just(2))
-        .concatMapDelayError(Functions.<Observable<Integer>>identity(), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.<Observable<Integer>>identity(), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1, 2);
     }
@@ -517,7 +517,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Object v) throws Exception {
                 return Observable.just(1);
             }
-        }, 16, true, ImmediateThinScheduler.INSTANCE)
+        }, true, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
 
@@ -544,7 +544,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Object v) throws Exception {
                 return Observable.just(1);
             }
-        }, 16, false, ImmediateThinScheduler.INSTANCE)
+        }, false, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
     }
@@ -560,7 +560,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapEmptyDelayError() {
         Observable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Observable.empty()), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Observable.empty()), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult();
     }
@@ -576,7 +576,7 @@ public class ObservableConcatMapSchedulerTest {
         TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Observable<Object> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Observable.just(2)), 2, true, ImmediateThinScheduler.INSTANCE);
+                return f.concatMapDelayError(Functions.justFunction(Observable.just(2)), true, 2, ImmediateThinScheduler.INSTANCE);
             }
         });
     }
@@ -640,7 +640,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapInnerErrorDelayError() {
         Observable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Observable.error(new TestException())), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Observable.error(new TestException())), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -692,7 +692,7 @@ public class ObservableConcatMapSchedulerTest {
                 o.onSubscribe(Disposables.empty());
                 o.onError(new TestException("First"));
             }
-        }), 2, true, ImmediateThinScheduler.INSTANCE)
+        }), true, 2, ImmediateThinScheduler.INSTANCE)
         .to(TestHelper.<Integer>testConsumer());
 
         to.assertFailureAndMessage(TestException.class, "First");
@@ -712,7 +712,7 @@ public class ObservableConcatMapSchedulerTest {
         TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
             @Override
             public Object apply(Observable<Integer> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Observable.just(1).hide()), 2, true, ImmediateThinScheduler.INSTANCE);
+                return f.concatMapDelayError(Functions.justFunction(Observable.just(1).hide()), true, 2, ImmediateThinScheduler.INSTANCE);
             }
         }, true, 1, 1, 1);
     }
@@ -736,7 +736,7 @@ public class ObservableConcatMapSchedulerTest {
             @Override
             public Object apply(Integer v) throws Exception { throw new TestException(); }
         })
-        .concatMapDelayError(Functions.justFunction(Observable.just(1)), 2, true, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Observable.just(1)), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -762,7 +762,7 @@ public class ObservableConcatMapSchedulerTest {
             public Object call() throws Exception {
                 throw new TestException();
             }
-        })), 2, true, ImmediateThinScheduler.INSTANCE)
+        })), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -773,13 +773,13 @@ public class ObservableConcatMapSchedulerTest {
         .concatMap(Functions.justFunction(Observable.just(1)), 2, ImmediateThinScheduler.INSTANCE));
 
         TestHelper.checkDisposed(Observable.range(1, 2)
-        .concatMapDelayError(Functions.justFunction(Observable.just(1)), 2, true, ImmediateThinScheduler.INSTANCE));
+        .concatMapDelayError(Functions.justFunction(Observable.just(1)), true, 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test
     public void notVeryEnd() {
         Observable.range(1, 2)
-        .concatMapDelayError(Functions.justFunction(Observable.error(new TestException())), 16, false, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Observable.error(new TestException())), false, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -787,7 +787,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void error() {
         Observable.error(new TestException())
-        .concatMapDelayError(Functions.justFunction(Observable.just(2)), 16, false, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(Functions.justFunction(Observable.just(2)), false, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -816,7 +816,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Integer v) {
                 return Observable.range(v, 2);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         source.onNext(1);
         source.onNext(2);
@@ -839,7 +839,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Integer v) {
                 return inner;
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValues(1, 2, 1, 2, 1, 2);
         to.assertError(CompositeException.class);
@@ -859,7 +859,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Integer v) {
                 return inner;
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValues(1, 2);
         to.assertError(TestException.class);
@@ -877,7 +877,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Integer v) {
                 return null;
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertNoValues();
         to.assertError(NullPointerException.class);
@@ -895,7 +895,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Integer v) {
                 throw new TestException();
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertNoValues();
         to.assertError(TestException.class);
@@ -912,7 +912,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Integer v) {
                 return v == 2 ? Observable.<Integer>empty() : Observable.range(1, 2);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValues(1, 2, 1, 2);
         to.assertNoErrors();
@@ -929,7 +929,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<Integer> apply(Integer v) {
                 return v == 2 ? Observable.just(3) : Observable.range(1, 2);
             }
-        }, 2, true, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValues(1, 2, 3, 1, 2);
         to.assertNoErrors();
@@ -971,7 +971,7 @@ public class ObservableConcatMapSchedulerTest {
                         .repeat(1000)
                         .observeOn(Schedulers.io());
             }
-        }, 2, false, Schedulers.single())
+        }, false, 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -994,7 +994,7 @@ public class ObservableConcatMapSchedulerTest {
                         .repeat(1000)
                         .observeOn(Schedulers.io());
             }
-        }, 2, true, Schedulers.single())
+        }, true, 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1030,7 +1030,7 @@ public class ObservableConcatMapSchedulerTest {
                     public Observable<Integer> apply(Integer v) throws Throwable {
                         return Observable.just(v).hide();
                     }
-                }, 2, false, ImmediateThinScheduler.INSTANCE);
+                }, false, 2, ImmediateThinScheduler.INSTANCE);
             }
         });
     }
@@ -1045,7 +1045,7 @@ public class ObservableConcatMapSchedulerTest {
                     public Observable<Integer> apply(Integer v) throws Throwable {
                         return Observable.just(v).hide();
                     }
-                }, 2, true, ImmediateThinScheduler.INSTANCE);
+                }, true, 2, ImmediateThinScheduler.INSTANCE);
             }
         });
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapTest.java
@@ -226,7 +226,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
             public ObservableSource<Integer> apply(Integer v) throws Exception {
                 return Observable.range(v, 2);
             }
-        }, 16, true)
+        }, true, 16)
         .test()
         .assertResult(1, 2);
     }
@@ -548,7 +548,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
                     public Observable<Integer> apply(Integer v) throws Throwable {
                         return Observable.just(v).hide();
                     }
-                }, 2, false);
+                }, false, 2);
             }
         });
     }
@@ -563,7 +563,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
                     public Observable<Integer> apply(Integer v) throws Throwable {
                         return Observable.just(v).hide();
                     }
-                }, 2, true);
+                }, true, 2);
             }
         });
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
@@ -908,7 +908,7 @@ public class ObservableConcatTest extends RxJavaTest {
                     public ObservableSource<Integer> apply(Object v) throws Exception {
                         return Observable.just(1);
                     }
-                }, 16, true));
+                }, true, 16));
     }
 
     @Test
@@ -919,7 +919,7 @@ public class ObservableConcatTest extends RxJavaTest {
             public ObservableSource<Integer> apply(Object v) throws Exception {
                 return Observable.just(1);
             }
-        }, 16, true)
+        }, true, 16)
         .test()
         .assertResult(1);
 

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
@@ -701,33 +701,8 @@ public class ObservableNullTests extends RxJavaTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void zipObservableNull() {
-        Observable.zip((Observable<Observable<Object>>)null, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return 1;
-            }
-        });
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void zipObservableFunctionNull() {
-        Observable.zip((Observable.just(just1)), null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void zipObservableFunctionReturnsNull() {
-        Observable.zip((Observable.just(just1)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return null;
-            }
-        }).blockingLast();
-    }
-
-    @Test(expected = NullPointerException.class)
     public void zipIterable2Null() {
-        Observable.zipIterable((Iterable<Observable<Object>>)null, new Function<Object[], Object>() {
+        Observable.zip((Iterable<Observable<Object>>)null, new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] a) {
                 return 1;
@@ -737,7 +712,7 @@ public class ObservableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2IteratorNull() {
-        Observable.zipIterable(new Iterable<Observable<Object>>() {
+        Observable.zip(new Iterable<Observable<Object>>() {
             @Override
             public Iterator<Observable<Object>> iterator() {
                 return null;
@@ -753,13 +728,13 @@ public class ObservableNullTests extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionNull() {
-        Observable.zipIterable(Arrays.asList(just1, just1), null, true, 128);
+        Observable.zip(Arrays.asList(just1, just1), null, true, 128);
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionReturnsNull() {
-        Observable.zipIterable(Arrays.asList(just1, just1), new Function<Object[], Object>() {
+        Observable.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] a) {
                 return null;


### PR DESCRIPTION
- Rename `zipIterable` to `zip`
- Remove `zip(ObservableSource<ObservableSource<T>>)` and `zip(Publisher<Publisher<T>>)`
- Change the order of the `tillTheEnd` argument in `concatMapDelayError` and `concatMapEagerDelayError` to be consistent with other operators taking a `boolean` parameter before `prefetch`/`maxConcurrency`.

Related: #6610