### PR TITLE
3.x: Add fair mode overload to Schedulers.from(Executor)

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
@@ -33,20 +33,23 @@ public final class ExecutorScheduler extends Scheduler {
 
     final boolean interruptibleWorker;
 
+    final boolean fair;
+
     @NonNull
     final Executor executor;
 
     static final Scheduler HELPER = Schedulers.single();
 
-    public ExecutorScheduler(@NonNull Executor executor, boolean interruptibleWorker) {
+    public ExecutorScheduler(@NonNull Executor executor, boolean interruptibleWorker, boolean fair) {
         this.executor = executor;
         this.interruptibleWorker = interruptibleWorker;
+        this.fair = fair;
     }
 
     @NonNull
     @Override
     public Worker createWorker() {
-        return new ExecutorWorker(executor, interruptibleWorker);
+        return new ExecutorWorker(executor, interruptibleWorker, fair);
     }
 
     @NonNull
@@ -123,6 +126,8 @@ public final class ExecutorScheduler extends Scheduler {
 
         final boolean interruptibleWorker;
 
+        final boolean fair;
+
         final Executor executor;
 
         final MpscLinkedQueue<Runnable> queue;
@@ -133,10 +138,11 @@ public final class ExecutorScheduler extends Scheduler {
 
         final CompositeDisposable tasks = new CompositeDisposable();
 
-        public ExecutorWorker(Executor executor, boolean interruptibleWorker) {
+        public ExecutorWorker(Executor executor, boolean interruptibleWorker, boolean fair) {
             this.executor = executor;
             this.queue = new MpscLinkedQueue<Runnable>();
             this.interruptibleWorker = interruptibleWorker;
+            this.fair = fair;
         }
 
         @NonNull
@@ -236,6 +242,36 @@ public final class ExecutorScheduler extends Scheduler {
 
         @Override
         public void run() {
+            if (fair) {
+                runFair();
+            } else {
+                runEager();
+            }
+        }
+
+        void runFair() {
+            final MpscLinkedQueue<Runnable> q = queue;
+            if (disposed) {
+                q.clear();
+                return;
+            }
+
+            Runnable run = q.poll();
+            if (run != null) {
+                run.run();
+            }
+
+            if (disposed) {
+                q.clear();
+                return;
+            }
+
+            if (wip.decrementAndGet() != 0) {
+                executor.execute(this);
+            }
+        }
+
+        void runEager() {
             int missed = 1;
             final MpscLinkedQueue<Runnable> q = queue;
             for (;;) {


### PR DESCRIPTION
The default `Schedulers.from` implementation uses an eager approach to execute tasks on the underlying `Executor` which can lead to excessive thread occupation on its own, even if operators use buffering/prefetch of 1.

This PR introduces a new overload with a fairness option so that tasks are submitted to the `Executor` in a non-overlapping and FIFO manner one by one.

In addition, the scheduler retention tests have been cleaned up and reworked to not wait unnecessarily long for the GC to finish.

Related: #6696, #6697