### PR TITLE
3.x: [Java 8] Add fromOpt/Stage, mapOptional, toCompletionStage to M/S/C

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/CompletableFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/CompletableFromCompletionStage.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.internal.jdk8.FlowableFromCompletionStage.BiConsumerAtomicReference;
+
+/**
+ * Wrap a CompletionStage and signal its outcome.
+ * @param <T> the element type of the CompletionsStage
+ * @since 3.0.0
+ */
+public final class CompletableFromCompletionStage<T> extends Completable {
+
+    final CompletionStage<T> stage;
+
+    public CompletableFromCompletionStage(CompletionStage<T> stage) {
+        this.stage = stage;
+    }
+
+    @Override
+    protected void subscribeActual(CompletableObserver observer) {
+        // We need an indirection because one can't detach from a whenComplete
+        // and cancellation should not hold onto the stage.
+        BiConsumerAtomicReference<Object> whenReference = new BiConsumerAtomicReference<>();
+        CompletionStageHandler<Object> handler = new CompletionStageHandler<>(observer, whenReference);
+        whenReference.lazySet(handler);
+
+        observer.onSubscribe(handler);
+        stage.whenComplete(whenReference);
+    }
+
+    static final class CompletionStageHandler<T>
+    implements Disposable, BiConsumer<T, Throwable> {
+
+        final CompletableObserver downstream;
+
+        final BiConsumerAtomicReference<T> whenReference;
+
+        CompletionStageHandler(CompletableObserver downstream, BiConsumerAtomicReference<T> whenReference) {
+            this.downstream = downstream;
+            this.whenReference = whenReference;
+        }
+
+        @Override
+        public void accept(T item, Throwable error) {
+            if (error != null) {
+                downstream.onError(error);
+            } else {
+                downstream.onComplete();
+            }
+        }
+
+        @Override
+        public void dispose() {
+            whenReference.set(null);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return whenReference.get() == null;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/CompletionStageConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/CompletionStageConsumer.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Class that extends CompletableFuture and converts multiple types of reactive consumers
+ * and their signals into completion signals.
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class CompletionStageConsumer<T> extends CompletableFuture<T>
+implements MaybeObserver<T>, SingleObserver<T>, CompletableObserver {
+
+    final AtomicReference<Disposable> upstream;
+
+    final boolean hasDefault;
+
+    final T defaultItem;
+
+    public CompletionStageConsumer(boolean hasDefault, T defaultItem) {
+        this.hasDefault = hasDefault;
+        this.defaultItem = defaultItem;
+        this.upstream = new AtomicReference<>();
+    }
+
+    @Override
+    public void onSubscribe(@NonNull Disposable d) {
+        DisposableHelper.setOnce(upstream, d);
+    }
+
+    @Override
+    public void onSuccess(@NonNull T t) {
+        clear();
+        complete(t);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        clear();
+        if (!completeExceptionally(t)) {
+            RxJavaPlugins.onError(t);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (hasDefault) {
+            complete(defaultItem);
+        } else {
+            completeExceptionally(new NoSuchElementException("The source was empty"));
+        }
+    }
+
+    void cancelUpstream() {
+        DisposableHelper.dispose(upstream);
+    }
+
+    void clear() {
+        upstream.lazySet(DisposableHelper.DISPOSED);
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        cancelUpstream();
+        return super.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean complete(T value) {
+        cancelUpstream();
+        return super.complete(value);
+    }
+
+    @Override
+    public boolean completeExceptionally(Throwable ex) {
+        cancelUpstream();
+        return super.completeExceptionally(ex);
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFromCompletionStage.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.internal.jdk8.FlowableFromCompletionStage.BiConsumerAtomicReference;
+
+/**
+ * Wrap a CompletionStage and signal its outcome.
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class MaybeFromCompletionStage<T> extends Maybe<T> {
+
+    final CompletionStage<T> stage;
+
+    public MaybeFromCompletionStage(CompletionStage<T> stage) {
+        this.stage = stage;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        // We need an indirection because one can't detach from a whenComplete
+        // and cancellation should not hold onto the stage.
+        BiConsumerAtomicReference<T> whenReference = new BiConsumerAtomicReference<>();
+        CompletionStageHandler<T> handler = new CompletionStageHandler<>(observer, whenReference);
+        whenReference.lazySet(handler);
+
+        observer.onSubscribe(handler);
+        stage.whenComplete(whenReference);
+    }
+
+    static final class CompletionStageHandler<T>
+    implements Disposable, BiConsumer<T, Throwable> {
+
+        final MaybeObserver<? super T> downstream;
+
+        final BiConsumerAtomicReference<T> whenReference;
+
+        CompletionStageHandler(MaybeObserver<? super T> downstream, BiConsumerAtomicReference<T> whenReference) {
+            this.downstream = downstream;
+            this.whenReference = whenReference;
+        }
+
+        @Override
+        public void accept(T item, Throwable error) {
+            if (error != null) {
+                downstream.onError(error);
+            }
+            else if (item != null) {
+                downstream.onSuccess(item);
+            } else {
+                downstream.onComplete();
+            }
+        }
+
+        @Override
+        public void dispose() {
+            whenReference.set(null);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return whenReference.get() == null;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeMapOptional.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeMapOptional.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+
+/**
+ * Maps the success value to an {@link Optional} and emits its non-empty value or completes.
+ *
+ * @param <T> the upstream success value type
+ * @param <R> the result value type
+ * @since 3.0.0
+ */
+public final class MaybeMapOptional<T, R> extends Maybe<R> {
+
+    final Maybe<T> source;
+
+    final Function<? super T, Optional<? extends R>> mapper;
+
+    public MaybeMapOptional(Maybe<T> source, Function<? super T, Optional<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super R> observer) {
+        source.subscribe(new MapOptionalMaybeObserver<>(observer, mapper));
+    }
+
+    static final class MapOptionalMaybeObserver<T, R> implements MaybeObserver<T>, Disposable {
+
+        final MaybeObserver<? super R> downstream;
+
+        final Function<? super T, Optional<? extends R>> mapper;
+
+        Disposable upstream;
+
+        MapOptionalMaybeObserver(MaybeObserver<? super R> downstream, Function<? super T, Optional<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void dispose() {
+            Disposable d = this.upstream;
+            this.upstream = DisposableHelper.DISPOSED;
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return upstream.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            Optional<? extends R> v;
+
+            try {
+                v = Objects.requireNonNull(mapper.apply(value), "The mapper returned a null item");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            if (v.isPresent()) {
+                downstream.onSuccess(v.get());
+            } else {
+                downstream.onComplete();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            downstream.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/SingleFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/SingleFromCompletionStage.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.internal.jdk8.FlowableFromCompletionStage.BiConsumerAtomicReference;
+
+/**
+ * Wrap a CompletionStage and signal its outcome.
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class SingleFromCompletionStage<T> extends Single<T> {
+
+    final CompletionStage<T> stage;
+
+    public SingleFromCompletionStage(CompletionStage<T> stage) {
+        this.stage = stage;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        // We need an indirection because one can't detach from a whenComplete
+        // and cancellation should not hold onto the stage.
+        BiConsumerAtomicReference<T> whenReference = new BiConsumerAtomicReference<>();
+        CompletionStageHandler<T> handler = new CompletionStageHandler<>(observer, whenReference);
+        whenReference.lazySet(handler);
+
+        observer.onSubscribe(handler);
+        stage.whenComplete(whenReference);
+    }
+
+    static final class CompletionStageHandler<T>
+    implements Disposable, BiConsumer<T, Throwable> {
+
+        final SingleObserver<? super T> downstream;
+
+        final BiConsumerAtomicReference<T> whenReference;
+
+        CompletionStageHandler(SingleObserver<? super T> downstream, BiConsumerAtomicReference<T> whenReference) {
+            this.downstream = downstream;
+            this.whenReference = whenReference;
+        }
+
+        @Override
+        public void accept(T item, Throwable error) {
+            if (error != null) {
+                downstream.onError(error);
+            }
+            else if (item != null) {
+                downstream.onSuccess(item);
+            } else {
+                downstream.onError(new NullPointerException("The CompletionStage terminated with null."));
+            }
+        }
+
+        @Override
+        public void dispose() {
+            whenReference.set(null);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return whenReference.get() == null;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/SingleMapOptional.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/SingleMapOptional.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+
+/**
+ * Maps the success value to an {@link Optional} and emits its non-empty value or completes.
+ *
+ * @param <T> the upstream success value type
+ * @param <R> the result value type
+ * @since 3.0.0
+ */
+public final class SingleMapOptional<T, R> extends Maybe<R> {
+
+    final Single<T> source;
+
+    final Function<? super T, Optional<? extends R>> mapper;
+
+    public SingleMapOptional(Single<T> source, Function<? super T, Optional<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super R> observer) {
+        source.subscribe(new MapOptionalSingleObserver<>(observer, mapper));
+    }
+
+    static final class MapOptionalSingleObserver<T, R> implements SingleObserver<T>, Disposable {
+
+        final MaybeObserver<? super R> downstream;
+
+        final Function<? super T, Optional<? extends R>> mapper;
+
+        Disposable upstream;
+
+        MapOptionalSingleObserver(MaybeObserver<? super R> downstream, Function<? super T, Optional<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void dispose() {
+            Disposable d = this.upstream;
+            this.upstream = DisposableHelper.DISPOSED;
+            d.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return upstream.isDisposed();
+        }
+
+        @Override
+        public void onSubscribe(Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(T value) {
+            Optional<? extends R> v;
+
+            try {
+                v = Objects.requireNonNull(mapper.apply(value), "The mapper returned a null item");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            if (v.isPresent()) {
+                downstream.onSuccess(v.get());
+            } else {
+                downstream.onComplete();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            downstream.onError(e);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/CompletableFromCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/CompletableFromCompletionStageTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class CompletableFromCompletionStageTest extends RxJavaTest {
+
+    @Test
+    public void syncSuccess() {
+        Completable.fromCompletionStage(CompletableFuture.completedFuture(1))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void syncSuccessNull() {
+        Completable.fromCompletionStage(CompletableFuture.completedFuture(null))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void syncFailure() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+        cf.completeExceptionally(new TestException());
+
+        Completable.fromCompletionStage(cf)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void syncNull() {
+        Completable.fromCompletionStage(CompletableFuture.<Integer>completedFuture(null))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void dispose() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+
+        TestObserver<Void> to = Completable.fromCompletionStage(cf)
+        .test();
+
+        to.assertEmpty();
+
+        to.dispose();
+
+        cf.complete(1);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void dispose2() {
+        TestHelper.checkDisposed(Completable.fromCompletionStage(new CompletableFuture<>()));
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/CompletableToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/CompletableToCompletionStageTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.subjects.CompletableSubject;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class CompletableToCompletionStageTest extends RxJavaTest {
+
+    @Test
+    public void complete() throws Exception {
+        Object v = Completable.complete()
+                .toCompletionStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertNull(v);
+    }
+
+    @Test
+    public void completableFutureCancels() throws Exception {
+        CompletableSubject source = CompletableSubject.create();
+
+        CompletableFuture<Object> cf = source
+                .toCompletionStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void completableManualCompleteCancels() throws Exception {
+        CompletableSubject source = CompletableSubject.create();
+
+        CompletableFuture<Object> cf = source
+                .toCompletionStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals(1, cf.get());
+    }
+
+    @Test
+    public void completableManualCompleteExceptionallyCancels() throws Exception {
+        CompletableSubject source = CompletableSubject.create();
+
+        CompletableFuture<Object> cf = source
+                .toCompletionStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void error() throws Exception {
+        CompletableFuture<Object> cf = Completable.error(new TestException())
+                .toCompletionStage(null)
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void sourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Object v = new Completable() {
+                @Override
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onComplete();
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .toCompletionStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertNull(v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void doubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Object v = new Completable() {
+                @Override
+                protected void subscribeActual(CompletableObserver observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onComplete();
+                }
+            }
+            .toCompletionStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertNull(v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFromCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFromCompletionStageTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class MaybeFromCompletionStageTest extends RxJavaTest {
+
+    @Test
+    public void syncSuccess() {
+        Maybe.fromCompletionStage(CompletableFuture.completedFuture(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void syncFailure() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+        cf.completeExceptionally(new TestException());
+
+        Maybe.fromCompletionStage(cf)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void syncNull() {
+        Maybe.fromCompletionStage(CompletableFuture.<Integer>completedFuture(null))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void dispose() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+
+        TestObserver<Integer> to = Maybe.fromCompletionStage(cf)
+        .test();
+
+        to.assertEmpty();
+
+        to.dispose();
+
+        cf.complete(1);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void dispose2() {
+        TestHelper.checkDisposed(Maybe.fromCompletionStage(new CompletableFuture<>()));
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFromOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFromOptionalTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+
+public class MaybeFromOptionalTest extends RxJavaTest {
+
+    @Test
+    public void hasValue() {
+        Maybe.fromOptional(Optional.of(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void empty() {
+        Maybe.fromOptional(Optional.empty())
+        .test()
+        .assertResult();
+    }
+
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeMapOptionalTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class MaybeMapOptionalTest extends RxJavaTest {
+
+    @Test
+    public void successSuccess() {
+        Maybe.just(1)
+        .mapOptional(Optional::of)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void successEmpty() {
+        Maybe.just(1)
+        .mapOptional(v -> Optional.empty())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Optional<? extends Integer>> f = mock(Function.class);
+
+        Maybe.<Integer>empty()
+        .mapOptional(f)
+        .test()
+        .assertResult();
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void error() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Optional<? extends Integer>> f = mock(Function.class);
+
+        Maybe.<Integer>error(new TestException())
+        .mapOptional(f)
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void mapperCrash() {
+        Maybe.just(1)
+        .mapOptional(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Maybe.never().mapOptional(Optional::of));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybe(m -> m.mapOptional(Optional::of));
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeToCompletionStageTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.subjects.MaybeSubject;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class MaybeToCompletionStageTest extends RxJavaTest {
+
+    @Test
+    public void just() throws Exception {
+        Integer v = Maybe.just(1)
+                .toCompletionStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void empty() throws Exception {
+        Integer v = Maybe.<Integer>empty()
+                .toCompletionStage(2)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)2, v);
+    }
+
+    @Test
+    public void emptyError() throws Exception {
+        CompletableFuture<Integer> cf = Maybe.<Integer>empty()
+                .toCompletionStage()
+                .toCompletableFuture();
+
+        TestHelper.assertError(cf, NoSuchElementException.class);
+    }
+
+    @Test
+    public void completableFutureCancels() throws Exception {
+        MaybeSubject<Integer> source = MaybeSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .toCompletionStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void completableManualCompleteCancels() throws Exception {
+        MaybeSubject<Integer> source = MaybeSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .toCompletionStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void completableManualCompleteExceptionallyCancels() throws Exception {
+        MaybeSubject<Integer> source = MaybeSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .toCompletionStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void error() throws Exception {
+        CompletableFuture<Integer> cf = Maybe.<Integer>error(new TestException())
+                .toCompletionStage(null)
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void sourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Maybe<Integer>() {
+                @Override
+                protected void subscribeActual(MaybeObserver<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSuccess(1);
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .toCompletionStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void doubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Maybe<Integer>() {
+                @Override
+                protected void subscribeActual(MaybeObserver<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSuccess(1);
+                }
+            }
+            .toCompletionStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleFromCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleFromCompletionStageTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class SingleFromCompletionStageTest extends RxJavaTest {
+
+    @Test
+    public void syncSuccess() {
+        Single.fromCompletionStage(CompletableFuture.completedFuture(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void syncFailure() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+        cf.completeExceptionally(new TestException());
+
+        Single.fromCompletionStage(cf)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void syncNull() {
+        Single.fromCompletionStage(CompletableFuture.<Integer>completedFuture(null))
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void dispose() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+
+        TestObserver<Integer> to = Single.fromCompletionStage(cf)
+        .test();
+
+        to.assertEmpty();
+
+        to.dispose();
+
+        cf.complete(1);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void dispose2() {
+        TestHelper.checkDisposed(Single.fromCompletionStage(new CompletableFuture<>()));
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleMapOptionalTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class SingleMapOptionalTest extends RxJavaTest {
+
+    @Test
+    public void successSuccess() {
+        Single.just(1)
+        .mapOptional(Optional::of)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void successEmpty() {
+        Single.just(1)
+        .mapOptional(v -> Optional.empty())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void error() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Optional<? extends Integer>> f = mock(Function.class);
+
+        Single.<Integer>error(new TestException())
+        .mapOptional(f)
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void mapperCrash() {
+        Single.just(1)
+        .mapOptional(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Single.never().mapOptional(Optional::of));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe(m -> m.mapOptional(Optional::of));
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleToCompletionStageTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.subjects.SingleSubject;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class SingleToCompletionStageTest extends RxJavaTest {
+
+    @Test
+    public void just() throws Exception {
+        Integer v = Single.just(1)
+                .toCompletionStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void completableFutureCancels() throws Exception {
+        SingleSubject<Integer> source = SingleSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .toCompletionStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void completableManualCompleteCancels() throws Exception {
+        SingleSubject<Integer> source = SingleSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .toCompletionStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void completableManualCompleteExceptionallyCancels() throws Exception {
+        SingleSubject<Integer> source = SingleSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .toCompletionStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void error() throws Exception {
+        CompletableFuture<Integer> cf = Single.<Integer>error(new TestException())
+                .toCompletionStage()
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void sourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Single<Integer>() {
+                @Override
+                protected void subscribeActual(SingleObserver<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSuccess(1);
+                    observer.onError(new TestException());
+                }
+            }
+            .toCompletionStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void doubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Single<Integer>() {
+                @Override
+                protected void subscribeActual(SingleObserver<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSuccess(1);
+                }
+            }
+            .toCompletionStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -509,6 +509,9 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "singleStage", Object.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "lastStage", Object.class));
 
+        addOverride(new ParamOverride(Maybe.class, 0, ParamMode.ANY, "toCompletionStage", Object.class));
+        addOverride(new ParamOverride(Completable.class, 0, ParamMode.ANY, "toCompletionStage", Object.class));
+
         // -----------------------------------------------------------------------------------
 
         ignores = new HashMap<String, List<ParamIgnore>>();


### PR DESCRIPTION
Add the following Java 8 operators to various reactive base classes:

| Operator | `Maybe` | `Single` | `Completable` |
|---|:---:|:---:|:---:|
| `fromOptional` | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | (1) | (2) |
| `fromCompletionStage` | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) |
| `mapOptional` | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | (3) |
| `toCompletionStage` | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | (4) |
| `toCompletionStage(T)` | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | (5) | ![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) |

1. Should it be implemented as `Optional.empty() -> Single.error(new NoSuchElementException())`?
2. No reason to implement. Always `Completable.complete()`.
3. No value to map.
4. No value to emit thus it is better to ask the user for a completion value.
5. Never empty, no reason to implement.

Related #6776 

Marbles:

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromOptional.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromCompletionStage.s.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/fromCompletionStage.c.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mapOptional.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mapOptional.s.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toCompletionStage.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toCompletionStage.mv.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toCompletionStage.s.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toCompletionStage.c.png)
