### PR TITLE
Javadoc cleanup 1203

### DIFF
--- a/src/main/java/io/reactivex/Flowable.java
+++ b/src/main/java/io/reactivex/Flowable.java
@@ -8266,7 +8266,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Single that emits a single item: the number of items emitted by the source Publisher as a
      *         64-bit Long item
      * @see <a href="http://reactivex.io/documentation/operators/count.html">ReactiveX operators documentation: Count</a>
-     * @see #count()
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
@@ -15121,6 +15120,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            Publisher
      * @return a Flowable that emits the items emitted by the Publisher returned from applying {@code func} to the most recently emitted item emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMapDelayError(Function)
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
@@ -15156,6 +15156,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the number of elements to prefetch from the current active inner Publisher
      * @return a Flowable that emits the items emitted by the Publisher returned from applying {@code func} to the most recently emitted item emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMapDelayError(Function, int)
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
@@ -15245,7 +15246,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *               {@link CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
      * @return the new Completable instance
-     * @see #switchMapCompletableDelayError(Function)
+     * @see #switchMapCompletable(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -15283,6 +15284,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            Publisher
      * @return a Flowable that emits the items emitted by the Publisher returned from applying {@code func} to the most recently emitted item emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMap(Function)
      * @since 2.0
      */
     @CheckReturnValue
@@ -15320,6 +15322,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the number of elements to prefetch from the current active inner Publisher
      * @return a Flowable that emits the items emitted by the Publisher returned from applying {@code func} to the most recently emitted item emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMap(Function, int)
      * @since 2.0
      */
     @CheckReturnValue
@@ -15373,6 +15376,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *               and get subscribed to.
      * @return the new Flowable instance
      * @see #switchMapMaybe(Function)
+     * @see #switchMapMaybeDelayError(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -15444,7 +15448,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *               return a {@code SingleSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Flowable instance
-     * @see #switchMapSingle(Function)
+     * @see #switchMapSingleDelayError(Function)
      * @since 2.2
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -7283,7 +7283,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return a Single that emits a single item: the number of items emitted by the source ObservableSource as a
      *         64-bit Long item
      * @see <a href="http://reactivex.io/documentation/operators/count.html">ReactiveX operators documentation: Count</a>
-     * @see #count()
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -12405,6 +12404,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            ObservableSource
      * @return an Observable that emits the items emitted by the ObservableSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMapDelayError(Function)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -12434,6 +12434,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the number of elements to prefetch from the current active inner ObservableSource
      * @return an Observable that emits the items emitted by the ObservableSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMapDelayError(Function, int)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -12524,7 +12525,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *               {@link CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
      * @return the new Completable instance
-     * @see #switchMapCompletableDelayError(Function)
+     * @see #switchMapCompletable(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -12560,7 +12561,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *               return a {@code MaybeSource} to replace the current active inner source
      *               and get subscribed to.
      * @return the new Observable instance
-     * @see #switchMapMaybe(Function)
+     * @see #switchMapMaybeDelayError(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -12616,6 +12617,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            SingleSource
      * @return an Observable that emits the item emitted by the SingleSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMapSingleDelayError(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -12647,6 +12649,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            SingleSource
      * @return an Observable that emits the item emitted by the SingleSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMapSingle(Function)
      * @since 2.2
      */
     @CheckReturnValue
@@ -12678,6 +12681,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            ObservableSource
      * @return an Observable that emits the items emitted by the ObservableSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMap(Function)
      * @since 2.0
      */
     @CheckReturnValue
@@ -12709,6 +12713,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the number of elements to prefetch from the current active inner ObservableSource
      * @return an Observable that emits the items emitted by the ObservableSource returned from applying {@code func} to the most recently emitted item emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #switchMap(Function, int)
      * @since 2.0
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/disposables/ActionDisposable.java
+++ b/src/main/java/io/reactivex/disposables/ActionDisposable.java
@@ -16,6 +16,9 @@ import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Action;
 import io.reactivex.internal.util.ExceptionHelper;
 
+/**
+ * A Disposable container that manages an Action instance.
+ */
 final class ActionDisposable extends ReferenceDisposable<Action> {
 
     private static final long serialVersionUID = -8219729196779211169L;

--- a/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/BlockingFlowableMostRecent.java
@@ -42,10 +42,6 @@ public final class BlockingFlowableMostRecent<T> implements Iterable<T> {
     public Iterator<T> iterator() {
         MostRecentSubscriber<T> mostRecentSubscriber = new MostRecentSubscriber<T>(initialValue);
 
-        /**
-         * Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
-         * since it is for BlockingObservable.
-         */
         source.subscribe(mostRecentSubscriber);
 
         return mostRecentSubscriber.getIterable();

--- a/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableMostRecent.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/BlockingObservableMostRecent.java
@@ -42,10 +42,6 @@ public final class BlockingObservableMostRecent<T> implements Iterable<T> {
     public Iterator<T> iterator() {
         MostRecentObserver<T> mostRecentObserver = new MostRecentObserver<T>(initialValue);
 
-        /**
-         * Subscribe instead of unsafeSubscribe since this is the final subscribe in the chain
-         * since it is for BlockingObservable.
-         */
         source.subscribe(mostRecentObserver);
 
         return mostRecentObserver.getIterable();


### PR DESCRIPTION
This PR is simply a backport of #6729 to the RxJava 2.x branch.
