### PR TITLE
3.x: Fix groupBy not canceling upstream due to group abandonment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script: gradle/buildViaTravis.sh
 
 # Code coverage
 after_success:
-  - bash <(curl -s --retry 10 --retry-connrefused https://codecov.io/bash)
+  - bash <(curl -s --retry 10 https://codecov.io/bash)
   - bash gradle/push_javadoc.sh
 
 # cache between builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script: gradle/buildViaTravis.sh
 
 # Code coverage
 after_success:
-  - bash <(curl -s --retry 10 --retry-connrefuse https://codecov.io/bash)
+  - bash <(curl -s --retry 10 --retry-connrefused https://codecov.io/bash)
   - bash gradle/push_javadoc.sh
 
 # cache between builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script: gradle/buildViaTravis.sh
 
 # Code coverage
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s --retry 10 --retry-connrefuse https://codecov.io/bash)
   - bash gradle/push_javadoc.sh
 
 # cache between builds

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -10414,6 +10414,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10462,6 +10467,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>Both the returned and its inner {@code Publisher}s honor backpressure and the source {@code Publisher}
@@ -10512,6 +10523,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10565,6 +10581,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10621,6 +10642,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10726,6 +10752,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -9067,6 +9067,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * is subscribed to. For this reason, in order to avoid memory leaks, you should not simply ignore those
      * {@code GroupedObservableSource}s that do not concern you. Instead, you can signal to them that they may
      * discard their buffers by applying an operator like {@link #ignoreElements} to them.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9101,6 +9107,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * is subscribed to. For this reason, in order to avoid memory leaks, you should not simply ignore those
      * {@code GroupedObservableSource}s that do not concern you. Instead, you can signal to them that they may
      * discard their buffers by applying an operator like {@link #ignoreElements} to them.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9138,6 +9150,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * is subscribed to. For this reason, in order to avoid memory leaks, you should not simply ignore those
      * {@code GroupedObservableSource}s that do not concern you. Instead, you can signal to them that they may
      * discard their buffers by applying an operator like {@link #ignoreElements} to them.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9176,6 +9194,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * is subscribed to. For this reason, in order to avoid memory leaks, you should not simply ignore those
      * {@code GroupedObservableSource}s that do not concern you. Instead, you can signal to them that they may
      * discard their buffers by applying an operator like {@link #ignoreElements} to them.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -9217,6 +9241,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * is subscribed to. For this reason, in order to avoid memory leaks, you should not simply ignore those
      * {@code GroupedObservableSource}s that do not concern you. Instead, you can signal to them that they may
      * discard their buffers by applying an operator like {@link #ignoreElements} to them.
+     * <p>
+     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
+     * so-called group abandonment where a group will only contain one element and the group will be
+     * re-created over and over as new upstream items trigger a new group. The behavior is
+     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -179,6 +179,13 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             if (newGroup) {
                 q.offer(group);
                 drain();
+
+                if (group.state.tryAbandon()) {
+                    cancel(key);
+                    group.onComplete();
+
+                    upstream.request(1);
+                }
             }
         }
 
@@ -489,11 +496,16 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
         final AtomicReference<Subscriber<? super T>> actual = new AtomicReference<Subscriber<? super T>>();
 
-        final AtomicBoolean once = new AtomicBoolean();
-
         boolean outputFused;
 
         int produced;
+
+        final AtomicInteger once = new AtomicInteger();
+
+        static final int FRESH = 0;
+        static final int HAS_SUBSCRIBER = 1;
+        static final int ABANDONED = 2;
+        static final int ABANDONED_HAS_SUBSCRIBER = ABANDONED | HAS_SUBSCRIBER;
 
         State(int bufferSize, GroupBySubscriber<?, K, T> parent, K key, boolean delayError) {
             this.queue = new SpscLinkedArrayQueue<T>(bufferSize);
@@ -513,19 +525,30 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         @Override
         public void cancel() {
             if (cancelled.compareAndSet(false, true)) {
-                parent.cancel(key);
+                cancelParent();
             }
         }
 
         @Override
-        public void subscribe(Subscriber<? super T> s) {
-            if (once.compareAndSet(false, true)) {
-                s.onSubscribe(this);
-                actual.lazySet(s);
-                drain();
-            } else {
-                EmptySubscription.error(new IllegalStateException("Only one Subscriber allowed!"), s);
+        public void subscribe(Subscriber<? super T> subscriber) {
+            for (;;) {
+                int s = once.get();
+                if ((s & HAS_SUBSCRIBER) != 0) {
+                    break;
+                }
+                int u = s | HAS_SUBSCRIBER;
+                if (once.compareAndSet(s, u)) {
+                    subscriber.onSubscribe(this);
+                    actual.lazySet(subscriber);
+                    if (cancelled.get()) {
+                        actual.lazySet(null);
+                    } else {
+                        drain();
+                    }
+                    return;
+                }
             }
+            EmptySubscription.error(new IllegalStateException("Only one Subscriber allowed!"), subscriber);
         }
 
         public void onNext(T t) {
@@ -542,6 +565,16 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         public void onComplete() {
             done = true;
             drain();
+        }
+
+        void cancelParent() {
+            if ((once.get() & ABANDONED) == 0) {
+                parent.cancel(key);
+            }
+        }
+
+        boolean tryAbandon() {
+            return once.get() == FRESH && once.compareAndSet(FRESH, ABANDONED);
         }
 
         void drain() {
@@ -640,7 +673,9 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                         if (r != Long.MAX_VALUE) {
                             requested.addAndGet(-e);
                         }
-                        parent.upstream.request(e);
+                        if ((once.get() & ABANDONED) == 0) {
+                            parent.upstream.request(e);
+                        }
                     }
                 }
 
@@ -708,7 +743,9 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             int p = produced;
             if (p != 0) {
                 produced = 0;
-                parent.upstream.request(p);
+                if ((once.get() & ABANDONED) == 0) {
+                    parent.upstream.request(p);
+                }
             }
             return null;
         }

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableGroupByTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableGroupByTests.java
@@ -102,7 +102,13 @@ public class FlowableGroupByTests extends RxJavaTest {
             }
         }).subscribe(ts);
 
-        ts.assertValues(0, 5, 10, 15, 1, 6, 11, 16, 2, 7, 12, 17, 3, 8, 13, 18, 4, 9, 14, 19);
+        // Behavior change: this now counts as group abandonment because concatMap
+        // doesn't subscribe to the 2nd+ emitted groups immediately
+        ts.assertValues(
+                0, 5, 10, 15, // First group is okay
+                // any other group gets abandoned so we get 16 one-element group
+                1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 13, 14, 16, 17, 18, 19
+                );
         ts.assertComplete();
         ts.assertNoErrors();
     }


### PR DESCRIPTION
This PR fixes the issue when a group is not subscribed to, the upstream may never cancel due to seemingly open groups.

The fix is a tradeoff with group abandonment and possible excessive group re-creation so that elements are not lost in case the groups do get subscribed to a bit later. Therefore, the groups should be subscribed to immediately and synchronously:

```java
Observable.range(1, 1000)
.groupBy(v -> v % 10)
.flatMap(v -> {
    System.out.println("New group: " + v.getKey());
    return v;
})
.subscribe();

Observable.range(1, 1000)
.groupBy(v -> v % 10)
.flatMap(v -> {
    System.out.println("New group: " + v.getKey());
    return v.observeOn(Schedulers.io()); //  <-------------------------------- OK
})
.blockingSubscribe();
```

Consequently, the following setups will result in constant group recreations:

```java
Observable.range(1, 1000)
.groupBy(v -> v % 10)
.observeOn(Schedulers.io()) // <------------------------------------- TROUBLE
.flatMap(v -> {
    System.out.println("New group: " + v.getKey());
    return v;
})
.blockingSubscribe();

Observable.range(1, 1000)
.groupBy(v -> v % 10)
.flatMap(v -> {
    System.out.println("New group: " + v.getKey());
    return v.subscribeOn(Schedulers.io()); // <----------------------- TROUBLE
})
.blockingSubscribe();
```

For the `subscribeOn` "trouble", since groups were essentially unicast subjects/processors, `subscribeOn` had no practical use on them and instead `observeOn` should be used to move the observation of the group's items to the desired thread.

Resolves #6596