### PR TITLE
3.x: Fix Observable amb, combineLatest & zip ArrayStoreException

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmb.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmb.java
@@ -36,7 +36,7 @@ public final class ObservableAmb<T> extends Observable<T> {
         ObservableSource<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
-            sources = new Observable[8];
+            sources = new ObservableSource[8];
             try {
                 for (ObservableSource<? extends T> p : sourcesIterable) {
                     if (p == null) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatest.java
@@ -48,7 +48,7 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
         ObservableSource<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
-            sources = new Observable[8];
+            sources = new ObservableSource[8];
             for (ObservableSource<? extends T> p : sourcesIterable) {
                 if (count == sources.length) {
                     ObservableSource<? extends T>[] b = new ObservableSource[count + (count >> 2)];

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZip.java
@@ -50,7 +50,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
         ObservableSource<? extends T>[] sources = this.sources;
         int count = 0;
         if (sources == null) {
-            sources = new Observable[8];
+            sources = new ObservableSource[8];
             for (ObservableSource<? extends T> p : sourcesIterable) {
                 if (count == sources.length) {
                     ObservableSource<? extends T>[] b = new ObservableSource[count + (count >> 2)];

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableAmbTest.java
@@ -315,4 +315,18 @@ public class CompletableAmbTest extends RxJavaTest {
             assertFalse("Interrupted!", interrupted.get());
         }
     }
+
+    @Test
+    public void completableSourcesInIterable() {
+        CompletableSource source = new CompletableSource() {
+            @Override
+            public void subscribe(CompletableObserver observer) {
+                Completable.complete().subscribe(observer);
+            }
+        };
+
+        Completable.amb(Arrays.asList(source, source))
+        .test()
+        .assertResult();
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmbTest.java
@@ -667,4 +667,19 @@ public class FlowableAmbTest extends RxJavaTest {
             assertFalse("Interrupted!", interrupted.get());
         }
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void publishersInIterable() {
+        Publisher<Integer> source = new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                Flowable.just(1).subscribe(subscriber);
+            }
+        };
+
+        Flowable.amb(Arrays.asList(source, source))
+        .test()
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1551,4 +1551,24 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class, 42);
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void publishersInIterable() {
+        Publisher<Integer> source = new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                Flowable.just(1).subscribe(subscriber);
+            }
+        };
+
+        Flowable.combineLatest(Arrays.asList(source, source), new Function<Object[], Integer>() {
+            @Override
+            public Integer apply(Object[] t) throws Throwable {
+                return 2;
+            }
+        })
+        .test()
+        .assertResult(2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
@@ -1896,4 +1896,24 @@ public class FlowableZipTest extends RxJavaTest {
 
         assertEquals(0, counter.get());
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void publishersInIterable() {
+        Publisher<Integer> source = new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                Flowable.just(1).subscribe(subscriber);
+            }
+        };
+
+        Flowable.zip(Arrays.asList(source, source), new Function<Object[], Integer>() {
+            @Override
+            public Integer apply(Object[] t) throws Throwable {
+                return 2;
+            }
+        })
+        .test()
+        .assertResult(2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeAmbTest.java
@@ -254,4 +254,19 @@ public class MaybeAmbTest extends RxJavaTest {
             }
         }
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void maybeSourcesInIterable() {
+        MaybeSource<Integer> source = new MaybeSource<Integer>() {
+            @Override
+            public void subscribe(MaybeObserver<? super Integer> observer) {
+                Maybe.just(1).subscribe(observer);
+            }
+        };
+
+        Maybe.amb(Arrays.asList(source, source))
+        .test()
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterableTest.java
@@ -221,4 +221,24 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The zipper returned a null value");
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void maybeSourcesInIterable() {
+        MaybeSource<Integer> source = new MaybeSource<Integer>() {
+            @Override
+            public void subscribe(MaybeObserver<? super Integer> observer) {
+                Maybe.just(1).subscribe(observer);
+            }
+        };
+
+        Maybe.zip(Arrays.asList(source, source), new Function<Object[], Integer>() {
+            @Override
+            public Integer apply(Object[] t) throws Throwable {
+                return 2;
+            }
+        })
+        .test()
+        .assertResult(2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
@@ -467,4 +467,18 @@ public class ObservableAmbTest extends RxJavaTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void observableSourcesInIterable() {
+        ObservableSource<Integer> source = new ObservableSource<Integer>() {
+            @Override
+            public void subscribe(Observer<? super Integer> observer) {
+                Observable.just(1).subscribe(observer);
+            }
+        };
+
+        Observable.amb(Arrays.asList(source, source))
+        .test()
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
@@ -1212,4 +1212,24 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class, 42);
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void observableSourcesInIterable() {
+        ObservableSource<Integer> source = new ObservableSource<Integer>() {
+            @Override
+            public void subscribe(Observer<? super Integer> observer) {
+                Observable.just(1).subscribe(observer);
+            }
+        };
+
+        Observable.combineLatest(Arrays.asList(source, source), new Function<Object[], Integer>() {
+            @Override
+            public Integer apply(Object[] t) throws Throwable {
+                return 2;
+            }
+        })
+        .test()
+        .assertResult(2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
@@ -1429,4 +1429,24 @@ public class ObservableZipTest extends RxJavaTest {
 
         assertEquals(0, counter.get());
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void observableSourcesInIterable() {
+        ObservableSource<Integer> source = new ObservableSource<Integer>() {
+            @Override
+            public void subscribe(Observer<? super Integer> observer) {
+                Observable.just(1).subscribe(observer);
+            }
+        };
+
+        Observable.zip(Arrays.asList(source, source), new Function<Object[], Integer>() {
+            @Override
+            public Integer apply(Object[] t) throws Throwable {
+                return 2;
+            }
+        })
+        .test()
+        .assertResult(2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleAmbTest.java
@@ -342,4 +342,19 @@ public class SingleAmbTest extends RxJavaTest {
             assertFalse("Interrupted!", interrupted.get());
         }
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void singleSourcesInIterable() {
+        SingleSource<Integer> source = new SingleSource<Integer>() {
+            @Override
+            public void subscribe(SingleObserver<? super Integer> observer) {
+                Single.just(1).subscribe(observer);
+            }
+        };
+
+        Single.amb(Arrays.asList(source, source))
+        .test()
+        .assertResult(1);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipIterableTest.java
@@ -245,4 +245,24 @@ public class SingleZipIterableTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The zipper returned a null value");
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void singleSourcesInIterable() {
+        SingleSource<Integer> source = new SingleSource<Integer>() {
+            @Override
+            public void subscribe(SingleObserver<? super Integer> observer) {
+                Single.just(1).subscribe(observer);
+            }
+        };
+
+        Single.zip(Arrays.asList(source, source), new Function<Object[], Integer>() {
+            @Override
+            public Integer apply(Object[] t) throws Throwable {
+                return 2;
+            }
+        })
+        .test()
+        .assertResult(2);
+    }
 }


### PR DESCRIPTION
When using iterable of sources, the initial array is the wrong type and causes `ArrayStoreException`.

Unit tests were added to verify the other implementations.

Fixes #6753