### PR TITLE
3.x: Do not update snapshot Javadocs from secondary branches

### DIFF
--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -12,10 +12,15 @@ export GRADLE_OPTS=-Xmx1024m
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew -PreleaseMode=pr build
+  ./gradlew -PreleaseMode=pr build --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
-  echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew -PreleaseMode=branch -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build --stacktrace
+  if [ "$TRAVIS_BRANCH" != "3.x" ]; then
+     echo -e 'Build secondary Branch (no snapshot) => Branch ['$TRAVIS_BRANCH']'
+     ./gradlew -PreleaseMode=pr build --stacktrace
+  else
+     echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
+     ./gradlew -PreleaseMode=branch -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build --stacktrace
+  fi
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   ./gradlew -PreleaseMode=full -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build --stacktrace

--- a/gradle/push_javadoc.sh
+++ b/gradle/push_javadoc.sh
@@ -14,8 +14,8 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
 	exit 0
 fi
 
-# only when on the 3.x branch
-if [ "$TRAVIS_BRANCH" != "3.x" ]; then
+# only when on the 3.x branch and not tagged
+if ["$TRAVIS_BRANCH" != "3.x"] && [ "$TRAVIS_TAG" == "" ]; then
     echo -e "On a secondary branch '$TRAVIS_BRANCH', skipping JavaDocs pushback."
     exit 0
 fi

--- a/gradle/push_javadoc.sh
+++ b/gradle/push_javadoc.sh
@@ -14,6 +14,12 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
 	exit 0
 fi
 
+# only when on the 3.x branch
+if [ "$TRAVIS_BRANCH" != "3.x" ]; then
+    echo -e "On a secondary branch '$TRAVIS_BRANCH', skipping JavaDocs pushback."
+    exit 0
+fi
+
 # get the current build tag if any
 buildTag="$TRAVIS_TAG"
 echo -e "Travis tag: '$buildTag'"

--- a/gradle/push_javadoc.sh
+++ b/gradle/push_javadoc.sh
@@ -15,7 +15,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
 fi
 
 # only when on the 3.x branch and not tagged
-if ["$TRAVIS_BRANCH" != "3.x"] && [ "$TRAVIS_TAG" == "" ]; then
+if [ "$TRAVIS_BRANCH" != "3.x" ] && [ "$TRAVIS_TAG" == "" ]; then
     echo -e "On a secondary branch '$TRAVIS_BRANCH', skipping JavaDocs pushback."
     exit 0
 fi


### PR DESCRIPTION
This PR changes `buildViaTravis.sh` to not publish a snapshot for branches other than `3.x` and `push_javadoc.sh` to not upload the generated javadocs for branches other than `3.x`. 

This will prevent the unnecessary uploads when [Dependabot](https://dependabot.com/) creates a new bump branch.