### PR TITLE
Add javadoc on ActionDisposable, correction of dangling javadoc comme…

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -8134,7 +8134,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Single that emits a single item: the number of items emitted by the source Publisher as a
      *         64-bit Long item
      * @see <a href="http://reactivex.io/documentation/operators/count.html">ReactiveX operators documentation: Count</a>
-     * @see #count()
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
@@ -15102,7 +15101,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      *               {@link CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
      * @return the new Completable instance
-     * @see #switchMapCompletableDelayError(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -15229,7 +15227,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      *               return a {@code MaybeSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Flowable instance
-     * @see #switchMapMaybe(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -15301,7 +15298,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      *               return a {@code SingleSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Flowable instance
-     * @see #switchMapSingle(Function)
      * @since 2.2
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -2537,7 +2537,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Single that emits a single item: the number of items emitted by the source Maybe as a
      *         64-bit Long item
      * @see <a href="http://reactivex.io/documentation/operators/count.html">ReactiveX operators documentation: Count</a>
-     * @see #count()
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2940,7 +2939,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param onTerminate the action to invoke when the consumer calls {@code onComplete} or {@code onError}
      * @return the new Maybe instance
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @see #doOnTerminate(Action)
      * @since 3.0.0
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -7191,7 +7191,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Single that emits a single item: the number of items emitted by the source ObservableSource as a
      *         64-bit Long item
      * @see <a href="http://reactivex.io/documentation/operators/count.html">ReactiveX operators documentation: Count</a>
-     * @see #count()
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -12476,7 +12475,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *               {@link CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
      * @return the new Completable instance
-     * @see #switchMapCompletableDelayError(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -12512,7 +12510,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *               return a {@code MaybeSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Observable instance
-     * @see #switchMapMaybe(Function)
      * @since 2.2
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -2568,7 +2568,6 @@ public abstract class Single<T> implements SingleSource<T> {
      * @param onTerminate the action to invoke when the consumer calls {@code onSuccess} or {@code onError}
      * @return the new Single instance
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
-     * @see #doOnTerminate(Action)
      * @since 3.0.0
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/rxjava3/disposables/ActionDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/disposables/ActionDisposable.java
@@ -16,6 +16,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.functions.Action;
 import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
+/**
+ * A Disposable container that manages an Action instance.
+ */
 final class ActionDisposable extends ReferenceDisposable<Action> {
 
     private static final long serialVersionUID = -8219729196779211169L;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableMostRecent.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableMostRecent.java
@@ -42,10 +42,8 @@ public final class BlockingFlowableMostRecent<T> implements Iterable<T> {
     public Iterator<T> iterator() {
         MostRecentSubscriber<T> mostRecentSubscriber = new MostRecentSubscriber<T>(initialValue);
 
-        /**
-         * Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
-         * since it is for BlockingObservable.
-         */
+        // Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
+        // since it is for BlockingObservable.
         source.subscribe(mostRecentSubscriber);
 
         return mostRecentSubscriber.getIterable();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableMostRecent.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableMostRecent.java
@@ -42,10 +42,8 @@ public final class BlockingObservableMostRecent<T> implements Iterable<T> {
     public Iterator<T> iterator() {
         MostRecentObserver<T> mostRecentObserver = new MostRecentObserver<T>(initialValue);
 
-        /**
-         * Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
-         * since it is for BlockingObservable.
-         */
+        // Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
+        // since it is for BlockingObservable.
         source.subscribe(mostRecentObserver);
 
         return mostRecentObserver.getIterable();


### PR DESCRIPTION
Javadoc corrections :
- add javadoc on ActionDisposable
- correction of dangling javadoc comments
- remove of unnecessary '@see' (on same method)

Issue #4535.