### PR TITLE
2.x: Fix takeLast(time) last events time window calculation.

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimed.java
@@ -139,6 +139,7 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
             final Observer<? super T> a = downstream;
             final SpscLinkedArrayQueue<Object> q = queue;
             final boolean delayError = this.delayError;
+            final long timestampLimit = scheduler.now(unit) - time;
 
             for (;;) {
                 if (cancelled) {
@@ -171,7 +172,7 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
                 @SuppressWarnings("unchecked")
                 T o = (T)q.poll();
 
-                if ((Long)ts < scheduler.now(unit) - time) {
+                if ((Long)ts < timestampLimit) {
                     continue;
                 }
 

--- a/src/test/java/io/reactivex/TimesteppingScheduler.java
+++ b/src/test/java/io/reactivex/TimesteppingScheduler.java
@@ -42,11 +42,13 @@ public class TimesteppingScheduler extends Scheduler {
 
         @Override
         public long now(TimeUnit unit) {
-            return time++;
+            return TimesteppingScheduler.this.now(unit);
         }
     }
 
-    long time;
+    public long time;
+
+    public boolean stepEnabled;
 
     @Override
     public Worker createWorker() {
@@ -55,6 +57,9 @@ public class TimesteppingScheduler extends Scheduler {
 
     @Override
     public long now(TimeUnit unit) {
-        return time++;
+        if (stepEnabled) {
+            return time++;
+        }
+        return time;
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -336,4 +336,27 @@ public class FlowableTakeLastTimedTest {
     public void badRequest() {
         TestHelper.assertBadRequestReported(PublishProcessor.create().takeLast(1, TimeUnit.SECONDS));
     }
+
+    @Test
+    public void lastWindowIsFixedInTime() {
+        TimesteppingScheduler scheduler = new TimesteppingScheduler();
+        scheduler.stepEnabled = false;
+
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp
+        .takeLast(2, TimeUnit.SECONDS, scheduler)
+        .test();
+
+        pp.onNext(1);
+        pp.onNext(2);
+        pp.onNext(3);
+        pp.onNext(4);
+
+        scheduler.stepEnabled = true;
+
+        pp.onComplete();
+
+        ts.assertResult(1, 2, 3, 4);
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableTakeLastTimedTest.java
@@ -275,4 +275,27 @@ public class ObservableTakeLastTimedTest {
             TestHelper.race(r1, r2);
         }
     }
+
+    @Test
+    public void lastWindowIsFixedInTime() {
+        TimesteppingScheduler scheduler = new TimesteppingScheduler();
+        scheduler.stepEnabled = false;
+
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps
+        .takeLast(2, TimeUnit.SECONDS, scheduler)
+        .test();
+
+        ps.onNext(1);
+        ps.onNext(2);
+        ps.onNext(3);
+        ps.onNext(4);
+
+        scheduler.stepEnabled = true;
+
+        ps.onComplete();
+
+        to.assertResult(1, 2, 3, 4);
+    }
 }


### PR DESCRIPTION
The logic inside the `Observable.takeLast(time)` was not using a fixed timestamp to compare against but one that could change between calls, resulting in items wrongly skipped from the accumulated buffer. The PR makes this timestamp limit fixed outside the drain loop.

The `Flowable` variant did not have the issue but both received the unit test verifying the correct behavior.

Fixes: #6647