### PR TITLE
2.x: Add ProGuard rule to avoid j.u.c.Flow warnings due to RS 1.0.3

### DIFF
--- a/src/main/resources/META-INF/proguard/rxjava2.pro
+++ b/src/main/resources/META-INF/proguard/rxjava2.pro
@@ -1,0 +1,1 @@
+-dontwarn java.util.concurrent.Flow


### PR DESCRIPTION
Add rule to ignore `java.util.concurrent.Flow` when using Android's R8 to prevent warnings about the `FlowAdapter.class` contained within the Reactive Streams JAR file.