### PR TITLE
Add Export-Package declarations for OSGi headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,8 @@ jar {
             'Import-Package': '!org.junit,!junit.framework,!org.mockito.*,!org.testng.*,*',
             'Bundle-DocURL': 'https://github.com/ReactiveX/RxJava',
             'Eclipse-ExtensibleAPI': 'true',
-            'Automatic-Module-Name': 'io.reactivex.rxjava3'
+            'Automatic-Module-Name': 'io.reactivex.rxjava3',
+            'Export-Package': '!io.reactivex.rxjava3.internal.*, io.reactivex.rxjava3.*'
     )
 }
 


### PR DESCRIPTION
This adds the necessary declarations to the Bnd plugin to export all
non-internal packages for use in an OSGi environment.

Affects: https://github.com/ReactiveX/RxJava/issues/6671