### PR TITLE
3.x: Fix Observable.window (size & time) cancellation and abandonment

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindow.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindow.java
@@ -92,14 +92,14 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
             long i = index;
 
             UnicastProcessor<T> w = window;
-            WindowSubscribeIntercept<T> intercept = null;
+            FlowableWindowSubscribeIntercept<T> intercept = null;
             if (i == 0) {
                 getAndIncrement();
 
                 w = UnicastProcessor.<T>create(bufferSize, this);
                 window = w;
 
-                intercept = new WindowSubscribeIntercept<T>(w);
+                intercept = new FlowableWindowSubscribeIntercept<T>(w);
                 downstream.onNext(intercept);
             }
 
@@ -211,7 +211,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
         public void onNext(T t) {
             long i = index;
 
-            WindowSubscribeIntercept<T> intercept = null;
+            FlowableWindowSubscribeIntercept<T> intercept = null;
             UnicastProcessor<T> w = window;
             if (i == 0) {
                 getAndIncrement();
@@ -219,7 +219,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
                 w = UnicastProcessor.<T>create(bufferSize, this);
                 window = w;
 
-                intercept = new WindowSubscribeIntercept<T>(w);
+                intercept = new FlowableWindowSubscribeIntercept<T>(w);
                 downstream.onNext(intercept);
             }
 
@@ -477,7 +477,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
                             break;
                         }
 
-                        WindowSubscribeIntercept<T> intercept = new WindowSubscribeIntercept<T>(t);
+                        FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(t);
                         a.onNext(intercept);
 
                         if (intercept.tryAbandon()) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowSubscribeIntercept.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowSubscribeIntercept.java
@@ -25,13 +25,13 @@ import io.reactivex.rxjava3.processors.FlowableProcessor;
  * @param <T> the element type of the flow.
  * @since 3.0.0
  */
-final class WindowSubscribeIntercept<T> extends Flowable<T> {
+final class FlowableWindowSubscribeIntercept<T> extends Flowable<T> {
 
     final FlowableProcessor<T> window;
 
     final AtomicBoolean once;
 
-    WindowSubscribeIntercept(FlowableProcessor<T> source) {
+    FlowableWindowSubscribeIntercept(FlowableProcessor<T> source) {
         this.window = source;
         this.once = new AtomicBoolean();
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowSubscribeIntercept.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowSubscribeIntercept.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.observable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.subjects.Subject;
+
+/**
+ * Wrapper for a Subject that detects an incoming subscriber.
+ * @param <T> the element type of the flow.
+ * @since 3.0.0
+ */
+final class ObservableWindowSubscribeIntercept<T> extends Observable<T> {
+
+    final Subject<T> window;
+
+    final AtomicBoolean once;
+
+    ObservableWindowSubscribeIntercept(Subject<T> source) {
+        this.window = source;
+        this.once = new AtomicBoolean();
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+        window.subscribe(s);
+        once.set(true);
+    }
+
+    boolean tryAbandon() {
+        return !once.get() && once.compareAndSet(false, true);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -949,4 +949,154 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         assertFalse("The doOnNext got interrupted!", isInterrupted.get());
     }
+
+    @Test
+    public void cancellingWindowCancelsUpstreamExactTime() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps.window(10, TimeUnit.MINUTES)
+        .take(1)
+        .flatMap(new Function<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> w) throws Throwable {
+                return w.take(1);
+            }
+        })
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        to
+        .assertResult(1);
+
+        assertFalse("Subject still has subscribers!", ps.hasObservers());
+    }
+
+    @Test
+    public void windowAbandonmentCancelsUpstreamExactTime() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+
+        TestObserver<Observable<Integer>> to = ps.window(10, TimeUnit.MINUTES)
+        .take(1)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            @Override
+            public void accept(Observable<Integer> v) throws Throwable {
+                inner.set(v);
+            }
+        })
+        .test();
+
+        assertFalse("Subject still has subscribers!", ps.hasObservers());
+
+        to
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        inner.get().test().assertResult();
+    }
+
+    @Test
+    public void cancellingWindowCancelsUpstreamExactTimeAndSize() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps.window(10, TimeUnit.MINUTES, 100)
+        .take(1)
+        .flatMap(new Function<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> w) throws Throwable {
+                return w.take(1);
+            }
+        })
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        to
+        .assertResult(1);
+
+        assertFalse("Subject still has subscribers!", ps.hasObservers());
+    }
+
+    @Test
+    public void windowAbandonmentCancelsUpstreamExactTimeAndSize() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+
+        TestObserver<Observable<Integer>> to = ps.window(10, TimeUnit.MINUTES, 100)
+        .take(1)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            @Override
+            public void accept(Observable<Integer> v) throws Throwable {
+                inner.set(v);
+            }
+        })
+        .test();
+
+        assertFalse("Subject still has subscribers!", ps.hasObservers());
+
+        to
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        inner.get().test().assertResult();
+    }
+
+    @Test
+    public void cancellingWindowCancelsUpstreamExactTimeSkip() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps.window(10, 15, TimeUnit.MINUTES)
+        .take(1)
+        .flatMap(new Function<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> w) throws Throwable {
+                return w.take(1);
+            }
+        })
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        to
+        .assertResult(1);
+
+        assertFalse("Subject still has subscribers!", ps.hasObservers());
+    }
+
+    @Test
+    public void windowAbandonmentCancelsUpstreamExactTimeSkip() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+
+        TestObserver<Observable<Integer>> to = ps.window(10, 15, TimeUnit.MINUTES)
+        .take(1)
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            @Override
+            public void accept(Observable<Integer> v) throws Throwable {
+                inner.set(v);
+            }
+        })
+        .test();
+
+        assertFalse("Subject still has subscribers!", ps.hasObservers());
+
+        to
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertComplete();
+
+        inner.get().test().assertResult();
+    }
 }


### PR DESCRIPTION
This PR fixes the `Observable.window` operator (with size and time boundaries) so that

- cancelling the inner windows allows cancelling the upstream once neither the main output nor other windows are being consumed further,
- ignoring a window still allows cancelling the upstream.

Follow-up to #6758 

The boundary and start-stop publisher boundarywill be updated in subsequent PRs.

In addition, the previous `WindowSubscribeIntercept` has been renamed to match the reactive type naming as well as removed the unnecessary serialization of the emission of window processors.