### PR TITLE
3.x: Change Flowable.groupBy to signal MBE instead of possibly hanging

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.flowables.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.*;
@@ -10421,13 +10421,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Both the returned and its inner {@code Publisher}s honor backpressure and the source {@code Publisher}
-     *  is consumed in a bounded mode (i.e., requested a fixed amount upfront and replenished based on
-     *  downstream consumption). Note that both the returned and its inner {@code Publisher}s use
-     *  unbounded internal buffers and if the source {@code Publisher} doesn't honor backpressure, that <em>may</em>
-     *  lead to {@code OutOfMemoryError}.</dd>
+     *  <dd>The consumer of the returned {@code Flowable} has to be ready to receive new {@code GroupedFlowable}s or else
+     *  this operator will signal {@link MissingBackpressureException}. To avoid this exception, make
+     *  sure a combining operator (such as {@code flatMap}) has adequate amount of buffering/prefetch configured.
+     *  The inner {@code GroupedFlowable}s honor backpressure but due to the single-source multiple consumer
+     *  nature of this operator, each group must be consumed so the whole operator can make progress and not hang.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
+     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10438,9 +10441,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         unique key value and each of which emits those items from the source Publisher that share that
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
+     * @see #groupBy(Function, boolean)
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.FULL)
+    @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<GroupedFlowable<K, T>> groupBy(Function<? super T, ? extends K> keySelector) {
         return groupBy(keySelector, Functions.<T>identity(), false, bufferSize());
@@ -10474,13 +10478,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Both the returned and its inner {@code Publisher}s honor backpressure and the source {@code Publisher}
-     *  is consumed in a bounded mode (i.e., requested a fixed amount upfront and replenished based on
-     *  downstream consumption). Note that both the returned and its inner {@code Publisher}s use
-     *  unbounded internal buffers and if the source {@code Publisher} doesn't honor backpressure, that <em>may</em>
-     *  lead to {@code OutOfMemoryError}.</dd>
+     *  <dd>The consumer of the returned {@code Flowable} has to be ready to receive new {@code GroupedFlowable}s or else
+     *  this operator will signal {@link MissingBackpressureException}. To avoid this exception, make
+     *  sure a combining operator (such as {@code flatMap}) has adequate amount of buffering/prefetch configured.
+     *  The inner {@code GroupedFlowable}s honor backpressure but due to the single-source multiple consumer
+     *  nature of this operator, each group must be consumed so the whole operator can make progress and not hang.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
+     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10530,13 +10537,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Both the returned and its inner {@code Publisher}s honor backpressure and the source {@code Publisher}
-     *  is consumed in a bounded mode (i.e., requested a fixed amount upfront and replenished based on
-     *  downstream consumption). Note that both the returned and its inner {@code Publisher}s use
-     *  unbounded internal buffers and if the source {@code Publisher} doesn't honor backpressure, that <em>may</em>
-     *  lead to {@code OutOfMemoryError}.</dd>
+     *  <dd>The consumer of the returned {@code Flowable} has to be ready to receive new {@code GroupedFlowable}s or else
+     *  this operator will signal {@link MissingBackpressureException}. To avoid this exception, make
+     *  sure a combining operator (such as {@code flatMap}) has adequate amount of buffering/prefetch configured.
+     *  The inner {@code GroupedFlowable}s honor backpressure but due to the single-source multiple consumer
+     *  nature of this operator, each group must be consumed so the whole operator can make progress and not hang.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
+     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10588,13 +10598,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Both the returned and its inner {@code Publisher}s honor backpressure and the source {@code Publisher}
-     *  is consumed in a bounded mode (i.e., requested a fixed amount upfront and replenished based on
-     *  downstream consumption). Note that both the returned and its inner {@code Publisher}s use
-     *  unbounded internal buffers and if the source {@code Publisher} doesn't honor backpressure, that <em>may</em>
-     *  lead to {@code OutOfMemoryError}.</dd>
+     *  <dd>The consumer of the returned {@code Flowable} has to be ready to receive new {@code GroupedFlowable}s or else
+     *  this operator will signal {@link MissingBackpressureException}. To avoid this exception, make
+     *  sure a combining operator (such as {@code flatMap}) has adequate amount of buffering/prefetch configured.
+     *  The inner {@code GroupedFlowable}s honor backpressure but due to the single-source multiple consumer
+     *  nature of this operator, each group must be consumed so the whole operator can make progress and not hang.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
+     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10649,13 +10662,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Both the returned and its inner {@code Publisher}s honor backpressure and the source {@code Publisher}
-     *  is consumed in a bounded mode (i.e., requested a fixed amount upfront and replenished based on
-     *  downstream consumption). Note that both the returned and its inner {@code Publisher}s use
-     *  unbounded internal buffers and if the source {@code Publisher} doesn't honor backpressure, that <em>may</em>
-     *  lead to {@code OutOfMemoryError}.</dd>
+     *  <dd>The consumer of the returned {@code Flowable} has to be ready to receive new {@code GroupedFlowable}s or else
+     *  this operator will signal {@link MissingBackpressureException}. To avoid this exception, make
+     *  sure a combining operator (such as {@code flatMap}) has adequate amount of buffering/prefetch configured.
+     *  The inner {@code GroupedFlowable}s honor backpressure but due to the single-source multiple consumer
+     *  nature of this operator, each group must be consumed so the whole operator can make progress and not hang.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
+     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10759,13 +10775,16 @@ public abstract class Flowable<T> implements Publisher<T> {
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Both the returned and its inner {@code GroupedFlowable}s honor backpressure and the source {@code Publisher}
-     *  is consumed in a bounded mode (i.e., requested a fixed amount upfront and replenished based on
-     *  downstream consumption). Note that both the returned and its inner {@code GroupedFlowable}s use
-     *  unbounded internal buffers and if the source {@code Publisher} doesn't honor backpressure, that <em>may</em>
-     *  lead to {@code OutOfMemoryError}.</dd>
+     *  <dd>The consumer of the returned {@code Flowable} has to be ready to receive new {@code GroupedFlowable}s or else
+     *  this operator will signal {@link MissingBackpressureException}. To avoid this exception, make
+     *  sure a combining operator (such as {@code flatMap}) has adequate amount of buffering/prefetch configured.
+     *  The inner {@code GroupedFlowable}s honor backpressure but due to the single-source multiple consumer
+     *  nature of this operator, each group must be consumed so the whole operator can make progress and not hang.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
+     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      * <p>History: 2.1.10 - beta
      * @param keySelector

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -10442,9 +10442,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
      * @see #groupBy(Function, boolean)
+     * @see #groupBy(Function, Function)
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.SPECIAL)
+    @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<GroupedFlowable<K, T>> groupBy(Function<? super T, ? extends K> keySelector) {
         return groupBy(keySelector, Functions.<T>identity(), false, bufferSize());
@@ -10503,7 +10504,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.FULL)
+    @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Flowable<GroupedFlowable<K, T>> groupBy(Function<? super T, ? extends K> keySelector, boolean delayError) {
         return groupBy(keySelector, Functions.<T>identity(), delayError, bufferSize());
@@ -10561,9 +10562,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         unique key value and each of which emits those items from the source Publisher that share that
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
+     * @see #groupBy(Function, Function, boolean)
+     * @see #groupBy(Function, Function, boolean, int)
+     * @see #groupBy(Function, Function, boolean, int, Function)
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.FULL)
+    @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector) {
@@ -10625,9 +10629,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         unique key value and each of which emits those items from the source Publisher that share that
      *         key value
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
+     * @see #groupBy(Function, Function, boolean, int)
      */
     @CheckReturnValue
-    @BackpressureSupport(BackpressureKind.FULL)
+    @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector, boolean delayError) {
@@ -10694,7 +10699,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @CheckReturnValue
     @NonNull
-    @BackpressureSupport(BackpressureKind.FULL)
+    @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector,
@@ -10815,7 +10820,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @CheckReturnValue
     @NonNull
-    @BackpressureSupport(BackpressureKind.FULL)
+    @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector,

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -10430,7 +10430,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
-     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
+     *  all active inner {@code GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10488,7 +10488,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
-     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
+     *  all active inner {@code GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10547,7 +10547,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
-     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
+     *  all active inner {@code GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10611,7 +10611,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
-     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
+     *  all active inner {@code GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10676,7 +10676,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
-     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
+     *  all active inner {@code GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      *
      * @param keySelector
@@ -10789,7 +10789,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If the upstream signals or the callback(s) throw an exception, the returned {@code Flowable} and
-     *  all active inner {@GroupedFlowable}s will signal the same exception.</dd>
+     *  all active inner {@code GroupedFlowable}s will signal the same exception.</dd>
      * </dl>
      * <p>History: 2.1.10 - beta
      * @param keySelector

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableGroupByTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableGroupByTests.java
@@ -100,7 +100,8 @@ public class FlowableGroupByTests extends RxJavaTest {
             public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> v) {
                 return v;
             }
-        }).subscribe(ts);
+        }, 20) // need to prefetch as many groups as groupBy produces to avoid MBE
+        .subscribe(ts);
 
         // Behavior change: this now counts as group abandonment because concatMap
         // doesn't subscribe to the 2nd+ emitted groups immediately

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -34,9 +34,8 @@ import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.flowables.GroupedFlowable;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
-import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.internal.fuseable.QueueFuseable;
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.processors.PublishProcessor;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.PublishSubject;
@@ -1322,29 +1321,30 @@ public class FlowableGroupByTest extends RxJavaTest {
                     System.out.println("testgroupByBackpressure2 >> " + v);
                 }
             })
