### PR TITLE
3.x: Fix window(time) possible interrupts while terminating

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowTimed.java
@@ -90,8 +90,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
         static final Object NEXT = new Object();
 
-        static final Object DISPOSE = new Object();
-
         volatile boolean terminated;
 
         WindowExactUnboundedSubscriber(Subscriber<? super Flowable<T>> actual, long timespan, TimeUnit unit,
@@ -162,10 +160,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             }
 
             downstream.onError(t);
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -176,11 +170,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             }
 
             downstream.onComplete();
-
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -220,7 +209,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
                     Object o = q.poll();
 
-                    if (d && (o == null || o == NEXT || o == DISPOSE)) {
+                    if (d && (o == null || o == NEXT)) {
                         window = null;
                         q.clear();
                         Throwable err = error;
@@ -231,13 +220,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                         }
                         timer.dispose();
                         return;
-                    }
-
-                    if (o == DISPOSE) {
-                        window = null;
-                        q.clear();
-                        timer.dispose();
-                        break;
                     }
 
                     if (o == null) {
@@ -303,8 +285,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
         volatile boolean terminated;
 
         final SequentialDisposable timer = new SequentialDisposable();
-
-        static final Object DISPOSE = new Object();
 
         WindowExactBoundedSubscriber(
                 Subscriber<? super Flowable<T>> actual,
@@ -435,10 +415,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             }
 
             downstream.onError(t);
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -449,10 +425,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             }
 
             downstream.onComplete();
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -495,9 +467,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
                     boolean empty = o == null;
                     boolean isHolder = o instanceof ConsumerIndexHolder;
-                    boolean isDispose = o == DISPOSE;
 
-                    if (d && (empty || isHolder || isDispose)) {
+                    if (d && (empty || isHolder)) {
                         window = null;
                         q.clear();
                         Throwable err = error;
@@ -508,13 +479,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                         }
                         disposeTimer();
                         return;
-                    }
-
-                    if (isDispose) {
-                        window = null;
-                        q.clear();
-                        disposeTimer();
-                        break;
                     }
 
                     if (empty) {
@@ -633,8 +597,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
         volatile boolean terminated;
 
-        static final Object DISPOSE = new Object();
-
         WindowSkipSubscriber(Subscriber<? super Flowable<T>> actual,
                 long timespan, long timeskip, TimeUnit unit,
                 Worker worker, int bufferSize) {
@@ -708,10 +670,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             }
 
             downstream.onError(t);
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -722,10 +680,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             }
 
             downstream.onComplete();
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -770,9 +724,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
                     boolean empty = v == null;
                     boolean sw = v instanceof SubjectWork;
-                    boolean isDispose = v == DISPOSE;
 
-                    if (d && (empty || sw || isDispose)) {
+                    if (d && (empty || sw)) {
                         q.clear();
                         Throwable e = error;
                         if (e != null) {
@@ -787,13 +740,6 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                         ws.clear();
                         worker.dispose();
                         return;
-                    }
-
-                    if (isDispose) {
-                        q.clear();
-                        ws.clear();
-                        worker.dispose();
-                        break;
                     }
 
                     if (empty) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowTimed.java
@@ -88,8 +88,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
         static final Object NEXT = new Object();
 
-        static final Object DISPOSE = new Object();
-
         volatile boolean terminated;
 
         WindowExactUnboundedObserver(Observer<? super Observable<T>> actual, long timespan, TimeUnit unit,
@@ -148,10 +146,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             }
 
             downstream.onError(t);
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -162,10 +156,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             }
 
             downstream.onComplete();
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -205,7 +195,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
                     Object o = q.poll();
 
-                    if (d && (o == null || o == NEXT || o == DISPOSE)) {
+                    if (d && (o == null || o == NEXT)) {
                         window = null;
                         q.clear();
                         Throwable err = error;
@@ -216,13 +206,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                         }
                         timer.dispose();
                         return;
-                    }
-
-                    if (o == DISPOSE) {
-                        window = null;
-                        q.clear();
-                        timer.dispose();
-                        break;
                     }
 
                     if (o == null) {
@@ -276,8 +259,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
         volatile boolean terminated;
 
         final SequentialDisposable timer = new SequentialDisposable();
-
-        static final Object DISPOSE = new Object();
 
         WindowExactBoundedObserver(
                 Observer<? super Observable<T>> actual,
@@ -381,10 +362,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             }
 
             downstream.onError(t);
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -395,10 +372,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             }
 
             downstream.onComplete();
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -441,9 +414,8 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
                     boolean empty = o == null;
                     boolean isHolder = o instanceof ConsumerIndexHolder;
-                    boolean isDispose = o == DISPOSE;
 
-                    if (d && (empty || isHolder || isDispose)) {
+                    if (d && (empty || isHolder)) {
                         window = null;
                         q.clear();
                         Throwable err = error;
@@ -454,13 +426,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                         }
                         disposeTimer();
                         return;
-                    }
-
-                    if (isDispose) {
-                        window = null;
-                        q.clear();
-                        disposeTimer();
-                        break;
                     }
 
                     if (empty) {
@@ -555,8 +520,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
         volatile boolean terminated;
 
-        static final Object DISPOSE = new Object();
-
         WindowSkipObserver(Observer<? super Observable<T>> actual,
                 long timespan, long timeskip, TimeUnit unit,
                 Worker worker, int bufferSize) {
@@ -618,10 +581,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             }
 
             downstream.onError(t);
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -632,10 +591,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             }
 
             downstream.onComplete();
-            queue.offer(DISPOSE);
-            if (enter()) {
-                drainLoop();
-            }
         }
 
         @Override
