### PR TITLE
3.x: Make DisposableContainer public API

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/disposables/CompositeDisposable.java
@@ -16,7 +16,6 @@ import java.util.*;
 
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.exceptions.*;
-import io.reactivex.rxjava3.internal.disposables.DisposableContainer;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.util.*;
 

--- a/src/main/java/io/reactivex/rxjava3/disposables/DisposableContainer.java
+++ b/src/main/java/io/reactivex/rxjava3/disposables/DisposableContainer.java
@@ -11,9 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.rxjava3.internal.disposables;
-
-import io.reactivex.rxjava3.disposables.Disposable;
+package io.reactivex.rxjava3.disposables;
 
 /**
  * Common interface to add and remove disposables from a container.
@@ -38,7 +36,7 @@ public interface DisposableContainer {
     boolean remove(Disposable d);
 
     /**
-     * Removes (but does not dispose) the given disposable if it is part of this
+     * Removes but does not dispose the given disposable if it is part of this
      * container.
      * @param d the disposable to remove, not null
      * @return true if the operation was successful

--- a/src/main/java/io/reactivex/rxjava3/internal/disposables/ListCompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/disposables/ListCompositeDisposable.java
@@ -14,7 +14,7 @@ package io.reactivex.rxjava3.internal.disposables;
 
 import java.util.*;
 
-import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.internal.functions.ObjectHelper;
 import io.reactivex.rxjava3.internal.util.ExceptionHelper;

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
@@ -17,7 +17,7 @@ import java.util.concurrent.*;
 
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.Scheduler;
-import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.internal.disposables.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java
@@ -16,8 +16,7 @@ package io.reactivex.rxjava3.internal.schedulers;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.internal.disposables.DisposableContainer;
+import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class ScheduledRunnable extends AtomicReferenceArray<Object>


### PR DESCRIPTION
Make the internal interface `DisposableContainer` public as it can be one safely.

(I've seen some 3rd party usage in custom containers, this will make them now legit on 3.x.)

**Edit**
Also [should resolve](https://travis-ci.org/ReactiveX/RxJava/builds/620175320#L219) the OSGi private reference warning.

Resolves #6742