### PR TITLE
3.x: Fix MulticastProcessor not requesting more after limit is reached

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
@@ -570,6 +570,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
                 }
             }
 
+            consumed = c;
             missed = wip.addAndGet(-missed);
             if (missed == 0) {
                 break;

--- a/src/test/java/io/reactivex/rxjava3/processors/MulticastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/MulticastProcessorTest.java
@@ -787,7 +787,7 @@ public class MulticastProcessorTest extends RxJavaTest {
     @Test
     public void requestUpstreamPrefetchNonFused() {
         for (int j = 1; j < 12; j++) {
-            MulticastProcessor<Integer> mp = MulticastProcessor.create(2, true);
+            MulticastProcessor<Integer> mp = MulticastProcessor.create(j, true);
 
             TestSubscriber<Integer> ts = mp.test(0).withTag("Prefetch: " + j);
 
@@ -799,6 +799,25 @@ public class MulticastProcessorTest extends RxJavaTest {
             .requestMore(3)
             .assertValuesOnly(1, 2, 3, 4, 5, 6)
             .requestMore(4)
+            .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        }
+    }
+
+    @Test
+    public void requestUpstreamPrefetchNonFused2() {
+        for (int j = 1; j < 12; j++) {
+            MulticastProcessor<Integer> mp = MulticastProcessor.create(j, true);
+
+            TestSubscriber<Integer> ts = mp.test(0).withTag("Prefetch: " + j);
+
+            Flowable.range(1, 10).hide().subscribe(mp);
+
+            ts.assertEmpty()
+            .requestMore(2)
+            .assertValuesOnly(1, 2)
+            .requestMore(2)
+            .assertValuesOnly(1, 2, 3, 4)
+            .requestMore(6)
             .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         }
     }

--- a/src/test/java/io/reactivex/rxjava3/processors/MulticastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/MulticastProcessorTest.java
@@ -784,4 +784,22 @@ public class MulticastProcessorTest extends RxJavaTest {
         assertTrue(mp.hasSubscribers());
     }
 
+    @Test
+    public void requestUpstreamPrefetchNonFused() {
+        for (int j = 1; j < 12; j++) {
+            MulticastProcessor<Integer> mp = MulticastProcessor.create(2, true);
+
+            TestSubscriber<Integer> ts = mp.test(0).withTag("Prefetch: " + j);
+
+            Flowable.range(1, 10).hide().subscribe(mp);
+
+            ts.assertEmpty()
+            .requestMore(3)
+            .assertValuesOnly(1, 2, 3)
+            .requestMore(3)
+            .assertValuesOnly(1, 2, 3, 4, 5, 6)
+            .requestMore(4)
+            .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        }
+    }
 }


### PR DESCRIPTION
After reaching the prefetch limit, the updated `consumed` counter was not written back so the processor stopped requesting more (consumed > limit).

Affects 2.x to. A separate PR will be posted for it.

Resolves #6713