### PR TITLE
3.x: [Java 8] Add blockingStream & flatMapStream to Flowable

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStream.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+import java.util.stream.Stream;
+
+import org.reactivestreams.*;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
+import io.reactivex.rxjava3.internal.subscriptions.*;
+import io.reactivex.rxjava3.internal.util.*;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Maps the upstream values onto {@link Stream}s and emits their items in order to the downstream.
+ *
+ * @param <T> the upstream element type
+ * @param <R> the inner {@code Stream} and result element type
+ * @since 3.0.0
+ */
+public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
+
+    final Flowable<T> source;
+
+    final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+    final int prefetch;
+
+    public FlowableFlatMapStream(Flowable<T> source, Function<? super T, ? extends Stream<? extends R>> mapper, int prefetch) {
+        this.source = source;
+        this.mapper = mapper;
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        if (source instanceof Supplier) {
+            Stream<? extends R> stream = null;
+            try {
+                @SuppressWarnings("unchecked")
+                T t = ((Supplier<T>)source).get();
+                if (t != null) {
+                    stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
+                }
+            } catch (Throwable ex) {
+                EmptySubscription.error(ex, s);
+                return;
+            }
+
+            if (stream != null) {
+                FlowableFromStream.subscribeStream(s, stream);
+            } else {
+                EmptySubscription.complete(s);
+            }
+        } else {
+            source.subscribe(new FlatMapStreamSubscriber<>(s, mapper, prefetch));
+        }
+    }
+
+    static final class FlatMapStreamSubscriber<T, R> extends AtomicInteger
+    implements FlowableSubscriber<T>, Subscription {
+
+        private static final long serialVersionUID = -5127032662980523968L;
+
+        final Subscriber<? super R> downstream;
+
+        final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+        final int prefetch;
+
+        final AtomicLong requested;
+
+        SimpleQueue<T> queue;
+
+        Subscription upstream;
+
+        Iterator<? extends R> currentIterator;
+
+        AutoCloseable currentCloseable;
+
+        volatile boolean cancelled;
+
+        volatile boolean upstreamDone;
+        final AtomicThrowable error;
+
+        long emitted;
+
+        int consumed;
+
+        int sourceMode;
+
+        FlatMapStreamSubscriber(Subscriber<? super R> downstream, Function<? super T, ? extends Stream<? extends R>> mapper, int prefetch) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+            this.prefetch = prefetch;
+            this.requested = new AtomicLong();
+            this.error = new AtomicThrowable();
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Subscription s) {
+            if (SubscriptionHelper.validate(this.upstream, s)) {
+                this.upstream = s;
+
+                if (s instanceof QueueSubscription) {
+
+                    @SuppressWarnings("unchecked")
+                    QueueSubscription<T> qs = (QueueSubscription<T>)s;
+
+                    int m = qs.requestFusion(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
+                    if (m == QueueFuseable.SYNC) {
+                        sourceMode = m;
+                        queue = qs;
+                        upstreamDone = true;
+
+                        downstream.onSubscribe(this);
+                        return;
+                    }
+                    else if (m == QueueFuseable.ASYNC) {
+                        sourceMode = m;
+                        queue = qs;
+
+                        downstream.onSubscribe(this);
+
+                        s.request(prefetch);
+                        return;
+                    }
+                }
+
+                queue = new SpscArrayQueue<>(prefetch);
+
+                downstream.onSubscribe(this);
+
+                s.request(prefetch);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (sourceMode != QueueFuseable.ASYNC) {
+                if (!queue.offer(t)) {
+                    upstream.cancel();
+                    onError(new MissingBackpressureException("Queue full?!"));
+                    return;
+                }
+            }
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (error.compareAndSet(null, t)) {
+                upstreamDone = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            upstreamDone = true;
+            drain();
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            upstream.cancel();
+            drain();
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+
+            final Subscriber<? super R> downstream = this.downstream;
+            final SimpleQueue<T> queue = this.queue;
+            final AtomicThrowable error = this.error;
+            Iterator<? extends R> iterator = this.currentIterator;
+            long requested = this.requested.get();
+            long emitted = this.emitted;
+            final int limit = prefetch - (prefetch >> 2);
+            boolean canRequest = sourceMode != QueueFuseable.SYNC;
+
+            for (;;) {
+                if (cancelled) {
+                    queue.clear();
+                    clearCurrentSuppressCloseError();
+                } else {
+                    boolean isDone = upstreamDone;
+                    if (error.get() != null) {
+                        downstream.onError(error.get());
+                        cancelled = true;
+                        continue;
+                    }
+
+                    if (iterator == null) {
+                        T t;
+
+                        try {
+                            t = queue.poll();
+                        } catch (Throwable ex) {
+                            trySignalError(downstream, ex);
+                            continue;
+                        }
+
+                        boolean isEmpty = t == null;
+
+                        if (isDone && isEmpty) {
+                            downstream.onComplete();
+                            cancelled = true;
+                        }
+                        else if (!isEmpty) {
+                            if (canRequest && ++consumed == limit) {
+                                consumed = 0;
+                                upstream.request(limit);
+                            }
+
+                            Stream<? extends R> stream;
+                            try {
+                                stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
+                                iterator = stream.iterator();
+
+                                if (iterator.hasNext()) {
+                                    currentIterator = iterator;
+                                    currentCloseable = stream;
+                                } else {
+                                    iterator = null;
+                                }
+                            } catch (Throwable ex) {
+                                trySignalError(downstream, ex);
+                            }
+                            continue;
+                        }
+                    }
+                    if (iterator != null && emitted != requested) {
+                        R item;
+
+                        try {
+                            item = Objects.requireNonNull(iterator.next(), "The Stream.Iterator returned a null value");
+                        } catch (Throwable ex) {
+                            trySignalError(downstream, ex);
+                            continue;
+                        }
+
+                        if (!cancelled) {
+                            downstream.onNext(item);
+                            emitted++;
+
+                            if (!cancelled) {
+                                try {
+                                    if (!iterator.hasNext()) {
+                                        iterator = null;
+                                        clearCurrentRethrowCloseError();
+                                    }
+                                } catch (Throwable ex) {
+                                    trySignalError(downstream, ex);
+                                }
+                            }
+                        }
+
+                        continue;
+                    }
+                }
+
+                this.emitted = emitted;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+                requested = this.requested.get();
+            }
+        }
+
+        void clearCurrentRethrowCloseError() throws Throwable {
+            currentIterator = null;
+            AutoCloseable ac = currentCloseable;
+            currentCloseable = null;
+            if (ac != null) {
+                ac.close();
+            }
+        }
+
+        void clearCurrentSuppressCloseError() {
+            try {
+                clearCurrentRethrowCloseError();
+            } catch (Throwable ex) {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void trySignalError(Subscriber<?> downstream, Throwable ex) {
+            if (error.compareAndSet(null, ex)) {
+                upstream.cancel();
+                cancelled = true;
+                downstream.onError(ex);
+            } else {
+                RxJavaPlugins.onError(ex);
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromStream.java
@@ -42,6 +42,16 @@ public final class FlowableFromStream<T> extends Flowable<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
+        subscribeStream(s, stream);
+    }
+
+    /**
+     * Subscribes to the Stream by picking the normal or conditional stream Subscription implementation.
+     * @param <T> the element type of the flow
+     * @param s the subscriber to drive
+     * @param stream the sequence to consume
+     */
+    public static <T> void subscribeStream(Subscriber<? super T> s, Stream<T> stream) {
         Iterator<T> iterator;
         try {
             iterator = stream.iterator();

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream0HTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream0HTckTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class FlatMapStream0HTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        return
+                Flowable.just(1).hide().flatMapStream(v -> IntStream.range(0, (int)elements).boxed())
+            ;
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Flowable.just(1).hide().flatMapStream(v -> stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream0TckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream0TckTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class FlatMapStream0TckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        return
+                Flowable.just(1).flatMapStream(v -> IntStream.range(0, (int)elements).boxed())
+            ;
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Flowable.just(1).flatMapStream(v -> stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream1HTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream1HTckTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class FlatMapStream1HTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        return
+                Flowable.range(1, (int)elements).hide().flatMapStream(v -> Stream.of(v))
+            ;
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Flowable.just(1).hide().flatMapStream(v -> stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream1TckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream1TckTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class FlatMapStream1TckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        return
+                Flowable.range(1, (int)elements).flatMapStream(v -> Stream.of(v))
+            ;
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Flowable.just(1).flatMapStream(v -> stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream2HTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream2HTckTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class FlatMapStream2HTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        if (elements % 2 == 0) {
+            return Flowable.range(0, (int)elements / 2).hide().flatMapStream(v -> Stream.of(v, v + 1));
+        }
+        return
+                Flowable.range(-1, 1 + (int)elements / 2).hide().flatMapStream(v -> {
+                    if (v != -1) {
+                        return Stream.of(v, v + 1);
+                    }
+                    return Stream.of(v);
+                });
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Flowable.just(1).hide().flatMapStream(v -> stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream2TckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlatMapStream2TckTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class FlatMapStream2TckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        if (elements % 2 == 0) {
+            return Flowable.range(0, (int)elements / 2).flatMapStream(v -> Stream.of(v, v + 1));
+        }
+        return
+                Flowable.range(-1, 1 + (int)elements / 2).flatMapStream(v -> {
+                    if (v != -1) {
+                        return Stream.of(v, v + 1);
+                    }
+                    return Stream.of(v);
+                });
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Flowable.just(1).flatMapStream(v -> stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableBlockingStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableBlockingStreamTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.stream.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.processors.UnicastProcessor;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+public class FlowableBlockingStreamTest extends RxJavaTest {
+
+    @Test
+    public void empty() {
+        try (Stream<Integer> stream = Flowable.<Integer>empty().blockingStream()) {
+            assertEquals(0, stream.toArray().length);
+        }
+    }
+
+    @Test
+    public void just() {
+        try (Stream<Integer> stream = Flowable.just(1).blockingStream()) {
+            assertArrayEquals(new Integer[] { 1 }, stream.toArray(Integer[]::new));
+        }
+    }
+
+    @Test
+    public void range() {
+        try (Stream<Integer> stream = Flowable.range(1, 5).blockingStream()) {
+            assertArrayEquals(new Integer[] { 1, 2, 3, 4, 5 }, stream.toArray(Integer[]::new));
+        }
+    }
+
+    @Test
+    public void rangeBackpressured() {
+        try (Stream<Integer> stream = Flowable.range(1, 5).blockingStream(1)) {
+            assertArrayEquals(new Integer[] { 1, 2, 3, 4, 5 }, stream.toArray(Integer[]::new));
+        }
+    }
+
+    @Test
+    public void rangeAsyncBackpressured() {
+        try (Stream<Integer> stream = Flowable.range(1, 1000).subscribeOn(Schedulers.computation()).blockingStream()) {
+            List<Integer> list = stream.collect(Collectors.toList());
+
+            assertEquals(1000, list.size());
+            for (int i = 1; i <= 1000; i++) {
+                assertEquals(i, list.get(i - 1).intValue());
+            }
+        }
+    }
+
+    @Test
+    public void rangeAsyncBackpressured1() {
+        try (Stream<Integer> stream = Flowable.range(1, 1000).subscribeOn(Schedulers.computation()).blockingStream(1)) {
+            List<Integer> list = stream.collect(Collectors.toList());
+
+            assertEquals(1000, list.size());
+            for (int i = 1; i <= 1000; i++) {
+                assertEquals(i, list.get(i - 1).intValue());
+            }
+        }
+    }
+
+    @Test
+    public void error() {
+        try (Stream<Integer> stream = Flowable.<Integer>error(new TestException()).blockingStream()) {
+            stream.toArray(Integer[]::new);
+            fail("Should have thrown!");
+        } catch (TestException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void close() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        up.onNext(1);
+        up.onNext(2);
+        up.onNext(3);
+        up.onNext(4);
+        up.onNext(5);
+
+        try (Stream<Integer> stream = up.blockingStream()) {
+            assertArrayEquals(new Integer[] { 1, 2, 3 }, stream.limit(3).toArray(Integer[]::new));
+        }
+
+        assertFalse(up.hasSubscribers());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStreamTest.java
@@ -1,0 +1,451 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class FlowableFlatMapStreamTest extends RxJavaTest {
+
+    @Test
+    public void empty() {
+        Flowable.empty()
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void emptyHidden() {
+        Flowable.empty()
+        .hide()
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void just() {
+        Flowable.just(1)
+        .flatMapStream(v -> Stream.of(v + 1, v + 2, v + 3, v + 4, v + 5))
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void justHidden() {
+        Flowable.just(1).hide()
+        .flatMapStream(v -> Stream.of(v + 1, v + 2, v + 3, v + 4, v + 5))
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void error() {
+        Flowable.error(new TestException())
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void supplierFusedError() {
+        Flowable.fromCallable(() -> { throw new TestException(); })
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorHidden() {
+        Flowable.error(new TestException())
+        .hide()
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void range() {
+        Flowable.range(1, 5)
+        .flatMapStream(v -> IntStream.range(v * 10, v * 10 + 5).boxed())
+        .test()
+        .assertResult(
+                10, 11, 12, 13, 14,
+                20, 21, 22, 23, 24,
+                30, 31, 32, 33, 34,
+                40, 41, 42, 43, 44,
+                50, 51, 52, 53, 54
+        );
+    }
+
+    @Test
+    public void rangeHidden() {
+        Flowable.range(1, 5)
+        .hide()
+        .flatMapStream(v -> IntStream.range(v * 10, v * 10 + 5).boxed())
+        .test()
+        .assertResult(
+                10, 11, 12, 13, 14,
+                20, 21, 22, 23, 24,
+                30, 31, 32, 33, 34,
+                40, 41, 42, 43, 44,
+                50, 51, 52, 53, 54
+        );
+    }
+
+    @Test
+    public void rangeToEmpty() {
+        Flowable.range(1, 5)
+        .flatMapStream(v -> Stream.of())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void rangeTake() {
+        Flowable.range(1, 5)
+        .flatMapStream(v -> IntStream.range(v * 10, v * 10 + 5).boxed())
+        .take(12)
+        .test()
+        .assertResult(
+                10, 11, 12, 13, 14,
+                20, 21, 22, 23, 24,
+                30, 31
+        );
+    }
+
+    @Test
+    public void rangeTakeHidden() {
+        Flowable.range(1, 5)
+        .hide()
+        .flatMapStream(v -> IntStream.range(v * 10, v * 10 + 5).boxed())
+        .take(12)
+        .test()
+        .assertResult(
+                10, 11, 12, 13, 14,
+                20, 21, 22, 23, 24,
+                30, 31
+        );
+    }
+
+    @Test
+    public void upstreamCancelled() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        TestSubscriber<Integer> ts = pp
+                .flatMapStream(v -> Stream.of(v + 1, v + 2).onClose(() -> calls.getAndIncrement()))
+                .test(1);
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onNext(1);
+
+        ts.assertValuesOnly(2);
+        ts.cancel();
+
+        assertFalse(pp.hasSubscribers());
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void upstreamCancelledCloseCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            TestSubscriber<Integer> ts = pp
+                    .flatMapStream(v -> Stream.of(v + 1, v + 2).onClose(() -> { throw new TestException(); }))
+                    .test(1);
+
+            assertTrue(pp.hasSubscribers());
+
+            pp.onNext(1);
+
+            ts.assertValuesOnly(2);
+            ts.cancel();
+
+            assertFalse(pp.hasSubscribers());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void crossMap() {
+        Flowable.range(1, 1000)
+        .flatMapStream(v -> IntStream.range(v * 1000, v * 1000 + 1000).boxed())
+        .test()
+        .assertValueCount(1_000_000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void crossMapHidden() {
+        Flowable.range(1, 1000)
+        .hide()
+        .flatMapStream(v -> IntStream.range(v * 1000, v * 1000 + 1000).boxed())
+        .test()
+        .assertValueCount(1_000_000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void crossMapBackpressured() {
+        for (int n = 1; n < 2048; n *= 2) {
+            Flowable.range(1, 1000)
+            .flatMapStream(v -> IntStream.range(v * 1000, v * 1000 + 1000).boxed())
+            .rebatchRequests(n)
+            .test()
+            .withTag("rebatch: " + n)
+            .assertValueCount(1_000_000)
+            .assertNoErrors()
+            .assertComplete();
+        }
+    }
+
+    @Test
+    public void crossMapBackpressuredHidden() {
+        for (int n = 1; n < 2048; n *= 2) {
+            Flowable.range(1, 1000)
+            .hide()
+            .flatMapStream(v -> IntStream.range(v * 1000, v * 1000 + 1000).boxed())
+            .rebatchRequests(n)
+            .test()
+            .withTag("rebatch: " + n)
+            .assertValueCount(1_000_000)
+            .assertNoErrors()
+            .assertComplete();
+        }
+    }
+
+    @Test
+    public void onSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.flatMapStream(v -> Stream.of(1, 2)));
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(UnicastProcessor.create().flatMapStream(v -> Stream.of(1, 2)));
+    }
+
+    @Test
+    public void queueOverflow() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            new Flowable<Integer>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onNext(2);
+                    s.onNext(3);
+                    s.onError(new TestException());
+                }
+            }
+            .flatMapStream(v -> Stream.of(1, 2), 1)
+            .test(0)
+            .assertFailure(MissingBackpressureException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void mapperThrows() {
+        Flowable.just(1).hide()
+        .concatMapStream(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapperNull() {
+        Flowable.just(1).hide()
+        .concatMapStream(v -> null)
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void streamNull() {
+        Flowable.just(1).hide()
+        .concatMapStream(v -> Stream.of(1, null))
+        .test()
+        .assertFailure(NullPointerException.class, 1);
+    }
+
+    @Test
+    public void hasNextThrows() {
+        Flowable.just(1).hide()
+        .concatMapStream(v -> Stream.generate(() -> { throw new TestException(); }))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void hasNextThrowsLater() {
+        AtomicInteger counter = new AtomicInteger();
+        Flowable.just(1).hide()
+        .concatMapStream(v -> Stream.generate(() -> {
+            if (counter.getAndIncrement() == 0) {
+                return 1;
+            }
+            throw new TestException();
+        }))
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void mapperThrowsWhenUpstreamErrors() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            AtomicInteger counter = new AtomicInteger();
+
+            TestSubscriber<Integer> ts = pp.hide()
+            .concatMapStream(v -> {
+                if (counter.getAndIncrement() == 0) {
+                    return Stream.of(1, 2);
+                }
+                pp.onError(new IOException());
+                throw new TestException();
+            })
+            .test();
+
+            pp.onNext(1);
+            pp.onNext(2);
+
+            ts
+            .assertFailure(IOException.class, 1, 2);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void rangeBackpressured() {
+        Flowable.range(1, 5)
+        .hide()
+        .concatMapStream(v -> Stream.of(v), 1)
+        .test(0)
+        .assertEmpty()
+        .requestMore(5)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void cancelAfterIteratorNext() throws Exception {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                ts.cancel();
+                return 1;
+            }
+        });
+
+        Flowable.just(1)
+        .hide()
+        .concatMapStream(v -> stream)
+        .subscribe(ts);
+
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void asyncUpstreamFused() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+
+        TestSubscriber<Integer> ts = up.flatMapStream(v -> Stream.of(1, 2))
+        .test();
+
+        assertTrue(up.hasSubscribers());
+
+        up.onNext(1);
+
+        ts.assertValuesOnly(1, 2);
+
+        up.onComplete();
+
+        ts.assertResult(1, 2);
+    }
+
+    @Test
+    public void asyncUpstreamFusionBoundary() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+
+        TestSubscriber<Integer> ts = up
+                .map(v -> v + 1)
+                .flatMapStream(v -> Stream.of(1, 2))
+        .test();
+
+        assertTrue(up.hasSubscribers());
+
+        up.onNext(1);
+
+        ts.assertValuesOnly(1, 2);
+
+        up.onComplete();
+
+        ts.assertResult(1, 2);
+    }
+
+    @Test
+    public void fusedPollCrash() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+
+        TestSubscriber<Integer> ts = up
+                .map(v -> { throw new TestException(); })
+                .compose(TestHelper.flowableStripBoundary())
+                .flatMapStream(v -> Stream.of(1, 2))
+        .test();
+
+        assertTrue(up.hasSubscribers());
+
+        up.onNext(1);
+
+        assertFalse(up.hasSubscribers());
+
+        ts.assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -2987,6 +2987,17 @@ public enum TestHelper {
         }
     }
 
+    /**
+     * Strips the {@link QueueFuseable#BOUNDARY} mode flag when the downstream calls {@link QueueSubscription#requestFusion(int)}.
+     * <p>
+     * By default, many operators use {@link QueueFuseable#BOUNDARY} to indicate upstream side-effects
+     * should not leak over a fused boundary. However, some tests want to verify if {@link QueueSubscription#poll()} crashes
+     * are handled correctly and the most convenient way is to crash {@link Flowable#map} that won't fuse with {@code BOUNDARY}
+     * flag. This transformer strips this flag and thus allows the function of {@code map} to be executed as part of the
+     * {@code poll()} chain.
+     * @param <T> the element type of the flow
+     * @return the new Transformer instance
+     */
     public static <T> FlowableTransformer<T, T> flowableStripBoundary() {
         return new FlowableStripBoundary<>(null);
     }
@@ -3092,6 +3103,17 @@ public enum TestHelper {
         }
     }
 
+    /**
+     * Strips the {@link QueueFuseable#BOUNDARY} mode flag when the downstream calls {@link QueueDisposable#requestFusion(int)}.
+     * <p>
+     * By default, many operators use {@link QueueFuseable#BOUNDARY} to indicate upstream side-effects
+     * should not leak over a fused boundary. However, some tests want to verify if {@link QueueDisposable#poll()} crashes
+     * are handled correctly and the most convenient way is to crash {@link Observable#map} that won't fuse with {@code BOUNDARY}
+     * flag. This transformer strips this flag and thus allows the function of {@code map} to be executed as part of the
+     * {@code poll()} chain.
+     * @param <T> the element type of the flow
+     * @return the new Transformer instance
+     */
     public static <T> ObservableTransformer<T, T> observableStripBoundary() {
         return new ObservableStripBoundary<>(null);
     }


### PR DESCRIPTION
Add Java 8 interoperation methods to `Flowable`:
- `blockingStream` - essentially `blockingIterable` with close support
- `concatMapStream` - map and concatenate streams
- `flatMapStream` - map and concatenate streams, inherently same as `concatMapStream`

Related #6776 

Marbles:

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/blockingStream.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/blockingStream.fi.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapStream.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapStream.fi.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flatMapStream.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flatMapStream.fi.png)