### PR TITLE
Backport marble diagrams for Single from 3.x

### DIFF
--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -400,6 +400,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Concatenates a sequence of SingleSource eagerly into a single stream of values.
      * <p>
+     * <img width="640" height="257" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.concatArrayEager.png" alt="">
+     * <p>
      * Eager concatenation means that once a subscriber subscribes, this operator subscribes to all of the
      * source SingleSources. The operator buffers the value emitted by these SingleSources and then drains them
      * in order, each one after the previous one completes.
@@ -1108,6 +1110,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Merges an Iterable sequence of SingleSource instances into a single Flowable sequence,
      * running all SingleSources at once and delaying any error(s) until all sources succeed or fail.
+     * <p>
+     * <img width="640" height="469" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.mergeDelayError.i.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
@@ -1132,6 +1136,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Merges a Flowable sequence of SingleSource instances into a single Flowable sequence,
      * running all SingleSources at once and delaying any error(s) until all sources succeed or fail.
+     * <p>
+     * <img width="640" height="356" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.mergeDelayError.p.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
@@ -1159,7 +1165,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Flattens two Singles into a single Flowable, without any transformation, delaying
      * any error(s) until all sources succeed or fail.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <img width="640" height="554" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.mergeDelayError.2.png" alt="">
      * <p>
      * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by
      * using the {@code mergeDelayError} method.
@@ -1197,7 +1203,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Flattens three Singles into a single Flowable, without any transformation, delaying
      * any error(s) until all sources succeed or fail.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <img width="640" height="496" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.mergeDelayError.3.png" alt="">
      * <p>
      * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by using
      * the {@code mergeDelayError} method.
@@ -1239,7 +1245,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * Flattens four Singles into a single Flowable, without any transformation, delaying
      * any error(s) until all sources succeed or fail.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.merge.png" alt="">
+     * <img width="640" height="509" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.mergeDelayError.4.png" alt="">
      * <p>
      * You can combine items emitted by multiple Singles so that they appear as a single Flowable, by using
      * the {@code mergeDelayError} method.
@@ -1370,6 +1376,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * <strong>Advanced use only:</strong> creates a Single instance without
      * any safeguards by using a callback that is called with a SingleObserver.
+     * <p>
+     * <img width="640" height="261" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.unsafeCreate.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code unsafeCreate} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1396,6 +1404,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Allows using and disposing a resource while running a SingleSource instance generated from
      * that resource (similar to a try-with-resources).
+     * <p>
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.using.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1423,6 +1433,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Allows using and disposing a resource while running a SingleSource instance generated from
      * that resource (similar to a try-with-resources).
+     * <p>
+     * <img width="640" height="325" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.using.b.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -1460,6 +1472,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Wraps a SingleSource instance into a new Single instance if not already a Single
      * instance.
+     * <p>
+     * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.wrap.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code wrap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2067,6 +2081,7 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Stores the success value or exception from the current Single and replays it to late SingleObservers.
      * <p>
+     * <img width="640" height="363" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.cache.png" alt="">
      * The returned Single subscribes to the current Single when the first SingleObserver subscribes.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -2085,6 +2100,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Casts the success value of the current Single into the target type or signals a
      * ClassCastException if not compatible.
+     * <p>
+     * <img width="640" height="393" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.cast.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code cast} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2225,6 +2242,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Delays the actual subscription to the current Single until the given other CompletableSource
      * completes.
+     * <p>
+     * <img width="640" height="309" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.delaySubscription.c.png" alt="">
      * <p>If the delaying source signals an error, that error is re-emitted and no subscription
      * to the current Single happens.
      * <dl>
@@ -2247,6 +2266,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Delays the actual subscription to the current Single until the given other SingleSource
      * signals success.
+     * <p>
+     * <img width="640" height="309" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.delaySubscription.s.png" alt="">
      * <p>If the delaying source signals an error, that error is re-emitted and no subscription
      * to the current Single happens.
      * <dl>
@@ -2270,6 +2291,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Delays the actual subscription to the current Single until the given other ObservableSource
      * signals its first value or completes.
+     * <p>
+     * <img width="640" height="214" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.delaySubscription.o.png" alt="">
      * <p>If the delaying source signals an error, that error is re-emitted and no subscription
      * to the current Single happens.
      * <dl>