@@ -680,9 +635,8 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
                     boolean empty = v == null;
                     boolean sw = v instanceof SubjectWork;
-                    boolean isDispose = v == DISPOSE;
 
-                    if (d && (empty || sw || isDispose)) {
+                    if (d && (empty || sw)) {
                         q.clear();
                         Throwable e = error;
                         if (e != null) {
@@ -697,13 +651,6 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                         ws.clear();
                         worker.dispose();
                         return;
-                    }
-
-                    if (isDispose) {
-                        q.clear();
-                        ws.clear();
-                        worker.dispose();
-                        break;
                     }
 
                     if (empty) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -918,6 +918,246 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         ts.assertValueCount(1)
         .assertError(MissingBackpressureException.class)
         .assertNotComplete();
+    }
+
+    @Test
+    public void exactTimeBoundNoInterruptWindowOutputOnComplete() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        pp.window(100, TimeUnit.MILLISECONDS)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Flowable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        pp.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        pp.onComplete();
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void exactTimeBoundNoInterruptWindowOutputOnError() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        pp.window(100, TimeUnit.MILLISECONDS)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Flowable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        pp.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        pp.onError(new TestException());
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void exactTimeAndSizeBoundNoInterruptWindowOutputOnComplete() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        pp.window(100, TimeUnit.MILLISECONDS, 10)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Flowable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        pp.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        pp.onComplete();
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void exactTimeAndSizeBoundNoInterruptWindowOutputOnError() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        pp.window(100, TimeUnit.MILLISECONDS, 10)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Flowable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        pp.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        pp.onError(new TestException());
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void skipTimeAndSizeBoundNoInterruptWindowOutputOnComplete() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        pp.window(90, 100, TimeUnit.MILLISECONDS)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Flowable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        pp.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        pp.onComplete();
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void skipTimeAndSizeBoundNoInterruptWindowOutputOnError() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        pp.window(90, 100, TimeUnit.MILLISECONDS)
+        .doOnNext(new Consumer<Flowable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Flowable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        pp.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        pp.onError(new TestException());
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
     }
 }
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -16,8 +16,8 @@ package io.reactivex.rxjava3.internal.operators.observable;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import org.junit.*;
 
@@ -708,5 +708,245 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         to.assertValueCount(2)
         .assertNoErrors()
         .assertNotComplete();
+    }
+
+    @Test
+    public void exactTimeBoundNoInterruptWindowOutputOnComplete() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        ps.window(100, TimeUnit.MILLISECONDS)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Observable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        ps.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        ps.onComplete();
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void exactTimeBoundNoInterruptWindowOutputOnError() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        ps.window(100, TimeUnit.MILLISECONDS)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Observable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        ps.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        ps.onError(new TestException());
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void exactTimeAndSizeBoundNoInterruptWindowOutputOnComplete() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        ps.window(100, TimeUnit.MILLISECONDS, 10)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Observable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        ps.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        ps.onComplete();
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void exactTimeAndSizeBoundNoInterruptWindowOutputOnError() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        ps.window(100, TimeUnit.MILLISECONDS, 10)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Observable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        ps.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        ps.onError(new TestException());
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void skipTimeAndSizeBoundNoInterruptWindowOutputOnComplete() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        ps.window(90, 100, TimeUnit.MILLISECONDS)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Observable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        ps.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        ps.onComplete();
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
+    }
+
+    @Test
+    public void skipTimeAndSizeBoundNoInterruptWindowOutputOnError() throws Exception {
+        final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+        final PublishSubject<Integer> ps = PublishSubject.create();
+
+        final CountDownLatch doOnNextDone = new CountDownLatch(1);
+        final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
+
+        ps.window(90, 100, TimeUnit.MILLISECONDS)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            int count;
+            @Override
+            public void accept(Observable<Integer> v) throws Exception {
+                System.out.println(Thread.currentThread());
+                if (count++ == 1) {
+                    secondWindowProcessing.countDown();
+                    try {
+                        Thread.sleep(200);
+                        isInterrupted.set(Thread.interrupted());
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                    doOnNextDone.countDown();
+                }
+            }
+        })
+        .test();
+
+        ps.onNext(1);
+
+        assertTrue(secondWindowProcessing.await(5, TimeUnit.SECONDS));
+
+        ps.onError(new TestException());
+
+        assertTrue(doOnNextDone.await(5, TimeUnit.SECONDS));
+
+        assertFalse("The doOnNext got interrupted!", isInterrupted.get());
     }
 }


### PR DESCRIPTION
Fix the case in `window(time)` variants where the timer thread is busy with window emission and the upstream terminates on some other thread, the window emission is interrupted.

~~So instead of disposing the timer/worker right after the upstream termination, a `DISPOSE` message is queued up. Thus any ongoing drain loop from the timer thread can cleanup gracefully.~~

After some additional considerations, there is no need for `DISPOSE`. The drain loop will take care of disposing the timer and the main downstream can simply be terminated.

The 2.x fix will be in a separate PR shortly.

Fixes #6672