### PR TITLE
3.x: Fix window (boundary, start/end) cancel and abandonment

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -17965,6 +17965,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Publisher.
      * <p>
      * <img width="640" height="475" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window8.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The outer Publisher of this operator does not support backpressure as it uses a {@code boundary} Publisher to control data
@@ -17995,6 +18000,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Publisher.
      * <p>
      * <img width="640" height="475" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window8.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The outer Publisher of this operator does not support backpressure as it uses a {@code boundary} Publisher to control data
@@ -18031,6 +18041,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code closingSelector} emits an item.
      * <p>
      * <img width="640" height="550" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window2.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The outer Publisher of this operator doesn't support backpressure because the emission of new
@@ -18068,6 +18083,11 @@ public abstract class Flowable<T> implements Publisher<T> {
      * {@code closingSelector} emits an item.
      * <p>
      * <img width="640" height="550" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window2.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The outer Publisher of this operator doesn't support backpressure because the emission of new

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -14536,6 +14536,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window7.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -14564,6 +14569,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window7.s.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -14594,6 +14604,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window7.s.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -14630,6 +14645,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * ObservableSource emits the current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="375" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window5.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -14658,6 +14678,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * emits the current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window6.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -14690,6 +14715,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * emits the current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window6.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -14723,6 +14753,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * ObservableSource emits the current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="375" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window5.s.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -14754,6 +14789,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window6.s.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -14788,6 +14828,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window6.s.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -14824,6 +14869,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * current window and propagates the notification from the source ObservableSource.
      * <p>
      * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window6.s.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -14865,6 +14915,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * ObservableSource.
      * <p>
      * <img width="640" height="475" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window8.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -14891,6 +14946,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * ObservableSource.
      * <p>
      * <img width="640" height="475" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window8.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -14922,6 +14982,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code closingIndicator} emits an item.
      * <p>
      * <img width="640" height="550" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window2.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -14953,6 +15018,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * {@code closingIndicator} emits an item.
      * <p>
      * <img width="640" height="550" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/window2.png" alt="">
+     * <p>
+     * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
+     * so-called window abandonment where a window may not contain any elements. In this case, subsequent
+     * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
+     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundary.java
@@ -240,7 +240,11 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
 
                         if (emitted != requested.get()) {
                             emitted++;
-                            downstream.onNext(w);
+                            FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(w);
+                            downstream.onNext(intercept);
+                            if (intercept.tryAbandon()) {
+                                w.onComplete();
+                            }
                         } else {
                             SubscriptionHelper.cancel(upstream);
                             boundarySubscriber.dispose();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundary.java
@@ -230,7 +230,11 @@ public final class ObservableWindowBoundary<T, B> extends AbstractObservableWith
                         window = w;
                         windows.getAndIncrement();
 
-                        downstream.onNext(w);
+                        ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<T>(w);
+                        downstream.onNext(intercept);
+                        if (intercept.tryAbandon()) {
+                            w.onComplete();
+                        }
                     }
                 }
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -28,7 +28,7 @@ import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.exceptions.*;
-import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.observers.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
@@ -378,6 +378,12 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
                     ref.set(observer);
                 }
             })
+            .doOnNext(new Consumer<Observable<Object>>() {
+                @Override
+                public void accept(Observable<Object> w) throws Throwable {
+                    w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
+                }
+            })
             .to(TestHelper.<Observable<Object>>testConsumer());
 
             to
@@ -635,5 +641,66 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
             TestHelper.race(r1, r2);
         }
+    }
+
+    @Test
+    public void cancellingWindowCancelsUpstream() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps.window(Observable.<Integer>never())
+        .take(1)
+        .flatMap(new Function<Observable<Integer>, Observable<Integer>>() {
+            @Override
+            public Observable<Integer> apply(Observable<Integer> w) throws Throwable {
+                return w.take(1);
+            }
+        })
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        to
+        .assertResult(1);
+
+        assertFalse("Subject still has observers!", ps.hasObservers());
+    }
+
+    @Test
+    public void windowAbandonmentCancelsUpstream() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+
+        TestObserver<Observable<Integer>> to = ps.window(Observable.<Integer>never())
+        .doOnNext(new Consumer<Observable<Integer>>() {
+            @Override
+            public void accept(Observable<Integer> v) throws Throwable {
+                inner.set(v);
+            }
+        })
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        to
+        .assertValueCount(1)
+        ;
+
+        ps.onNext(1);
+
+        assertTrue(ps.hasObservers());
+
+        to.dispose();
+
+        to
+        .assertValueCount(1)
+        .assertNoErrors()
+        .assertNotComplete();
+
+        assertFalse("Subject still has observers!", ps.hasObservers());
+
+        inner.get().test().assertResult();
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -398,7 +398,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         to
         .assertResult(1);
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
     }
 
     @Test
@@ -426,7 +426,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
 
         inner.get().test().assertResult(1);
     }
@@ -452,7 +452,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         to
         .assertResult(1);
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
     }
 
     @Test
@@ -480,7 +480,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
 
         inner.get().test().assertResult(1);
     }
@@ -506,7 +506,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         to
         .assertResult(1);
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
     }
 
     @Test
@@ -534,7 +534,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
 
         inner.get().test().assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -971,7 +971,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         to
         .assertResult(1);
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
     }
 
     @Test
@@ -990,7 +990,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         })
         .test();
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
 
         to
         .assertValueCount(1)
@@ -1021,7 +1021,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         to
         .assertResult(1);
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
     }
 
     @Test
@@ -1040,7 +1040,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         })
         .test();
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
 
         to
         .assertValueCount(1)
@@ -1071,7 +1071,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         to
         .assertResult(1);
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
     }
 
     @Test
@@ -1090,7 +1090,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         })
         .test();
 
-        assertFalse("Subject still has subscribers!", ps.hasObservers());
+        assertFalse("Subject still has observers!", ps.hasObservers());
 
         to
         .assertValueCount(1)


### PR DESCRIPTION
This PR fixes the `window` operator (with boundary and start-end sources) so that

- cancelling the inner windows allows cancelling the upstream once neither the main output nor other windows are being consumed further,
- ignoring a window still allows cancelling the upstream.

Follow-up to #6758 and #6761