@@ -2293,6 +2316,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Delays the actual subscription to the current Single until the given other Publisher
      * signals its first value or completes.
+     * <p>
+     * <img width="640" height="214" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.delaySubscription.p.png" alt="">
      * <p>If the delaying source signals an error, that error is re-emitted and no subscription
      * to the current Single happens.
      * <p>The other source is consumed in an unbounded manner (requesting Long.MAX_VALUE from it).
@@ -2320,6 +2345,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Delays the actual subscription to the current Single until the given time delay elapsed.
+     * <p>
+     * <img width="640" height="472" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.delaySubscription.t.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code delaySubscription} does by default subscribe to the current Single
@@ -2338,6 +2365,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Delays the actual subscription to the current Single until the given time delay elapsed.
+     * <p>
+     * <img width="640" height="420" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.delaySubscription.ts.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code delaySubscription} does by default subscribe to the current Single
@@ -2359,6 +2388,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * Maps the {@link Notification} success value of this Single back into normal
      * {@code onSuccess}, {@code onError} or {@code onComplete} signals as a
      * {@link Maybe} source.
+     * <p>
+     * <img width="640" height="341" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.dematerialize.png" alt="">
      * <p>
      * The intended use of the {@code selector} function is to perform a
      * type-safe identity mapping (see example) on a source that is already of type
@@ -2547,6 +2578,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Calls the shared consumer with the error sent via onError or the value
      * via onSuccess for each SingleObserver that subscribes to the current Single.
+     * <p>
+     * <img width="640" height="264" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.doOnEvent.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnEvent} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2817,6 +2850,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Waits in a blocking fashion until the current Single signals a success value (which is returned) or
      * an exception (which is propagated).
+     * <p>
+     * <img width="640" height="429" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.blockingGet.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code blockingGet} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2843,6 +2878,8 @@ public abstract class Single<T> implements SingleSource<T> {
      * insertion of a custom operator by accessing the downstream's {@link SingleObserver} during this subscription phase
      * and providing a new {@code SingleObserver}, containing the custom operator's intended business logic, that will be
      * used in the subscription process going further upstream.
+     * <p>
+     * <img width="640" height="304" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.lift.png" alt="">
      * <p>
      * Generally, such a new {@code SingleObserver} will wrap the downstream's {@code SingleObserver} and forwards the
      * {@code onSuccess} and {@code onError} events from the upstream directly or according to the
@@ -3031,6 +3068,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Signals true if the current Single signals a success value that is Object-equals with the value
      * provided.
+     * <p>
+     * <img width="640" height="401" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.contains.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code contains} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3048,6 +3087,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Signals true if the current Single signals a success value that is equal with
      * the value provided by calling a bi-predicate.
+     * <p>
+     * <img width="640" height="401" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.contains.f.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code contains} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3249,6 +3290,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Nulls out references to the upstream producer and downstream SingleObserver if
      * the sequence is terminated or downstream calls dispose().
+     * <p>
+     * <img width="640" height="346" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onTerminateDetach.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3356,6 +3399,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Repeatedly re-subscribes to the current Single indefinitely if it fails with an onError.
+     * <p>
+     * <img width="640" height="399" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.retry.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3372,6 +3417,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Repeatedly re-subscribe at most the specified times to the current Single
      * if it fails with an onError.
+     * <p>
+     * <img width="640" height="329" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.retry.n.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3389,6 +3436,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Re-subscribe to the current Single if the given predicate returns true when the Single fails
      * with an onError.
+     * <p>
+     * <img width="640" height="230" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.retry.f2.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3407,6 +3456,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Repeatedly re-subscribe at most times or until the predicate returns false, whichever happens first
      * if it fails with an onError.
+     * <p>
+     * <img width="640" height="259" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.retry.nf.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3427,6 +3478,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Re-subscribe to the current Single if the given predicate returns true when the Single fails
      * with an onError.
+     * <p>
+     * <img width="640" height="240" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.retry.f.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3445,6 +3498,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Re-subscribes to the current Single if and when the Publisher returned by the handler
      * function signals a value.
+     * <p>
+     * <img width="640" height="405" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.retryWhen.png" alt="">
      * <p>
      * If the Publisher signals an onComplete, the resulting Single will signal a NoSuchElementException.
      * <p>
@@ -3492,6 +3547,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Subscribes to a Single but ignore its emission or notification.
      * <p>