-            .groupBy(IS_EVEN2).flatMap(new Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>() {
+            .groupBy(IS_EVEN2)
+            .flatMap(new Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>() {
+                @Override
+                public Flowable<String> apply(final GroupedFlowable<Boolean, Integer> g) {
+                    return g.take(2)
+                            .observeOn(Schedulers.computation())
+                            .map(new Function<Integer, String>() {
+                                @Override
+                                public String apply(Integer l) {
+                                    if (g.getKey()) {
+                                        try {
+                                            Thread.sleep(1);
+                                        } catch (InterruptedException e) {
+                                        }
+                                        return l + " is even.";
+                                    } else {
+                                        return l + " is odd.";
+                                    }
+                                }
+                            });
+                }
+            }, 4000) // a lot of groups are created due to take(2)
+            .subscribe(ts);
 
-            @Override
-            public Flowable<String> apply(final GroupedFlowable<Boolean, Integer> g) {
-                return g.take(2).observeOn(Schedulers.computation()).map(new Function<Integer, String>() {
-
-                    @Override
-                    public String apply(Integer l) {
-                        if (g.getKey()) {
-                            try {
-                                Thread.sleep(1);
-                            } catch (InterruptedException e) {
-                            }
-                            return l + " is even.";
-                        } else {
-                            return l + " is odd.";
-                        }
-                    }
-
-                });
-            }
-
-        }).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
     }
