### PR TITLE
3.x: Mockito fix deprecated API use after bump to 3.2.0

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/disposables/SequentialDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/SequentialDisposableTest.java
@@ -78,7 +78,7 @@ public class SequentialDisposableTest extends RxJavaTest {
     public void settingSameDisposableTwiceDoesUnsubscribeIt() {
         Disposable underlying = mock(Disposable.class);
         serialDisposable.update(underlying);
-        verifyZeroInteractions(underlying);
+        verifyNoInteractions(underlying);
         serialDisposable.update(underlying);
         verify(underlying).dispose();
     }

--- a/src/test/java/io/reactivex/rxjava3/disposables/SerialDisposableTests.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/SerialDisposableTests.java
@@ -78,7 +78,7 @@ public class SerialDisposableTests extends RxJavaTest {
     public void settingSameDisposableTwiceDoesUnsubscribeIt() {
         Disposable underlying = mock(Disposable.class);
         serialDisposable.set(underlying);
-        verifyZeroInteractions(underlying);
+        verifyNoInteractions(underlying);
         serialDisposable.set(underlying);
         verify(underlying).dispose();
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDeferTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDeferTest.java
@@ -38,7 +38,7 @@ public class FlowableDeferTest extends RxJavaTest {
 
         Flowable<String> deferred = Flowable.defer(factory);
 
-        verifyZeroInteractions(factory);
+        verifyNoInteractions(factory);
 
         Subscriber<String> firstSubscriber = TestHelper.mockSubscriber();
         deferred.subscribe(firstSubscriber);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromCallableTest.java
@@ -47,7 +47,7 @@ public class FlowableFromCallableTest extends RxJavaTest {
 
         Flowable<Object> fromCallableFlowable = Flowable.fromCallable(func);
 
-        verifyZeroInteractions(func);
+        verifyNoInteractions(func);
 
         fromCallableFlowable.subscribe();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSupplierTest.java
@@ -47,7 +47,7 @@ public class FlowableFromSupplierTest extends RxJavaTest {
 
         Flowable<Object> fromSupplierFlowable = Flowable.fromSupplier(func);
 
-        verifyZeroInteractions(func);
+        verifyNoInteractions(func);
 
         fromSupplierFlowable.subscribe();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDeferTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDeferTest.java
@@ -37,7 +37,7 @@ public class ObservableDeferTest extends RxJavaTest {
 
         Observable<String> deferred = Observable.defer(factory);
 
-        verifyZeroInteractions(factory);
+        verifyNoInteractions(factory);
 
         Observer<String> firstObserver = TestHelper.mockObserver();
         deferred.subscribe(firstObserver);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromCallableTest.java
@@ -47,7 +47,7 @@ public class ObservableFromCallableTest extends RxJavaTest {
 
         Observable<Object> fromCallableObservable = Observable.fromCallable(func);
 
-        verifyZeroInteractions(func);
+        verifyNoInteractions(func);
 
         fromCallableObservable.subscribe();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromSupplierTest.java
@@ -47,7 +47,7 @@ public class ObservableFromSupplierTest extends RxJavaTest {
 
         Observable<Object> fromSupplierObservable = Observable.fromSupplier(func);
 
-        verifyZeroInteractions(func);
+        verifyNoInteractions(func);
 
         fromSupplierObservable.subscribe();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFromCallableTest.java
@@ -100,7 +100,7 @@ public class SingleFromCallableTest extends RxJavaTest {
 
         Single<Object> fromCallableSingle = Single.fromCallable(func);
 
-        verifyZeroInteractions(func);
+        verifyNoInteractions(func);
 
         fromCallableSingle.subscribe();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFromSupplierTest.java
@@ -101,7 +101,7 @@ public class SingleFromSupplierTest extends RxJavaTest {
 
         Single<Object> fromSupplierSingle = Single.fromSupplier(func);
 
-        verifyZeroInteractions(func);
+        verifyNoInteractions(func);
 
         fromSupplierSingle.subscribe();
 


### PR DESCRIPTION
Use the suggested `verifyNoInteractions` instead of `verifyZeroInteractions`.