+     * <img width="640" height="340" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.subscribe.png" alt="">
+     * <p>
      * If the Single emits an error, it is wrapped into an
      * {@link io.reactivex.exceptions.OnErrorNotImplementedException OnErrorNotImplementedException}
      * and routed to the RxJavaPlugins.onError handler.
@@ -3511,6 +3568,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Subscribes to a Single and provides a composite callback to handle the item it emits
      * or any error notification it issues.
+     * <p>
+     * <img width="640" height="340" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.subscribe.c2.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3538,6 +3597,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Subscribes to a Single and provides a callback to handle the item it emits.
      * <p>
+     * <img width="640" height="341" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.subscribe.c.png" alt="">
+     * <p>
      * If the Single emits an error, it is wrapped into an
      * {@link io.reactivex.exceptions.OnErrorNotImplementedException OnErrorNotImplementedException}
      * and routed to the RxJavaPlugins.onError handler.
@@ -3562,6 +3623,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Subscribes to a Single and provides callbacks to handle the item it emits or any error notification it
      * issues.
+     * <p>
+     * <img width="640" height="340" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.subscribe.cc.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3623,6 +3686,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Subscribes a given SingleObserver (subclass) to this Single and returns the given
      * SingleObserver as is.
+     * <p>
+     * <img width="640" height="338" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.subscribeWith.png" alt="">
      * <p>Usage example:
      * <pre><code>
      * Single&lt;Integer&gt; source = Single.just(1);
@@ -3680,7 +3745,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * termination of {@code other}, this will emit a {@link CancellationException} rather than go to
      * {@link SingleObserver#onSuccess(Object)}.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <img width="640" height="333" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.takeUntil.c.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3705,7 +3770,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * emission of an item from {@code other}, this will emit a {@link CancellationException} rather than go to
      * {@link SingleObserver#onSuccess(Object)}.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <img width="640" height="215" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.takeUntil.p.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The {@code other} publisher is consumed in an unbounded fashion but will be
@@ -3737,7 +3802,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * emission of an item from {@code other}, this will emit a {@link CancellationException} rather than go to
      * {@link SingleObserver#onSuccess(Object)}.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
+     * <img width="640" height="314" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.takeUntil.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -3761,6 +3826,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Signals a TimeoutException if the current Single doesn't signal a success value within the
      * specified timeout window.
+     * <p>
+     * <img width="640" height="364" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.timeout.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} signals the TimeoutException on the {@code computation} {@link Scheduler}.</dd>
@@ -3779,6 +3846,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Signals a TimeoutException if the current Single doesn't signal a success value within the
      * specified timeout window.
+     * <p>
+     * <img width="640" height="334" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.timeout.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} signals the TimeoutException on the {@link Scheduler} you specify.</dd>
@@ -3799,6 +3868,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Runs the current Single and if it doesn't signal within the specified timeout window, it is
      * disposed and the other SingleSource subscribed to.
+     * <p>
+     * <img width="640" height="283" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.timeout.sb.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} subscribes to the other SingleSource on the {@link Scheduler} you specify.</dd>
@@ -3821,6 +3892,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Runs the current Single and if it doesn't signal within the specified timeout window, it is
      * disposed and the other SingleSource subscribed to.
+     * <p>
+     * <img width="640" height="282" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.timeout.b.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} subscribes to the other SingleSource on
@@ -4005,6 +4078,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Returns a Single which makes sure when a SingleObserver disposes the Disposable,
      * that call is propagated up on the specified scheduler.
+     * <p>
+     * <img width="640" height="693" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.unsubscribeOn.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code unsubscribeOn} calls dispose() of the upstream on the {@link Scheduler} you specify.</dd>
@@ -4058,6 +4133,8 @@ public abstract class Single<T> implements SingleSource<T> {
     /**
      * Creates a TestObserver and subscribes
      * it to this Single.
+     * <p>
+     * <img width="640" height="442" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.test.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -4075,6 +4152,8 @@ public abstract class Single<T> implements SingleSource<T> {
 
     /**
      * Creates a TestObserver optionally in cancelled state, then subscribes it to this Single.
+     * <p>
+     * <img width="640" height="482" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.test.b.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>


### PR DESCRIPTION
This PR is to backport the marble images of Single class from 3.x. The method `onErrorResumeWith` does not exist in 2.x and hence I have left that out.

Closes #6679