### PR TITLE
3.x: Change how the cause of CompositeException is generated

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/CompositeException.java
@@ -149,14 +149,17 @@ public final class CompositeException extends RuntimeException {
                             inner = inner.getCause();
                             depth++;
                         } else {
-                            for (int i = 0; i < depth + 2; i++) {
-                                aggregateMessage.append("  ");
+                            inner = inner.getCause();
+                            if (inner != null) {
+                                for (int i = 0; i < depth + 2; i++) {
+                                    aggregateMessage.append("  ");
+                                }
+                                aggregateMessage.append("|-- ");
+                                aggregateMessage.append("(cause not expanded again) ");
+                                aggregateMessage.append(inner.getClass().getCanonicalName()).append(": ");
+                                aggregateMessage.append(inner.getMessage());
+                                aggregateMessage.append(separator);
                             }
-                            aggregateMessage.append("|-- ");
-                            aggregateMessage.append("(cause not expanded again) ");
-                            aggregateMessage.append(inner.getClass().getCanonicalName()).append(": ");
-                            aggregateMessage.append(inner.getMessage());
-                            aggregateMessage.append(separator);
                             break;
                         }
                     }

--- a/src/main/java/io/reactivex/rxjava3/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/CompositeException.java
@@ -106,40 +106,66 @@ public final class CompositeException extends RuntimeException {
     @NonNull
     public synchronized Throwable getCause() { // NOPMD
         if (cause == null) {
-            // we lazily generate this causal chain if this is called
-            CompositeExceptionCausalChain localCause = new CompositeExceptionCausalChain();
-            Set<Throwable> seenCauses = new HashSet<Throwable>();
+            String separator = System.getProperty("line.separator");
+            if (exceptions.size() > 1) {
+                Map<Throwable, Boolean> seenCauses = new IdentityHashMap<Throwable, Boolean>();
 
-            Throwable chain = localCause;
-            for (Throwable e : exceptions) {
-                if (seenCauses.contains(e)) {
-                    // already seen this outer Throwable so skip
-                    continue;
-                }
-                seenCauses.add(e);
+                StringBuilder aggregateMessage = new StringBuilder();
+                aggregateMessage.append("Multiple exceptions (").append(exceptions.size()).append(")").append(separator);
 
-                List<Throwable> listOfCauses = getListOfCauses(e);
-                // check if any of them have been seen before
-                for (Throwable child : listOfCauses) {
-                    if (seenCauses.contains(child)) {
-                        // already seen this outer Throwable so skip
-                        e = new RuntimeException("Duplicate found in causal chain so cropping to prevent loop ...");
-                        continue;
+                for (Throwable inner : exceptions) {
+                    int depth = 0;
+                    while (inner != null) {
+                        for (int i = 0; i < depth; i++) {
+                            aggregateMessage.append("  ");
+                        }
+                        aggregateMessage.append("|-- ");
+                        aggregateMessage.append(inner.getClass().getCanonicalName()).append(": ");
+                        String innerMessage = inner.getMessage();
+                        if (innerMessage != null && innerMessage.contains(separator)) {
+                            aggregateMessage.append(separator);
+                            for (String line : innerMessage.split(separator)) {
+                                for (int i = 0; i < depth + 2; i++) {
+                                    aggregateMessage.append("  ");
+                                }
+                                aggregateMessage.append(line).append(separator);
+                            }
+                        } else {
+                            aggregateMessage.append(innerMessage);
+                            aggregateMessage.append(separator);
+                        }
+
+                        for (int i = 0; i < depth + 2; i++) {
+                            aggregateMessage.append("  ");
+                        }
+                        StackTraceElement[] st = inner.getStackTrace();
+                        if (st.length > 0) {
+                            aggregateMessage.append("at ").append(st[0]).append(separator);
+                        }
+
+                        if (!seenCauses.containsKey(inner)) {
+                            seenCauses.put(inner, true);
+
+                            inner = inner.getCause();
+                            depth++;
+                        } else {
+                            for (int i = 0; i < depth + 2; i++) {
+                                aggregateMessage.append("  ");
+                            }
+                            aggregateMessage.append("|-- ");
+                            aggregateMessage.append("(cause not expanded again) ");
+                            aggregateMessage.append(inner.getClass().getCanonicalName()).append(": ");
+                            aggregateMessage.append(inner.getMessage());
+                            aggregateMessage.append(separator);
+                            break;
+                        }
                     }
-                    seenCauses.add(child);
                 }
 
-                // we now have 'e' as the last in the chain
-                try {
-                    chain.initCause(e);
-                } catch (Throwable t) { // NOPMD
-                    // ignore
-                    // the JavaDocs say that some Throwables (depending on how they're made) will never
-                    // let me call initCause without blowing up even if it returns null
-                }
-                chain = getRootCause(chain);
+                cause = new ExceptionOverview(aggregateMessage.toString().trim());
+            } else {
+                cause = exceptions.get(0);
             }
-            cause = localCause;
         }
         return cause;
     }
@@ -236,31 +262,21 @@ public final class CompositeException extends RuntimeException {
         }
     }
 
-    static final class CompositeExceptionCausalChain extends RuntimeException {
+    /**
+     * Contains a formatted message with a simplified representation of the exception graph
+     * contained within the CompositeException.
+     */
+    static final class ExceptionOverview extends RuntimeException {
+
         private static final long serialVersionUID = 3875212506787802066L;
-        /* package-private */static final String MESSAGE = "Chain of Causes for CompositeException In Order Received =>";
+
+        ExceptionOverview(String message) {
+            super(message);
+        }
 
         @Override
-        public String getMessage() {
-            return MESSAGE;
-        }
-    }
-
-    private List<Throwable> getListOfCauses(Throwable ex) {
-        List<Throwable> list = new ArrayList<Throwable>();
-        Throwable root = ex.getCause();
-        if (root == null || root == ex) {
-            return list;
-        } else {
-            while (true) {
-                list.add(root);
-                Throwable cause = root.getCause();
-                if (cause == null || cause == root) {
-                    return list;
-                } else {
-                    root = cause;
-                }
-            }
+        public synchronized Throwable fillInStackTrace() {
+            return this;
         }
     }
 
@@ -270,25 +286,5 @@ public final class CompositeException extends RuntimeException {
      */
     public int size() {
         return exceptions.size();
-    }
-
-    /**
-     * Returns the root cause of {@code e}. If {@code e.getCause()} returns {@code null} or {@code e}, just return {@code e} itself.
-     *
-     * @param e the {@link Throwable} {@code e}.
-     * @return The root cause of {@code e}. If {@code e.getCause()} returns {@code null} or {@code e}, just return {@code e} itself.
-     */
-    /*private */Throwable getRootCause(Throwable e) {
-        Throwable root = e.getCause();
-        if (root == null || e == root) {
-            return e;
-        }
-        while (true) {
-            Throwable cause = root.getCause();
-            if (cause == null || cause == root) {
-                return root;
-            }
-            root = cause;
-        }
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/exceptions/CompositeExceptionTest.java
@@ -350,7 +350,7 @@ public class CompositeExceptionTest extends RxJavaTest {
         System.err.println(overview);
 
         assertTrue(overview, overview.contains("        Multiple exceptions (2)"));
-        assertTrue(overview, overview.contains("        |- io.reactivex.rxjava3.exceptions.TestException: ex1"));
+        assertTrue(overview, overview.contains("        |-- io.reactivex.rxjava3.exceptions.TestException: ex1"));
         assertTrue(overview, overview.contains("        |-- io.reactivex.rxjava3.exceptions.TestException: ex2"));
     }
 

--- a/src/test/java/io/reactivex/rxjava3/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/exceptions/CompositeExceptionTest.java
@@ -326,7 +326,7 @@ public class CompositeExceptionTest extends RxJavaTest {
         assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex0"));
         assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex1"));
         assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex2"));
-        assertTrue(overview, overview.contains("(cause not expanded again) io.reactivex.rxjava3.exceptions.TestException: ex1"));
+        assertTrue(overview, overview.contains("(cause not expanded again) io.reactivex.rxjava3.exceptions.TestException: ex0"));
         assertEquals(overview, 5, overview.split("at\\s").length);
     }
 
@@ -350,7 +350,7 @@ public class CompositeExceptionTest extends RxJavaTest {
         System.err.println(overview);
 
         assertTrue(overview, overview.contains("        Multiple exceptions (2)"));
-        assertTrue(overview, overview.contains("        |-- io.reactivex.rxjava3.exceptions.TestException: ex1"));
+        assertTrue(overview, overview.contains("        |- io.reactivex.rxjava3.exceptions.TestException: ex1"));
         assertTrue(overview, overview.contains("        |-- io.reactivex.rxjava3.exceptions.TestException: ex2"));
     }
 

--- a/src/test/java/io/reactivex/rxjava3/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/exceptions/CompositeExceptionTest.java
@@ -23,7 +23,6 @@ import java.util.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava3.core.RxJavaTest;
-import io.reactivex.rxjava3.exceptions.CompositeException.CompositeExceptionCausalChain;
 
 public class CompositeExceptionTest extends RxJavaTest {
 
@@ -252,41 +251,6 @@ public class CompositeExceptionTest extends RxJavaTest {
     }
 
     @Test
-    public void complexCauses() {
-        Throwable e1 = new Throwable("1");
-        Throwable e2 = new Throwable("2");
-        e1.initCause(e2);
-
-        Throwable e3 = new Throwable("3");
-        Throwable e4 = new Throwable("4");
-        e3.initCause(e4);
-
-        Throwable e5 = new Throwable("5");
-        Throwable e6 = new Throwable("6");
-        e5.initCause(e6);
-
-        CompositeException compositeException = new CompositeException(e1, e3, e5);
-        assertTrue(compositeException.getCause() instanceof CompositeExceptionCausalChain);
-
-        List<Throwable> causeChain = new ArrayList<Throwable>();
-        Throwable cause = compositeException.getCause().getCause();
-        while (cause != null) {
-            causeChain.add(cause);
-            cause = cause.getCause();
-        }
-        // The original relations
-        //
-        // e1 -> e2
-        // e3 -> e4
-        // e5 -> e6
-        //
-        // will be set to
-        //
-        // e1 -> e2 -> e3 -> e4 -> e5 -> e6
-        assertEquals(Arrays.asList(e1, e2, e3, e4, e5, e6), causeChain);
-    }
-
-    @Test
     public void constructorWithNull() {
         assertTrue(new CompositeException((Throwable[])null).getExceptions().get(0) instanceof NullPointerException);
 
@@ -306,46 +270,6 @@ public class CompositeExceptionTest extends RxJavaTest {
     }
 
     @Test
-    public void cyclicRootCause() {
-        RuntimeException te = new RuntimeException() {
-
-            private static final long serialVersionUID = -8492568224555229753L;
-            Throwable cause;
-
-            @Override
-            public Throwable initCause(Throwable c) {
-                return this;
-            }
-
-            @Override
-            public Throwable getCause() {
-                return cause;
-            }
-        };
-
-        assertSame(te, new CompositeException(te).getCause().getCause());
-
-        assertSame(te, new CompositeException(new RuntimeException(te)).getCause().getCause().getCause());
-    }
-
-    @Test
-    public void nullRootCause() {
-        RuntimeException te = new RuntimeException() {
-
-            private static final long serialVersionUID = -8492568224555229753L;
-
-            @Override
-            public Throwable getCause() {
-                return null;
-            }
-        };
-
-        assertSame(te, new CompositeException(te).getCause().getCause());
-
-        assertSame(te, new CompositeException(new RuntimeException(te)).getCause().getCause().getCause());
-    }
-
-    @Test
     public void badException() {
         Throwable e = new BadException();
         assertSame(e, new CompositeException(e).getCause().getCause());
@@ -353,34 +277,89 @@ public class CompositeExceptionTest extends RxJavaTest {
     }
 
     @Test
-    public void rootCauseEval() {
-        final TestException ex0 = new TestException();
-        Throwable throwable = new Throwable() {
+    public void exceptionOverview() {
+        CompositeException composite = new CompositeException(
+                new TestException("ex1"),
+                new TestException("ex2"),
+                new TestException("ex3", new TestException("ex4"))
+        );
 
-            private static final long serialVersionUID = 3597694032723032281L;
+        String overview = composite.getCause().getMessage();
 
-            @Override
-            public synchronized Throwable getCause() {
-                return ex0;
-            }
-        };
-        CompositeException ex = new CompositeException(throwable);
-        assertSame(ex0, ex.getRootCause(ex));
+        assertTrue(overview, overview.contains("Multiple exceptions (3)"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex1"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex2"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex3"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex4"));
+        assertTrue(overview, overview.contains("at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.exceptionOverview"));
     }
 
     @Test
-    public void rootCauseSelf() {
-        Throwable throwable = new Throwable() {
+    public void causeWithExceptionWithoutStacktrace() {
+        CompositeException composite = new CompositeException(
+                new TestException("ex1"),
+                new CompositeException.ExceptionOverview("example")
+        );
 
-            private static final long serialVersionUID = -4398003222998914415L;
+        String overview = composite.getCause().getMessage();
 
-            @Override
-            public synchronized Throwable getCause() {
-                return this;
-            }
-        };
-        CompositeException tmp = new CompositeException(new TestException());
-        assertSame(throwable, tmp.getRootCause(throwable));
+        assertTrue(overview, overview.contains("Multiple exceptions (2)"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex1"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.CompositeException.ExceptionOverview: example"));
+
+        assertEquals(overview, 2, overview.split("at\\s").length);
+    }
+
+    @Test
+    public void reoccurringException() {
+        TestException ex0 = new TestException("ex0");
+        TestException ex1 = new TestException("ex1", ex0);
+        CompositeException composite = new CompositeException(
+                ex1,
+                new TestException("ex2", ex1)
+        );
+
+        String overview = composite.getCause().getMessage();
+        System.err.println(overview);
+
+        assertTrue(overview, overview.contains("Multiple exceptions (2)"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex0"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex1"));
+        assertTrue(overview, overview.contains("io.reactivex.rxjava3.exceptions.TestException: ex2"));
+        assertTrue(overview, overview.contains("(cause not expanded again) io.reactivex.rxjava3.exceptions.TestException: ex1"));
+        assertEquals(overview, 5, overview.split("at\\s").length);
+    }
+
+    @Test
+    public void nestedMultilineMessage() {
+        TestException ex1 = new TestException("ex1");
+        TestException ex2 = new TestException("ex2");
+        CompositeException composite1 = new CompositeException(
+                ex1,
+                ex2
+        );
+        TestException ex3 = new TestException("ex3");
+        TestException ex4 = new TestException("ex4", composite1);
+
+        CompositeException composite2 = new CompositeException(
+                ex3,
+                ex4
+        );
+
+        String overview = composite2.getCause().getMessage();
+        System.err.println(overview);
+
+        assertTrue(overview, overview.contains("        Multiple exceptions (2)"));
+        assertTrue(overview, overview.contains("        |-- io.reactivex.rxjava3.exceptions.TestException: ex1"));
+        assertTrue(overview, overview.contains("        |-- io.reactivex.rxjava3.exceptions.TestException: ex2"));
+    }
+
+    @Test
+    public void singleExceptionIsTheCause() {
+        TestException ex = new TestException("ex1");
+        CompositeException composite = new CompositeException(ex);
+
+        assertSame(composite.getCause(), ex);
     }
 }
 


### PR DESCRIPTION
This PR changes how `CompositeException.getCause` creates a cause exception on demand. In 1.x and 2.x, the code tried to link up the various inner exceptions via their `initCause`, which was in on itself fishy as well as could lead to excessive memory usage.

Instead, the new code will present the inner exceptions as part of a formatted message, which in theory, should be still picked up by IDE exception listings and allow navigation:

```
Multiple exceptions (2)
|-- io.reactivex.rxjava3.exceptions.TestException: ex3
    at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.nestedMultilineMessage(CompositeExceptionTest.java:341)
|-- io.reactivex.rxjava3.exceptions.TestException: ex4
    at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.nestedMultilineMessage(CompositeExceptionTest.java:342)
  |-- io.reactivex.rxjava3.exceptions.CompositeException: 2 exceptions occurred. 
      at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.nestedMultilineMessage(CompositeExceptionTest.java:337)
    |-- io.reactivex.rxjava3.exceptions.CompositeException.ExceptionOverview: 
        Multiple exceptions (2)
        |-- io.reactivex.rxjava3.exceptions.TestException: ex1
            at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.nestedMultilineMessage(CompositeExceptionTest.java:335)
        |-- io.reactivex.rxjava3.exceptions.TestException: ex2
            at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.nestedMultilineMessage(CompositeExceptionTest.java:336)
```

![image](https://user-images.githubusercontent.com/1269832/70315342-a9308600-1819-11ea-81d2-b56694dbd9e8.png)

There are a few formatting conveniences:
- If there is only one inner exception, the `CompositeException`'s cause will be simply that exception. This can happen when the very same exception is aggregated into the composite and get deduplicated.
- If an inner exception's message is multi-lined, the message and cause traces should be indented properly.
- Reoccurring causes are not expanded over and over:

```
Multiple exceptions (2)
|-- io.reactivex.rxjava3.exceptions.TestException: ex1
    at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.reoccurringException(CompositeExceptionTest.java:316)
  |-- io.reactivex.rxjava3.exceptions.TestException: ex0
      at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.reoccurringException(CompositeExceptionTest.java:315)
|-- io.reactivex.rxjava3.exceptions.TestException: ex2
    at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.reoccurringException(CompositeExceptionTest.java:319)
  |-- io.reactivex.rxjava3.exceptions.TestException: ex1
      at io.reactivex.rxjava3.exceptions.CompositeExceptionTest.reoccurringException(CompositeExceptionTest.java:316)
      |-- (cause not expanded again) io.reactivex.rxjava3.exceptions.TestException: ex0
```

Currently, only the first line of the stacktraces are shown because it can get quite long (and thus memory consuming) to list them all. Maybe a system parameter can be introduced to control the verbosity.

Fixes #6747