### PR TITLE
3.x: [Java 8] Implement mapOptional, collector, first/last/single stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
   ext.bintrayVersion = "1.8.4"
   ext.jfrogExtractorVersion = "4.11.0"
   ext.bndVersion = "4.3.1"
-  ext.checkstyleVersion = "6.19"
+  ext.checkstyleVersion = "8.26"
 
   // --------------------------------------
 

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableCollectWithCollector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableCollectWithCollector.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.Objects;
+import java.util.function.*;
+import java.util.stream.Collector;
+
+import org.reactivestreams.*;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.internal.subscriptions.*;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Collect items into a container defined by a Stream {@link Collector} callback set.
+ *
+ * @param <T> the upstream value type
+ * @param <A> the intermediate accumulator type
+ * @param <R> the result type
+ * @since 3.0.0
+ */
+public final class FlowableCollectWithCollector<T, A, R> extends Flowable<R> {
+
+    final Flowable<T> source;
+
+    final Collector<T, A, R> collector;
+
+    public FlowableCollectWithCollector(Flowable<T> source, Collector<T, A, R> collector) {
+        this.source = source;
+        this.collector = collector;
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull Subscriber<? super R> s) {
+        A container;
+        BiConsumer<A, T> accumulator;
+        Function<A, R> finisher;
+
+        try {
+            container = collector.supplier().get();
+            accumulator = collector.accumulator();
+            finisher = collector.finisher();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptySubscription.error(ex, s);
+            return;
+        }
+
+        source.subscribe(new CollectorSubscriber<>(s, container, accumulator, finisher));
+    }
+
+    static final class CollectorSubscriber<T, A, R>
+    extends DeferredScalarSubscription<R>
+    implements FlowableSubscriber<T> {
+
+        private static final long serialVersionUID = -229544830565448758L;
+
+        final BiConsumer<A, T> accumulator;
+
+        final Function<A, R> finisher;
+
+        Subscription upstream;
+
+        boolean done;
+
+        A container;
+
+        CollectorSubscriber(Subscriber<? super R> downstream, A container, BiConsumer<A, T> accumulator, Function<A, R> finisher) {
+            super(downstream);
+            this.container = container;
+            this.accumulator = accumulator;
+            this.finisher = finisher;
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Subscription s) {
+            if (SubscriptionHelper.validate(this.upstream, s)) {
+                this.upstream = s;
+
+                downstream.onSubscribe(this);
+
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            try {
+                accumulator.accept(container, t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                upstream.cancel();
+                onError(ex);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+            } else {
+                done = true;
+                upstream = SubscriptionHelper.CANCELLED;
+                this.container = null;
+                downstream.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+
+            done = true;
+            upstream = SubscriptionHelper.CANCELLED;
+            A container = this.container;
+            this.container = null;
+            R result;
+            try {
+                result = Objects.requireNonNull(finisher.apply(container), "The finisher returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            complete(result);
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            upstream.cancel();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableCollectWithCollectorSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableCollectWithCollectorSingle.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.Objects;
+import java.util.function.*;
+import java.util.stream.Collector;
+
+import org.reactivestreams.Subscription;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
+import io.reactivex.rxjava3.internal.fuseable.FuseToFlowable;
+import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Collect items into a container defined by a Stream {@link Collector} callback set.
+ *
+ * @param <T> the upstream value type
+ * @param <A> the intermediate accumulator type
+ * @param <R> the result type
+ * @since 3.0.0
+ */
+public final class FlowableCollectWithCollectorSingle<T, A, R> extends Single<R> implements FuseToFlowable<R> {
+
+    final Flowable<T> source;
+
+    final Collector<T, A, R> collector;
+
+    public FlowableCollectWithCollectorSingle(Flowable<T> source, Collector<T, A, R> collector) {
+        this.source = source;
+        this.collector = collector;
+    }
+
+    @Override
+    public Flowable<R> fuseToFlowable() {
+        return new FlowableCollectWithCollector<>(source, collector);
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull SingleObserver<? super R> observer) {
+        A container;
+        BiConsumer<A, T> accumulator;
+        Function<A, R> finisher;
+
+        try {
+            container = collector.supplier().get();
+            accumulator = collector.accumulator();
+            finisher = collector.finisher();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        source.subscribe(new CollectorSingleObserver<>(observer, container, accumulator, finisher));
+    }
+
+    static final class CollectorSingleObserver<T, A, R> implements FlowableSubscriber<T>, Disposable {
+
+        final SingleObserver<? super R> downstream;
+
+        final BiConsumer<A, T> accumulator;
+
+        final Function<A, R> finisher;
+
+        Subscription upstream;
+
+        boolean done;
+
+        A container;
+
+        CollectorSingleObserver(SingleObserver<? super R> downstream, A container, BiConsumer<A, T> accumulator, Function<A, R> finisher) {
+            this.downstream = downstream;
+            this.container = container;
+            this.accumulator = accumulator;
+            this.finisher = finisher;
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Subscription s) {
+            if (SubscriptionHelper.validate(this.upstream, s)) {
+                this.upstream = s;
+
+                downstream.onSubscribe(this);
+
+                s.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            try {
+                accumulator.accept(container, t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                upstream.cancel();
+                onError(ex);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+            } else {
+                done = true;
+                upstream = SubscriptionHelper.CANCELLED;
+                this.container = null;
+                downstream.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+
+            done = true;
+            upstream = SubscriptionHelper.CANCELLED;
+            A container = this.container;
+            this.container = null;
+            R result;
+            try {
+                result = Objects.requireNonNull(finisher.apply(container), "The finisher returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            downstream.onSuccess(result);
+        }
+
+        @Override
+        public void dispose() {
+            upstream.cancel();
+            upstream = SubscriptionHelper.CANCELLED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return upstream == SubscriptionHelper.CANCELLED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFirstStageSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFirstStageSubscriber.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.NoSuchElementException;
+
+import org.reactivestreams.Subscription;
+
+/**
+ * Signals the first element of the source via the underlying CompletableFuture,
+ * signals the a default item if the upstream is empty or signals {@link NoSuchElementException}.
+ *
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class FlowableFirstStageSubscriber<T> extends FlowableStageSubscriber<T> {
+
+    final boolean hasDefault;
+
+    final T defaultItem;
+
+    public FlowableFirstStageSubscriber(boolean hasDefault, T defaultItem) {
+        this.hasDefault = hasDefault;
+        this.defaultItem = defaultItem;
+    }
+
+    @Override
+    public void onNext(T t) {
+        complete(t);
+    }
+
+    @Override
+    public void onComplete() {
+        if (!isDone()) {
+            clear();
+            if (hasDefault) {
+                complete(defaultItem);
+            } else {
+                completeExceptionally(new NoSuchElementException());
+            }
+        }
+    }
+
+    @Override
+    protected void afterSubscribe(Subscription s) {
+        s.request(1);
+    }
+
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableLastStageSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableLastStageSubscriber.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.NoSuchElementException;
+
+import org.reactivestreams.Subscription;
+
+/**
+ * Signals the last element of the source via the underlying CompletableFuture,
+ * signals the a default item if the upstream is empty or signals {@link NoSuchElementException}.
+ *
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class FlowableLastStageSubscriber<T> extends FlowableStageSubscriber<T> {
+
+    final boolean hasDefault;
+
+    final T defaultItem;
+
+    public FlowableLastStageSubscriber(boolean hasDefault, T defaultItem) {
+        this.hasDefault = hasDefault;
+        this.defaultItem = defaultItem;
+    }
+
+    @Override
+    public void onNext(T t) {
+        value = t;
+    }
+
+    @Override
+    public void onComplete() {
+        if (!isDone()) {
+            T v = value;
+            clear();
+            if (v != null) {
+                complete(v);
+            } else if (hasDefault) {
+                complete(defaultItem);
+            } else {
+                completeExceptionally(new NoSuchElementException());
+            }
+        }
+    }
+
+    @Override
+    protected void afterSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+    }
+
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableMapOptional.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableMapOptional.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.rxjava3.internal.subscribers.*;
+
+/**
+ * Map the upstream values into an Optional and emit its value if any.
+ * @param <T> the upstream element type
+ * @param <R> the output element type
+ * @since 3.0.0
+ */
+public final class FlowableMapOptional<T, R> extends Flowable<R> {
+
+    final Flowable<T> source;
+
+    final Function<? super T, Optional<? extends R>> mapper;
+
+    public FlowableMapOptional(Flowable<T> source, Function<? super T, Optional<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        if (s instanceof ConditionalSubscriber) {
+            source.subscribe(new MapOptionalConditionalSubscriber<>((ConditionalSubscriber<? super R>)s, mapper));
+        } else {
+            source.subscribe(new MapOptionalSubscriber<>(s, mapper));
+        }
+    }
+
+    static final class MapOptionalSubscriber<T, R> extends BasicFuseableSubscriber<T, R>
+    implements ConditionalSubscriber<T> {
+
+        final Function<? super T, Optional<? extends R>> mapper;
+
+        MapOptionalSubscriber(Subscriber<? super R> downstream, Function<? super T, Optional<? extends R>> mapper) {
+            super(downstream);
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!tryOnNext(t)) {
+                upstream.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return true;
+            }
+
+            if (sourceMode != NONE) {
+                downstream.onNext(null);
+                return true;
+            }
+
+            Optional<? extends R> result;
+            try {
+                result = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Optional");
+            } catch (Throwable ex) {
+                fail(ex);
+                return true;
+            }
+
+            if (result.isPresent()) {
+                downstream.onNext(result.get());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public R poll() throws Throwable {
+            for (;;) {
+                T item = qs.poll();
+                if (item == null) {
+                    return null;
+                }
+                Optional<? extends R> result = Objects.requireNonNull(mapper.apply(item), "The mapper returned a null Optional");
+                if (result.isPresent()) {
+                    return result.get();
+                }
+                if (sourceMode == ASYNC) {
+                    qs.request(1);
+                }
+            }
+        }
+    }
+
+    static final class MapOptionalConditionalSubscriber<T, R> extends BasicFuseableConditionalSubscriber<T, R> {
+
+        final Function<? super T, Optional<? extends R>> mapper;
+
+        MapOptionalConditionalSubscriber(ConditionalSubscriber<? super R> downstream, Function<? super T, Optional<? extends R>> mapper) {
+            super(downstream);
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (!tryOnNext(t)) {
+                upstream.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (done) {
+                return true;
+            }
+
+            if (sourceMode != NONE) {
+                downstream.onNext(null);
+                return true;
+            }
+
+            Optional<? extends R> result;
+            try {
+                result = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Optional");
+            } catch (Throwable ex) {
+                fail(ex);
+                return true;
+            }
+
+            if (result.isPresent()) {
+                return downstream.tryOnNext(result.get());
+            }
+            return false;
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public R poll() throws Throwable {
+            for (;;) {
+                T item = qs.poll();
+                if (item == null) {
+                    return null;
+                }
+                Optional<? extends R> result = Objects.requireNonNull(mapper.apply(item), "The mapper returned a null Optional");
+                if (result.isPresent()) {
+                    return result.get();
+                }
+                if (sourceMode == ASYNC) {
+                    qs.request(1);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableSingleStageSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableSingleStageSubscriber.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.NoSuchElementException;
+
+import org.reactivestreams.Subscription;
+
+/**
+ * Signals the only element of the source via the underlying CompletableFuture,
+ * signals the a default item if the upstream is empty or signals {@link IllegalArgumentException}
+ * if the upstream has more than one item.
+ *
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class FlowableSingleStageSubscriber<T> extends FlowableStageSubscriber<T> {
+
+    final boolean hasDefault;
+
+    final T defaultItem;
+
+    public FlowableSingleStageSubscriber(boolean hasDefault, T defaultItem) {
+        this.hasDefault = hasDefault;
+        this.defaultItem = defaultItem;
+    }
+
+    @Override
+    public void onNext(T t) {
+        if (value != null) {
+            value = null;
+            completeExceptionally(new IllegalArgumentException("Sequence contains more than one element!"));
+        } else {
+            value = t;
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (!isDone()) {
+            T v = value;
+            clear();
+            if (v != null) {
+                complete(v);
+            } else if (hasDefault) {
+                complete(defaultItem);
+            } else {
+                completeExceptionally(new NoSuchElementException());
+            }
+        }
+    }
+
+    @Override
+    protected void afterSubscribe(Subscription s) {
+        s.request(2);
+    }
+
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableStageSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableStageSubscriber.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscription;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.FlowableSubscriber;
+import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Base class that extends CompletableFuture and provides basic infrastructure
+ * to notify watchers upon upstream signals.
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+abstract class FlowableStageSubscriber<T> extends CompletableFuture<T> implements FlowableSubscriber<T> {
+
+    final AtomicReference<Subscription> upstream = new AtomicReference<>();
+
+    T value;
+
+    @Override
+    public final void onSubscribe(@NonNull Subscription s) {
+        if (SubscriptionHelper.setOnce(upstream, s)) {
+            afterSubscribe(s);
+        }
+    }
+
+    protected abstract void afterSubscribe(Subscription s);
+
+    @Override
+    public final void onError(Throwable t) {
+        clear();
+        if (!completeExceptionally(t)) {
+            RxJavaPlugins.onError(t);
+        }
+    }
+
+    protected final void cancelUpstream() {
+        SubscriptionHelper.cancel(upstream);
+    }
+
+    protected final void clear() {
+        value = null;
+        upstream.lazySet(SubscriptionHelper.CANCELLED);
+    }
+
+    @Override
+    public final boolean cancel(boolean mayInterruptIfRunning) {
+        cancelUpstream();
+        return super.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public final boolean complete(T value) {
+        cancelUpstream();
+        return super.complete(value);
+    }
+
+    @Override
+    public final boolean completeExceptionally(Throwable ex) {
+        cancelUpstream();
+        return super.completeExceptionally(ex);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/CollectWithCollectorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/CollectWithCollectorTckTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class CollectWithCollectorTckTest extends BaseTck<List<Integer>> {
+
+    @Override
+    public Publisher<List<Integer>> createPublisher(final long elements) {
+        return
+                Flowable.range(0, (int)elements).collect(Collectors.toList()).toFlowable()
+            ;
+    }
+
+    @Override
+    public Publisher<List<Integer>> createFailedPublisher() {
+        return Flowable.<Integer>error(new TestException()).collect(Collectors.toList()).toFlowable();
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableCollectWithCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableCollectWithCollectorTest.java
@@ -1,0 +1,420 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class FlowableCollectWithCollectorTest extends RxJavaTest {
+
+    @Test
+    public void basic() {
+        Flowable.range(1, 5)
+        .collect(Collectors.toList())
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void empty() {
+        Flowable.empty()
+        .collect(Collectors.toList())
+        .test()
+        .assertResult(Collections.emptyList());
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .collect(Collectors.toList())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorSupplierCrash() {
+        Flowable.range(1, 5)
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                throw new TestException();
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> { };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> a;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorAccumulatorCrash() {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        source
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                return () -> 1;
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> { throw new TestException(); };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> a;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void collectorFinisherCrash() {
+        Flowable.range(1, 5)
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                return () -> 1;
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> {  };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> { throw new TestException(); };
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorAccumulatorDropSignals() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Flowable<Integer> source = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onNext(2);
+                    s.onError(new IOException());
+                    s.onComplete();
+                }
+            };
+
+            source
+            .collect(new Collector<Integer, Integer, Integer>() {
+
+                @Override
+                public Supplier<Integer> supplier() {
+                    return () -> 1;
+                }
+
+                @Override
+                public BiConsumer<Integer, Integer> accumulator() {
+                    return (a, b) -> { throw new TestException(); };
+                }
+
+                @Override
+                public BinaryOperator<Integer> combiner() {
+                    return (a, b) -> a + b;
+                }
+
+                @Override
+                public Function<Integer, Integer> finisher() {
+                    return a -> a;
+                }
+
+                @Override
+                public Set<Characteristics> characteristics() {
+                    return Collections.emptySet();
+                }
+            })
+            .test()
+            .assertFailure(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        });
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishProcessor.create()
+                .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void onSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(f -> f.collect(Collectors.toList()));
+    }
+
+    @Test
+    public void basicToFlowable() {
+        Flowable.range(1, 5)
+        .collect(Collectors.toList())
+        .toFlowable()
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void emptyToFlowable() {
+        Flowable.empty()
+        .collect(Collectors.toList())
+        .toFlowable()
+        .test()
+        .assertResult(Collections.emptyList());
+    }
+
+    @Test
+    public void errorToFlowable() {
+        Flowable.error(new TestException())
+        .collect(Collectors.toList())
+        .toFlowable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorSupplierCrashToFlowable() {
+        Flowable.range(1, 5)
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                throw new TestException();
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> { };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> a;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .toFlowable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorAccumulatorCrashToFlowable() {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        source
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                return () -> 1;
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> { throw new TestException(); };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> a;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .toFlowable()
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void collectorFinisherCrashToFlowable() {
+        Flowable.range(1, 5)
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                return () -> 1;
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> {  };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> { throw new TestException(); };
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .toFlowable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorAccumulatorDropSignalsToFlowable() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Flowable<Integer> source = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onNext(2);
+                    s.onError(new IOException());
+                    s.onComplete();
+                }
+            };
+
+            source
+            .collect(new Collector<Integer, Integer, Integer>() {
+
+                @Override
+                public Supplier<Integer> supplier() {
+                    return () -> 1;
+                }
+
+                @Override
+                public BiConsumer<Integer, Integer> accumulator() {
+                    return (a, b) -> { throw new TestException(); };
+                }
+
+                @Override
+                public BinaryOperator<Integer> combiner() {
+                    return (a, b) -> a + b;
+                }
+
+                @Override
+                public Function<Integer, Integer> finisher() {
+                    return a -> a;
+                }
+
+                @Override
+                public Set<Characteristics> characteristics() {
+                    return Collections.emptySet();
+                }
+            })
+            .toFlowable()
+            .test()
+            .assertFailure(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        });
+    }
+
+    @Test
+    public void disposeToFlowable() {
+        TestHelper.checkDisposed(PublishProcessor.create()
+                .collect(Collectors.toList()).toFlowable());
+    }
+
+    @Test
+    public void onSubscribeToFlowable() {
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.collect(Collectors.toList()).toFlowable());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableMapOptionalTest.java
@@ -1,0 +1,470 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.Optional;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.fuseable.QueueFuseable;
+import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class FlowableMapOptionalTest extends RxJavaTest {
+
+    static final Function<? super Integer, Optional<? extends Integer>> MODULO = v -> v % 2 == 0 ? Optional.of(v) : Optional.<Integer>empty();
+
+    @Test
+    public void allPresent() {
+        Flowable.range(1, 5)
+        .mapOptional(Optional::of)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void allEmpty() {
+        Flowable.range(1, 5)
+        .mapOptional(v -> Optional.<Integer>empty())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void mixed() {
+        Flowable.range(1, 10)
+        .mapOptional(MODULO)
+        .test()
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void mapperChash() {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        source
+        .mapOptional(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void mapperNull() {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        source
+        .mapOptional(v -> null)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void crashDropsOnNexts() {
+        Flowable<Integer> source = new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+            }
+        };
+
+        source
+        .mapOptional(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void backpressureAll() {
+        Flowable.range(1, 5)
+        .mapOptional(Optional::of)
+        .test(0L)
+        .assertEmpty()
+        .requestMore(2)
+        .assertValuesOnly(1, 2)
+        .requestMore(2)
+        .assertValuesOnly(1, 2, 3, 4)
+        .requestMore(1)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void backpressureNone() {
+        Flowable.range(1, 5)
+        .mapOptional(v -> Optional.empty())
+        .test(1L)
+        .assertResult();
+    }
+
+    @Test
+    public void backpressureMixed() {
+        Flowable.range(1, 10)
+        .mapOptional(MODULO)
+        .test(0L)
+        .assertEmpty()
+        .requestMore(2)
+        .assertValuesOnly(2, 4)
+        .requestMore(2)
+        .assertValuesOnly(2, 4, 6, 8)
+        .requestMore(1)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void syncFusedAll() {
+        Flowable.range(1, 5)
+        .mapOptional(Optional::of)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void asyncFusedAll() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .mapOptional(Optional::of)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void boundaryFusedAll() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .mapOptional(Optional::of)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void syncFusedNone() {
+        Flowable.range(1, 5)
+        .mapOptional(v -> Optional.empty())
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void asyncFusedNone() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .mapOptional(v -> Optional.empty())
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void boundaryFusedNone() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .mapOptional(v -> Optional.empty())
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult();
+    }
+
+    @Test
+    public void syncFusedMixed() {
+        Flowable.range(1, 10)
+        .mapOptional(MODULO)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void asyncFusedMixed() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        up
+        .mapOptional(MODULO)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void boundaryFusedMixed() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        up
+        .mapOptional(MODULO)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void allPresentConditional() {
+        Flowable.range(1, 5)
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void allEmptyConditional() {
+        Flowable.range(1, 5)
+        .mapOptional(v -> Optional.<Integer>empty())
+        .filter(v -> true)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void mixedConditional() {
+        Flowable.range(1, 10)
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .test()
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void mapperChashConditional() {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        source
+        .mapOptional(v -> { throw new TestException(); })
+        .filter(v -> true)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void mapperNullConditional() {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        source
+        .mapOptional(v -> null)
+        .filter(v -> true)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void crashDropsOnNextsConditional() {
+        Flowable<Integer> source = new Flowable<Integer>() {
+            @Override
+            protected void subscribeActual(Subscriber<? super Integer> s) {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+            }
+        };
+
+        source
+        .mapOptional(v -> { throw new TestException(); })
+        .filter(v -> true)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void backpressureAllConditional() {
+        Flowable.range(1, 5)
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .test(0L)
+        .assertEmpty()
+        .requestMore(2)
+        .assertValuesOnly(1, 2)
+        .requestMore(2)
+        .assertValuesOnly(1, 2, 3, 4)
+        .requestMore(1)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void backpressureNoneConditional() {
+        Flowable.range(1, 5)
+        .mapOptional(v -> Optional.empty())
+        .filter(v -> true)
+        .test(1L)
+        .assertResult();
+    }
+
+    @Test
+    public void backpressureMixedConditional() {
+        Flowable.range(1, 10)
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .test(0L)
+        .assertEmpty()
+        .requestMore(2)
+        .assertValuesOnly(2, 4)
+        .requestMore(2)
+        .assertValuesOnly(2, 4, 6, 8)
+        .requestMore(1)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void syncFusedAllConditional() {
+        Flowable.range(1, 5)
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void asyncFusedAllConditional() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void boundaryFusedAllConditiona() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void syncFusedNoneConditional() {
+        Flowable.range(1, 5)
+        .mapOptional(v -> Optional.empty())
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void asyncFusedNoneConditional() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .mapOptional(v -> Optional.empty())
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void boundaryFusedNoneConditional() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .mapOptional(v -> Optional.empty())
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult();
+    }
+
+    @Test
+    public void syncFusedMixedConditional() {
+        Flowable.range(1, 10)
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void asyncFusedMixedConditional() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        up
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void boundaryFusedMixedConditional() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        up
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java
@@ -1,0 +1,476 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
+
+    @Test
+    public void firstJust() throws Exception {
+        Integer v = Flowable.just(1)
+                .firstStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void firstEmpty() throws Exception {
+        Integer v = Flowable.<Integer>empty()
+                .firstStage(2)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)2, v);
+    }
+
+    @Test
+    public void firstCancels() throws Exception {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        Integer v = source
+                .firstStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void firstCompletableFutureCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void firstCompletableManualCompleteCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void firstCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void firstError() throws Exception {
+        CompletableFuture<Integer> cf = Flowable.<Integer>error(new TestException())
+                .firstStage(null)
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void firstSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onError(new TestException());
+                    s.onComplete();
+                }
+            }
+            .firstStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void firstDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                }
+            }
+            .firstStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+
+    @Test
+    public void singleJust() throws Exception {
+        Integer v = Flowable.just(1)
+                .singleStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void singleEmpty() throws Exception {
+        Integer v = Flowable.<Integer>empty()
+                .singleStage(2)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)2, v);
+    }
+
+    @Test
+    public void singleTooManyCancels() throws Exception {
+        ReplayProcessor<Integer> source = ReplayProcessor.create();
+        source.onNext(1);
+        source.onNext(2);
+
+        TestHelper.assertError(source
+                .singleStage(null)
+                .toCompletableFuture(), IllegalArgumentException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void singleCompletableFutureCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void singleCompletableManualCompleteCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void singleCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void singleError() throws Exception {
+        CompletableFuture<Integer> cf = Flowable.<Integer>error(new TestException())
+                .singleStage(null)
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void singleSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onComplete();
+                    s.onError(new TestException());
+                    s.onComplete();
+                }
+            }
+            .singleStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void singleDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onComplete();
+                }
+            }
+            .singleStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+
+    @Test
+    public void lastJust() throws Exception {
+        Integer v = Flowable.just(1)
+                .lastStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void lastRange() throws Exception {
+        Integer v = Flowable.range(1, 5)
+                .lastStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)5, v);
+    }
+
+    @Test
+    public void lastEmpty() throws Exception {
+        Integer v = Flowable.<Integer>empty()
+                .lastStage(2)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)2, v);
+    }
+
+    @Test
+    public void lastCompletableFutureCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void lastCompletableManualCompleteCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void lastCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void lastError() throws Exception {
+        CompletableFuture<Integer> cf = Flowable.<Integer>error(new TestException())
+                .lastStage(null)
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void lastSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onComplete();
+                    s.onError(new TestException());
+                    s.onComplete();
+                }
+            }
+            .lastStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void lastDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onComplete();
+                }
+            }
+            .lastStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableStageSubscriberOrErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableStageSubscriberOrErrorTest.java
@@ -1,0 +1,470 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
+
+    @Test
+    public void firstJust() throws Exception {
+        Integer v = Flowable.just(1)
+                .firstOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void firstEmpty() throws Exception {
+        TestHelper.assertError(
+                Flowable.<Integer>empty()
+                .firstOrErrorStage()
+                .toCompletableFuture(), NoSuchElementException.class);
+    }
+
+    @Test
+    public void firstCancels() throws Exception {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        Integer v = source
+                .firstOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void firstCompletableFutureCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void firstCompletableManualCompleteCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void firstCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void firstError() throws Exception {
+        CompletableFuture<Integer> cf = Flowable.<Integer>error(new TestException())
+                .firstOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void firstSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onError(new TestException());
+                    s.onComplete();
+                }
+            }
+            .firstOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void firstDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                }
+            }
+            .firstOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+
+    @Test
+    public void singleJust() throws Exception {
+        Integer v = Flowable.just(1)
+                .singleOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void singleEmpty() throws Exception {
+        TestHelper.assertError(
+                Flowable.<Integer>empty()
+                .singleOrErrorStage()
+                .toCompletableFuture(), NoSuchElementException.class);
+    }
+
+    @Test
+    public void singleTooManyCancels() throws Exception {
+        ReplayProcessor<Integer> source = ReplayProcessor.create();
+        source.onNext(1);
+        source.onNext(2);
+
+        TestHelper.assertError(source
+            .singleOrErrorStage()
+            .toCompletableFuture(), IllegalArgumentException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void singleCompletableFutureCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void singleCompletableManualCompleteCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void singleCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void singleError() throws Exception {
+        CompletableFuture<Integer> cf = Flowable.<Integer>error(new TestException())
+                .singleOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void singleSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onComplete();
+                    s.onError(new TestException());
+                    s.onComplete();
+                }
+            }
+            .singleOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void singleDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onComplete();
+                }
+            }
+            .singleOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+
+    @Test
+    public void lastJust() throws Exception {
+        Integer v = Flowable.just(1)
+                .lastOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void lastRange() throws Exception {
+        Integer v = Flowable.range(1, 5)
+                .lastOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)5, v);
+    }
+
+    @Test
+    public void lastEmpty() throws Exception {
+        TestHelper.assertError(Flowable.<Integer>empty()
+                .lastOrErrorStage()
+                .toCompletableFuture(), NoSuchElementException.class);
+    }
+
+    @Test
+    public void lastCompletableFutureCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void lastCompletableManualCompleteCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void lastCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasSubscribers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasSubscribers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void lastError() throws Exception {
+        CompletableFuture<Integer> cf = Flowable.<Integer>error(new TestException())
+                .lastOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void lastSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onComplete();
+                    s.onError(new TestException());
+                    s.onComplete();
+                }
+            }
+            .lastOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void lastDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onComplete();
+                }
+            }
+            .lastOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/MapOptionalTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/MapOptionalTckTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.Optional;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class MapOptionalTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        return
+                Flowable.range(0, (int)(2 * elements)).mapOptional(v -> v % 2 == 0 ? Optional.of(v) : Optional.empty())
+            ;
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        return Flowable.just(1).<Integer>mapOptional(v -> null).onBackpressureDrop();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -3438,4 +3438,21 @@ public enum TestHelper {
             RxJavaPlugins.reset();
         }
     }
+
+    /**
+     * Assert if the given CompletableFuture fails with a specified error inside an ExecutionException.
+     * @param cf the CompletableFuture to test
+     * @param error the error class expected
+     */
+    public static void assertError(CompletableFuture<?> cf, Class<? extends Throwable> error) {
+        try {
+            cf.get();
+            fail("Should have thrown!");
+        } catch (Throwable ex) {
+            if (!error.isInstance(ex.getCause())) {
+                ex.printStackTrace();
+                fail("Wrong cause: " + ex.getCause());
+            }
+        }
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -503,6 +503,12 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "window", Long.TYPE, TimeUnit.class, Scheduler.class, Long.TYPE, Boolean.TYPE));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "window", Long.TYPE, TimeUnit.class, Scheduler.class, Long.TYPE, Boolean.TYPE, Integer.TYPE));
 
+        // null value allowed
+
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "firstStage", Object.class));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "singleStage", Object.class));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "lastStage", Object.class));
+
         // -----------------------------------------------------------------------------------
 
         ignores = new HashMap<String, List<ParamIgnore>>();


### PR DESCRIPTION
This PR implements the following `Flowable` operators:

- `mapOptional` - essentially a map-filter via `Optional`s.
- `collect(Collector)` - use the Java 8 `Collector` API, see [`Collectors`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html).
- `firstStage` - return the first item or a default value as a `CompletionStage`.
- `firstOrErrorStage` - return the first item or error as a `CompletionStage`.
- `singleStage` - return the only item or a default value as a `CompletionStage`.
- `singleOrErrorStage` - return the only item or error as a `CompletionStage`.
- `lastStage` - return the last item or a default value as a `CompletionStage`.
- `lastOrErrorStage` - return the last item or error as a `CompletionStage`.

Related: #6776

Diagrams:

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mapOptional.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/collector.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstStage.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstOrErrorStage.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleStage.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleOrErrorStage.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/lastStage.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/lastOrErrorStage.f.png)