@@ -1513,9 +1513,30 @@ public class FlowableGroupByTest extends RxJavaTest {
      * or emit to a completely different group. In this test, the merge requests N which
      * must be produced by the range, however it will create a bunch of groups before the actual
      * group receives a value.
+     * 
+     * 12/03/2019: this test produces abandoned groups and as such keeps producing new groups
+     * that have to be ready to be received by observeOn and merge.
      */
     @Test
     public void backpressureObserveOnOuter() {
+        int n = 500;
+        for (int j = 0; j < 1000; j++) {
+            Flowable.merge(
+                    Flowable.range(0, n)
+                    .groupBy(new Function<Integer, Object>() {
+                        @Override
+                        public Object apply(Integer i) {
+                            return i % (Flowable.bufferSize() + 2);
+                        }
+                    })
+                    .observeOn(Schedulers.computation(), false, n)
+            , n)
+            .blockingLast();
+        }
+    }
+
+    @Test(expected = MissingBackpressureException.class)
+    public void backpressureObserveOnOuterMissingBackpressure() {
         for (int j = 0; j < 1000; j++) {
             Flowable.merge(
                     Flowable.range(0, 500)
@@ -1537,8 +1558,9 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void backpressureInnerDoesntOverflowOuter() {
         TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<GroupedFlowable<Integer, Integer>>(0L);
 
-        Flowable.fromArray(1, 2)
-                .groupBy(new Function<Integer, Integer>() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        pp.groupBy(new Function<Integer, Integer>() {
                     @Override
                     public Integer apply(Integer v) {
                         return v;
@@ -1554,9 +1576,35 @@ public class FlowableGroupByTest extends RxJavaTest {
                 ;
         ts.request(1);
 
+        pp.onNext(1);
+
         ts.assertNotComplete();
         ts.assertNoErrors();
         ts.assertValueCount(1);
+    }
+
+    @Test
+    public void backpressureInnerDoesntOverflowOuterMissingBackpressure() {
+        TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<GroupedFlowable<Integer, Integer>>(1);
+
+        Flowable.fromArray(1, 2)
+                .groupBy(new Function<Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer v) {
+                        return v;
+                    }
+                })
+                .doOnNext(new Consumer<GroupedFlowable<Integer, Integer>>() {
+                    @Override
+                    public void accept(GroupedFlowable<Integer, Integer> g) {
+                        g.subscribe();
+                    }
+                }) // this will request Long.MAX_VALUE
+                .subscribe(ts)
+                ;
+        ts.assertValueCount(1)
+        .assertError(MissingBackpressureException.class)
+        .assertNotComplete();
     }
 
     @Test
@@ -1628,7 +1676,6 @@ public class FlowableGroupByTest extends RxJavaTest {
         .assertComplete();
 
         ts2
-        .assertFusionMode(QueueFuseable.ASYNC)
         .assertValueCount(1)
         .assertNoErrors()
         .assertComplete();
@@ -1788,30 +1835,6 @@ public class FlowableGroupByTest extends RxJavaTest {
         })
         .test()
         .assertResult(1);
-    }
-
-    @Test
-    public void errorFused() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>().setInitialFusionMode(QueueFuseable.ANY);
-
-        Flowable.error(new TestException())
-        .groupBy(Functions.justFunction(1))
-        .subscribe(ts);
-
-        ts.assertFusionMode(QueueFuseable.ASYNC)
-        .assertFailure(TestException.class);
-    }
-
-    @Test
-    public void errorFusedDelayed() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>().setInitialFusionMode(QueueFuseable.ANY);
-
-        Flowable.error(new TestException())
-        .groupBy(Functions.justFunction(1), true)
-        .subscribe(ts);
-
-        ts.assertFusionMode(QueueFuseable.ASYNC)
-        .assertFailure(TestException.class);
     }
 
     @Test
@@ -2335,86 +2358,6 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
 
     @Test
-    public void fusedNoConcurrentCleanDueToCancel() {
-        for (int j = 0; j < TestHelper.RACE_LONG_LOOPS; j++) {
-            List<Throwable> errors = TestHelper.trackPluginErrors();
-            try {
-                final PublishProcessor<Integer> pp = PublishProcessor.create();
-
-                final AtomicReference<QueueSubscription<GroupedFlowable<Integer, Integer>>> qs =
-                        new AtomicReference<QueueSubscription<GroupedFlowable<Integer, Integer>>>();
-
-                final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
-
-                pp.groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), false, 4)
-                .subscribe(new FlowableSubscriber<GroupedFlowable<Integer, Integer>>() {
-
-                    boolean once;
-
-                    @Override
-                    public void onNext(GroupedFlowable<Integer, Integer> g) {
-                        if (!once) {
-                            try {
-                                GroupedFlowable<Integer, Integer> t = qs.get().poll();
-                                if (t != null) {
-                                    once = true;
-                                    t.subscribe(ts2);
-                                }
-                            } catch (Throwable ignored) {
-                                // not relevant here
-                            }
-                        }
-                    }
-
-                    @Override
-                    public void onError(Throwable t) {
-                    }
-
-                    @Override
-                    public void onComplete() {
-                    }
-
-                    @Override
-                    public void onSubscribe(Subscription s) {
-                        @SuppressWarnings("unchecked")
-                        QueueSubscription<GroupedFlowable<Integer, Integer>> q = (QueueSubscription<GroupedFlowable<Integer, Integer>>)s;
-                        qs.set(q);
-                        q.requestFusion(QueueFuseable.ANY);
-                        q.request(1);
-                    }
-                })
-                ;
-
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        qs.get().cancel();
-                        qs.get().clear();
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ts2.cancel();
-                    }
-                };
-
-                for (int i = 0; i < 100; i++) {
-                    pp.onNext(i);
-                }
-
-                TestHelper.race(r1, r2);
-
-                if (!errors.isEmpty()) {
-                    throw new CompositeException(errors);
-                }
-            } finally {
-                RxJavaPlugins.reset();
-            }
-        }
-    }
-
-    @Test
     public void fusedParallelGroupProcessing() {
         Flowable.range(0, 500000)
         .subscribeOn(Schedulers.single())
@@ -2442,5 +2385,25 @@ public class FlowableGroupByTest extends RxJavaTest {
         .assertValueCount(500000)
         .assertComplete()
         .assertNoErrors();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void valueSelectorCrashAndMissingBackpressure() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriberEx<GroupedFlowable<Integer, Integer>> ts = pp.groupBy(Functions.justFunction(1), new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer t) throws Throwable {
+                throw new TestException();
+            }
+        })
+        .subscribeWith(new TestSubscriberEx<GroupedFlowable<Integer, Integer>>(0L));
+
+        assertTrue(pp.offer(1));
+
+        ts.assertFailure(MissingBackpressureException.class);
+
+        assertTrue("" + ts.errors().get(0).getCause(), ts.errors().get(0).getCause() instanceof TestException);
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryTest.java
@@ -864,7 +864,7 @@ public class FlowableRetryTest extends RxJavaTest {
             public Flowable<String> apply(GroupedFlowable<String, String> t1) {
                 return t1.take(1);
             }
-        })
+        }, NUM_MSG) // Must request as many groups as groupBy produces to avoid MBE
         .subscribe(new TestSubscriber<String>(subscriber));
 
         InOrder inOrder = inOrder(subscriber);


### PR DESCRIPTION
This PR changes the backpressure behavior of `Flowable.groupBy` to signal `MissingBackpressureException` instead of silently hanging if the produced groups are not ready to be accepted by the downstream. 

This can happen if one `flatMap`s a `groupBy` but there are more groups produced than the concurrency level of `flatMap`. Since replenishment is tied to item consumption from the groups, not consuming them can result in none of the groups receiving any further items and the whole operator hangs.

The following changes have been applied:

- Removed the queue from the main operator since it will now try to emit directly and not buffer groups.
- The main `Flowable`, lacking a queue, no longer supports operator fusion. Tests checking this property have been removed as well.
- When a group is drained, consumed items are replenished in batch if possible. Detecting a cancellation will also trigger a replenishment.
- When a group is pulled (fusion mode), now all `pull`, `isEmpty` and `clear` will trigger replenishment so that other groups can make progress too.
- Unit tests have been modified to have large enough bufferSize/prefetch amounts to allow them to pass.

Fixes #6641