### PR TITLE
3.x: cleanup of some Javadoc parts

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableBackpressureTests.java
@@ -634,10 +634,10 @@ public class FlowableBackpressureTests extends RxJavaTest {
     }
 
     /**
-     * A synchronous Observable that will emit incrementing integers as requested.
+     * A synchronous Flowable that will emit incrementing integers as requested.
      *
-     * @param counter
-     * @return
+     * @param counter the shared value to be incremented
+     * @return the incrementing Flowable instance
      */
     private static Flowable<Integer> incrementingIntegers(final AtomicInteger counter) {
         return incrementingIntegers(counter, null);
@@ -689,8 +689,8 @@ public class FlowableBackpressureTests extends RxJavaTest {
     /**
      * Incrementing int without backpressure.
      *
-     * @param counter
-     * @return
+     * @param counter the shared value to increment
+     * @return the Flowable doing the increments
      */
     private static Flowable<Integer> firehose(final AtomicInteger counter) {
         return Flowable.unsafeCreate(new Publisher<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/AbstractSchedulerTests.java
@@ -466,7 +466,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
     /**
      * Used to determine if onNext is being invoked concurrently.
      *
-     * @param <T>
+     * @param <T> the element type
      */
     private static class ConcurrentObserverValidator<T> extends DefaultSubscriber<T> {
 

--- a/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerTestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerTestHelper.java
@@ -28,9 +28,6 @@ final class SchedulerTestHelper {
     /**
      * Verifies that the given Scheduler does not deliver handled errors to its executing Thread's
      * {@link java.lang.Thread.UncaughtExceptionHandler}.
-     * <p>
-     * This is a companion test to {@link #testUnhandledErrorIsDeliveredToThreadHandler}, and is needed only for the
-     * same Schedulers.
      */
     static void handledErrorIsNotDeliveredToThreadHandler(Scheduler scheduler) throws InterruptedException {
         Thread.UncaughtExceptionHandler originalHandler = Thread.getDefaultUncaughtExceptionHandler();


### PR DESCRIPTION
Enabled some Javadoc validation and found a few mistakes. As far as I can tell, there is no `testUnhandledErrorIsDeliveredToThreadHandler` method or similar to reference there.