### PR TITLE
2.x: Fix parallel() on grouped flowable not replenishing properly

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableGroupBy.java
@@ -709,17 +709,25 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                 produced++;
                 return v;
             }
-            int p = produced;
-            if (p != 0) {
-                produced = 0;
-                parent.upstream.request(p);
-            }
+            tryReplenish();
             return null;
         }
 
         @Override
         public boolean isEmpty() {
-            return queue.isEmpty();
+            if (queue.isEmpty()) {
+                tryReplenish();
+                return true;
+            }
+            return false;
+        }
+
+        void tryReplenish() {
+            int p = produced;
+            if (p != 0) {
+                produced = 0;
+                parent.upstream.request(p);
+            }
         }
 
         @Override


### PR DESCRIPTION
## Backport of #6719 

Fix a case when the GroupedFlowable is consumed by a parallel() in fusion mode causing the source to stop replenishing items from the upstream, hanging the whole sequence.

parallel() was slightly different from the usual queue consumers because it checks for isEmpty before trying to pull for an item. This was necessary because the rails may not be ready for more and an eager pull to check for emptyness would lose that item. The replenishing was done in GroupedFlowable.pull but a call to GroupedFlowable.isEmpty would not replenish.

The fix is to have isEmpty replenish similar to when poll detects emptyness and replenishes.

Reported in reactor/reactor-core#1959