### PR TITLE
2.x: Fix concurrent clear() calls when fused chains are canceled

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -262,7 +262,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             if (groupCount.decrementAndGet() == 0) {
                 upstream.cancel();
 
-                if (getAndIncrement() == 0) {
+                if (!outputFused && getAndIncrement() == 0) {
                     queue.clear();
                 }
             }
@@ -288,7 +288,6 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
             for (;;) {
                 if (cancelled.get()) {
-                    q.clear();
                     return;
                 }
 

--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -150,7 +150,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
                 cancelled = true;
                 upstream.cancel();
 
-                if (getAndIncrement() == 0) {
+                if (!outputFused && getAndIncrement() == 0) {
                     queue.clear();
                 }
             }

--- a/src/main/java/io/reactivex/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/processors/UnicastProcessor.java
@@ -347,7 +347,6 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
         for (;;) {
 
             if (cancelled) {
-                q.clear();
                 downstream.lazySet(null);
                 return;
             }
@@ -550,10 +549,11 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
 
             doTerminate();
 
-            if (!enableOperatorFusion) {
-                if (wip.getAndIncrement() == 0) {
+            downstream.lazySet(null);
+            if (wip.getAndIncrement() == 0) {
+                downstream.lazySet(null);
+                if (!enableOperatorFusion) {
                     queue.clear();
-                    downstream.lazySet(null);
                 }
             }
         }

--- a/src/main/java/io/reactivex/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/subjects/UnicastSubject.java
@@ -420,7 +420,6 @@ public final class UnicastSubject<T> extends Subject<T> {
 
             if (disposed) {
                 downstream.lazySet(null);
-                q.clear();
                 return;
             }
             boolean d = done;
@@ -558,7 +557,9 @@ public final class UnicastSubject<T> extends Subject<T> {
                 downstream.lazySet(null);
                 if (wip.getAndIncrement() == 0) {
                     downstream.lazySet(null);
-                    queue.clear();
+                    if (!enableOperatorFusion) {
+                        queue.clear();
+                    }
                 }
             }
         }

--- a/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/processors/UnicastProcessorTest.java
@@ -16,16 +16,20 @@ package io.reactivex.processors;
 import static org.junit.Assert.*;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.fuseable.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.*;
 
 public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
@@ -436,6 +440,39 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
             TestHelper.assertError(errors, 0, IllegalArgumentException.class);
         } finally {
             RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void fusedNoConcurrentCleanDueToCancel() {
+        for (int j = 0; j < TestHelper.RACE_LONG_LOOPS; j++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final UnicastProcessor<Integer> us = UnicastProcessor.create();
+
+                TestObserver<Integer> to = us
+                .observeOn(Schedulers.io())
+                .map(Functions.<Integer>identity())
+                .observeOn(Schedulers.single())
+                .firstOrError()
+                .test();
+
+                for (int i = 0; us.hasSubscribers(); i++) {
+                    us.onNext(i);
+                }
+
+                to
+                .awaitDone(5, TimeUnit.SECONDS)
+                ;
+
+                if (!errors.isEmpty()) {
+                    throw new CompositeException(errors);
+                }
+
+                to.assertResult(0);
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 }

--- a/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/subjects/UnicastSubjectTest.java
@@ -17,16 +17,19 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
 import io.reactivex.*;
 import io.reactivex.disposables.*;
-import io.reactivex.exceptions.TestException;
-import io.reactivex.internal.fuseable.*;
+import io.reactivex.exceptions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.fuseable.QueueFuseable;
 import io.reactivex.observers.*;
 import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
 
 public class UnicastSubjectTest extends SubjectTest<Integer> {
 
@@ -455,5 +458,38 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         us.drainFused(to);
 
         to.assertEmpty();
+    }
+
+    @Test
+    public void fusedNoConcurrentCleanDueToCancel() {
+        for (int j = 0; j < TestHelper.RACE_LONG_LOOPS; j++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                final UnicastSubject<Integer> us = UnicastSubject.create();
+
+                TestObserver<Integer> to = us
+                .observeOn(Schedulers.io())
+                .map(Functions.<Integer>identity())
+                .observeOn(Schedulers.single())
+                .firstOrError()
+                .test();
+
+                for (int i = 0; us.hasObservers(); i++) {
+                    us.onNext(i);
+                }
+
+                to
+                .awaitDone(5, TimeUnit.SECONDS)
+                ;
+
+                if (!errors.isEmpty()) {
+                    throw new CompositeException(errors);
+                }
+
+                to.assertResult(0);
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Backport of #6676

When a fuseable source backed by an SpscLinkedArrayQueue is cancelled and cleared concurrently (i.e., one thread clears while the other cancels the chain), the `clear()` method could run concurrently and either crash with NPE or end up in an infinite loop due to corrupted queue state.

This PR fixes two kinds of mistakes leading to this scenario:

- Calling `clear()` from `cancel`/`dispose` when the output is fused.
- Calling `clear()` from a fused drain loop when cancellation is detected.

When fused, similar to `poll()`, calling `clear()` is the responsibility of the consumer and the producer side is not allowed to call them.

The bug affected the following operators:
- `FlowableOnBackpressureBuffer`
- `FlowableGroupBy`
- `UnicastProcessor`
- `UnicastSubject`

Fixes #6673