### PR TITLE
3.x: Fix groupBy group emission in some cases

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -168,6 +168,10 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 upstream.cancel();
+                if (newGroup) {
+                    q.offer(group);
+                    drain();
+                }
                 onError(ex);
                 return;
             }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -2275,4 +2275,30 @@ public class FlowableGroupByTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
     }
-}
+
+    @Test
+    public void newGroupValueSelectorFails() {
+        TestSubscriber<Object> ts1 = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>();
+
+        Flowable.just(1)
+        .groupBy(Functions.<Integer>identity(), new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Throwable {
+                throw new TestException();
+            }
+        })
+        .doOnNext(new Consumer<GroupedFlowable<Integer, Object>>() {
+            @Override
+            public void accept(GroupedFlowable<Integer, Object> g) throws Throwable {
+                g.subscribe(ts2);
+            }
+        })
+        .subscribe(ts1);
+
+        ts1.assertValueCount(1)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        ts2.assertFailure(TestException.class);
+    }}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
@@ -1615,4 +1615,31 @@ public class ObservableGroupByTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
     }
+
+    @Test
+    public void newGroupValueSelectorFails() {
+        TestObserver<Object> to1 = new TestObserver<Object>();
+        final TestObserver<Object> to2 = new TestObserver<Object>();
+
+        Observable.just(1)
+        .groupBy(Functions.<Integer>identity(), new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Throwable {
+                throw new TestException();
+            }
+        })
+        .doOnNext(new Consumer<GroupedObservable<Integer, Object>>() {
+            @Override
+            public void accept(GroupedObservable<Integer, Object> g) throws Throwable {
+                g.subscribe(to2);
+            }
+        })
+        .subscribe(to1);
+
+        to1.assertValueCount(1)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        to2.assertFailure(TestException.class);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
@@ -1642,4 +1642,34 @@ public class ObservableGroupByTest extends RxJavaTest {
 
         to2.assertFailure(TestException.class);
     }
+
+    @Test
+    public void existingGroupValueSelectorFails() {
+        TestObserver<Object> to1 = new TestObserver<Object>();
+        final TestObserver<Object> to2 = new TestObserver<Object>();
+
+        Observable.just(1, 2)
+        .groupBy(Functions.justFunction(1), new Function<Integer, Object>() {
+            @Override
+            public Object apply(Integer v) throws Throwable {
+                if (v == 2) {
+                    throw new TestException();
+                }
+                return v;
+            }
+        })
+        .doOnNext(new Consumer<GroupedObservable<Integer, Object>>() {
+            @Override
+            public void accept(GroupedObservable<Integer, Object> g) throws Throwable {
+                g.subscribe(to2);
+            }
+        })
+        .subscribe(to1);
+
+        to1.assertValueCount(1)
+        .assertError(TestException.class)
+        .assertNotComplete();
+
+        to2.assertFailure(TestException.class, 1);
+    }
 }


### PR DESCRIPTION
This PR fixes two issues:

- when the `Observable.groupBy` operator would abandon a newly created group before the group's only item was emitted, causing dataloss.
- when the `groupBy`'s value selector failed for a new group, thus the new group would never be emitted and report the failure.

It should fix the first test failure of #6663 but may not be the cause for the second.