### PR TITLE
2.x: ProGuard R8 dont warn Flow* classes

### DIFF
--- a/src/main/resources/META-INF/proguard/rxjava2.pro
+++ b/src/main/resources/META-INF/proguard/rxjava2.pro
@@ -1,1 +1,1 @@
--dontwarn java.util.concurrent.Flow
+-dontwarn java.util.concurrent.Flow*


### PR DESCRIPTION
#6704 didn't work, probably because the filter has to match a filename `java.util.concurrent.Flow$Publisher`, not some parent class name. 

Having `-dontwarn java.util.concurrent.Flow*` did work in a test project's proguard file locally.

