### PR TITLE
3.x: Cleanup addThrowable, "2.x" and null-value error messages

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableCreate.java
@@ -20,6 +20,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Cancellable;
 import io.reactivex.rxjava3.internal.disposables.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class CompletableCreate extends Completable {
@@ -81,7 +82,7 @@ public final class CompletableCreate extends Completable {
         @Override
         public boolean tryOnError(Throwable t) {
             if (t == null) {
-                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+                t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
             }
             if (get() != DisposableHelper.DISPOSED) {
                 Disposable d = getAndSet(DisposableHelper.DISPOSED);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMap.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.internal.fuseable.*;
 import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.*;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<T, R> {
 
@@ -196,14 +195,12 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 inner.cancel();
 
                 if (getAndIncrement() == 0) {
                     errors.tryTerminateConsumer(downstream);
                 }
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -220,14 +217,12 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
         @Override
         public void innerError(Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 upstream.cancel();
 
                 if (getAndIncrement() == 0) {
                     errors.tryTerminateConsumer(downstream);
                 }
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 
@@ -266,7 +261,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                         } catch (Throwable e) {
                             Exceptions.throwIfFatal(e);
                             upstream.cancel();
-                            errors.addThrowable(e);
+                            errors.tryAddThrowableOrReport(e);
                             errors.tryTerminateConsumer(downstream);
                             return;
                         }
@@ -287,7 +282,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                 Exceptions.throwIfFatal(e);
 
                                 upstream.cancel();
-                                errors.addThrowable(e);
+                                errors.tryAddThrowableOrReport(e);
                                 errors.tryTerminateConsumer(downstream);
                                 return;
                             }
@@ -313,7 +308,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                 } catch (Throwable e) {
                                     Exceptions.throwIfFatal(e);
                                     upstream.cancel();
-                                    errors.addThrowable(e);
+                                    errors.tryAddThrowableOrReport(e);
                                     errors.tryTerminateConsumer(downstream);
                                     return;
                                 }
@@ -400,11 +395,9 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -415,15 +408,13 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
         @Override
         public void innerError(Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (!veryEnd) {
                     upstream.cancel();
                     done = true;
                 }
                 active = false;
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 
@@ -472,11 +463,8 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                         } catch (Throwable e) {
                             Exceptions.throwIfFatal(e);
                             upstream.cancel();
-                            if (errors.addThrowable(e)) {
-                                errors.tryTerminateConsumer(downstream);
-                            } else {
-                                RxJavaPlugins.onError(e);
-                            }
+                            errors.tryAddThrowableOrReport(e);
+                            errors.tryTerminateConsumer(downstream);
                             return;
                         }
 
@@ -496,7 +484,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                 Exceptions.throwIfFatal(e);
 
                                 upstream.cancel();
-                                errors.addThrowable(e);
+                                errors.tryAddThrowableOrReport(e);
                                 errors.tryTerminateConsumer(downstream);
                                 return;
                             }
@@ -521,7 +509,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                     vr = supplier.get();
                                 } catch (Throwable e) {
                                     Exceptions.throwIfFatal(e);
-                                    errors.addThrowable(e);
+                                    errors.tryAddThrowableOrReport(e);
                                     if (!veryEnd) {
                                         upstream.cancel();
                                         errors.tryTerminateConsumer(downstream);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEager.java
@@ -26,7 +26,6 @@ import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.subscribers.*;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpstream<T, R> {
 
@@ -142,11 +141,9 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -209,14 +206,12 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
 
         @Override
         public void innerError(InnerQueuedSubscriber<R> inner, Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 inner.setDone();
                 if (errorMode != ErrorMode.END) {
                     upstream.cancel();
                 }
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
@@ -25,7 +25,6 @@ import io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMap.*;
 import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWithUpstream<T, R> {
 
@@ -195,15 +194,13 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 inner.cancel();
 
                 if (getAndIncrement() == 0) {
                     errors.tryTerminateConsumer(downstream);
                     worker.dispose();
                 }
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -221,15 +218,13 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
 
         @Override
         public void innerError(Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 upstream.cancel();
 
                 if (getAndIncrement() == 0) {
                     errors.tryTerminateConsumer(downstream);
                     worker.dispose();
                 }
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 
@@ -274,7 +269,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                     } catch (Throwable e) {
                         Exceptions.throwIfFatal(e);
                         upstream.cancel();
-                        errors.addThrowable(e);
+                        errors.tryAddThrowableOrReport(e);
                         errors.tryTerminateConsumer(downstream);
                         worker.dispose();
                         return;
@@ -297,7 +292,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                             Exceptions.throwIfFatal(e);
 
                             upstream.cancel();
-                            errors.addThrowable(e);
+                            errors.tryAddThrowableOrReport(e);
                             errors.tryTerminateConsumer(downstream);
                             worker.dispose();
                             return;
@@ -324,7 +319,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                             } catch (Throwable e) {
                                 Exceptions.throwIfFatal(e);
                                 upstream.cancel();
-                                errors.addThrowable(e);
+                                errors.tryAddThrowableOrReport(e);
                                 errors.tryTerminateConsumer(downstream);
                                 worker.dispose();
                                 return;
@@ -386,11 +381,9 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 done = true;
                 schedule();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -401,15 +394,13 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
 
         @Override
         public void innerError(Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (!veryEnd) {
                     upstream.cancel();
                     done = true;
                 }
                 active = false;
                 schedule();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 
@@ -465,7 +456,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                     } catch (Throwable e) {
                         Exceptions.throwIfFatal(e);
                         upstream.cancel();
-                        errors.addThrowable(e);
+                        errors.tryAddThrowableOrReport(e);
                         errors.tryTerminateConsumer(downstream);
                         worker.dispose();
                         return;
@@ -488,7 +479,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                             Exceptions.throwIfFatal(e);
 
                             upstream.cancel();
-                            errors.addThrowable(e);
+                            errors.tryAddThrowableOrReport(e);
                             errors.tryTerminateConsumer(downstream);
                             worker.dispose();
                             return;
@@ -514,7 +505,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                                 vr = supplier.get();
                             } catch (Throwable e) {
                                 Exceptions.throwIfFatal(e);
-                                errors.addThrowable(e);
+                                errors.tryAddThrowableOrReport(e);
                                 if (!veryEnd) {
                                     upstream.cancel();
                                     errors.tryTerminateConsumer(downstream);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinct.java
@@ -25,6 +25,7 @@ import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.fuseable.QueueFuseable;
 import io.reactivex.rxjava3.internal.subscribers.BasicFuseableSubscriber;
 import io.reactivex.rxjava3.internal.subscriptions.EmptySubscription;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T, T> {
@@ -44,7 +45,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
         Collection<? super K> collection;
 
         try {
-            collection = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            collection = ExceptionHelper.nullCheck(collectionSupplier.get(), "The collectionSupplier returned a null Collection.");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptySubscription.error(ex, subscriber);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableError.java
@@ -18,8 +18,8 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.subscriptions.EmptySubscription;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public final class FlowableError<T> extends Flowable<T> {
     final Supplier<? extends Throwable> errorSupplier;
@@ -31,7 +31,7 @@ public final class FlowableError<T> extends Flowable<T> {
     public void subscribeActual(Subscriber<? super T> s) {
         Throwable error;
         try {
-            error = ObjectHelper.requireNonNull(errorSupplier.get(), "Callable returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
+            error = ExceptionHelper.nullCheck(errorSupplier.get(), "Callable returned a null Throwable.");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             error = t;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMap.java
@@ -142,7 +142,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                     u  = ((Supplier<U>)p).get();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    errors.addThrowable(ex);
+                    errors.tryAddThrowableOrReport(ex);
                     drain();
                     return;
                 }
@@ -319,11 +319,9 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                 RxJavaPlugins.onError(t);
                 return;
             }
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -474,7 +472,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                                 } catch (Throwable ex) {
                                     Exceptions.throwIfFatal(ex);
                                     is.dispose();
-                                    errors.addThrowable(ex);
+                                    errors.tryAddThrowableOrReport(ex);
                                     if (!delayErrors) {
                                         upstream.cancel();
                                     }
@@ -581,7 +579,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
         }
 
         void innerError(InnerSubscriber<T, U> inner, Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 inner.done = true;
                 if (!delayErrors) {
                     upstream.cancel();
@@ -590,8 +588,6 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                     }
                 }
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -26,7 +26,6 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.subscriptions.*;
 import io.reactivex.rxjava3.internal.util.AtomicThrowable;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Maps a sequence of values into CompletableSources and awaits their termination.
@@ -126,7 +125,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
         @Override
         public void onError(Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (delayErrors) {
                     if (decrementAndGet() == 0) {
                         errors.tryTerminateConsumer(downstream);
@@ -143,8 +142,6 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
                         errors.tryTerminateConsumer(downstream);
                     }
                 }
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -133,7 +133,7 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
 
         @Override
         public void onError(Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (delayErrors) {
                     if (decrementAndGet() == 0) {
                         errors.tryTerminateConsumer(downstream);
@@ -150,8 +150,6 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
                         errors.tryTerminateConsumer(downstream);
                     }
                 }
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -26,7 +26,6 @@ import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Maps upstream values into MaybeSources and merges their signals into one sequence.
@@ -136,13 +135,11 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
         @Override
         public void onError(Throwable t) {
             active.decrementAndGet();
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (!delayErrors) {
                     set.dispose();
                 }
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -222,7 +219,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
 
         void innerError(InnerObserver inner, Throwable e) {
             set.delete(inner);
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (!delayErrors) {
                     upstream.cancel();
                     set.dispose();
@@ -233,8 +230,6 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                 }
                 active.decrementAndGet();
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -26,7 +26,6 @@ import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Maps upstream values into SingleSources and merges their signals into one sequence.
@@ -136,13 +135,11 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
         @Override
         public void onError(Throwable t) {
             active.decrementAndGet();
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (!delayErrors) {
                     set.dispose();
                 }
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -222,7 +219,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
 
         void innerError(InnerObserver inner, Throwable e) {
             set.delete(inner);
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (!delayErrors) {
                     upstream.cancel();
                     set.dispose();
@@ -233,8 +230,6 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                 }
                 active.decrementAndGet();
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromFuture.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromFuture.java
@@ -20,6 +20,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.internal.subscriptions.DeferredScalarSubscription;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public final class FlowableFromFuture<T> extends Flowable<T> {
     final Future<? extends T> future;
@@ -48,7 +49,7 @@ public final class FlowableFromFuture<T> extends Flowable<T> {
             return;
         }
         if (v == null) {
-            s.onError(new NullPointerException("The future returned null"));
+            s.onError(ExceptionHelper.createNullPointerException("The future returned a null value."));
         } else {
             deferred.complete(v);
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGenerate.java
@@ -21,7 +21,7 @@ import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.subscriptions.*;
-import io.reactivex.rxjava3.internal.util.BackpressureHelper;
+import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class FlowableGenerate<T, S> extends Flowable<T> {
@@ -167,7 +167,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
                     onError(new IllegalStateException("onNext already called in this generate turn"));
                 } else {
                     if (t == null) {
-                        onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+                        onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
                     } else {
                         hasNext = true;
                         downstream.onNext(t);
@@ -182,7 +182,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
                 RxJavaPlugins.onError(t);
             } else {
                 if (t == null) {
-                    t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+                    t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
                 }
                 terminate = true;
                 downstream.onError(t);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.flowables.GroupedFlowable;
 import io.reactivex.rxjava3.functions.*;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.*;
 import io.reactivex.rxjava3.internal.util.*;
@@ -165,7 +164,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
             V v;
             try {
-                v = ObjectHelper.requireNonNull(valueSelector.apply(t), "The valueSelector returned null");
+                v = ExceptionHelper.nullCheck(valueSelector.apply(t), "The valueSelector returned a null value.");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 upstream.cancel();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
 import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Merges an Observable and a Maybe by emitting the items of the Observable and the success
@@ -142,11 +141,9 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
 
         @Override
         public void onError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 DisposableHelper.dispose(otherObserver);
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 
@@ -200,11 +197,9 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
         }
 
         void otherError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 SubscriptionHelper.cancel(mainSubscription);
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithSingle.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
 import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Merges an Observable and a Maybe by emitting the items of the Observable and the success
@@ -142,11 +141,9 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
 
         @Override
         public void onError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 DisposableHelper.dispose(otherObserver);
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 
@@ -200,11 +197,9 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
         }
 
         void otherError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 SubscriptionHelper.cancel(mainSubscription);
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplay.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.flowables.ConnectableFlowable;
 import io.reactivex.rxjava3.functions.*;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.fuseable.HasUpstreamPublisher;
 import io.reactivex.rxjava3.internal.subscribers.SubscriberResourceWrapper;
 import io.reactivex.rxjava3.internal.subscriptions.*;
@@ -1112,7 +1111,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         protected void subscribeActual(Subscriber<? super R> child) {
             ConnectableFlowable<U> cf;
             try {
-                cf = ObjectHelper.requireNonNull(connectableFactory.get(), "The connectableFactory returned null");
+                cf = ExceptionHelper.nullCheck(connectableFactory.get(), "The connectableFactory returned a null ConnectableFlowable.");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 EmptySubscription.error(e, child);
@@ -1121,7 +1120,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
             Publisher<R> observable;
             try {
-                observable = ObjectHelper.requireNonNull(selector.apply(cf), "The selector returned a null Publisher");
+                observable = ExceptionHelper.nullCheck(selector.apply(cf), "The selector returned a null Publisher.");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
                 EmptySubscription.error(e, child);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqual.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqual.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.internal.fuseable.*;
 import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.*;
 import io.reactivex.rxjava3.internal.util.AtomicThrowable;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
     final Publisher<? extends T> first;
@@ -146,11 +145,8 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
                             } catch (Throwable exc) {
                                 Exceptions.throwIfFatal(exc);
                                 cancelAndClear();
-                                if (errors.addThrowable(exc)) {
-                                    errors.tryTerminateConsumer(downstream);
-                                } else {
-                                    RxJavaPlugins.onError(exc);
-                                }
+                                errors.tryAddThrowableOrReport(exc);
+                                errors.tryTerminateConsumer(downstream);
                                 return;
                             }
                             v1 = a;
@@ -165,11 +161,8 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
                             } catch (Throwable exc) {
                                 Exceptions.throwIfFatal(exc);
                                 cancelAndClear();
-                                if (errors.addThrowable(exc)) {
-                                    errors.tryTerminateConsumer(downstream);
-                                } else {
-                                    RxJavaPlugins.onError(exc);
-                                }
+                                errors.tryAddThrowableOrReport(exc);
+                                errors.tryTerminateConsumer(downstream);
                                 return;
                             }
                             v2 = b;
@@ -198,7 +191,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
                         } catch (Throwable exc) {
                             Exceptions.throwIfFatal(exc);
                             cancelAndClear();
-                            errors.addThrowable(exc);
+                            errors.tryAddThrowableOrReport(exc);
                             errors.tryTerminateConsumer(downstream);
                             return;
                         }
@@ -241,10 +234,8 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
 
         @Override
         public void innerError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqualSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqualSingle.java
@@ -146,11 +146,8 @@ public final class FlowableSequenceEqualSingle<T> extends Single<Boolean> implem
                             } catch (Throwable exc) {
                                 Exceptions.throwIfFatal(exc);
                                 cancelAndClear();
-                                if (errors.addThrowable(exc)) {
-                                    errors.tryTerminateConsumer(downstream);
-                                } else {
-                                    RxJavaPlugins.onError(exc);
-                                }
+                                errors.tryAddThrowableOrReport(exc);
+                                errors.tryTerminateConsumer(downstream);
                                 return;
                             }
                             v1 = a;
@@ -165,11 +162,8 @@ public final class FlowableSequenceEqualSingle<T> extends Single<Boolean> implem
                             } catch (Throwable exc) {
                                 Exceptions.throwIfFatal(exc);
                                 cancelAndClear();
-                                if (errors.addThrowable(exc)) {
-                                    errors.tryTerminateConsumer(downstream);
-                                } else {
-                                    RxJavaPlugins.onError(exc);
-                                }
+                                errors.tryAddThrowableOrReport(exc);
+                                errors.tryTerminateConsumer(downstream);
                                 return;
                             }
                             v2 = b;
@@ -198,7 +192,7 @@ public final class FlowableSequenceEqualSingle<T> extends Single<Boolean> implem
                         } catch (Throwable exc) {
                             Exceptions.throwIfFatal(exc);
                             cancelAndClear();
-                            errors.addThrowable(exc);
+                            errors.tryAddThrowableOrReport(exc);
                             errors.tryTerminateConsumer(downstream);
                             return;
                         }
@@ -241,10 +235,8 @@ public final class FlowableSequenceEqualSingle<T> extends Single<Boolean> implem
 
         @Override
         public void innerError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
@@ -134,7 +134,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
 
         @Override
         public void onError(Throwable t) {
-            if (!done && errors.addThrowable(t)) {
+            if (!done && errors.tryAddThrowable(t)) {
                 if (!delayErrors) {
                     disposeInner();
                 }
@@ -265,7 +265,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
                         } catch (Throwable ex) {
                             Exceptions.throwIfFatal(ex);
                             inner.cancel();
-                            errors.addThrowable(ex);
+                            errors.tryAddThrowableOrReport(ex);
                             d = true;
                             v = null;
                         }
@@ -392,7 +392,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
         @Override
         public void onError(Throwable t) {
             SwitchMapSubscriber<T, R> p = parent;
-            if (index == p.unique && p.errors.addThrowable(t)) {
+            if (index == p.unique && p.errors.tryAddThrowable(t)) {
                 if (!p.delayErrors) {
                     p.upstream.cancel();
                     p.done = true;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToList.java
@@ -20,8 +20,8 @@ import org.reactivestreams.*;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.subscriptions.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public final class FlowableToList<T, U extends Collection<? super T>> extends AbstractFlowableWithUpstream<T, U> {
     final Supplier<U> collectionSupplier;
@@ -35,7 +35,7 @@ public final class FlowableToList<T, U extends Collection<? super T>> extends Ab
     protected void subscribeActual(Subscriber<? super U> s) {
         U coll;
         try {
-            coll = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            coll = ExceptionHelper.nullCheck(collectionSupplier.get(), "The collectionSupplier returned a null Collection.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListSingle.java
@@ -22,10 +22,9 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.fuseable.FuseToFlowable;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.rxjava3.internal.util.ArrayListSupplier;
+import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class FlowableToListSingle<T, U extends Collection<? super T>> extends Single<U> implements FuseToFlowable<U> {
@@ -48,7 +47,7 @@ public final class FlowableToListSingle<T, U extends Collection<? super T>> exte
     protected void subscribeActual(SingleObserver<? super U> observer) {
         U coll;
         try {
-            coll = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            coll = ExceptionHelper.nullCheck(collectionSupplier.get(), "The collectionSupplier returned a null Collection.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, observer);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundary.java
@@ -107,11 +107,9 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
         @Override
         public void onError(Throwable e) {
             boundarySubscriber.dispose();
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 
@@ -151,11 +149,9 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
 
         void innerError(Throwable e) {
             SubscriptionHelper.cancel(upstream);
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 
@@ -248,7 +244,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
                         } else {
                             SubscriptionHelper.cancel(upstream);
                             boundarySubscriber.dispose();
-                            errors.addThrowable(new MissingBackpressureException("Could not deliver a window due to lack of requests"));
+                            errors.tryAddThrowableOrReport(new MissingBackpressureException("Could not deliver a window due to lack of requests"));
                             done = true;
                         }
                     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArrayDelayError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArrayDelayError.java
@@ -22,7 +22,6 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.internal.disposables.SequentialDisposable;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Concatenate values of each MaybeSource provided in an array and delays
@@ -104,10 +103,8 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
         @Override
         public void onError(Throwable e) {
             current.lazySet(NotificationLite.COMPLETE);
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCreate.java
@@ -20,6 +20,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Cancellable;
 import io.reactivex.rxjava3.internal.disposables.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -68,7 +69,7 @@ public final class MaybeCreate<T> extends Maybe<T> {
                 if (d != DisposableHelper.DISPOSED) {
                     try {
                         if (value == null) {
-                            downstream.onError(new NullPointerException("onSuccess called with null. Null values are generally not allowed in 2.x operators and sources."));
+                            downstream.onError(ExceptionHelper.createNullPointerException("onSuccess called with a null value."));
                         } else {
                             downstream.onSuccess(value);
                         }
@@ -91,7 +92,7 @@ public final class MaybeCreate<T> extends Maybe<T> {
         @Override
         public boolean tryOnError(Throwable t) {
             if (t == null) {
-                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+                t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
             }
             if (get() != DisposableHelper.DISPOSED) {
                 Disposable d = getAndSet(DisposableHelper.DISPOSED);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeErrorCallable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeErrorCallable.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposables;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 /**
  * Signals a Throwable returned by a Supplier.
@@ -38,7 +38,7 @@ public final class MaybeErrorCallable<T> extends Maybe<T> {
         Throwable ex;
 
         try {
-            ex = ObjectHelper.requireNonNull(errorSupplier.get(), "Supplier returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
+            ex = ExceptionHelper.nullCheck(errorSupplier.get(), "Supplier returned a null Throwable.");
         } catch (Throwable ex1) {
             Exceptions.throwIfFatal(ex1);
             ex = ex1;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -27,7 +27,6 @@ import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
 import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Maps each upstream item into a {@link SingleSource}, subscribes to them one after the other terminates
@@ -139,14 +138,12 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (errorMode == ErrorMode.IMMEDIATE) {
                     inner.dispose();
                 }
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -181,14 +178,12 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
         }
 
         void innerError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 if (errorMode != ErrorMode.END) {
                     upstream.cancel();
                 }
                 this.state = STATE_INACTIVE;
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 
@@ -256,7 +251,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
                             Exceptions.throwIfFatal(ex);
                             upstream.cancel();
                             queue.clear();
-                            errors.addThrowable(ex);
+                            errors.tryAddThrowableOrReport(ex);
                             errors.tryTerminateConsumer(downstream);
                             return;
                         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapCompletable.java
@@ -123,15 +123,13 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (delayErrors) {
                     onComplete();
                 } else {
                     disposeInner();
                     errors.tryTerminateConsumer(downstream);
                 }
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -164,7 +162,7 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
 
         void innerError(SwitchMapInnerObserver sender, Throwable error) {
             if (inner.compareAndSet(sender, null)) {
-                if (errors.addThrowable(error)) {
+                if (errors.tryAddThrowableOrReport(error)) {
                     if (delayErrors) {
                         if (done) {
                             errors.tryTerminateConsumer(downstream);
@@ -174,10 +172,10 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
                         disposeInner();
                         errors.tryTerminateConsumer(downstream);
                     }
-                    return;
                 }
+            } else {
+                RxJavaPlugins.onError(error);
             }
-            RxJavaPlugins.onError(error);
         }
 
         void innerComplete(SwitchMapInnerObserver sender) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapMaybe.java
@@ -141,14 +141,12 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (!delayErrors) {
                     disposeInner();
                 }
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -182,16 +180,16 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
 
         void innerError(SwitchMapMaybeObserver<R> sender, Throwable ex) {
             if (inner.compareAndSet(sender, null)) {
-                if (errors.addThrowable(ex)) {
+                if (errors.tryAddThrowableOrReport(ex)) {
                     if (!delayErrors) {
                         upstream.cancel();
                         disposeInner();
                     }
                     drain();
-                    return;
                 }
+            } else {
+                RxJavaPlugins.onError(ex);
             }
-            RxJavaPlugins.onError(ex);
         }
 
         void innerComplete(SwitchMapMaybeObserver<R> sender) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapSingle.java
@@ -141,14 +141,12 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (!delayErrors) {
                     disposeInner();
                 }
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -182,16 +180,16 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
 
         void innerError(SwitchMapSingleObserver<R> sender, Throwable ex) {
             if (inner.compareAndSet(sender, null)) {
-                if (errors.addThrowable(ex)) {
+                if (errors.tryAddThrowableOrReport(ex)) {
                     if (!delayErrors) {
                         upstream.cancel();
                         disposeInner();
                     }
                     drain();
-                    return;
                 }
+            } else {
+                RxJavaPlugins.onError(ex);
             }
-            RxJavaPlugins.onError(ex);
         }
 
         void drain() {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.util.*;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Maps each upstream item into a {@link SingleSource}, subscribes to them one after the other terminates
@@ -123,14 +122,12 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (errorMode == ErrorMode.IMMEDIATE) {
                     inner.dispose();
                 }
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -164,14 +161,12 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
         }
 
         void innerError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 if (errorMode != ErrorMode.END) {
                     upstream.dispose();
                 }
                 this.state = STATE_INACTIVE;
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 
@@ -229,7 +224,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
                             Exceptions.throwIfFatal(ex);
                             upstream.dispose();
                             queue.clear();
-                            errors.addThrowable(ex);
+                            errors.tryAddThrowableOrReport(ex);
                             errors.tryTerminateConsumer(downstream);
                             return;
                         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapCompletable.java
@@ -121,15 +121,13 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (delayErrors) {
                     onComplete();
                 } else {
                     disposeInner();
                     errors.tryTerminateConsumer(downstream);
                 }
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -162,7 +160,7 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
 
         void innerError(SwitchMapInnerObserver sender, Throwable error) {
             if (inner.compareAndSet(sender, null)) {
-                if (errors.addThrowable(error)) {
+                if (errors.tryAddThrowableOrReport(error)) {
                     if (delayErrors) {
                         if (done) {
                             errors.tryTerminateConsumer(downstream);
@@ -172,10 +170,10 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
                         disposeInner();
                         errors.tryTerminateConsumer(downstream);
                     }
-                    return;
                 }
+            } else {
+                RxJavaPlugins.onError(error);
             }
-            RxJavaPlugins.onError(error);
         }
 
         void innerComplete(SwitchMapInnerObserver sender) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapMaybe.java
@@ -134,14 +134,12 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (!delayErrors) {
                     disposeInner();
                 }
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -174,16 +172,16 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
 
         void innerError(SwitchMapMaybeObserver<R> sender, Throwable ex) {
             if (inner.compareAndSet(sender, null)) {
-                if (errors.addThrowable(ex)) {
+                if (errors.tryAddThrowableOrReport(ex)) {
                     if (!delayErrors) {
                         upstream.dispose();
                         disposeInner();
                     }
                     drain();
-                    return;
                 }
+            } else {
+                RxJavaPlugins.onError(ex);
             }
-            RxJavaPlugins.onError(ex);
         }
 
         void innerComplete(SwitchMapMaybeObserver<R> sender) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapSingle.java
@@ -134,14 +134,12 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (!delayErrors) {
                     disposeInner();
                 }
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -174,16 +172,16 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
 
         void innerError(SwitchMapSingleObserver<R> sender, Throwable ex) {
             if (inner.compareAndSet(sender, null)) {
-                if (errors.addThrowable(ex)) {
+                if (errors.tryAddThrowableOrReport(ex)) {
                     if (!delayErrors) {
                         upstream.dispose();
                         disposeInner();
                     }
                     drain();
-                    return;
                 }
+            } else {
+                RxJavaPlugins.onError(ex);
             }
-            RxJavaPlugins.onError(ex);
         }
 
         void drain() {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBuffer.java
@@ -23,6 +23,7 @@ import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
 import io.reactivex.rxjava3.internal.disposables.*;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public final class ObservableBuffer<T, U extends Collection<? super T>> extends AbstractObservableWithUpstream<T, U> {
     final int count;
@@ -184,7 +185,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
                 U b;
 
                 try {
-                    b = ObjectHelper.requireNonNull(bufferSupplier.get(), "The bufferSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+                    b = ExceptionHelper.nullCheck(bufferSupplier.get(), "The bufferSupplier returned a null Collection.");
                 } catch (Throwable e) {
                     buffers.clear();
                     upstream.dispose();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferBoundary.java
@@ -122,15 +122,13 @@ extends AbstractObservableWithUpstream<T, U> {
 
         @Override
         public void onError(Throwable t) {
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 observers.dispose();
                 synchronized (this) {
                     buffers = null;
                 }
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -252,8 +250,7 @@ extends AbstractObservableWithUpstream<T, U> {
                     boolean d = done;
                     if (d && errors.get() != null) {
                         q.clear();
-                        Throwable ex = errors.terminate();
-                        a.onError(ex);
+                        errors.tryTerminateConsumer(a);
                         return;
                     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinct.java
@@ -22,6 +22,7 @@ import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.observers.BasicFuseableObserver;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstream<T, T> {
@@ -41,7 +42,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
         Collection<? super K> collection;
 
         try {
-            collection = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            collection = ExceptionHelper.nullCheck(collectionSupplier.get(), "The collectionSupplier returned a null Collection.");
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
             EmptyDisposable.error(ex, observer);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableError.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public final class ObservableError<T> extends Observable<T> {
     final Supplier<? extends Throwable> errorSupplier;
@@ -29,7 +29,7 @@ public final class ObservableError<T> extends Observable<T> {
     public void subscribeActual(Observer<? super T> observer) {
         Throwable error;
         try {
-            error = ObjectHelper.requireNonNull(errorSupplier.get(), "Supplier returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
+            error = ExceptionHelper.nullCheck(errorSupplier.get(), "Supplier returned a null Throwable.");
         } catch (Throwable t) {
             Exceptions.throwIfFatal(t);
             error = t;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMap.java
@@ -222,7 +222,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 u = value.get();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                errors.addThrowable(ex);
+                errors.tryAddThrowableOrReport(ex);
                 drain();
                 return true;
             }
@@ -285,11 +285,9 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 RxJavaPlugins.onError(t);
                 return;
             }
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -407,7 +405,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                                 } catch (Throwable ex) {
                                     Exceptions.throwIfFatal(ex);
                                     is.dispose();
-                                    errors.addThrowable(ex);
+                                    errors.tryAddThrowableOrReport(ex);
                                     if (checkTerminate()) {
                                         return;
                                     }
@@ -553,14 +551,12 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
 
         @Override
         public void onError(Throwable t) {
-            if (parent.errors.addThrowable(t)) {
+            if (parent.errors.tryAddThrowableOrReport(t)) {
                 if (!parent.delayErrors) {
                     parent.disposeAll();
                 }
                 done = true;
                 parent.drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.observers.BasicIntQueueDisposable;
 import io.reactivex.rxjava3.internal.util.AtomicThrowable;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Maps a sequence of values into CompletableSources and awaits their termination.
@@ -108,7 +107,7 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
 
         @Override
         public void onError(Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (delayErrors) {
                     if (decrementAndGet() == 0) {
                         errors.tryTerminateConsumer(downstream);
@@ -121,8 +120,6 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
                         errors.tryTerminateConsumer(downstream);
                     }
                 }
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
@@ -113,7 +113,7 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
 
         @Override
         public void onError(Throwable e) {
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (delayErrors) {
                     if (decrementAndGet() == 0) {
                         errors.tryTerminateConsumer(downstream);
@@ -126,8 +126,6 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
                         errors.tryTerminateConsumer(downstream);
                     }
                 }
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.util.AtomicThrowable;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Maps upstream values into MaybeSources and merges their signals into one sequence.
@@ -117,13 +116,11 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
         @Override
         public void onError(Throwable t) {
             active.decrementAndGet();
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (!delayErrors) {
                     set.dispose();
                 }
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -189,15 +186,13 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
 
         void innerError(InnerObserver inner, Throwable e) {
             set.delete(inner);
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (!delayErrors) {
                     upstream.dispose();
                     set.dispose();
                 }
                 active.decrementAndGet();
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapSingle.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.util.AtomicThrowable;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Maps upstream values into SingleSources and merges their signals into one sequence.
@@ -117,13 +116,11 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
         @Override
         public void onError(Throwable t) {
             active.decrementAndGet();
-            if (errors.addThrowable(t)) {
+            if (errors.tryAddThrowableOrReport(t)) {
                 if (!delayErrors) {
                     set.dispose();
                 }
                 drain();
-            } else {
-                RxJavaPlugins.onError(t);
             }
         }
 
@@ -189,15 +186,13 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
 
         void innerError(InnerObserver inner, Throwable e) {
             set.delete(inner);
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 if (!delayErrors) {
                     upstream.dispose();
                     set.dispose();
                 }
                 active.decrementAndGet();
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromCallable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromCallable.java
@@ -18,8 +18,8 @@ import java.util.concurrent.Callable;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.observers.DeferredScalarDisposable;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -43,7 +43,7 @@ public final class ObservableFromCallable<T> extends Observable<T> implements Su
         }
         T value;
         try {
-            value = ObjectHelper.requireNonNull(callable.call(), "Callable returned null");
+            value = ExceptionHelper.nullCheck(callable.call(), "Callable returned a null value.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
@@ -58,6 +58,6 @@ public final class ObservableFromCallable<T> extends Observable<T> implements Su
 
     @Override
     public T get() throws Throwable {
-        return ObjectHelper.requireNonNull(callable.call(), "The callable returned a null value");
+        return ExceptionHelper.nullCheck(callable.call(), "The Callable returned a null value.");
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromFuture.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromFuture.java
@@ -17,8 +17,8 @@ import java.util.concurrent.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.Exceptions;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.observers.DeferredScalarDisposable;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public final class ObservableFromFuture<T> extends Observable<T> {
     final Future<? extends T> future;
@@ -38,7 +38,7 @@ public final class ObservableFromFuture<T> extends Observable<T> {
         if (!d.isDisposed()) {
             T v;
             try {
-                v = ObjectHelper.requireNonNull(unit != null ? future.get(timeout, unit) : future.get(), "Future returned null");
+                v = ExceptionHelper.nullCheck(unit != null ? future.get(timeout, unit) : future.get(), "Future returned a null value.");
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 if (!d.isDisposed()) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromSupplier.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromSupplier.java
@@ -16,8 +16,8 @@ package io.reactivex.rxjava3.internal.operators.observable;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.observers.DeferredScalarDisposable;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -42,7 +42,7 @@ public final class ObservableFromSupplier<T> extends Observable<T> implements Su
         }
         T value;
         try {
-            value = ObjectHelper.requireNonNull(supplier.get(), "Supplier returned null");
+            value = ExceptionHelper.nullCheck(supplier.get(), "Supplier returned a null value.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             if (!d.isDisposed()) {
@@ -57,6 +57,6 @@ public final class ObservableFromSupplier<T> extends Observable<T> implements Su
 
     @Override
     public T get() throws Throwable {
-        return ObjectHelper.requireNonNull(supplier.get(), "The supplier returned a null value");
+        return ExceptionHelper.nullCheck(supplier.get(), "The supplier returned a null value.");
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGenerate.java
@@ -18,6 +18,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class ObservableGenerate<T, S> extends Observable<T> {
@@ -141,7 +142,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
                     onError(new IllegalStateException("onNext already called in this generate turn"));
                 } else {
                     if (t == null) {
-                        onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+                        onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
                     } else {
                         hasNext = true;
                         downstream.onNext(t);
@@ -156,7 +157,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
                 RxJavaPlugins.onError(t);
             } else {
                 if (t == null) {
-                    t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+                    t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
                 }
                 terminate = true;
                 downstream.onError(t);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithMaybe.java
@@ -21,7 +21,6 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.util.AtomicThrowable;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Merges an Observable and a Maybe by emitting the items of the Observable and the success
@@ -105,11 +104,9 @@ public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUps
 
         @Override
         public void onError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 DisposableHelper.dispose(otherObserver);
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 
@@ -151,11 +148,9 @@ public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUps
         }
 
         void otherError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 DisposableHelper.dispose(mainDisposable);
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithSingle.java
@@ -21,7 +21,6 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.util.AtomicThrowable;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Merges an Observable and a Single by emitting the items of the Observable and the success
@@ -105,11 +104,9 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
 
         @Override
         public void onError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 DisposableHelper.dispose(otherObserver);
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 
@@ -151,11 +148,9 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
         }
 
         void otherError(Throwable ex) {
-            if (errors.addThrowable(ex)) {
+            if (errors.tryAddThrowableOrReport(ex)) {
                 DisposableHelper.dispose(mainDisposable);
                 drain();
-            } else {
-                RxJavaPlugins.onError(ex);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchMap.java
@@ -132,7 +132,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
 
         @Override
         public void onError(Throwable t) {
-            if (!done && errors.addThrowable(t)) {
+            if (!done && errors.tryAddThrowable(t)) {
                 if (!delayErrors) {
                     disposeInner();
                 }
@@ -272,7 +272,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                                 v = q.poll();
                             } catch (Throwable ex) {
                                 Exceptions.throwIfFatal(ex);
-                                errors.addThrowable(ex);
+                                errors.tryAddThrowableOrReport(ex);
                                 active.compareAndSet(inner, null);
                                 if (!delayErrors) {
                                     disposeInner();
@@ -313,7 +313,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
         }
 
         void innerError(SwitchMapInnerObserver<T, R> inner, Throwable ex) {
-            if (inner.index == unique && errors.addThrowable(ex)) {
+            if (inner.index == unique && errors.tryAddThrowable(ex)) {
                 if (!delayErrors) {
                     upstream.dispose();
                     done = true;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToList.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToList.java
@@ -20,7 +20,8 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
 import io.reactivex.rxjava3.internal.disposables.*;
-import io.reactivex.rxjava3.internal.functions.*;
+import io.reactivex.rxjava3.internal.functions.Functions;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public final class ObservableToList<T, U extends Collection<? super T>>
 extends AbstractObservableWithUpstream<T, U> {
@@ -42,7 +43,7 @@ extends AbstractObservableWithUpstream<T, U> {
     public void subscribeActual(Observer<? super U> t) {
         U coll;
         try {
-            coll = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            coll = ExceptionHelper.nullCheck(collectionSupplier.get(), "The collectionSupplier returned a null Collection.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToListSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToListSingle.java
@@ -20,8 +20,9 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
 import io.reactivex.rxjava3.internal.disposables.*;
-import io.reactivex.rxjava3.internal.functions.*;
+import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.internal.fuseable.FuseToObservable;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class ObservableToListSingle<T, U extends Collection<? super T>>
@@ -46,7 +47,7 @@ extends Single<U> implements FuseToObservable<U> {
     public void subscribeActual(SingleObserver<? super U> t) {
         U coll;
         try {
-            coll = ObjectHelper.requireNonNull(collectionSupplier.get(), "The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+            coll = ExceptionHelper.nullCheck(collectionSupplier.get(), "The collectionSupplier returned a null Collection.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundary.java
@@ -100,11 +100,9 @@ public final class ObservableWindowBoundary<T, B> extends AbstractObservableWith
         @Override
         public void onError(Throwable e) {
             boundaryObserver.dispose();
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 
@@ -144,11 +142,9 @@ public final class ObservableWindowBoundary<T, B> extends AbstractObservableWith
 
         void innerError(Throwable e) {
             DisposableHelper.dispose(upstream);
-            if (errors.addThrowable(e)) {
+            if (errors.tryAddThrowableOrReport(e)) {
                 done = true;
                 drain();
-            } else {
-                RxJavaPlugins.onError(e);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleCreate.java
@@ -20,6 +20,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Cancellable;
 import io.reactivex.rxjava3.internal.disposables.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class SingleCreate<T> extends Single<T> {
@@ -62,7 +63,7 @@ public final class SingleCreate<T> extends Single<T> {
                 if (d != DisposableHelper.DISPOSED) {
                     try {
                         if (value == null) {
-                            downstream.onError(new NullPointerException("onSuccess called with null. Null values are generally not allowed in 2.x operators and sources."));
+                            downstream.onError(ExceptionHelper.createNullPointerException("onSuccess called with a null value."));
                         } else {
                             downstream.onSuccess(value);
                         }
@@ -85,7 +86,7 @@ public final class SingleCreate<T> extends Single<T> {
         @Override
         public boolean tryOnError(Throwable t) {
             if (t == null) {
-                t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+                t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
             }
             if (get() != DisposableHelper.DISPOSED) {
                 Disposable d = getAndSet(DisposableHelper.DISPOSED);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleError.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Supplier;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public final class SingleError<T> extends Single<T> {
 
@@ -32,7 +32,7 @@ public final class SingleError<T> extends Single<T> {
         Throwable error;
 
         try {
-            error = ObjectHelper.requireNonNull(errorSupplier.get(), "Supplier returned null throwable. Null values are generally not allowed in 2.x operators and sources.");
+            error = ExceptionHelper.nullCheck(errorSupplier.get(), "Supplier returned a null Throwable.");
         } catch (Throwable e) {
             Exceptions.throwIfFatal(e);
             error = e;

--- a/src/main/java/io/reactivex/rxjava3/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/ExceptionHelper.java
@@ -143,4 +143,41 @@ public final class ExceptionHelper {
             return this;
         }
     }
+
+    /**
+     * Composes a String with a null warning message.
+     * @param prefix the prefix to add to the message.
+     * @return the composed String
+     * @since 3.0.0
+     */
+    public static String nullWarning(String prefix) {
+        return prefix + " Null values are generally not allowed in 3.x operators and sources.";
+    }
+
+    /**
+     * Creates a NullPointerException with a composed message via {@link #nullWarning(String)}.
+     * @param prefix the prefix to add to the message.
+     * @return the composed String
+     * @since 3.0.0
+     */
+    public static NullPointerException createNullPointerException(String prefix) {
+        return new NullPointerException(nullWarning(prefix));
+    }
+
+    /**
+     * Similar to ObjectHelper.requireNonNull but composes the error message via
+     * {@link #nullWarning(String)}.
+     * @param <T> the value type
+     * @param value the value to check
+     * @param prefix the prefix to the error message
+     * @return the value
+     * @throws NullPointerException if value is null
+     * @since 3.0.0
+     */
+    public static <T> T nullCheck(T value, String prefix) {
+        if (value == null) {
+            throw createNullPointerException(prefix);
+        }
+        return value;
+    }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/util/HalfSerializer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/HalfSerializer.java
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.rxjava3.core.Observer;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Utility methods to perform half-serialization: a form of serialization
@@ -37,14 +36,14 @@ public final class HalfSerializer {
      * @param subscriber the target Subscriber to emit to
      * @param value the value to emit
      * @param wip the serialization work-in-progress counter/indicator
-     * @param error the holder of Throwables
+     * @param errors the holder of Throwables
      */
     public static <T> void onNext(Subscriber<? super T> subscriber, T value,
-            AtomicInteger wip, AtomicThrowable error) {
+            AtomicInteger wip, AtomicThrowable errors) {
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
             subscriber.onNext(value);
             if (wip.decrementAndGet() != 0) {
-                error.tryTerminateConsumer(subscriber);
+                errors.tryTerminateConsumer(subscriber);
             }
         }
     }
@@ -56,16 +55,14 @@ public final class HalfSerializer {
      * @param subscriber the target Subscriber to emit to
      * @param ex the Throwable to emit
      * @param wip the serialization work-in-progress counter/indicator
-     * @param error the holder of Throwables
+     * @param errors the holder of Throwables
      */
     public static void onError(Subscriber<?> subscriber, Throwable ex,
-            AtomicInteger wip, AtomicThrowable error) {
-        if (error.addThrowable(ex)) {
+            AtomicInteger wip, AtomicThrowable errors) {
+        if (errors.tryAddThrowableOrReport(ex)) {
             if (wip.getAndIncrement() == 0) {
-                error.tryTerminateConsumer(subscriber);
+                errors.tryTerminateConsumer(subscriber);
             }
-        } else {
-            RxJavaPlugins.onError(ex);
         }
     }
 
@@ -74,11 +71,11 @@ public final class HalfSerializer {
      * the concurrently running onNext should do that.
      * @param subscriber the target Subscriber to emit to
      * @param wip the serialization work-in-progress counter/indicator
-     * @param error the holder of Throwables
+     * @param errors the holder of Throwables
      */
-    public static void onComplete(Subscriber<?> subscriber, AtomicInteger wip, AtomicThrowable error) {
+    public static void onComplete(Subscriber<?> subscriber, AtomicInteger wip, AtomicThrowable errors) {
         if (wip.getAndIncrement() == 0) {
-            error.tryTerminateConsumer(subscriber);
+            errors.tryTerminateConsumer(subscriber);
         }
     }
 
@@ -89,14 +86,14 @@ public final class HalfSerializer {
      * @param observer the target Observer to emit to
      * @param value the value to emit
      * @param wip the serialization work-in-progress counter/indicator
-     * @param error the holder of Throwables
+     * @param errors the holder of Throwables
      */
     public static <T> void onNext(Observer<? super T> observer, T value,
-            AtomicInteger wip, AtomicThrowable error) {
+            AtomicInteger wip, AtomicThrowable errors) {
         if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
             observer.onNext(value);
             if (wip.decrementAndGet() != 0) {
-                error.tryTerminateConsumer(observer);
+                errors.tryTerminateConsumer(observer);
             }
         }
     }
@@ -108,16 +105,14 @@ public final class HalfSerializer {
      * @param observer the target Subscriber to emit to
      * @param ex the Throwable to emit
      * @param wip the serialization work-in-progress counter/indicator
-     * @param error the holder of Throwables
+     * @param errors the holder of Throwables
      */
     public static void onError(Observer<?> observer, Throwable ex,
-            AtomicInteger wip, AtomicThrowable error) {
-        if (error.addThrowable(ex)) {
+            AtomicInteger wip, AtomicThrowable errors) {
+        if (errors.tryAddThrowableOrReport(ex)) {
             if (wip.getAndIncrement() == 0) {
-                error.tryTerminateConsumer(observer);
+                errors.tryTerminateConsumer(observer);
             }
-        } else {
-            RxJavaPlugins.onError(ex);
         }
     }
 
@@ -126,11 +121,11 @@ public final class HalfSerializer {
      * the concurrently running onNext should do that.
      * @param observer the target Subscriber to emit to
      * @param wip the serialization work-in-progress counter/indicator
-     * @param error the holder of Throwables
+     * @param errors the holder of Throwables
      */
-    public static void onComplete(Observer<?> observer, AtomicInteger wip, AtomicThrowable error) {
+    public static void onComplete(Observer<?> observer, AtomicInteger wip, AtomicThrowable errors) {
         if (wip.getAndIncrement() == 0) {
-            error.tryTerminateConsumer(observer);
+            errors.tryTerminateConsumer(observer);
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava3/observers/SafeObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/SafeObserver.java
@@ -17,6 +17,7 @@ import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.internal.disposables.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -84,7 +85,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         }
 
         if (t == null) {
-            Throwable ex = new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+            Throwable ex = ExceptionHelper.createNullPointerException("onNext called with a null value.");
             try {
                 upstream.dispose();
             } catch (Throwable e1) {
@@ -163,7 +164,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
         }
 
         if (t == null) {
-            t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+            t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
         }
 
         try {

--- a/src/main/java/io/reactivex/rxjava3/observers/SerializedObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/SerializedObserver.java
@@ -90,7 +90,7 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
         }
         if (t == null) {
             upstream.dispose();
-            onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+            onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
             return;
         }
         synchronized (this) {

--- a/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
@@ -361,7 +361,7 @@ public final class RxJavaPlugins {
         Consumer<? super Throwable> f = errorHandler;
 
         if (error == null) {
-            error = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+            error = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
         } else {
             if (!isBug(error)) {
                 error = new UndeliverableException(error);

--- a/src/main/java/io/reactivex/rxjava3/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/AsyncProcessor.java
@@ -17,8 +17,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.*;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.subscriptions.DeferredScalarSubscription;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -161,7 +161,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         if (subscribers.get() == TERMINATED) {
             return;
         }
@@ -171,7 +171,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     @SuppressWarnings("unchecked")
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (subscribers.get() == TERMINATED) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
@@ -268,7 +268,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
 
         if (terminalEvent.get() != null) {
             return;
@@ -282,7 +282,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (!terminalEvent.compareAndSet(null, t)) {
             RxJavaPlugins.onError(t);
             return;
@@ -311,8 +311,8 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * This method should be called in a sequential manner just like the onXXX methods
      * of the PublishProcessor.
      * <p>
-     * Calling with null will terminate the PublishProcessor and a NullPointerException
-     * is signalled to the Subscribers.
+     * Calling with a null value will terminate the PublishProcessor and a NullPointerException
+     * is signaled to the Subscribers.
      * <p>History: 2.0.8 - experimental
      * @param t the item to emit, not null
      * @return true if the item was emitted to all Subscribers
@@ -320,7 +320,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      */
     public boolean offer(T t) {
         if (t == null) {
-            onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+            onError(ExceptionHelper.createNullPointerException("offer called with a null value."));
             return true;
         }
         BehaviorSubscription<T>[] array = subscribers.get();

--- a/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
@@ -23,6 +23,7 @@ import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.fuseable.*;
 import io.reactivex.rxjava3.internal.queue.*;
 import io.reactivex.rxjava3.internal.subscriptions.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -292,7 +293,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
             return;
         }
         if (fusionMode == QueueSubscription.NONE) {
-            ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+            ExceptionHelper.nullCheck(t, "onNext called with a null value.");
             if (!queue.offer(t)) {
                 SubscriptionHelper.cancel(upstream);
                 onError(new MissingBackpressureException());
@@ -312,7 +313,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
         if (once.get()) {
             return false;
         }
-        ObjectHelper.requireNonNull(t, "offer called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "offer called with a null value.");
         if (fusionMode == QueueSubscription.NONE) {
             if (queue.offer(t)) {
                 drain();
@@ -324,7 +325,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (once.compareAndSet(false, true)) {
             error = t;
             done = true;

--- a/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
@@ -18,9 +18,8 @@ import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.rxjava3.internal.util.BackpressureHelper;
+import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -238,7 +237,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         for (PublishSubscription<T> s : subscribers.get()) {
             s.onNext(t);
         }
@@ -247,7 +246,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     @SuppressWarnings("unchecked")
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (subscribers.get() == TERMINATED) {
             RxJavaPlugins.onError(t);
             return;
@@ -277,8 +276,8 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
      * This method should be called in a sequential manner just like the onXXX methods
      * of the PublishProcessor.
      * <p>
-     * Calling with null will terminate the PublishProcessor and a NullPointerException
-     * is signalled to the Subscribers.
+     * Calling with a null value will terminate the PublishProcessor and a NullPointerException
+     * is signaled to the Subscribers.
      * <p>History: 2.0.8 - experimental
      * @param t the item to emit, not null
      * @return true if the item was emitted to all Subscribers
@@ -286,7 +285,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
      */
     public boolean offer(T t) {
         if (t == null) {
-            onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+            onError(ExceptionHelper.createNullPointerException("offer called with a null value."));
             return true;
         }
         PublishSubscription<T>[] array = subscribers.get();

--- a/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
@@ -24,7 +24,7 @@ import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.rxjava3.internal.util.BackpressureHelper;
+import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -353,7 +353,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
 
         if (done) {
             return;
@@ -370,7 +370,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     @SuppressWarnings("unchecked")
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
 
         if (done) {
             RxJavaPlugins.onError(t);

--- a/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
@@ -22,7 +22,7 @@ import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.fuseable.QueueSubscription;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.*;
-import io.reactivex.rxjava3.internal.util.BackpressureHelper;
+import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -446,7 +446,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
 
         if (done || cancelled) {
             return;
@@ -458,7 +458,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
 
         if (done || cancelled) {
             RxJavaPlugins.onError(t);

--- a/src/main/java/io/reactivex/rxjava3/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/AsyncSubject.java
@@ -18,8 +18,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.observers.DeferredScalarDisposable;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -150,7 +150,7 @@ public final class AsyncSubject<T> extends Subject<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         if (subscribers.get() == TERMINATED) {
             return;
         }
@@ -160,7 +160,7 @@ public final class AsyncSubject<T> extends Subject<T> {
     @SuppressWarnings("unchecked")
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (subscribers.get() == TERMINATED) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/rxjava3/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/BehaviorSubject.java
@@ -250,7 +250,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
 
         if (terminalEvent.get() != null) {
             return;
@@ -264,7 +264,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
 
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (!terminalEvent.compareAndSet(null, t)) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/rxjava3/subjects/CompletableSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/CompletableSubject.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -119,7 +119,7 @@ public final class CompletableSubject extends Completable implements Completable
 
     @Override
     public void onError(Throwable e) {
-        ObjectHelper.requireNonNull(e, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(e, "onError called with a null Throwable.");
         if (once.compareAndSet(false, true)) {
             this.error = e;
             for (CompletableDisposable md : observers.getAndSet(TERMINATED)) {

--- a/src/main/java/io/reactivex/rxjava3/subjects/MaybeSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/MaybeSubject.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -150,7 +150,7 @@ public final class MaybeSubject<T> extends Maybe<T> implements MaybeObserver<T> 
     @SuppressWarnings("unchecked")
     @Override
     public void onSuccess(T value) {
-        ObjectHelper.requireNonNull(value, "onSuccess called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(value, "onSuccess called with a null value.");
         if (once.compareAndSet(false, true)) {
             this.value = value;
             for (MaybeDisposable<T> md : observers.getAndSet(TERMINATED)) {
@@ -162,7 +162,7 @@ public final class MaybeSubject<T> extends Maybe<T> implements MaybeObserver<T> 
     @SuppressWarnings("unchecked")
     @Override
     public void onError(Throwable e) {
-        ObjectHelper.requireNonNull(e, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(e, "onError called with a null Throwable.");
         if (once.compareAndSet(false, true)) {
             this.error = e;
             for (MaybeDisposable<T> md : observers.getAndSet(TERMINATED)) {

--- a/src/main/java/io/reactivex/rxjava3/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/PublishSubject.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -221,7 +221,7 @@ public final class PublishSubject<T> extends Subject<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         for (PublishDisposable<T> pd : subscribers.get()) {
             pd.onNext(t);
         }
@@ -230,7 +230,7 @@ public final class PublishSubject<T> extends Subject<T> {
     @SuppressWarnings("unchecked")
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (subscribers.get() == TERMINATED) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
@@ -23,7 +23,7 @@ import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
-import io.reactivex.rxjava3.internal.util.NotificationLite;
+import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -340,7 +340,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         if (done) {
             return;
         }
@@ -355,7 +355,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (done) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/rxjava3/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/SingleSubject.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -134,7 +134,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
     @SuppressWarnings("unchecked")
     @Override
     public void onSuccess(@NonNull T value) {
-        ObjectHelper.requireNonNull(value, "onSuccess called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(value, "onSuccess called with a null value.");
         if (once.compareAndSet(false, true)) {
             this.value = value;
             for (SingleDisposable<T> md : observers.getAndSet(TERMINATED)) {
@@ -146,7 +146,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
     @SuppressWarnings("unchecked")
     @Override
     public void onError(@NonNull Throwable e) {
-        ObjectHelper.requireNonNull(e, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(e, "onError called with a null Throwable.");
         if (once.compareAndSet(false, true)) {
             this.error = e;
             for (SingleDisposable<T> md : observers.getAndSet(TERMINATED)) {

--- a/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
@@ -23,6 +23,7 @@ import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.fuseable.SimpleQueue;
 import io.reactivex.rxjava3.internal.observers.BasicIntQueueDisposable;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -325,7 +326,7 @@ public final class UnicastSubject<T> extends Subject<T> {
 
     @Override
     public void onNext(T t) {
-        ObjectHelper.requireNonNull(t, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         if (done || disposed) {
             return;
         }
@@ -335,7 +336,7 @@ public final class UnicastSubject<T> extends Subject<T> {
 
     @Override
     public void onError(Throwable t) {
-        ObjectHelper.requireNonNull(t, "onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (done || disposed) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/rxjava3/subscribers/SafeSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/subscribers/SafeSubscriber.java
@@ -17,6 +17,7 @@ import org.reactivestreams.*;
 import io.reactivex.rxjava3.core.FlowableSubscriber;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.internal.subscriptions.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -74,7 +75,7 @@ public final class SafeSubscriber<T> implements FlowableSubscriber<T>, Subscript
         }
 
         if (t == null) {
-            Throwable ex = new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+            Throwable ex = ExceptionHelper.createNullPointerException("onNext called with a null Throwable.");
             try {
                 upstream.cancel();
             } catch (Throwable e1) {
@@ -152,7 +153,7 @@ public final class SafeSubscriber<T> implements FlowableSubscriber<T>, Subscript
         }
 
         if (t == null) {
-            t = new NullPointerException("onError called with null. Null values are generally not allowed in 2.x operators and sources.");
+            t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
         }
 
         try {

--- a/src/main/java/io/reactivex/rxjava3/subscribers/SerializedSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/subscribers/SerializedSubscriber.java
@@ -78,7 +78,7 @@ public final class SerializedSubscriber<T> implements FlowableSubscriber<T>, Sub
         }
         if (t == null) {
             upstream.cancel();
-            onError(new NullPointerException("onNext called with null. Null values are generally not allowed in 2.x operators and sources."));
+            onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
             return;
         }
         synchronized (this) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinctTest.java
@@ -29,6 +29,7 @@ import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.internal.fuseable.*;
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.processors.UnicastProcessor;
 import io.reactivex.rxjava3.testsupport.*;
@@ -193,7 +194,7 @@ public class FlowableDistinctTest extends RxJavaTest {
         })
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(NullPointerException.class)
-        .assertErrorMessage("The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+        .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListTest.java
@@ -26,6 +26,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.processors.PublishProcessor;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
@@ -244,7 +245,7 @@ public class FlowableToListTest extends RxJavaTest {
         .toFlowable()
         .to(TestHelper.<Collection<Integer>>testConsumer())
         .assertFailure(NullPointerException.class)
-        .assertErrorMessage("The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+        .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
     }
 
     @SuppressWarnings("unchecked")
@@ -273,7 +274,7 @@ public class FlowableToListTest extends RxJavaTest {
         })
         .to(TestHelper.<Collection<Integer>>testConsumer())
         .assertFailure(NullPointerException.class)
-        .assertErrorMessage("The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+        .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctTest.java
@@ -30,6 +30,7 @@ import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.subjects.UnicastSubject;
 import io.reactivex.rxjava3.testsupport.*;
@@ -194,7 +195,7 @@ public class ObservableDistinctTest extends RxJavaTest {
         })
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(NullPointerException.class)
-        .assertErrorMessage("The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+        .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToListTest.java
@@ -27,6 +27,7 @@ import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class ObservableToListTest extends RxJavaTest {
@@ -216,7 +217,7 @@ public class ObservableToListTest extends RxJavaTest {
         .toObservable()
         .to(TestHelper.<Collection<Integer>>testConsumer())
         .assertFailure(NullPointerException.class)
-        .assertErrorMessage("The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+        .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
     }
 
     @SuppressWarnings("unchecked")
@@ -245,7 +246,7 @@ public class ObservableToListTest extends RxJavaTest {
         })
         .to(TestHelper.<Collection<Integer>>testConsumer())
         .assertFailure(NullPointerException.class)
-        .assertErrorMessage("The collectionSupplier returned a null collection. Null values are generally not allowed in 2.x operators and sources.");
+        .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -26,6 +26,7 @@ import org.junit.*;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.testsupport.*;
@@ -1139,6 +1140,6 @@ public class SerializedObserverTest extends RxJavaTest {
 
         so.onNext(null);
 
-        to.assertFailureAndMessage(NullPointerException.class, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        to.assertFailureAndMessage(NullPointerException.class, ExceptionHelper.nullWarning("onNext called with a null value."));
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava3/plugins/RxJavaPluginsTest.java
@@ -45,6 +45,7 @@ import io.reactivex.rxjava3.internal.operators.parallel.ParallelFromPublisher;
 import io.reactivex.rxjava3.internal.operators.single.SingleJust;
 import io.reactivex.rxjava3.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.rxjava3.internal.subscriptions.ScalarSubscription;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.observables.ConnectableObservable;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -1534,7 +1535,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
             RxJavaPlugins.onError(null);
 
             final Throwable throwable = t.get();
-            assertEquals("onError called with null. Null values are generally not allowed in 2.x operators and sources.", throwable.getMessage());
+            assertEquals(ExceptionHelper.nullWarning("onError called with a null Throwable."), throwable.getMessage());
             assertTrue(throwable instanceof NullPointerException);
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/rxjava3/processors/FlowableProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/FlowableProcessorTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava3.core.RxJavaTest;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public abstract class FlowableProcessorTest<T>  extends RxJavaTest {
 
@@ -31,7 +32,7 @@ public abstract class FlowableProcessorTest<T>  extends RxJavaTest {
             p.onNext(null);
             fail("No NullPointerException thrown");
         } catch (NullPointerException ex) {
-            assertEquals("onNext called with null. Null values are generally not allowed in 2.x operators and sources.", ex.getMessage());
+            assertEquals(ExceptionHelper.nullWarning("onNext called with a null value."), ex.getMessage());
         }
 
         p.test().assertEmpty().cancel();
@@ -45,7 +46,7 @@ public abstract class FlowableProcessorTest<T>  extends RxJavaTest {
             p.onError(null);
             fail("No NullPointerException thrown");
         } catch (NullPointerException ex) {
-            assertEquals("onError called with null. Null values are generally not allowed in 2.x operators and sources.", ex.getMessage());
+            assertEquals(ExceptionHelper.nullWarning("onError called with a null Throwable."), ex.getMessage());
         }
 
         p.test().assertEmpty().cancel();

--- a/src/test/java/io/reactivex/rxjava3/subjects/CompletableSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/CompletableSubjectTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.TestHelper;
@@ -129,7 +130,7 @@ public class CompletableSubjectTest extends RxJavaTest {
             cs.onError(null);
             fail("No NullPointerException thrown");
         } catch (NullPointerException ex) {
-            assertEquals("onError called with null. Null values are generally not allowed in 2.x operators and sources.", ex.getMessage());
+            assertEquals(ExceptionHelper.nullWarning("onError called with a null Throwable."), ex.getMessage());
         }
 
         cs.test().assertEmpty().dispose();

--- a/src/test/java/io/reactivex/rxjava3/subjects/SingleSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/SingleSubjectTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.TestHelper;
@@ -135,7 +136,7 @@ public class SingleSubjectTest extends RxJavaTest {
             ss.onSuccess(null);
             fail("No NullPointerException thrown");
         } catch (NullPointerException ex) {
-            assertEquals("onSuccess called with null. Null values are generally not allowed in 2.x operators and sources.", ex.getMessage());
+            assertEquals(ExceptionHelper.nullWarning("onSuccess called with a null value."), ex.getMessage());
         }
 
         ss.test().assertEmpty().dispose();
@@ -149,7 +150,7 @@ public class SingleSubjectTest extends RxJavaTest {
             ss.onError(null);
             fail("No NullPointerException thrown");
         } catch (NullPointerException ex) {
-            assertEquals("onError called with null. Null values are generally not allowed in 2.x operators and sources.", ex.getMessage());
+            assertEquals(ExceptionHelper.nullWarning("onError called with a null Throwable."), ex.getMessage());
         }
 
         ss.test().assertEmpty().dispose();

--- a/src/test/java/io/reactivex/rxjava3/subjects/SubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/SubjectTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava3.core.RxJavaTest;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 public abstract class SubjectTest<T> extends RxJavaTest {
 
@@ -31,7 +32,7 @@ public abstract class SubjectTest<T> extends RxJavaTest {
             p.onNext(null);
             fail("No NullPointerException thrown");
         } catch (NullPointerException ex) {
-            assertEquals("onNext called with null. Null values are generally not allowed in 2.x operators and sources.", ex.getMessage());
+            assertEquals(ExceptionHelper.nullWarning("onNext called with a null value."), ex.getMessage());
         }
 
         p.test().assertEmpty().dispose();
@@ -45,7 +46,7 @@ public abstract class SubjectTest<T> extends RxJavaTest {
             p.onError(null);
             fail("No NullPointerException thrown");
         } catch (NullPointerException ex) {
-            assertEquals("onError called with null. Null values are generally not allowed in 2.x operators and sources.", ex.getMessage());
+            assertEquals(ExceptionHelper.nullWarning("onError called with a null Throwable."), ex.getMessage());
         }
 
         p.test().assertEmpty().dispose();

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
@@ -27,6 +27,7 @@ import org.reactivestreams.*;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.testsupport.*;
@@ -1131,6 +1132,6 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
         so.onNext(null);
 
-        ts.assertFailureAndMessage(NullPointerException.class, "onNext called with null. Null values are generally not allowed in 2.x operators and sources.");
+        ts.assertFailureAndMessage(NullPointerException.class, ExceptionHelper.nullWarning("onNext called with a null value."));
     }
 }


### PR DESCRIPTION
This PR renames the internal `addThrowable` to `tryAddThrowable` and introduces the `tryAddThrowableOrReport` to perform the common reporting to the global error handler. Usage places have been re-evaluated and fixed if necessary.

In addition, `null` exceptions have been made more uniform.

Resolves #6611