### PR TITLE
3.x: Fix concurrent clear in observeOn while output-fused

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
@@ -154,7 +154,7 @@ final Scheduler scheduler;
             upstream.cancel();
             worker.dispose();
 
-            if (getAndIncrement() == 0) {
+            if (!outputFused && getAndIncrement() == 0) {
                 queue.clear();
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableObserveOn.java
@@ -145,7 +145,7 @@ public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream
                 disposed = true;
                 upstream.dispose();
                 worker.dispose();
-                if (getAndIncrement() == 0) {
+                if (!outputFused && getAndIncrement() == 0) {
                     queue.clear();
                 }
             }


### PR DESCRIPTION
There was another cancel-clear race leading to NPE or infinite loop inside both `observeOn` implementations.

Related: #6676