### PR TITLE
3.x: Fix concurrent clear() calls when fused chains are canceled

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -268,7 +268,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             if (groupCount.decrementAndGet() == 0) {
                 upstream.cancel();
 
-                if (getAndIncrement() == 0) {
+                if (!outputFused && getAndIncrement() == 0) {
                     queue.clear();
                 }
             }
@@ -601,7 +601,6 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             for (;;) {
                 if (a != null) {
                     if (cancelled.get()) {
-                        q.clear();
                         return;
                     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -150,7 +150,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
                 cancelled = true;
                 upstream.cancel();
 
-                if (getAndIncrement() == 0) {
+                if (!outputFused && getAndIncrement() == 0) {
                     queue.clear();
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
@@ -345,7 +345,6 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
         for (;;) {
 
             if (cancelled) {
-                q.clear();
                 downstream.lazySet(null);
                 return;
             }
@@ -548,10 +547,11 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
 
             doTerminate();
 
-            if (!enableOperatorFusion) {
-                if (wip.getAndIncrement() == 0) {
+            downstream.lazySet(null);
+            if (wip.getAndIncrement() == 0) {
+                downstream.lazySet(null);
+                if (!enableOperatorFusion) {
                     queue.clear();
-                    downstream.lazySet(null);
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
@@ -418,7 +418,6 @@ public final class UnicastSubject<T> extends Subject<T> {
 
             if (disposed) {
                 downstream.lazySet(null);
-                q.clear();
                 return;
             }
             boolean d = done;
@@ -556,7 +555,9 @@ public final class UnicastSubject<T> extends Subject<T> {
                 downstream.lazySet(null);
                 if (wip.getAndIncrement() == 0) {
                     downstream.lazySet(null);
-                    queue.clear();
+                    if (!enableOperatorFusion) {
+                        queue.clear();
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a fuseable source backed by an SpscLinkedArrayQueue is cancelled and cleared concurrently (i.e., one thread clears while the other cancels the chain), the `clear()` method could run concurrently and either crash with NPE or end up in an infinite loop due to corrupted queue state.

This PR fixes two kinds of mistakes leading to this scenario:

- Calling `clear()` from `cancel`/`dispose` when the output is fused.
- Calling `clear()` from a fused drain loop when cancellation is detected.

When fused, similar to `poll()`, calling `clear()` is the responsibility of the consumer and the producer side is not allowed to call them.

The bug affected the following operators:
- `FlowableOnBackpressureBuffer`
- `FlowableGroupBy`
- `UnicastProcessor`
- `UnicastSubject`

Fixes #6673