### PR TITLE
3.x: [Java 8] Upgrade to Java 8, add Flowable.fromX operators

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,15 +66,15 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: "com.jfrog.artifactory"
 apply plugin: "eclipse"
 
-sourceCompatibility = JavaVersion.VERSION_1_6
-targetCompatibility = JavaVersion.VERSION_1_6
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
   mavenCentral()
 }
 
 dependencies {
-    signature "org.codehaus.mojo.signature:java16:1.1@signature"
+    signature "org.codehaus.mojo.signature:java18:1.0@signature"
 
     api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
     jmh "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
@@ -103,14 +103,9 @@ javadoc {
     options.stylesheetFile = new File(projectDir, "gradle/stylesheet.css");
 
     options.links(
-        "https://docs.oracle.com/javase/7/docs/api/",
+        "https://docs.oracle.com/javase/8/docs/api/",
         "http://www.reactive-streams.org/reactive-streams-${reactiveStreamsVersion}-javadoc/"
     )
-
-    if (JavaVersion.current().isJava7()) {
-        // "./gradle/stylesheet.css" only supports Java 7
-        options.addStringOption("stylesheetfile", rootProject.file("./gradle/stylesheet.css").toString())
-    }
 }
 
 animalsniffer {

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -18651,6 +18651,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T> Flowable<T> fromOptional(@NonNull Optional<T> optional) {
         ObjectHelper.requireNonNull(optional, "optional is null");
         return optional.map(Flowable::just).orElseGet(Flowable::empty);
@@ -18687,6 +18688,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T> Flowable<T> fromCompletionStage(@NonNull CompletionStage<T> stage) {
         ObjectHelper.requireNonNull(stage, "stage is null");
         return RxJavaPlugins.onAssembly(new FlowableFromCompletionStage<>(stage));
@@ -18732,6 +18734,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T> Flowable<T> fromStream(@NonNull Stream<T> stream) {
         ObjectHelper.requireNonNull(stream, "stream is null");
         return RxJavaPlugins.onAssembly(new FlowableFromStream<>(stream));

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -14,6 +14,7 @@ package io.reactivex.rxjava3.core;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 import org.reactivestreams.*;
 
@@ -24,6 +25,7 @@ import io.reactivex.rxjava3.flowables.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.*;
 import io.reactivex.rxjava3.internal.fuseable.ScalarSupplier;
+import io.reactivex.rxjava3.internal.jdk8.*;
 import io.reactivex.rxjava3.internal.operators.flowable.*;
 import io.reactivex.rxjava3.internal.operators.mixed.*;
 import io.reactivex.rxjava3.internal.operators.observable.ObservableFromPublisher;
@@ -211,6 +213,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T> Flowable<T> ambArray(Publisher<? extends T>... sources) {
         ObjectHelper.requireNonNull(sources, "sources is null");
         int len = sources.length;
@@ -1224,7 +1227,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1261,7 +1263,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1303,7 +1304,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1341,6 +1341,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T> Flowable<T> concatArray(Publisher<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
@@ -1373,6 +1374,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T> Flowable<T> concatArrayDelayError(Publisher<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
@@ -1408,6 +1410,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T> Flowable<T> concatArrayEager(Publisher<? extends T>... sources) {
         return concatArrayEager(bufferSize(), bufferSize(), sources);
     }
@@ -1475,6 +1478,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
+    @SafeVarargs
     public static <T> Flowable<T> concatArrayEagerDelayError(Publisher<? extends T>... sources) {
         return concatArrayEagerDelayError(bufferSize(), bufferSize(), sources);
     }
@@ -1914,6 +1918,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T> Flowable<T> fromArray(T... items) {
         ObjectHelper.requireNonNull(items, "items is null");
         if (items.length == 0) {
@@ -1977,6 +1982,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * <em>Important note:</em> This Publisher is blocking on the thread it gets subscribed on; you cannot cancel it.
      * <p>
+     * Also note that this operator will consume a {@link CompletionStage}-based {@code Future} subclass (such as
+     * {@link CompletableFuture}) in a blocking manner as well. Use the {@link #fromCompletionStage(CompletionStage)}
+     * operator to convert and consume such sources in a non-blocking fashion instead.
+     * <p>
      * Unlike 1.x, canceling the Flowable won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <dl>
@@ -1993,6 +2002,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the resulting Publisher
      * @return a Flowable that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
+     * @see #fromCompletionStage(CompletionStage)
      */
     @CheckReturnValue
     @NonNull
@@ -2016,6 +2026,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <p>
      * <em>Important note:</em> This Publisher is blocking on the thread it gets subscribed on; you cannot cancel it.
+     * <p>
+     * Also note that this operator will consume a {@link CompletionStage}-based {@code Future} subclass (such as
+     * {@link CompletableFuture}) in a blocking manner as well. Use the {@link #fromCompletionStage(CompletionStage)}
+     * operator to convert and consume such sources in a non-blocking fashion instead.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -2034,6 +2048,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the resulting Publisher
      * @return a Flowable that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
+     * @see #fromCompletionStage(CompletionStage)
      */
     @CheckReturnValue
     @NonNull
@@ -2058,6 +2073,10 @@ public abstract class Flowable<T> implements Publisher<T> {
      * cancellation effect: {@code futurePublisher.doOnCancel(() -> future.cancel(true));}.
      * <p>
      * <em>Important note:</em> This Publisher is blocking; you cannot cancel it.
+     * <p>
+     * Also note that this operator will consume a {@link CompletionStage}-based {@code Future} subclass (such as
+     * {@link CompletableFuture}) in a blocking manner as well. Use the {@link #fromCompletionStage(CompletionStage)}
+     * operator to convert and consume such sources in a non-blocking fashion instead.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -2079,8 +2098,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            the resulting Publisher
      * @return a Flowable that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
+     * @see #fromCompletionStage(CompletionStage)
      */
-    @SuppressWarnings({ "unchecked", "cast" })
+    @SuppressWarnings({ "unchecked" })
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2119,7 +2139,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the item from the source {@link Future}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
-    @SuppressWarnings({ "cast", "unchecked" })
+    @SuppressWarnings({ "unchecked" })
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2148,6 +2168,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *            resulting Publisher
      * @return a Flowable that emits each item in the source {@link Iterable} sequence
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
+     * @see #fromStream(Stream)
      */
     @CheckReturnValue
     @NonNull
@@ -2656,7 +2677,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2690,7 +2710,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2727,7 +2746,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2767,7 +2785,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2810,7 +2827,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2856,7 +2872,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2905,7 +2920,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2957,7 +2971,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -3012,7 +3025,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -4655,7 +4667,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -4717,7 +4728,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -4780,7 +4790,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -4845,7 +4854,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -4914,7 +4922,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -4988,7 +4995,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -5065,7 +5071,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -5146,7 +5151,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -5232,7 +5236,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -5322,7 +5325,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -5398,6 +5400,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T, R> Flowable<R> zipArray(Function<? super Object[], ? extends R> zipper,
             boolean delayError, int bufferSize, Publisher<? extends T>... sources) {
         if (sources.length == 0) {
@@ -5460,7 +5463,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         emitted an item or sent a termination notification
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX operators documentation: Amb</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -14548,7 +14550,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see #startWithItem(Object)
      * @since 3.0.0
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -14576,7 +14577,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      *         emitted by the source Publisher
      * @see <a href="http://reactivex.io/documentation/operators/startwith.html">ReactiveX operators documentation: StartWith</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -14609,7 +14609,6 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see #startWithIterable(Iterable)
      * @since 3.0.0
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
@@ -18620,4 +18619,121 @@ public abstract class Flowable<T> implements Publisher<T> {
         return ts;
     }
 
+    // -------------------------------------------------------------------------
+    // JDK 8 Support
+    // -------------------------------------------------------------------------
+
+    /**
+     * Converts the existing value of the provided optional into a {@link #just(Object)}
+     * or an empty optional into an {@link #empty()} {@code Flowable} instance.
+     * <p>
+     * <img width="640" height="335" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromOptional.f.png" alt="">
+     * <p>
+     * Note that the operator takes an already instantiated optional reference and does not
+     * by any means create this original optional. If the optional is to be created per
+     * consumer upon subscription, use {@link #defer(Supplier)} around {@code fromOptional}:
+     * <pre><code>
+     * Flowable.defer(() -&gt; Flowable.fromOptional(createOptional()));
+     * </code></pre>
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} supports backpressure.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromOptional} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the element type of the optional value
+     * @param optional the optional value to convert into a {@code Flowable}
+     * @return the new Flowable instance
+     * @see #just(Object)
+     * @see #empty()
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> fromOptional(@NonNull Optional<T> optional) {
+        ObjectHelper.requireNonNull(optional, "optional is null");
+        return optional.map(Flowable::just).orElseGet(Flowable::empty);
+    }
+
+    /**
+     * Signals the completion value or error of the given (hot) {@link CompletionStage}-based asynchronous calculation.
+     * <p>
+     * <img width="640" height="262" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromCompletionStage.f.png" alt="">
+     * <p>
+     * Note that the operator takes an already instantiated, running or terminated {@code CompletionStage}.
+     * If the optional is to be created per consumer upon subscription, use {@link #defer(Supplier)}
+     * around {@code fromCompletionStage}:
+     * <pre><code>
+     * Flowable.defer(() -&gt; Flowable.fromCompletionStage(createCompletionStage()));
+     * </code></pre>
+     * <p>
+     * If the {@code CompletionStage} completes with {@code null}, a {@link NullPointerException} is signaled.
+     * <p>
+     * Canceling the flow can't cancel the execution of the {@code CompletionStage} because {@code CompletionStage}
+     * itself doesn't support cancellation. Instead, the operator detaches from the {@code CompletionStage}.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} supports backpressure and caches the completion value until the
+     *  downstream is ready to receive it.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromCompletionStage} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the element type of the CompletionStage
+     * @param stage the CompletionStage to convert to Flowable and signal its terminal value or error
+     * @return the new Flowable instance
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> fromCompletionStage(@NonNull CompletionStage<T> stage) {
+        ObjectHelper.requireNonNull(stage, "stage is null");
+        return RxJavaPlugins.onAssembly(new FlowableFromCompletionStage<>(stage));
+    }
+
+    /**
+     * Converts a {@link Stream} into a finite {@code Flowable} and emits its items in the sequence.
+     * <p>
+     * <img width="640" height="347" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromStream.f.png" alt="">
+     * <p>
+     * The operator closes the {@code Stream} upon cancellation and when it terminates. Exceptions raised when
+     * closing a {@code Stream} are routed to the global error handler ({@link RxJavaPlugins#onError(Throwable)}.
+     * If a {@code Stream} should not be closed, turn it into an {@link Iterable} and use {@link #fromIterable(Iterable)}:
+     * <pre><code>
+     * Stream&lt;T&gt; stream = ...
+     * Flowable.fromIterable(stream::iterator);
+     * </code></pre>
+     * <p>
+     * Note that {@code Stream}s can be consumed only once; any subsequent attempt to consume a {@code Stream}
+     * will result in an {@link IllegalStateException}.
+     * <p>
+     * Primitive streams are not supported and items have to be boxed manually (e.g., via {@link IntStream#boxed()}):
+     * <pre><code>
+     * IntStream intStream = IntStream.rangeClosed(1, 10);
+     * Flowable.fromStream(intStream.boxed());
+     * </code></pre>
+     * <p>
+     * {@code Stream} does not support concurrent usage so creating and/or consuming the same instance multiple times
+     * from multiple threads can lead to undefined behavior.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream and iterates the given {@code Stream}
+     *  on demand (i.e., when requested).</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code fromStream} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the element type of the source {@code Stream}
+     * @param stream the {@code Stream} of values to emit
+     * @return the new Flowable instance
+     * @since 3.0.0
+     * @see #fromIterable(Iterable)
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> fromStream(@NonNull Stream<T> stream) {
+        ObjectHelper.requireNonNull(stream, "stream is null");
+        return RxJavaPlugins.onAssembly(new FlowableFromStream<>(stream));
+    }
 }

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -18652,7 +18652,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <T> Flowable<T> fromOptional(@NonNull Optional<T> optional) {
+    public static <T> Flowable<@NonNull T> fromOptional(@NonNull Optional<T> optional) {
         ObjectHelper.requireNonNull(optional, "optional is null");
         return optional.map(Flowable::just).orElseGet(Flowable::empty);
     }
@@ -18689,7 +18689,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <T> Flowable<T> fromCompletionStage(@NonNull CompletionStage<T> stage) {
+    public static <T> Flowable<@NonNull T> fromCompletionStage(@NonNull CompletionStage<T> stage) {
         ObjectHelper.requireNonNull(stage, "stage is null");
         return RxJavaPlugins.onAssembly(new FlowableFromCompletionStage<>(stage));
     }
@@ -18735,7 +18735,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <T> Flowable<T> fromStream(@NonNull Stream<T> stream) {
+    public static <T> Flowable<@NonNull T> fromStream(@NonNull Stream<T> stream) {
         ObjectHelper.requireNonNull(stream, "stream is null");
         return RxJavaPlugins.onAssembly(new FlowableFromStream<>(stream));
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromCompletionStage.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.internal.subscriptions.DeferredScalarSubscription;
+
+/**
+ * Wrap a CompletionStage and signal its outcome.
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class FlowableFromCompletionStage<T> extends Flowable<T> {
+
+    final CompletionStage<T> stage;
+
+    public FlowableFromCompletionStage(CompletionStage<T> stage) {
+        this.stage = stage;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        // We need an indirection because one can't detach from a whenComplete
+        // and cancellation should not hold onto the stage.
+        BiConsumerAtomicReference<T> whenReference = new BiConsumerAtomicReference<>();
+        CompletionStageHandler<T> handler = new CompletionStageHandler<>(s, whenReference);
+        whenReference.lazySet(handler);
+
+        s.onSubscribe(handler);
+        stage.whenComplete(whenReference);
+    }
+
+    static final class CompletionStageHandler<T>
+    extends DeferredScalarSubscription<T>
+    implements BiConsumer<T, Throwable> {
+
+        private static final long serialVersionUID = 4665335664328839859L;
+
+        final BiConsumerAtomicReference<T> whenReference;
+
+        CompletionStageHandler(Subscriber<? super T> downstream, BiConsumerAtomicReference<T> whenReference) {
+            super(downstream);
+            this.whenReference = whenReference;
+        }
+
+        @Override
+        public void accept(T item, Throwable error) {
+            if (error != null) {
+                downstream.onError(error);
+            }
+            else if (item != null) {
+                complete(item);
+            } else {
+                downstream.onError(new NullPointerException("The CompletionStage terminated with null."));
+            }
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            whenReference.set(null);
+        }
+    }
+
+    static final class BiConsumerAtomicReference<T> extends AtomicReference<BiConsumer<T, Throwable>>
+    implements BiConsumer<T, Throwable> {
+
+        private static final long serialVersionUID = 45838553147237545L;
+
+        @Override
+        public void accept(T t, Throwable u) {
+            BiConsumer<T, Throwable> biConsumer = get();
+            if (biConsumer != null) {
+                biConsumer.accept(t, u);
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromStream.java
@@ -1,0 +1,299 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.internal.subscriptions.*;
+import io.reactivex.rxjava3.internal.util.BackpressureHelper;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Wraps a {@link Stream} and emits its values as a Flowable sequence.
+ * @param <T> the element type of the Stream
+ * @since 3.0.0
+ */
+public final class FlowableFromStream<T> extends Flowable<T> {
+
+    final Stream<T> stream;
+
+    public FlowableFromStream(Stream<T> stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        Iterator<T> iterator;
+        try {
+            iterator = stream.iterator();
+
+            if (!iterator.hasNext()) {
+                EmptySubscription.complete(s);
+                closeSafely(stream);
+                return;
+            }
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptySubscription.error(ex, s);
+            closeSafely(stream);
+            return;
+        }
+
+        if (s instanceof ConditionalSubscriber) {
+            s.onSubscribe(new StreamConditionalSubscription<T>((ConditionalSubscriber<? super T>)s, iterator, stream));
+        } else {
+            s.onSubscribe(new StreamSubscription<>(s, iterator, stream));
+        }
+    }
+
+    static void closeSafely(AutoCloseable c) {
+        try {
+            c.close();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    }
+
+    abstract static class AbstractStreamSubscription<T> extends AtomicLong implements QueueSubscription<T> {
+
+        private static final long serialVersionUID = -9082954702547571853L;
+
+        Iterator<T> iterator;
+
+        AutoCloseable closeable;
+
+        volatile boolean cancelled;
+
+        boolean once;
+
+        AbstractStreamSubscription(Iterator<T> iterator, AutoCloseable closeable) {
+            this.iterator = iterator;
+            this.closeable = closeable;
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                if (BackpressureHelper.add(this, n) == 0L) {
+                    run(n);
+                }
+            }
+        }
+
+        abstract void run(long n);
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            request(1L);
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            if ((mode & SYNC) != 0) {
+                lazySet(Long.MAX_VALUE);
+                return SYNC;
+            }
+            return NONE;
+        }
+
+        @Override
+        public boolean offer(@NonNull T value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean offer(@NonNull T v1, @NonNull T v2) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nullable
+        @Override
+        public T poll() {
+            if (iterator == null) {
+                return null;
+            }
+            if (!once) {
+                once = true;
+            } else {
+                if (!iterator.hasNext()) {
+                    return null;
+                }
+            }
+            return ObjectHelper.requireNonNull(iterator.next(), "Iterator.next() returned a null value");
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return iterator == null || !iterator.hasNext();
+        }
+
+        @Override
+        public void clear() {
+            iterator = null;
+            AutoCloseable c = closeable;
+            closeable = null;
+            if (c != null) {
+                closeSafely(c);
+            }
+        }
+    }
+
+    static final class StreamSubscription<T> extends AbstractStreamSubscription<T> {
+
+        private static final long serialVersionUID = -9082954702547571853L;
+
+        final Subscriber<? super T> downstream;
+
+        StreamSubscription(Subscriber<? super T> downstream, Iterator<T> iterator, AutoCloseable closeable) {
+            super(iterator, closeable);
+            this.downstream = downstream;
+        }
+
+        @Override
+        public void run(long n) {
+            long emitted = 0L;
+            Iterator<T> iterator = this.iterator;
+            Subscriber<? super T> downstream = this.downstream;
+
+            for (;;) {
+
+                if (cancelled) {
+                    clear();
+                    break;
+                } else {
+                    T next;
+                    try {
+                        next = ObjectHelper.requireNonNull(iterator.next(), "The Stream's Iterator returned a null value");
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        downstream.onError(ex);
+                        cancelled = true;
+                        continue;
+                    }
+
+                    downstream.onNext(next);
+
+                    if (cancelled) {
+                        continue;
+                    }
+
+                    try {
+                        if (!iterator.hasNext()) {
+                            downstream.onComplete();
+                            cancelled = true;
+                            continue;
+                        }
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        downstream.onError(ex);
+                        cancelled = true;
+                        continue;
+                    }
+
+                    if (++emitted != n) {
+                        continue;
+                    }
+                }
+
+                n = get();
+                if (emitted == n) {
+                    if (compareAndSet(n, 0L)) {
+                        break;
+                    }
+                    n = get();
+                }
+            }
+        }
+    }
+
+    static final class StreamConditionalSubscription<T> extends AbstractStreamSubscription<T> {
+
+        private static final long serialVersionUID = -9082954702547571853L;
+
+        final ConditionalSubscriber<? super T> downstream;
+
+        StreamConditionalSubscription(ConditionalSubscriber<? super T> downstream, Iterator<T> iterator, AutoCloseable closeable) {
+            super(iterator, closeable);
+            this.downstream = downstream;
+        }
+
+        @Override
+        public void run(long n) {
+            long emitted = 0L;
+            Iterator<T> iterator = this.iterator;
+            ConditionalSubscriber<? super T> downstream = this.downstream;
+
+            for (;;) {
+
+                if (cancelled) {
+                    clear();
+                    break;
+                } else {
+                    T next;
+                    try {
+                        next = ObjectHelper.requireNonNull(iterator.next(), "The Stream's Iterator returned a null value");
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        downstream.onError(ex);
+                        cancelled = true;
+                        continue;
+                    }
+
+                    if (downstream.tryOnNext(next)) {
+                        emitted++;
+                    }
+
+                    if (cancelled) {
+                        continue;
+                    }
+
+                    try {
+                        if (!iterator.hasNext()) {
+                            downstream.onComplete();
+                            cancelled = true;
+                            continue;
+                        }
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        downstream.onError(ex);
+                        cancelled = true;
+                        continue;
+                    }
+
+                    if (emitted != n) {
+                        continue;
+                    }
+                }
+
+                n = get();
+                if (emitted == n) {
+                    if (compareAndSet(n, 0L)) {
+                        break;
+                    }
+                    n = get();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
@@ -228,7 +228,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @param errorClass the error class to expect
      * @return this
      */
-    @SuppressWarnings({ "unchecked", "rawtypes", "cast" })
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public final U assertError(Class<? extends Throwable> errorClass) {
         return (U)assertError((Predicate)Functions.isInstanceOf(errorClass));
     }
@@ -435,6 +435,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @return this
      * @since 2.2
      */
+    @SafeVarargs
     public final U assertValuesOnly(T... values) {
         return assertSubscribed()
                 .assertValues(values)
@@ -493,6 +494,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @return this
      * @see #assertFailure(Class, Object...)
      */
+    @SafeVarargs
     public final U assertResult(T... values) {
         return assertSubscribed()
                 .assertValues(values)
@@ -507,6 +509,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @param values the expected values, asserted in order
      * @return this
      */
+    @SafeVarargs
     public final U assertFailure(Class<? extends Throwable> error, T... values) {
         return assertSubscribed()
                 .assertValues(values)

--- a/src/test/java/io/reactivex/rxjava3/flowable/Burst.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/Burst.java
@@ -52,11 +52,11 @@ public final class Burst<T> extends Flowable<T> {
 
     }
 
-    @SuppressWarnings("unchecked")
     public static <T> Builder<T> item(T item) {
         return items(item);
     }
 
+    @SafeVarargs
     public static <T> Builder<T> items(T... items) {
         return new Builder<T>(Arrays.asList(items));
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromCompletionStageTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+
+public class FlowableFromCompletionStageTest extends RxJavaTest {
+
+    @Test
+    public void syncSuccess() {
+        Flowable.fromCompletionStage(CompletableFuture.completedFuture(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void syncFailure() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+        cf.completeExceptionally(new TestException());
+
+        Flowable.fromCompletionStage(cf)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void syncNull() {
+        Flowable.fromCompletionStage(CompletableFuture.<Integer>completedFuture(null))
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void cancel() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+
+        TestSubscriber<Integer> ts = Flowable.fromCompletionStage(cf)
+        .test();
+
+        ts.assertEmpty();
+
+        ts.cancel();
+
+        cf.complete(1);
+
+        ts.assertEmpty();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromOptionalTest.java
@@ -11,18 +11,28 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.rxjava3.annotations;
+package io.reactivex.rxjava3.internal.jdk8;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import java.util.Optional;
 
-import java.lang.annotation.*;
+import org.junit.Test;
 
-/**
- * Indicates that a field/parameter/variable/type parameter/return type is never null.
- */
-@Documented
-@Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE, TYPE_PARAMETER, TYPE_USE})
-@Retention(value = CLASS)
-public @interface NonNull { }
+import io.reactivex.rxjava3.core.*;
 
+public class FlowableFromOptionalTest extends RxJavaTest {
+
+    @Test
+    public void hasValue() {
+        Flowable.fromOptional(Optional.of(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void empty() {
+        Flowable.fromOptional(Optional.empty())
+        .test()
+        .assertResult();
+    }
+
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromStreamTest.java
@@ -1,0 +1,515 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.stream.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.testsupport.*;
+
+public class FlowableFromStreamTest extends RxJavaTest {
+
+    @Test
+    public void empty() {
+        Flowable.fromStream(Stream.<Integer>of())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void just() {
+        Flowable.fromStream(Stream.<Integer>of(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void many() {
+        Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void manyBackpressured() {
+        Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
+        .test(0L)
+        .assertEmpty()
+        .requestMore(1)
+        .assertValuesOnly(1)
+        .requestMore(2)
+        .assertValuesOnly(1, 2, 3)
+        .requestMore(2)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void noReuse() {
+        Flowable<Integer> source = Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5));
+
+        source
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        source
+        .test()
+        .assertFailure(IllegalStateException.class);
+    }
+
+    @Test
+    public void take() {
+        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .take(5)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void emptyConditional() {
+        Flowable.fromStream(Stream.<Integer>of())
+        .filter(v -> true)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void justConditional() {
+        Flowable.fromStream(Stream.<Integer>of(1))
+        .filter(v -> true)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void manyConditional() {
+        Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
+        .filter(v -> true)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void manyBackpressuredConditional() {
+        Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
+        .filter(v -> true)
+        .test(0L)
+        .assertEmpty()
+        .requestMore(1)
+        .assertValuesOnly(1)
+        .requestMore(2)
+        .assertValuesOnly(1, 2, 3)
+        .requestMore(2)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void manyConditionalSkip() {
+        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .filter(v -> v % 2 == 0)
+        .test()
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void takeConditional() {
+        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .filter(v -> true)
+        .take(5)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void noOfferNoCrashAfterClear() throws Throwable {
+        AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
+
+        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .subscribe(new FlowableSubscriber<Integer>() {
+            @Override
+            public void onSubscribe(@NonNull Subscription s) {
+                queue.set((SimpleQueue<?>)s);
+            }
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+
+        SimpleQueue<?> q = queue.get();
+        TestHelper.assertNoOffer(q);
+
+        assertFalse(q.isEmpty());
+
+        q.clear();
+
+        assertNull(q.poll());
+
+        assertTrue(q.isEmpty());
+
+        q.clear();
+
+        assertNull(q.poll());
+
+        assertTrue(q.isEmpty());
+    }
+
+    @Test
+    public void streamOfNull() {
+        Flowable.fromStream(Stream.of((Integer)null))
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void streamOfNullConditional() {
+        Flowable.fromStream(Stream.of((Integer)null))
+        .filter(v -> true)
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void syncFusionSupport() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .subscribeWith(ts)
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void asyncFusionNotSupported() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ASYNC);
+
+        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .subscribeWith(ts)
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void fusedForParallel() {
+        Flowable.fromStream(IntStream.rangeClosed(1, 1000).boxed())
+        .parallel()
+        .runOn(Schedulers.computation(), 1)
+        .map(v -> v + 1)
+        .sequential()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(1000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void runToEndCloseCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5).onClose(() -> { throw new TestException(); });
+
+            Flowable.fromStream(stream)
+            .test()
+            .assertResult(1, 2, 3, 4, 5);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void takeCloseCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5).onClose(() -> { throw new TestException(); });
+
+            Flowable.fromStream(stream)
+            .take(3)
+            .test()
+            .assertResult(1, 2, 3);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void hasNextCrash() {
+        AtomicInteger v = new AtomicInteger();
+        Flowable.fromStream(Stream.<Integer>generate(() -> {
+            int value = v.getAndIncrement();
+            if (value == 1) {
+                throw new TestException();
+            }
+            return value;
+        }))
+        .test()
+        .assertFailure(TestException.class, 0);
+    }
+
+    @Test
+    public void hasNextCrashConditional() {
+        AtomicInteger counter = new AtomicInteger();
+        Flowable.fromStream(Stream.<Integer>generate(() -> {
+            int value = counter.getAndIncrement();
+            if (value == 1) {
+                throw new TestException();
+            }
+            return value;
+        }))
+        .filter(v -> true)
+        .test()
+        .assertFailure(TestException.class, 0);
+    }
+
+    void requestOneByOneBase(boolean conditional) {
+        List<Object> list = new ArrayList<>();
+
+        Flowable<Integer> source = Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed());
+        if (conditional) {
+            source = source.filter(v -> true);
+        }
+
+        source.subscribe(new FlowableSubscriber<Integer>() {
+
+            @NonNull Subscription upstream;
+
+            @Override
+            public void onSubscribe(@NonNull Subscription s) {
+                this.upstream = s;
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                list.add(t);
+                upstream.request(1);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                list.add(t);
+            }
+
+            @Override
+            public void onComplete() {
+                list.add(100);
+            }
+        });
+
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100), list);
+    }
+
+    @Test
+    public void requestOneByOne() {
+        requestOneByOneBase(false);
+    }
+
+    @Test
+    public void requestOneByOneConditional() {
+        requestOneByOneBase(true);
+    }
+
+    void requestRaceBase(boolean conditional) throws Exception {
+        ExecutorService exec = Executors.newCachedThreadPool();
+        try {
+            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+
+                AtomicInteger counter = new AtomicInteger();
+
+                int max = 100;
+
+                Flowable<Integer> source = Flowable.fromStream(IntStream.rangeClosed(1, max).boxed());
+                if (conditional) {
+                    source = source.filter(v -> true);
+                }
+
+                CountDownLatch cdl = new CountDownLatch(1);
+
+                source
+                .subscribe(new FlowableSubscriber<Integer>() {
+
+                    @NonNull Subscription upstream;
+
+                    @Override
+                    public void onSubscribe(@NonNull Subscription s) {
+
+                        this.upstream = s;
+                        s.request(1);
+
+                    }
+
+                    @Override
+                    public void onNext(Integer t) {
+                        counter.getAndIncrement();
+
+                        AtomicInteger sync = new AtomicInteger(2);
+                        exec.submit(() -> {
+                            if (sync.decrementAndGet() != 0) {
+                                while (sync.get() != 0) { }
+                            }
+                            upstream.request(1);
+                        });
+
+                        if (sync.decrementAndGet() != 0) {
+                            while (sync.get() != 0) { }
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                        cdl.countDown();
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        counter.getAndIncrement();
+                        cdl.countDown();
+                    }
+                });
+
+                assertTrue(cdl.await(60, TimeUnit.SECONDS));
+
+                assertEquals(max + 1, counter.get());
+            }
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void requestRace() throws Exception {
+        requestRaceBase(false);
+    }
+
+    @Test
+    public void requestRaceConditional() throws Exception {
+        requestRaceBase(true);
+    }
+
+    @Test
+    public void closeCalledOnEmpty() {
+        AtomicInteger calls = new AtomicInteger();
+
+        Flowable.fromStream(Stream.of().onClose(() -> calls.getAndIncrement()))
+        .test()
+        .assertResult();
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void closeCalledAfterItems() {
+        AtomicInteger calls = new AtomicInteger();
+
+        Flowable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void closeCalledOnCancel() {
+        AtomicInteger calls = new AtomicInteger();
+
+        Flowable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
+        .take(3)
+        .test()
+        .assertResult(1, 2, 3);
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void closeCalledOnItemCrash() {
+        AtomicInteger calls = new AtomicInteger();
+        AtomicInteger counter = new AtomicInteger();
+        Flowable.fromStream(Stream.<Integer>generate(() -> {
+            int value = counter.getAndIncrement();
+            if (value == 1) {
+                throw new TestException();
+            }
+            return value;
+        }).onClose(() -> calls.getAndIncrement()))
+        .test()
+        .assertFailure(TestException.class, 0);
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void closeCalledAfterItemsConditional() {
+        AtomicInteger calls = new AtomicInteger();
+
+        Flowable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
+        .filter(v -> true)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void closeCalledOnCancelConditional() {
+        AtomicInteger calls = new AtomicInteger();
+
+        Flowable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
+        .filter(v -> true)
+        .take(3)
+        .test()
+        .assertResult(1, 2, 3);
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void closeCalledOnItemCrashConditional() {
+        AtomicInteger calls = new AtomicInteger();
+        AtomicInteger counter = new AtomicInteger();
+        Flowable.fromStream(Stream.<Integer>generate(() -> {
+            int value = counter.getAndIncrement();
+            if (value == 1) {
+                throw new TestException();
+            }
+            return value;
+        }).onClose(() -> calls.getAndIncrement()))
+        .filter(v -> true)
+        .test()
+        .assertFailure(TestException.class, 0);
+
+        assertEquals(1, calls.get());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FromCompletionStageTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FromCompletionStageTckTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class FromCompletionStageTckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createPublisher(final long elements) {
+        return
+                Flowable.fromCompletionStage(CompletableFuture.completedFuture(1L))
+            ;
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        CompletableFuture<Long> cf = new CompletableFuture<>();
+        cf.completeExceptionally(new TestException());
+        return
+                Flowable.fromCompletionStage(cf)
+            ;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FromOptional0TckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FromOptional0TckTest.java
@@ -11,18 +11,32 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.rxjava3.annotations;
+package io.reactivex.rxjava3.internal.jdk8;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import java.util.Optional;
 
-import java.lang.annotation.*;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
 
 /**
- * Indicates that a field/parameter/variable/type parameter/return type is never null.
+ * Test Optional.empty() wrapping.
+ * @see FromOptional1TckTest
  */
-@Documented
-@Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE, TYPE_PARAMETER, TYPE_USE})
-@Retention(value = CLASS)
-public @interface NonNull { }
+@Test
+public class FromOptional0TckTest extends BaseTck<Long> {
 
+    @Override
+    public Publisher<Long> createPublisher(final long elements) {
+        return
+                Flowable.fromOptional(Optional.empty())
+            ;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 0;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FromOptional1TckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FromOptional1TckTest.java
@@ -11,18 +11,32 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.rxjava3.annotations;
+package io.reactivex.rxjava3.internal.jdk8;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import java.util.Optional;
 
-import java.lang.annotation.*;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
 
 /**
- * Indicates that a field/parameter/variable/type parameter/return type is never null.
+ * Test Optional.of wrapping.
+ * @see FromOptional0TckTest
  */
-@Documented
-@Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE, TYPE_PARAMETER, TYPE_USE})
-@Retention(value = CLASS)
-public @interface NonNull { }
+@Test
+public class FromOptional1TckTest extends BaseTck<Long> {
 
+    @Override
+    public Publisher<Long> createPublisher(final long elements) {
+        return
+                Flowable.fromOptional(Optional.of(1L))
+            ;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FromStreamTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FromStreamTckTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+/**
+ * Test Optional.of wrapping.
+ * @see FromOptional0TckTest
+ */
+@Test
+public class FromStreamTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        return
+                Flowable.fromStream(IntStream.rangeClosed(1, (int)elements).boxed())
+            ;
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Flowable.fromStream(stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/Burst.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/Burst.java
@@ -47,11 +47,11 @@ public final class Burst<T> extends Observable<T> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public static <T> Builder<T> item(T item) {
         return items(item);
     }
 
+    @SafeVarargs
     public static <T> Builder<T> items(T... items) {
         return new Builder<T>(Arrays.asList(items));
     }

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -624,7 +624,7 @@ public enum TestHelper {
      * @param source the source to test
      */
     public static <T> void checkDisposed(Flowable<T> source) {
-        final TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
+        final TestSubscriber<Object> ts = new TestSubscriber<>(0L);
         source.subscribe(new FlowableSubscriber<Object>() {
             @Override
             public void onSubscribe(Subscription s) {
@@ -2123,10 +2123,10 @@ public enum TestHelper {
     public static <T, U> void checkDisposedMaybe(Function<Maybe<T>, ? extends MaybeSource<U>> composer) {
         PublishProcessor<T> pp = PublishProcessor.create();
 
-        TestSubscriber<U> ts = new TestSubscriber<U>();
+        TestSubscriber<U> ts = new TestSubscriber<>();
 
         try {
-            new MaybeToFlowable<U>(composer.apply(pp.singleElement())).subscribe(ts);
+            new MaybeToFlowable<>(composer.apply(pp.singleElement())).subscribe(ts);
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
@@ -2145,7 +2145,7 @@ public enum TestHelper {
     public static void checkDisposedCompletable(Function<Completable, ? extends CompletableSource> composer) {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         try {
             new CompletableToFlowable<Integer>(composer.apply(pp.ignoreElements())).subscribe(ts);
@@ -2169,10 +2169,10 @@ public enum TestHelper {
     public static <T, U> void checkDisposedMaybeToSingle(Function<Maybe<T>, ? extends SingleSource<U>> composer) {
         PublishProcessor<T> pp = PublishProcessor.create();
 
-        TestSubscriber<U> ts = new TestSubscriber<U>();
+        TestSubscriber<U> ts = new TestSubscriber<>();
 
         try {
-            new SingleToFlowable<U>(composer.apply(pp.singleElement())).subscribe(ts);
+            new SingleToFlowable<>(composer.apply(pp.singleElement())).subscribe(ts);
         } catch (Throwable ex) {
             throw ExceptionHelper.wrapOrThrow(ex);
         }
@@ -2190,6 +2190,7 @@ public enum TestHelper {
      * @param ts the TestSubscriber instance
      * @param classes the array of expected Throwables inside the Composite
      */
+    @SafeVarargs
     public static void assertCompositeExceptions(TestSubscriberEx<?> ts, Class<? extends Throwable>... classes) {
         ts
         .assertSubscribed()
@@ -2234,6 +2235,7 @@ public enum TestHelper {
      * @param to the TestSubscriber instance
      * @param classes the array of expected Throwables inside the Composite
      */
+    @SafeVarargs
     public static void assertCompositeExceptions(TestObserverEx<?> to, Class<? extends Throwable>... classes) {
         to
         .assertSubscribed()
@@ -2278,6 +2280,7 @@ public enum TestHelper {
      * @param p the target processor
      * @param values the values to emit
      */
+    @SafeVarargs
     public static <T> void emit(Processor<T, ?> p, T... values) {
         for (T v : values) {
             p.onNext(v);
@@ -2291,6 +2294,7 @@ public enum TestHelper {
      * @param p the target subject
      * @param values the values to emit
      */
+    @SafeVarargs
     public static <T> void emit(Subject<T> p, T... values) {
         for (T v : values) {
             p.onNext(v);
@@ -2495,7 +2499,7 @@ public enum TestHelper {
 
             if (o instanceof ObservableSource) {
                 ObservableSource<?> os = (ObservableSource<?>) o;
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
 
@@ -2517,7 +2521,7 @@ public enum TestHelper {
 
             if (o instanceof Publisher) {
                 Publisher<?> os = (Publisher<?>) o;
-                TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+                TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
                 os.subscribe(ts);
 
@@ -2539,7 +2543,7 @@ public enum TestHelper {
 
             if (o instanceof SingleSource) {
                 SingleSource<?> os = (SingleSource<?>) o;
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
 
@@ -2561,7 +2565,7 @@ public enum TestHelper {
 
             if (o instanceof MaybeSource) {
                 MaybeSource<?> os = (MaybeSource<?>) o;
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
 
@@ -2583,7 +2587,7 @@ public enum TestHelper {
 
             if (o instanceof CompletableSource) {
                 CompletableSource os = (CompletableSource) o;
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
 
@@ -2654,7 +2658,7 @@ public enum TestHelper {
 
             if (o instanceof ObservableSource) {
                 ObservableSource<?> os = (ObservableSource<?>) o;
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
 
@@ -2676,7 +2680,7 @@ public enum TestHelper {
 
             if (o instanceof Publisher) {
                 Publisher<?> os = (Publisher<?>) o;
-                TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+                TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
                 os.subscribe(ts);
 
@@ -2698,7 +2702,7 @@ public enum TestHelper {
 
             if (o instanceof SingleSource) {
                 SingleSource<?> os = (SingleSource<?>) o;
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
 
@@ -2720,7 +2724,7 @@ public enum TestHelper {
 
             if (o instanceof MaybeSource) {
                 MaybeSource<?> os = (MaybeSource<?>) o;
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
 
@@ -2742,7 +2746,7 @@ public enum TestHelper {
 
             if (o instanceof CompletableSource) {
                 CompletableSource os = (CompletableSource) o;
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
 
@@ -2778,7 +2782,7 @@ public enum TestHelper {
         @SuppressWarnings("unchecked")
         TestSubscriber<Object>[] tss = new TestSubscriber[n + 1];
         for (int i = 0; i <= n; i++) {
-            tss[i] = new TestSubscriber<Object>().withTag("" + i);
+            tss[i] = new TestSubscriber<>().withTag("" + i);
         }
 
         source.subscribe(tss);
@@ -2893,7 +2897,7 @@ public enum TestHelper {
 
         @Override
         public Flowable<T> apply(Flowable<T> upstream) {
-            return new FlowableStripBoundary<T>(upstream);
+            return new FlowableStripBoundary<>(upstream);
         }
 
         @Override
@@ -2985,7 +2989,7 @@ public enum TestHelper {
     }
 
     public static <T> FlowableTransformer<T, T> flowableStripBoundary() {
-        return new FlowableStripBoundary<T>(null);
+        return new FlowableStripBoundary<>(null);
     }
 
     static final class ObservableStripBoundary<T> extends Observable<T> implements ObservableTransformer<T, T> {
@@ -2998,7 +3002,7 @@ public enum TestHelper {
 
         @Override
         public Observable<T> apply(Observable<T> upstream) {
-            return new ObservableStripBoundary<T>(upstream);
+            return new ObservableStripBoundary<>(upstream);
         }
 
         @Override
@@ -3090,23 +3094,23 @@ public enum TestHelper {
     }
 
     public static <T> ObservableTransformer<T, T> observableStripBoundary() {
-        return new ObservableStripBoundary<T>(null);
+        return new ObservableStripBoundary<>(null);
     }
 
     public static <T> TestConsumerExConverters<T> testConsumer() {
-        return new TestConsumerExConverters<T>(false, 0);
+        return new TestConsumerExConverters<>(false, 0);
     }
 
     public static <T> TestConsumerExConverters<T> testConsumer(boolean cancelled) {
-        return new TestConsumerExConverters<T>(cancelled, 0);
+        return new TestConsumerExConverters<>(cancelled, 0);
     }
 
     public static <T> TestConsumerExConverters<T> testConsumer(final int fusionMode, final boolean cancelled) {
-        return new TestConsumerExConverters<T>(cancelled, fusionMode);
+        return new TestConsumerExConverters<>(cancelled, fusionMode);
     }
 
     public static <T> TestConsumerExConverters<T> testConsumer(final boolean cancelled, final int fusionMode) {
-        return new TestConsumerExConverters<T>(cancelled, fusionMode);
+        return new TestConsumerExConverters<>(cancelled, fusionMode);
     }
 
     public static <T> FlowableConverter<T, TestSubscriberEx<T>> testSubscriber(final long initialRequest) {
@@ -3125,7 +3129,7 @@ public enum TestHelper {
         return new FlowableConverter<T, TestSubscriberEx<T>>() {
             @Override
             public TestSubscriberEx<T> apply(Flowable<T> f) {
-                TestSubscriberEx<T> tse = new TestSubscriberEx<T>(initialRequest);
+                TestSubscriberEx<T> tse = new TestSubscriberEx<>(initialRequest);
                 if (cancelled) {
                     tse.cancel();
                 }
@@ -3153,7 +3157,7 @@ public enum TestHelper {
 
         @Override
         public TestObserverEx<Void> apply(Completable upstream) {
-            TestObserverEx<Void> toe = new TestObserverEx<Void>();
+            TestObserverEx<Void> toe = new TestObserverEx<>();
             if (cancelled) {
                 toe.dispose();
             }
@@ -3163,7 +3167,7 @@ public enum TestHelper {
 
         @Override
         public TestObserverEx<T> apply(Maybe<T> upstream) {
-            TestObserverEx<T> toe = new TestObserverEx<T>();
+            TestObserverEx<T> toe = new TestObserverEx<>();
             if (cancelled) {
                 toe.dispose();
             }
@@ -3173,7 +3177,7 @@ public enum TestHelper {
 
         @Override
         public TestObserverEx<T> apply(Single<T> upstream) {
-            TestObserverEx<T> toe = new TestObserverEx<T>();
+            TestObserverEx<T> toe = new TestObserverEx<>();
             if (cancelled) {
                 toe.dispose();
             }
@@ -3183,7 +3187,7 @@ public enum TestHelper {
 
         @Override
         public TestObserverEx<T> apply(Observable<T> upstream) {
-            TestObserverEx<T> toe = new TestObserverEx<T>();
+            TestObserverEx<T> toe = new TestObserverEx<>();
             if (cancelled) {
                 toe.dispose();
             }
@@ -3193,7 +3197,7 @@ public enum TestHelper {
 
         @Override
         public TestSubscriberEx<T> apply(Flowable<T> upstream) {
-            TestSubscriberEx<T> tse = new TestSubscriberEx<T>();
+            TestSubscriberEx<T> tse = new TestSubscriberEx<>();
             if (cancelled) {
                 tse.dispose();
             }
@@ -3202,8 +3206,9 @@ public enum TestHelper {
         }
     }
 
+    @SafeVarargs
     public static <T> TestSubscriberEx<T> assertValueSet(TestSubscriberEx<T> ts, T... values) {
-        Set<T> expectedSet = new HashSet<T>(Arrays.asList(values));
+        Set<T> expectedSet = new HashSet<>(Arrays.asList(values));
         for (T t : ts.values()) {
             if (!expectedSet.contains(t)) {
                 throw ts.failWith("Item not in the set: " + BaseTestConsumer.valueAndClass(t));
@@ -3212,8 +3217,9 @@ public enum TestHelper {
         return ts;
     }
 
+    @SafeVarargs
     public static <T> TestObserverEx<T> assertValueSet(TestObserverEx<T> to, T... values) {
-        Set<T> expectedSet = new HashSet<T>(Arrays.asList(values));
+        Set<T> expectedSet = new HashSet<>(Arrays.asList(values));
         for (T t : to.values()) {
             if (!expectedSet.contains(t)) {
                 throw to.failWith("Item not in the set: " + BaseTestConsumer.valueAndClass(t));
@@ -3280,35 +3286,35 @@ public enum TestHelper {
             .to(transform);
 
             if (result instanceof MaybeSource) {
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
                 disposable.set(to);
 
                 ((MaybeSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof SingleSource) {
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
                 disposable.set(to);
 
                 ((SingleSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof CompletableSource) {
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
                 disposable.set(to);
 
                 ((CompletableSource)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof ObservableSource) {
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
                 disposable.set(to);
 
                 ((ObservableSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof Publisher) {
-                TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+                TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
                 disposable.set(Disposables.fromSubscription(ts));
 
                 ((Publisher<?>)result)
@@ -3348,35 +3354,35 @@ public enum TestHelper {
             .to(transform);
 
             if (result instanceof MaybeSource) {
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
                 disposable.set(to);
 
                 ((MaybeSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof SingleSource) {
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
                 disposable.set(to);
 
                 ((SingleSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof CompletableSource) {
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
                 disposable.set(to);
 
                 ((CompletableSource)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof ObservableSource) {
-                TestObserverEx<Object> to = new TestObserverEx<Object>();
+                TestObserverEx<Object> to = new TestObserverEx<>();
                 disposable.set(to);
 
                 ((ObservableSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof Publisher) {
-                TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+                TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
                 disposable.set(Disposables.fromSubscription(ts));
 
                 ((Publisher<?>)result)
@@ -3418,5 +3424,19 @@ public enum TestHelper {
             Thread.sleep(oneSleep);
         }
         return bean.getHeapMemoryUsage().getUsed();
+    }
+
+    /**
+     * Enable thracking of the global errors for the duration of the action.
+     * @param action the action to run with a list of errors encountered
+     * @throws Throwable the exception rethrown from the action
+     */
+    public static void withErrorTracking(Consumer<List<Throwable>> action) throws Throwable {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            action.accept(errors);
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -14,8 +14,10 @@
 package io.reactivex.rxjava3.validators;
 
 import java.lang.reflect.*;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 import org.junit.Test;
 import org.reactivestreams.*;
@@ -583,6 +585,14 @@ public class ParamValidationCheckerTest {
         defaultValues.put(Subscriber[].class, new Subscriber[] { new AllFunctionals() });
 
         defaultValues.put(ParallelFailureHandling.class, ParallelFailureHandling.ERROR);
+
+        // JDK 8 types
+
+        defaultValues.put(Optional.class, Optional.of(1));
+        defaultValues.put(CompletionStage.class, CompletableFuture.completedFuture(1));
+        defaultValues.put(Stream.class, Stream.of(1, 2, 3));
+        defaultValues.put(Duration.class, Duration.ofSeconds(1));
+        defaultValues.put(Collector.class, Collectors.toList());
 
         @SuppressWarnings("rawtypes")
         class MixedConverters implements FlowableConverter, ObservableConverter, SingleConverter,


### PR DESCRIPTION
This PR upgrades RxJava to use and compile with Java 8.

- Build target set to 8
- AnimalSniffer set to 8
- JavaDocs link to the official JDK set to 8
- Implemented operators:
  - `Flowable.fromOptional`
  - `Flowable.fromCompletionStage`
  - `Flowable.fromStream`
- Applied `@SafeVarargs` to many methods
- Created marbles

Related #6695

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromOptional.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromCompletionStage.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromStream.f.png)