### PR TITLE
3.x: Cleanup and prettify Javadocs, widen XOperator throws

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/annotations/BackpressureKind.java
+++ b/src/main/java/io/reactivex/rxjava3/annotations/BackpressureKind.java
@@ -32,13 +32,13 @@ public enum BackpressureKind {
      */
     SPECIAL,
     /**
-     * The operator requests Long.MAX_VALUE from upstream but respects the backpressure
+     * The operator requests {@link Long#MAX_VALUE} from upstream but respects the backpressure
      * of the downstream.
      */
     UNBOUNDED_IN,
     /**
-     * The operator will emit a MissingBackpressureException if the downstream didn't request
-     * enough or in time.
+     * The operator will emit a {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException MissingBackpressureException}
+     * if the downstream didn't request enough or in time.
      */
     ERROR,
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/BackpressureOverflowStrategy.java
+++ b/src/main/java/io/reactivex/rxjava3/core/BackpressureOverflowStrategy.java
@@ -19,7 +19,10 @@ package io.reactivex.rxjava3.core;
  * Options to deal with buffer overflow when using onBackpressureBuffer.
  */
 public enum BackpressureOverflowStrategy {
-    /** Signal a MissingBackpressureException and terminate the sequence. */
+    /**
+     * Signal a {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException MissingBackpressureException}
+     * and terminate the sequence.
+     */
     ERROR,
     /** Drop the oldest value from the buffer. */
     DROP_OLDEST,

--- a/src/main/java/io/reactivex/rxjava3/core/BackpressureStrategy.java
+++ b/src/main/java/io/reactivex/rxjava3/core/BackpressureStrategy.java
@@ -18,25 +18,26 @@ package io.reactivex.rxjava3.core;
  */
 public enum BackpressureStrategy {
     /**
-     * OnNext events are written without any buffering or dropping.
+     * The {@code onNext} events are written without any buffering or dropping.
      * Downstream has to deal with any overflow.
      * <p>Useful when one applies one of the custom-parameter onBackpressureXXX operators.
      */
     MISSING,
     /**
-     * Signals a MissingBackpressureException in case the downstream can't keep up.
+     * Signals a {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException MissingBackpressureException}
+     * in case the downstream can't keep up.
      */
     ERROR,
     /**
-     * Buffers <em>all</em> onNext values until the downstream consumes it.
+     * Buffers <em>all</em> {@code onNext} values until the downstream consumes it.
      */
     BUFFER,
     /**
-     * Drops the most recent onNext value if the downstream can't keep up.
+     * Drops the most recent {@code onNext} value if the downstream can't keep up.
      */
     DROP,
     /**
-     * Keeps only the latest onNext value, overwriting any previous value if the
+     * Keeps only the latest {@code onNext} value, overwriting any previous value if the
      * downstream can't keep up.
      */
     LATEST

--- a/src/main/java/io/reactivex/rxjava3/core/CompletableEmitter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/CompletableEmitter.java
@@ -82,12 +82,12 @@ public interface CompletableEmitter {
     boolean isDisposed();
 
     /**
-     * Attempts to emit the specified {@code Throwable} error if the downstream
+     * Attempts to emit the specified {@link Throwable} error if the downstream
      * hasn't cancelled the sequence or is otherwise terminated, returning false
      * if the emission is not allowed to happen due to lifecycle restrictions.
      * <p>
-     * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
-     * if the error could not be delivered.
+     * Unlike {@link #onError(Throwable)}, the {@link io.reactivex.rxjava3.plugins.RxJavaPlugins#onError(Throwable) RxjavaPlugins.onError}
+     * is not called if the error could not be delivered.
      * <p>History: 2.1.1 - experimental
      * @param t the throwable error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further

--- a/src/main/java/io/reactivex/rxjava3/core/CompletableObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/core/CompletableObserver.java
@@ -49,9 +49,9 @@ import io.reactivex.rxjava3.disposables.Disposable;
  */
 public interface CompletableObserver {
     /**
-     * Called once by the Completable to set a Disposable on this instance which
+     * Called once by the {@link Completable} to set a {@link Disposable} on this instance which
      * then can be used to cancel the subscription at any time.
-     * @param d the Disposable instance to call dispose on for cancellation, not null
+     * @param d the {@code Disposable} instance to call dispose on for cancellation, not null
      */
     void onSubscribe(@NonNull Disposable d);
 
@@ -62,7 +62,7 @@ public interface CompletableObserver {
 
     /**
      * Called once if the deferred computation 'throws' an exception.
-     * @param e the exception, not null.
+     * @param e the exception, not {@code null}.
      */
     void onError(@NonNull Throwable e);
 }

--- a/src/main/java/io/reactivex/rxjava3/core/CompletableOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/CompletableOnSubscribe.java
@@ -23,8 +23,8 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface CompletableOnSubscribe {
 
     /**
-     * Called for each CompletableObserver that subscribes.
-     * @param emitter the safe emitter instance, never null
+     * Called for each {@link CompletableObserver} that subscribes.
+     * @param emitter the safe emitter instance, never {@code null}
      * @throws Throwable on error
      */
     void subscribe(@NonNull CompletableEmitter emitter) throws Throwable;

--- a/src/main/java/io/reactivex/rxjava3/core/CompletableOperator.java
+++ b/src/main/java/io/reactivex/rxjava3/core/CompletableOperator.java
@@ -21,11 +21,11 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface CompletableOperator {
     /**
-     * Applies a function to the child CompletableObserver and returns a new parent CompletableObserver.
-     * @param observer the child CompletableObservable instance
-     * @return the parent CompletableObserver instance
-     * @throws Exception on failure
+     * Applies a function to the child {@link CompletableObserver} and returns a new parent {@code CompletableObserver}.
+     * @param observer the child {@code CompletableObserver} instance
+     * @return the parent {@code CompletableObserver} instance
+     * @throws Throwable on failure
      */
     @NonNull
-    CompletableObserver apply(@NonNull CompletableObserver observer) throws Exception;
+    CompletableObserver apply(@NonNull CompletableObserver observer) throws Throwable;
 }

--- a/src/main/java/io/reactivex/rxjava3/core/CompletableSource.java
+++ b/src/main/java/io/reactivex/rxjava3/core/CompletableSource.java
@@ -24,9 +24,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface CompletableSource {
 
     /**
-     * Subscribes the given CompletableObserver to this CompletableSource instance.
-     * @param co the CompletableObserver, not null
-     * @throws NullPointerException if {@code co} is null
+     * Subscribes the given {@link CompletableObserver} to this {@code CompletableSource} instance.
+     * @param observer the {@code CompletableObserver}, not {@code null}
+     * @throws NullPointerException if {@code observer} is {@code null}
      */
-    void subscribe(@NonNull CompletableObserver co);
+    void subscribe(@NonNull CompletableObserver observer);
 }

--- a/src/main/java/io/reactivex/rxjava3/core/CompletableTransformer.java
+++ b/src/main/java/io/reactivex/rxjava3/core/CompletableTransformer.java
@@ -16,15 +16,15 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Convenience interface and callback used by the compose operator to turn a Completable into another
- * Completable fluently.
+ * Convenience interface and callback used by the compose operator to turn a {@link Completable} into another
+ * {@code Completable} fluently.
  */
 @FunctionalInterface
 public interface CompletableTransformer {
     /**
-     * Applies a function to the upstream Completable and returns a CompletableSource.
-     * @param upstream the upstream Completable instance
-     * @return the transformed CompletableSource instance
+     * Applies a function to the upstream {@link Completable} and returns a {@link CompletableSource}.
+     * @param upstream the upstream {@code Completable} instance
+     * @return the transformed {@code CompletableSource} instance
      */
     @NonNull
     CompletableSource apply(@NonNull Completable upstream);

--- a/src/main/java/io/reactivex/rxjava3/core/Emitter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Emitter.java
@@ -29,13 +29,13 @@ public interface Emitter<T> {
 
     /**
      * Signal a normal value.
-     * @param value the value to signal, not null
+     * @param value the value to signal, not {@code null}
      */
     void onNext(@NonNull T value);
 
     /**
-     * Signal a Throwable exception.
-     * @param error the Throwable to signal, not null
+     * Signal a {@link Throwable} exception.
+     * @param error the {@code Throwable} to signal, not {@code null}
      */
     void onError(@NonNull Throwable error);
 

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -1434,7 +1434,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * @param <T> the value type
      * @param sources an array of Publishers that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrent subscriptions at a time, Integer.MAX_VALUE
+     * @param maxConcurrency the maximum number of concurrent subscriptions at a time, {@link Integer#MAX_VALUE}
      *                       is interpreted as an indication to subscribe to all sources at once
      * @param prefetch the number of elements to prefetch from each Publisher source
      * @return the new Publisher instance with the specified concatenation behavior
@@ -1503,7 +1503,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * @param <T> the value type
      * @param sources an array of {@code Publisher}s that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrent subscriptions at a time, Integer.MAX_VALUE
+     * @param maxConcurrency the maximum number of concurrent subscriptions at a time, {@link Integer#MAX_VALUE}
      *                       is interpreted as indication to subscribe to all sources at once
      * @param prefetch the number of elements to prefetch from each {@code Publisher} source
      * @return the new Flowable instance with the specified concatenation behavior
@@ -1635,7 +1635,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * @param <T> the value type
      * @param sources a sequence of Publishers that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrently running inner Publishers; Integer.MAX_VALUE
+     * @param maxConcurrency the maximum number of concurrently running inner Publishers; {@link Integer#MAX_VALUE}
      *                       is interpreted as all inner Publishers can be active at the same time
      * @param prefetch the number of elements to prefetch from each inner Publisher source
      * @return the new Publisher instance with the specified concatenation behavior
@@ -1695,7 +1695,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * </dl>
      * @param <T> the value type
      * @param sources a sequence of Publishers that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrently running inner Publishers; Integer.MAX_VALUE
+     * @param maxConcurrency the maximum number of concurrently running inner Publishers; {@link Integer#MAX_VALUE}
      *                       is interpreted as all inner Publishers can be active at the same time
      * @param prefetch the number of elements to prefetch from each inner Publisher source
      * @return the new Publisher instance with the specified concatenation behavior
@@ -3976,7 +3976,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits a range of sequential Integers
      * @throws IllegalArgumentException
      *             if {@code count} is less than zero, or if {@code start} + {@code count} &minus; 1 exceeds
-     *             {@code Integer.MAX_VALUE}
+     *             {@link Integer#MAX_VALUE}
      * @see <a href="http://reactivex.io/documentation/operators/range.html">ReactiveX operators documentation: Range</a>
      */
     @CheckReturnValue
@@ -4016,7 +4016,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @return a Flowable that emits a range of sequential Longs
      * @throws IllegalArgumentException
      *             if {@code count} is less than zero, or if {@code start} + {@code count} &minus; 1 exceeds
-     *             {@code Long.MAX_VALUE}
+     *             {@link Long#MAX_VALUE}
      * @see <a href="http://reactivex.io/documentation/operators/range.html">ReactiveX operators documentation: Range</a>
      */
     @CheckReturnValue
@@ -6258,7 +6258,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer7.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
+     *  <dd>This operator does not support backpressure as it uses time. It requests {@link Long#MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code buffer} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -6293,7 +6293,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer7.s.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
+     *  <dd>This operator does not support backpressure as it uses time. It requests {@link Long#MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -6330,7 +6330,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer7.s.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
+     *  <dd>This operator does not support backpressure as it uses time. It requests {@link Long#MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -6375,7 +6375,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer5.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
+     *  <dd>This operator does not support backpressure as it uses time. It requests {@link Long#MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code buffer} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -6408,7 +6408,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer6.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
+     *  <dd>This operator does not support backpressure as it uses time. It requests {@link Long#MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code buffer} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -6445,7 +6445,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer6.s.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
+     *  <dd>This operator does not support backpressure as it uses time. It requests {@link Long#MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -6484,7 +6484,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer6.s.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
+     *  <dd>This operator does not support backpressure as it uses time. It requests {@link Long#MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -6536,7 +6536,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/buffer5.s.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>This operator does not support backpressure as it uses time. It requests {@code Long.MAX_VALUE}
+     *  <dd>This operator does not support backpressure as it uses time. It requests {@link Long#MAX_VALUE}
      *      upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -6571,7 +6571,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it is instead controlled by the given Publishers and
-     *      buffers data. It requests {@code Long.MAX_VALUE} upstream and does not obey downstream requests.</dd>
+     *      buffers data. It requests {@link Long#MAX_VALUE} upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code buffer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -6607,7 +6607,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it is instead controlled by the given Publishers and
-     *      buffers data. It requests {@code Long.MAX_VALUE} upstream and does not obey downstream requests.</dd>
+     *      buffers data. It requests {@link Long#MAX_VALUE} upstream and does not obey downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code buffer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -6652,7 +6652,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it is instead controlled by the {@code Publisher}
-     *      {@code boundary} and buffers data. It requests {@code Long.MAX_VALUE} upstream and does not obey
+     *      {@code boundary} and buffers data. It requests {@link Long#MAX_VALUE} upstream and does not obey
      *      downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code buffer} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -6686,7 +6686,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it is instead controlled by the {@code Publisher}
-     *      {@code boundary} and buffers data. It requests {@code Long.MAX_VALUE} upstream and does not obey
+     *      {@code boundary} and buffers data. It requests {@link Long#MAX_VALUE} upstream and does not obey
      *      downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code buffer} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -6723,7 +6723,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>This operator does not support backpressure as it is instead controlled by the {@code Publisher}
-     *      {@code boundary} and buffers data. It requests {@code Long.MAX_VALUE} upstream and does not obey
+     *      {@code boundary} and buffers data. It requests {@link Long#MAX_VALUE} upstream and does not obey
      *      downstream requests.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code buffer} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -8503,7 +8503,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator forwards the backpressure requests to this Publisher once
-     *  the subscription happens and requests Long.MAX_VALUE from the other Publisher</dd>
+     *  the subscription happens and requests {@link Long#MAX_VALUE} from the other Publisher</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -10004,9 +10004,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * waits until the upstream and all CompletableSources complete, optionally delaying all errors.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>If {@code maxConcurrency == Integer.MAX_VALUE} the operator consumes the upstream in an unbounded manner.
+     *  <dd>If {@code maxConcurrency == }{@link Integer#MAX_VALUE} the operator consumes the upstream in an unbounded manner.
      *  Otherwise, the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
-     *  the operator behaves as if {@code maxConcurrency == Integer.MAX_VALUE} was used.</dd>
+     *  the operator behaves as if {@code maxConcurrency == }{@link Integer#MAX_VALUE} was used.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -10198,9 +10198,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * in no particular order, into a single Flowable sequence, optionally delaying all errors.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>If {@code maxConcurrency == Integer.MAX_VALUE} the operator consumes the upstream in an unbounded manner.
+     *  <dd>If {@code maxConcurrency == }{@link Integer#MAX_VALUE} the operator consumes the upstream in an unbounded manner.
      *  Otherwise, the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
-     *  the operator behaves as if {@code maxConcurrency == Integer.MAX_VALUE} was used.</dd>
+     *  the operator behaves as if {@code maxConcurrency == }{@link Integer#MAX_VALUE} was used.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -10247,9 +10247,9 @@ public abstract class Flowable<T> implements Publisher<T> {
      * in no particular order, into a single Flowable sequence, optionally delaying all errors.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>If {@code maxConcurrency == Integer.MAX_VALUE} the operator consumes the upstream in an unbounded manner.
+     *  <dd>If {@code maxConcurrency == }{@link Integer#MAX_VALUE} the operator consumes the upstream in an unbounded manner.
      *  Otherwise, the operator expects the upstream to honor backpressure. If the upstream doesn't support backpressure
-     *  the operator behaves as if {@code maxConcurrency == Integer.MAX_VALUE} was used.</dd>
+     *  the operator behaves as if {@code maxConcurrency == }{@link Integer#MAX_VALUE} was used.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code flatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -10415,7 +10415,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
-     * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
@@ -10473,7 +10473,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
-     * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
@@ -10532,7 +10532,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
-     * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
@@ -10596,7 +10596,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
-     * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
@@ -10661,7 +10661,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
-     * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
@@ -10774,7 +10774,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
      * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
-     * {@code Integer.MAX_VALUE} if the number of expected groups is unknown.
+     * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
@@ -12337,7 +12337,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Requests {@code n} initially from the upstream and then 75% of {@code n} subsequently
      * after 75% of {@code n} values have been emitted to the downstream.
      *
-     * <p>This operator allows preventing the downstream to trigger unbounded mode via {@code request(Long.MAX_VALUE)}
+     * <p>This operator allows preventing the downstream to trigger unbounded mode via {@code request(}{@link Long#MAX_VALUE}{@code )}
      * or compensate for the per-item overhead of small and frequent requests.
      *
      * <dl>
@@ -17224,7 +17224,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>Observables don't support backpressure thus the current Flowable is consumed in an unbounded
-     *  manner (by requesting Long.MAX_VALUE).</dd>
+     *  manner (by requesting {@link Long#MAX_VALUE}).</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -18552,8 +18552,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     // Fluent test support, super handy and reduces test preparation boilerplate
     // -------------------------------------------------------------------------
     /**
-     * Creates a TestSubscriber that requests Long.MAX_VALUE and subscribes
-     * it to this Flowable.
+     * Creates a {@link TestSubscriber} that requests {@link Long#MAX_VALUE} and subscribes
+     * it to this {@code Flowable}.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned TestSubscriber consumes this Flowable in an unbounded fashion.</dd>

--- a/src/main/java/io/reactivex/rxjava3/core/FlowableConverter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableConverter.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Convenience interface and callback used by the {@link Flowable#to} operator to turn a Flowable into another
+ * Convenience interface and callback used by the {@link Flowable#to} operator to turn a {@link Flowable} into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
@@ -26,9 +26,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface FlowableConverter<T, R> {
     /**
-     * Applies a function to the upstream Flowable and returns a converted value of type {@code R}.
+     * Applies a function to the upstream {@link Flowable} and returns a converted value of type {@code R}.
      *
-     * @param upstream the upstream Flowable instance
+     * @param upstream the upstream {@code Flowable} instance
      * @return the converted value
      */
     @NonNull

--- a/src/main/java/io/reactivex/rxjava3/core/FlowableEmitter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableEmitter.java
@@ -53,14 +53,16 @@ public interface FlowableEmitter<T> extends Emitter<T> {
     /**
      * Sets a Disposable on this emitter; any previous {@link Disposable}
      * or {@link Cancellable} will be disposed/cancelled.
-     * @param d the disposable, null is allowed
+     * <p>This method is thread-safe.
+     * @param d the disposable, {@code null} is allowed
      */
     void setDisposable(@Nullable Disposable d);
 
     /**
-     * Sets a Cancellable on this emitter; any previous {@link Disposable}
-     * or {@link Cancellable} will be disposed/cancelled.
-     * @param c the cancellable resource, null is allowed
+     * Sets a {@link Cancellable} on this emitter; any previous {@link Disposable}
+     * or {@code Cancellable} will be disposed/cancelled.
+     * <p>This method is thread-safe.
+     * @param c the {@code Cancellable} resource, {@code null} is allowed
      */
     void setCancellable(@Nullable Cancellable c);
 
@@ -81,19 +83,19 @@ public interface FlowableEmitter<T> extends Emitter<T> {
     boolean isCancelled();
 
     /**
-     * Ensures that calls to onNext, onError and onComplete are properly serialized.
-     * @return the serialized FlowableEmitter
+     * Ensures that calls to {@code onNext}, {@code onError} and {@code onComplete} are properly serialized.
+     * @return the serialized {@link FlowableEmitter}
      */
     @NonNull
     FlowableEmitter<T> serialize();
 
     /**
-     * Attempts to emit the specified {@code Throwable} error if the downstream
+     * Attempts to emit the specified {@link Throwable} error if the downstream
      * hasn't cancelled the sequence or is otherwise terminated, returning false
      * if the emission is not allowed to happen due to lifecycle restrictions.
      * <p>
-     * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
-     * if the error could not be delivered.
+     * Unlike {@link #onError(Throwable)}, the {@link io.reactivex.rxjava3.plugins.RxJavaPlugins#onError(Throwable) RxjavaPlugins.onError}
+     * is not called if the error could not be delivered.
      * <p>History: 2.1.1 - experimental
      * @param t the throwable error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further

--- a/src/main/java/io/reactivex/rxjava3/core/FlowableOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableOnSubscribe.java
@@ -25,8 +25,8 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface FlowableOnSubscribe<T> {
 
     /**
-     * Called for each Subscriber that subscribes.
-     * @param emitter the safe emitter instance, never null
+     * Called for each {@link org.reactivestreams.Subscriber Subscriber} that subscribes.
+     * @param emitter the safe emitter instance, never {@code null}
      * @throws Throwable on error
      */
     void subscribe(@NonNull FlowableEmitter<T> emitter) throws Throwable;

--- a/src/main/java/io/reactivex/rxjava3/core/FlowableOperator.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableOperator.java
@@ -18,7 +18,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Interface to map/wrap a downstream subscriber to an upstream subscriber.
+ * Interface to map/wrap a downstream {@link Subscriber} to an upstream {@code Subscriber}.
  *
  * @param <Downstream> the value type of the downstream
  * @param <Upstream> the value type of the upstream
@@ -26,11 +26,11 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface FlowableOperator<Downstream, Upstream> {
     /**
-     * Applies a function to the child Subscriber and returns a new parent Subscriber.
-     * @param subscriber the child Subscriber instance
-     * @return the parent Subscriber instance
-     * @throws Exception on failure
+     * Applies a function to the child {@link Subscriber} and returns a new parent {@code Subscriber}.
+     * @param subscriber the child {@code Subscriber} instance
+     * @return the parent {@code Subscriber} instance
+     * @throws Throwable on failure
      */
     @NonNull
-    Subscriber<? super Upstream> apply(@NonNull Subscriber<? super Downstream> subscriber) throws Exception;
+    Subscriber<? super Upstream> apply(@NonNull Subscriber<? super Downstream> subscriber) throws Throwable;
 }

--- a/src/main/java/io/reactivex/rxjava3/core/FlowableSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableSubscriber.java
@@ -18,8 +18,8 @@ import org.reactivestreams.*;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Represents a Reactive-Streams inspired Subscriber that is RxJava 2 only
- * and weakens rules ยง1.3 and ยง3.9 of the specification for gaining performance.
+ * Represents a Reactive-Streams inspired {@link Subscriber} that is RxJava 2 only
+ * and weakens rules ง1.3 and ง3.9 of the specification for gaining performance.
  *
  * <p>History: 2.0.7 - experimental; 2.1 - beta
  * @param <T> the value type

--- a/src/main/java/io/reactivex/rxjava3/core/FlowableSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableSubscriber.java
@@ -19,7 +19,7 @@ import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
  * Represents a Reactive-Streams inspired {@link Subscriber} that is RxJava 2 only
- * and weakens rules ง1.3 and ง3.9 of the specification for gaining performance.
+ * and weakens rules ยง1.3 and ยง3.9 of the specification for gaining performance.
  *
  * <p>History: 2.0.7 - experimental; 2.1 - beta
  * @param <T> the value type

--- a/src/main/java/io/reactivex/rxjava3/core/FlowableTransformer.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableTransformer.java
@@ -18,7 +18,7 @@ import org.reactivestreams.Publisher;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Interface to compose Flowables.
+ * Interface to compose {@link Flowable}s.
  *
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
@@ -26,10 +26,10 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface FlowableTransformer<Upstream, Downstream> {
     /**
-     * Applies a function to the upstream Flowable and returns a Publisher with
+     * Applies a function to the upstream {@link Flowable} and returns a {@link Publisher} with
      * optionally different element type.
-     * @param upstream the upstream Flowable instance
-     * @return the transformed Publisher instance
+     * @param upstream the upstream {@code Flowable} instance
+     * @return the transformed {@code Publisher} instance
      */
     @NonNull
     Publisher<Downstream> apply(@NonNull Flowable<Upstream> upstream);

--- a/src/main/java/io/reactivex/rxjava3/core/MaybeConverter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/MaybeConverter.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Convenience interface and callback used by the {@link Maybe#to} operator to turn a Maybe into another
+ * Convenience interface and callback used by the {@link Maybe#to} operator to turn a {@link Maybe} into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
@@ -26,9 +26,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface MaybeConverter<T, R> {
     /**
-     * Applies a function to the upstream Maybe and returns a converted value of type {@code R}.
+     * Applies a function to the upstream {@link Maybe} and returns a converted value of type {@code R}.
      *
-     * @param upstream the upstream Maybe instance
+     * @param upstream the upstream {@code Maybe} instance
      * @return the converted value
      */
     @NonNull

--- a/src/main/java/io/reactivex/rxjava3/core/MaybeEmitter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/MaybeEmitter.java
@@ -57,7 +57,7 @@ public interface MaybeEmitter<T> {
 
     /**
      * Signal an exception.
-     * @param t the exception, not null
+     * @param t the exception, not {@code null}
      */
     void onError(@NonNull Throwable t);
 
@@ -67,16 +67,18 @@ public interface MaybeEmitter<T> {
     void onComplete();
 
     /**
-     * Sets a Disposable on this emitter; any previous {@link Disposable}
+     * Sets a {@link Disposable} on this emitter; any previous {@code Disposable}
      * or {@link Cancellable} will be disposed/cancelled.
-     * @param d the disposable, null is allowed
+     * <p>This method is thread-safe.
+     * @param d the disposable, {@code null} is allowed
      */
     void setDisposable(@Nullable Disposable d);
 
     /**
-     * Sets a Cancellable on this emitter; any previous {@link Disposable}
-     * or {@link Cancellable} will be disposed/cancelled.
-     * @param c the cancellable resource, null is allowed
+     * Sets a {@link Cancellable} on this emitter; any previous {@link Disposable}
+     * or {@code Cancellable} will be disposed/cancelled.
+     * <p>This method is thread-safe.
+     * @param c the {@code Cancellable} resource, {@code null} is allowed
      */
     void setCancellable(@Nullable Cancellable c);
 
@@ -91,14 +93,14 @@ public interface MaybeEmitter<T> {
     boolean isDisposed();
 
     /**
-     * Attempts to emit the specified {@code Throwable} error if the downstream
+     * Attempts to emit the specified {@link Throwable} error if the downstream
      * hasn't cancelled the sequence or is otherwise terminated, returning false
      * if the emission is not allowed to happen due to lifecycle restrictions.
      * <p>
-     * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
-     * if the error could not be delivered.
+     * Unlike {@link #onError(Throwable)}, the {@link io.reactivex.rxjava3.plugins.RxJavaPlugins#onError(Throwable) RxjavaPlugins.onError}
+     * is not called if the error could not be delivered.
      * <p>History: 2.1.1 - experimental
-     * @param t the throwable error to signal if possible
+     * @param t the {@code Throwable} error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further
      * events
      * @since 2.2

--- a/src/main/java/io/reactivex/rxjava3/core/MaybeObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/core/MaybeObserver.java
@@ -56,32 +56,32 @@ import io.reactivex.rxjava3.disposables.Disposable;
 public interface MaybeObserver<T> {
 
     /**
-     * Provides the MaybeObserver with the means of cancelling (disposing) the
-     * connection (channel) with the Maybe in both
+     * Provides the {@link MaybeObserver} with the means of cancelling (disposing) the
+     * connection (channel) with the {@link Maybe} in both
      * synchronous (from within {@code onSubscribe(Disposable)} itself) and asynchronous manner.
-     * @param d the Disposable instance whose {@link Disposable#dispose()} can
+     * @param d the {@link Disposable} instance whose {@link Disposable#dispose()} can
      * be called anytime to cancel the connection
      */
     void onSubscribe(@NonNull Disposable d);
 
     /**
-     * Notifies the MaybeObserver with one item and that the {@link Maybe} has finished sending
+     * Notifies the {@link MaybeObserver} with one item and that the {@link Maybe} has finished sending
      * push-based notifications.
      * <p>
      * The {@link Maybe} will not call this method if it calls {@link #onError}.
      *
      * @param t
-     *          the item emitted by the Maybe
+     *          the item emitted by the {@code Maybe}
      */
     void onSuccess(@NonNull T t);
 
     /**
-     * Notifies the MaybeObserver that the {@link Maybe} has experienced an error condition.
+     * Notifies the {@link MaybeObserver} that the {@link Maybe} has experienced an error condition.
      * <p>
      * If the {@link Maybe} calls this method, it will not thereafter call {@link #onSuccess}.
      *
      * @param e
-     *          the exception encountered by the Maybe
+     *          the exception encountered by the {@code Maybe}
      */
     void onError(@NonNull Throwable e);
 

--- a/src/main/java/io/reactivex/rxjava3/core/MaybeOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/MaybeOnSubscribe.java
@@ -25,8 +25,8 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface MaybeOnSubscribe<T> {
 
     /**
-     * Called for each MaybeObserver that subscribes.
-     * @param emitter the safe emitter instance, never null
+     * Called for each {@link MaybeObserver} that subscribes.
+     * @param emitter the safe emitter instance, never {@code null}
      * @throws Throwable on error
      */
     void subscribe(@NonNull MaybeEmitter<T> emitter) throws Throwable;

--- a/src/main/java/io/reactivex/rxjava3/core/MaybeOperator.java
+++ b/src/main/java/io/reactivex/rxjava3/core/MaybeOperator.java
@@ -15,7 +15,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Interface to map/wrap a downstream observer to an upstream observer.
+ * Interface to map/wrap a downstream {@link MaybeObserver} to an upstream {@code MaybeObserver}.
  *
  * @param <Downstream> the value type of the downstream
  * @param <Upstream> the value type of the upstream
@@ -23,11 +23,11 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface MaybeOperator<Downstream, Upstream> {
     /**
-     * Applies a function to the child MaybeObserver and returns a new parent MaybeObserver.
-     * @param observer the child MaybeObserver instance
-     * @return the parent MaybeObserver instance
-     * @throws Exception on failure
+     * Applies a function to the child {@link MaybeObserver} and returns a new parent {@code MaybeObserver}.
+     * @param observer the child {@code MaybeObserver} instance
+     * @return the parent {@code MaybeObserver} instance
+     * @throws Throwable on failure
      */
     @NonNull
-    MaybeObserver<? super Upstream> apply(@NonNull MaybeObserver<? super Downstream> observer) throws Exception;
+    MaybeObserver<? super Upstream> apply(@NonNull MaybeObserver<? super Downstream> observer) throws Throwable;
 }

--- a/src/main/java/io/reactivex/rxjava3/core/MaybeSource.java
+++ b/src/main/java/io/reactivex/rxjava3/core/MaybeSource.java
@@ -28,9 +28,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface MaybeSource<T> {
 
     /**
-     * Subscribes the given MaybeObserver to this MaybeSource instance.
-     * @param observer the MaybeObserver, not null
-     * @throws NullPointerException if {@code observer} is null
+     * Subscribes the given {@link MaybeObserver} to this {@link MaybeSource} instance.
+     * @param observer the {@code MaybeObserver}, not {@code null}
+     * @throws NullPointerException if {@code observer} is {@code null}
      */
     void subscribe(@NonNull MaybeObserver<? super T> observer);
 }

--- a/src/main/java/io/reactivex/rxjava3/core/MaybeTransformer.java
+++ b/src/main/java/io/reactivex/rxjava3/core/MaybeTransformer.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Interface to compose Maybes.
+ * Interface to compose {@link Maybe}s.
  *
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
@@ -24,10 +24,10 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface MaybeTransformer<Upstream, Downstream> {
     /**
-     * Applies a function to the upstream Maybe and returns a MaybeSource with
+     * Applies a function to the upstream {@link Maybe} and returns a {@link MaybeSource} with
      * optionally different element type.
-     * @param upstream the upstream Maybe instance
-     * @return the transformed MaybeSource instance
+     * @param upstream the upstream {@code Maybe} instance
+     * @return the transformed {@code MaybeSource} instance
      */
     @NonNull
     MaybeSource<Downstream> apply(@NonNull Maybe<Upstream> upstream);

--- a/src/main/java/io/reactivex/rxjava3/core/Notification.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Notification.java
@@ -18,8 +18,8 @@ import io.reactivex.rxjava3.internal.util.NotificationLite;
 import java.util.Objects;
 
 /**
- * Represents the reactive signal types: onNext, onError and onComplete and
- * holds their parameter values (a value, a Throwable, nothing).
+ * Represents the reactive signal types: {@code onNext}, {@code onError} and {@code onComplete} and
+ * holds their parameter values (a value, a {@link Throwable}, nothing).
  * @param <T> the value type
  */
 public final class Notification<T> {
@@ -32,17 +32,17 @@ public final class Notification<T> {
     }
 
     /**
-     * Returns true if this notification is an onComplete signal.
-     * @return true if this notification is an onComplete signal
+     * Returns true if this notification is an {@code onComplete} signal.
+     * @return true if this notification is an {@code onComplete} signal
      */
     public boolean isOnComplete() {
         return value == null;
     }
 
     /**
-     * Returns true if this notification is an onError signal and
-     * {@link #getError()} returns the contained Throwable.
-     * @return true if this notification is an onError signal
+     * Returns true if this notification is an {@code onError} signal and
+     * {@link #getError()} returns the contained {@link Throwable}.
+     * @return true if this notification is an {@code onError} signal
      * @see #getError()
      */
     public boolean isOnError() {
@@ -50,9 +50,9 @@ public final class Notification<T> {
     }
 
     /**
-     * Returns true if this notification is an onNext signal and
+     * Returns true if this notification is an {@code onNext} signal and
      * {@link #getValue()} returns the contained value.
-     * @return true if this notification is an onNext signal
+     * @return true if this notification is an {@code onNext} signal
      * @see #getValue()
      */
     public boolean isOnNext() {
@@ -61,7 +61,7 @@ public final class Notification<T> {
     }
 
     /**
-     * Returns the contained value if this notification is an onNext
+     * Returns the contained value if this notification is an {@code onNext}
      * signal, null otherwise.
      * @return the value contained or null
      * @see #isOnNext()
@@ -77,9 +77,9 @@ public final class Notification<T> {
     }
 
     /**
-     * Returns the container Throwable error if this notification is an onError
+     * Returns the container {@link Throwable} error if this notification is an {@code onError}
      * signal, null otherwise.
-     * @return the Throwable error contained or null
+     * @return the {@code Throwable} error contained or {@code null}
      * @see #isOnError()
      */
     @Nullable
@@ -121,14 +121,14 @@ public final class Notification<T> {
     /**
      * Constructs an onNext notification containing the given value.
      * @param <T> the value type
-     * @param value the value to carry around in the notification, not null
+     * @param value the value to carry around in the notification, not {@code null}
      * @return the new Notification instance
-     * @throws NullPointerException if value is null
+     * @throws NullPointerException if value is {@code null}
      */
     @NonNull
-    public static <T> Notification<T> createOnNext(@NonNull T value) {
+    public static <@NonNull T> Notification<T> createOnNext(T value) {
         Objects.requireNonNull(value, "value is null");
-        return new Notification<T>(value);
+        return new Notification<>(value);
     }
 
     /**
@@ -136,19 +136,19 @@ public final class Notification<T> {
      * @param <T> the value type
      * @param error the error Throwable to carry around in the notification, not null
      * @return the new Notification instance
-     * @throws NullPointerException if error is null
+     * @throws NullPointerException if error is {@code null}
      */
     @NonNull
     public static <T> Notification<T> createOnError(@NonNull Throwable error) {
         Objects.requireNonNull(error, "error is null");
-        return new Notification<T>(NotificationLite.error(error));
+        return new Notification<>(NotificationLite.error(error));
     }
 
     /**
      * Returns the empty and stateless shared instance of a notification representing
-     * an onComplete signal.
+     * an {@code onComplete} signal.
      * @param <T> the target value type
-     * @return the shared Notification instance representing an onComplete signal
+     * @return the shared Notification instance representing an {@code onComplete} signal
      */
     @SuppressWarnings("unchecked")
     @NonNull
@@ -157,5 +157,5 @@ public final class Notification<T> {
     }
 
     /** The singleton instance for createOnComplete. */
-    static final Notification<Object> COMPLETE = new Notification<Object>(null);
+    static final Notification<Object> COMPLETE = new Notification<>(null);
 }

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -1261,7 +1261,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      * @param <T> the value type
      * @param sources an array of ObservableSources that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrent subscriptions at a time, Integer.MAX_VALUE
+     * @param maxConcurrency the maximum number of concurrent subscriptions at a time, {@link Integer#MAX_VALUE}
      *                       is interpreted as indication to subscribe to all sources at once
      * @param prefetch the number of elements to prefetch from each ObservableSource source
      * @return the new ObservableSource instance with the specified concatenation behavior
@@ -1313,7 +1313,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      * @param <T> the value type
      * @param sources an array of {@code ObservableSource}s that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrent subscriptions at a time, Integer.MAX_VALUE
+     * @param maxConcurrency the maximum number of concurrent subscriptions at a time, {@link Integer#MAX_VALUE}
      *                       is interpreted as indication to subscribe to all sources at once
      * @param prefetch the number of elements to prefetch from each {@code ObservableSource} source
      * @return the new Observable instance with the specified concatenation behavior
@@ -1432,7 +1432,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      * @param <T> the value type
      * @param sources a sequence of ObservableSources that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrently running inner ObservableSources; Integer.MAX_VALUE
+     * @param maxConcurrency the maximum number of concurrently running inner ObservableSources; {@link Integer#MAX_VALUE}
      *                       is interpreted as all inner ObservableSources can be active at the same time
      * @param prefetch the number of elements to prefetch from each inner ObservableSource source
      * @return the new ObservableSource instance with the specified concatenation behavior
@@ -1482,7 +1482,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * </dl>
      * @param <T> the value type
      * @param sources a sequence of ObservableSources that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrently running inner ObservableSources; Integer.MAX_VALUE
+     * @param maxConcurrency the maximum number of concurrently running inner ObservableSources; {@link Integer#MAX_VALUE}
      *                       is interpreted as all inner ObservableSources can be active at the same time
      * @param prefetch the number of elements to prefetch from each inner ObservableSource source
      * @return the new ObservableSource instance with the specified concatenation behavior
@@ -3562,7 +3562,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits a range of sequential Integers
      * @throws IllegalArgumentException
      *             if {@code count} is less than zero, or if {@code start} + {@code count} &minus; 1 exceeds
-     *             {@code Integer.MAX_VALUE}
+     *             {@link Integer#MAX_VALUE}
      * @see <a href="http://reactivex.io/documentation/operators/range.html">ReactiveX operators documentation: Range</a>
      */
     @CheckReturnValue
@@ -3599,7 +3599,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits a range of sequential Longs
      * @throws IllegalArgumentException
      *             if {@code count} is less than zero, or if {@code start} + {@code count} &minus; 1 exceeds
-     *             {@code Long.MAX_VALUE}
+     *             {@link Long#MAX_VALUE}
      * @see <a href="http://reactivex.io/documentation/operators/range.html">ReactiveX operators documentation: Range</a>
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/rxjava3/core/ObservableConverter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/ObservableConverter.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Convenience interface and callback used by the {@link Observable#to} operator to turn an Observable into another
+ * Convenience interface and callback used by the {@link Observable#to} operator to turn an {@link Observable} into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
@@ -26,9 +26,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface ObservableConverter<T, R> {
     /**
-     * Applies a function to the upstream Observable and returns a converted value of type {@code R}.
+     * Applies a function to the upstream {@link Observable} and returns a converted value of type {@code R}.
      *
-     * @param upstream the upstream Observable instance
+     * @param upstream the upstream {@code Observable} instance
      * @return the converted value
      */
     @NonNull

--- a/src/main/java/io/reactivex/rxjava3/core/ObservableEmitter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/ObservableEmitter.java
@@ -50,16 +50,18 @@ import io.reactivex.rxjava3.functions.Cancellable;
 public interface ObservableEmitter<T> extends Emitter<T> {
 
     /**
-     * Sets a Disposable on this emitter; any previous {@link Disposable}
+     * Sets a {@link Disposable} on this emitter; any previous {@code Disposable}
      * or {@link Cancellable} will be disposed/cancelled.
-     * @param d the disposable, null is allowed
+     * <p>This method is thread-safe.
+     * @param d the {@code Disposable}, {@code null} is allowed
      */
     void setDisposable(@Nullable Disposable d);
 
     /**
-     * Sets a Cancellable on this emitter; any previous {@link Disposable}
-     * or {@link Cancellable} will be disposed/cancelled.
-     * @param c the cancellable resource, null is allowed
+     * Sets a {@link Cancellable} on this emitter; any previous {@link Disposable}
+     * or {@code Cancellable} will be disposed/cancelled.
+     * <p>This method is thread-safe.
+     * @param c the {@code Cancellable} resource, {@code null} is allowed
      */
     void setCancellable(@Nullable Cancellable c);
 
@@ -73,21 +75,21 @@ public interface ObservableEmitter<T> extends Emitter<T> {
     boolean isDisposed();
 
     /**
-     * Ensures that calls to onNext, onError and onComplete are properly serialized.
-     * @return the serialized ObservableEmitter
+     * Ensures that calls to {@code onNext}, {@code onError} and {@code onComplete} are properly serialized.
+     * @return the serialized {@link ObservableEmitter}
      */
     @NonNull
     ObservableEmitter<T> serialize();
 
     /**
-     * Attempts to emit the specified {@code Throwable} error if the downstream
+     * Attempts to emit the specified {@link Throwable} error if the downstream
      * hasn't cancelled the sequence or is otherwise terminated, returning false
      * if the emission is not allowed to happen due to lifecycle restrictions.
      * <p>
-     * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
-     * if the error could not be delivered.
+     * Unlike {@link #onError(Throwable)}, the {@link io.reactivex.rxjava3.plugins.RxJavaPlugins#onError(Throwable) RxjavaPlugins.onError}
+     * is not called if the error could not be delivered.
      * <p>History: 2.1.1 - experimental
-     * @param t the throwable error to signal if possible
+     * @param t the {@code Throwable} error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further
      * events
      * @since 2.2

--- a/src/main/java/io/reactivex/rxjava3/core/ObservableOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/ObservableOnSubscribe.java
@@ -25,8 +25,8 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface ObservableOnSubscribe<T> {
 
     /**
-     * Called for each Observer that subscribes.
-     * @param emitter the safe emitter instance, never null
+     * Called for each {@link Observer} that subscribes.
+     * @param emitter the safe emitter instance, never {@code null}
      * @throws Throwable on error
      */
     void subscribe(@NonNull ObservableEmitter<T> emitter) throws Throwable;

--- a/src/main/java/io/reactivex/rxjava3/core/ObservableOperator.java
+++ b/src/main/java/io/reactivex/rxjava3/core/ObservableOperator.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Interface to map/wrap a downstream observer to an upstream observer.
+ * Interface to map/wrap a downstream {@link Observer} to an upstream {@code Observer}.
  *
  * @param <Downstream> the value type of the downstream
  * @param <Upstream> the value type of the upstream
@@ -24,11 +24,11 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface ObservableOperator<Downstream, Upstream> {
     /**
-     * Applies a function to the child Observer and returns a new parent Observer.
-     * @param observer the child Observer instance
-     * @return the parent Observer instance
-     * @throws Exception on failure
+     * Applies a function to the child {@link Observer} and returns a new parent {@code Observer}.
+     * @param observer the child {@code Observer} instance
+     * @return the parent {@code Observer} instance
+     * @throws Throwable on failure
      */
     @NonNull
-    Observer<? super Upstream> apply(@NonNull Observer<? super Downstream> observer) throws Exception;
+    Observer<? super Upstream> apply(@NonNull Observer<? super Downstream> observer) throws Throwable;
 }

--- a/src/main/java/io/reactivex/rxjava3/core/ObservableSource.java
+++ b/src/main/java/io/reactivex/rxjava3/core/ObservableSource.java
@@ -25,9 +25,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface ObservableSource<T> {
 
     /**
-     * Subscribes the given Observer to this ObservableSource instance.
-     * @param observer the Observer, not null
-     * @throws NullPointerException if {@code observer} is null
+     * Subscribes the given {@link Observer} to this {@link ObservableSource} instance.
+     * @param observer the {@code Observer}, not {@code null}
+     * @throws NullPointerException if {@code observer} is {@code null}
      */
     void subscribe(@NonNull Observer<? super T> observer);
 }

--- a/src/main/java/io/reactivex/rxjava3/core/ObservableTransformer.java
+++ b/src/main/java/io/reactivex/rxjava3/core/ObservableTransformer.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Interface to compose Observables.
+ * Interface to compose {@link Observable}s.
  *
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
@@ -24,10 +24,10 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface ObservableTransformer<Upstream, Downstream> {
     /**
-     * Applies a function to the upstream Observable and returns an ObservableSource with
+     * Applies a function to the upstream {@link Observable} and returns an {@link ObservableSource} with
      * optionally different element type.
-     * @param upstream the upstream Observable instance
-     * @return the transformed ObservableSource instance
+     * @param upstream the upstream {@code Observable} instance
+     * @return the transformed {@code ObservableSource} instance
      */
     @NonNull
     ObservableSource<Downstream> apply(@NonNull Observable<Upstream> upstream);

--- a/src/main/java/io/reactivex/rxjava3/core/Observer.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observer.java
@@ -76,17 +76,17 @@ import io.reactivex.rxjava3.disposables.Disposable;
 public interface Observer<T> {
 
     /**
-     * Provides the Observer with the means of cancelling (disposing) the
-     * connection (channel) with the Observable in both
+     * Provides the {@link Observer} with the means of cancelling (disposing) the
+     * connection (channel) with the {@link Observable} in both
      * synchronous (from within {@link #onNext(Object)}) and asynchronous manner.
-     * @param d the Disposable instance whose {@link Disposable#dispose()} can
+     * @param d the {@link Disposable} instance whose {@link Disposable#dispose()} can
      * be called anytime to cancel the connection
      * @since 2.0
      */
     void onSubscribe(@NonNull Disposable d);
 
     /**
-     * Provides the Observer with a new item to observe.
+     * Provides the {@link Observer} with a new item to observe.
      * <p>
      * The {@link Observable} may call this method 0 or more times.
      * <p>
@@ -99,9 +99,9 @@ public interface Observer<T> {
     void onNext(@NonNull T t);
 
     /**
-     * Notifies the Observer that the {@link Observable} has experienced an error condition.
+     * Notifies the {@link Observer} that the {@link Observable} has experienced an error condition.
      * <p>
-     * If the {@link Observable} calls this method, it will not thereafter call {@link #onNext} or
+     * If the {@code Observable} calls this method, it will not thereafter call {@link #onNext} or
      * {@link #onComplete}.
      *
      * @param e
@@ -110,9 +110,9 @@ public interface Observer<T> {
     void onError(@NonNull Throwable e);
 
     /**
-     * Notifies the Observer that the {@link Observable} has finished sending push-based notifications.
+     * Notifies the {@link Observer} that the {@link Observable} has finished sending push-based notifications.
      * <p>
-     * The {@link Observable} will not call this method if it calls {@link #onError}.
+     * The {@code Observable} will not call this method if it calls {@link #onError}.
      */
     void onComplete();
 

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -2346,7 +2346,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <img width="640" height="214" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.delaySubscription.p.png" alt="">
      * <p>If the delaying source signals an error, that error is re-emitted and no subscription
      * to the current Single happens.
-     * <p>The other source is consumed in an unbounded manner (requesting Long.MAX_VALUE from it).
+     * <p>The other source is consumed in an unbounded manner (requesting {@link Long#MAX_VALUE} from it).
      * <dl>
      * <dt><b>Backpressure:</b></dt>
      * <dd>The {@code other} publisher is consumed in an unbounded fashion but will be

--- a/src/main/java/io/reactivex/rxjava3/core/SingleConverter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/SingleConverter.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Convenience interface and callback used by the {@link Single#to} operator to turn a Single into another
+ * Convenience interface and callback used by the {@link Single#to} operator to turn a {@link Single} into another
  * value fluently.
  * <p>History: 2.1.7 - experimental
  * @param <T> the upstream type
@@ -26,9 +26,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface SingleConverter<T, R> {
     /**
-     * Applies a function to the upstream Single and returns a converted value of type {@code R}.
+     * Applies a function to the upstream {@link Single} and returns a converted value of type {@code R}.
      *
-     * @param upstream the upstream Single instance
+     * @param upstream the upstream {@code Single} instance
      * @return the converted value
      */
     @NonNull

--- a/src/main/java/io/reactivex/rxjava3/core/SingleEmitter.java
+++ b/src/main/java/io/reactivex/rxjava3/core/SingleEmitter.java
@@ -57,21 +57,23 @@ public interface SingleEmitter<T> {
 
     /**
      * Signal an exception.
-     * @param t the exception, not null
+     * @param t the exception, not {@code null}
      */
     void onError(@NonNull Throwable t);
 
     /**
-     * Sets a Disposable on this emitter; any previous Disposable
-     * or Cancellable will be disposed/cancelled.
-     * @param d the disposable, null is allowed
+     * Sets a {@link Disposable} on this emitter; any previous {@code Disposable}
+     * or {@link Cancellable} will be disposed/cancelled.
+     * <p>This method is thread-safe.
+     * @param d the {@code Disposable}, {@code null} is allowed
      */
     void setDisposable(@Nullable Disposable d);
 
     /**
      * Sets a Cancellable on this emitter; any previous {@link Disposable}
      * or {@link Cancellable} will be disposed/cancelled.
-     * @param c the cancellable resource, null is allowed
+     * <p>This method is thread-safe.
+     * @param c the {@code Cancellable} resource, {@code null} is allowed
      */
     void setCancellable(@Nullable Cancellable c);
 
@@ -85,12 +87,12 @@ public interface SingleEmitter<T> {
     boolean isDisposed();
 
     /**
-     * Attempts to emit the specified {@code Throwable} error if the downstream
+     * Attempts to emit the specified {@link Throwable} error if the downstream
      * hasn't cancelled the sequence or is otherwise terminated, returning false
      * if the emission is not allowed to happen due to lifecycle restrictions.
      * <p>
-     * Unlike {@link #onError(Throwable)}, the {@code RxJavaPlugins.onError} is not called
-     * if the error could not be delivered.
+     * Unlike {@link #onError(Throwable)}, the {@link io.reactivex.rxjava3.plugins.RxJavaPlugins#onError(Throwable) RxjavaPlugins.onError}
+     * is not called if the error could not be delivered.
      * <p>History: 2.1.1 - experimental
      * @param t the throwable error to signal if possible
      * @return true if successful, false if the downstream is not able to accept further

--- a/src/main/java/io/reactivex/rxjava3/core/SingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/core/SingleObserver.java
@@ -53,7 +53,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 public interface SingleObserver<T> {
 
     /**
-     * Provides the SingleObserver with the means of cancelling (disposing) the
+     * Provides the {@link SingleObserver} with the means of cancelling (disposing) the
      * connection (channel) with the Single in both
      * synchronous (from within {@code onSubscribe(Disposable)} itself) and asynchronous manner.
      * @param d the Disposable instance whose {@link Disposable#dispose()} can
@@ -63,23 +63,23 @@ public interface SingleObserver<T> {
     void onSubscribe(@NonNull Disposable d);
 
     /**
-     * Notifies the SingleObserver with a single item and that the {@link Single} has finished sending
+     * Notifies the {@link SingleObserver} with a single item and that the {@link Single} has finished sending
      * push-based notifications.
      * <p>
-     * The {@link Single} will not call this method if it calls {@link #onError}.
+     * The {@code Single} will not call this method if it calls {@link #onError}.
      *
      * @param t
-     *          the item emitted by the Single
+     *          the item emitted by the {@code Single}
      */
     void onSuccess(@NonNull T t);
 
     /**
-     * Notifies the SingleObserver that the {@link Single} has experienced an error condition.
+     * Notifies the {@link SingleObserver} that the {@link Single} has experienced an error condition.
      * <p>
-     * If the {@link Single} calls this method, it will not thereafter call {@link #onSuccess}.
+     * If the {@code Single} calls this method, it will not thereafter call {@link #onSuccess}.
      *
      * @param e
-     *          the exception encountered by the Single
+     *          the exception encountered by the {@code Single}
      */
     void onError(@NonNull Throwable e);
 }

--- a/src/main/java/io/reactivex/rxjava3/core/SingleOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/SingleOnSubscribe.java
@@ -25,8 +25,8 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface SingleOnSubscribe<T> {
 
     /**
-     * Called for each SingleObserver that subscribes.
-     * @param emitter the safe emitter instance, never null
+     * Called for each {@link SingleObserver} that subscribes.
+     * @param emitter the safe emitter instance, never {@code null}
      * @throws Throwable on error
      */
     void subscribe(@NonNull SingleEmitter<T> emitter) throws Throwable;

--- a/src/main/java/io/reactivex/rxjava3/core/SingleOperator.java
+++ b/src/main/java/io/reactivex/rxjava3/core/SingleOperator.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Interface to map/wrap a downstream observer to an upstream observer.
+ * Interface to map/wrap a downstream {@link SingleObserver} to an upstream {@code SingleObserver}.
  *
  * @param <Downstream> the value type of the downstream
  * @param <Upstream> the value type of the upstream
@@ -24,11 +24,11 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface SingleOperator<Downstream, Upstream> {
     /**
-     * Applies a function to the child SingleObserver and returns a new parent SingleObserver.
-     * @param observer the child SingleObserver instance
-     * @return the parent SingleObserver instance
-     * @throws Exception on failure
+     * Applies a function to the child {@link SingleObserver} and returns a new parent {@code SingleObserver}.
+     * @param observer the child {@code SingleObserver} instance
+     * @return the parent {@code SingleObserver} instance
+     * @throws Throwable on failure
      */
     @NonNull
-    SingleObserver<? super Upstream> apply(@NonNull SingleObserver<? super Downstream> observer) throws Exception;
+    SingleObserver<? super Upstream> apply(@NonNull SingleObserver<? super Downstream> observer) throws Throwable;
 }

--- a/src/main/java/io/reactivex/rxjava3/core/SingleSource.java
+++ b/src/main/java/io/reactivex/rxjava3/core/SingleSource.java
@@ -28,9 +28,9 @@ import io.reactivex.rxjava3.annotations.NonNull;
 public interface SingleSource<T> {
 
     /**
-     * Subscribes the given SingleObserver to this SingleSource instance.
-     * @param observer the SingleObserver, not null
-     * @throws NullPointerException if {@code observer} is null
+     * Subscribes the given {@link SingleObserver} to this {@link SingleSource} instance.
+     * @param observer the {@code SingleObserver}, not {@code null}
+     * @throws NullPointerException if {@code observer} is {@code null}
      */
     void subscribe(@NonNull SingleObserver<? super T> observer);
 }

--- a/src/main/java/io/reactivex/rxjava3/core/SingleTransformer.java
+++ b/src/main/java/io/reactivex/rxjava3/core/SingleTransformer.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava3.core;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Interface to compose Singles.
+ * Interface to compose {@link Single}s.
  *
  * @param <Upstream> the upstream value type
  * @param <Downstream> the downstream value type
@@ -24,10 +24,10 @@ import io.reactivex.rxjava3.annotations.NonNull;
 @FunctionalInterface
 public interface SingleTransformer<Upstream, Downstream> {
     /**
-     * Applies a function to the upstream Single and returns a SingleSource with
+     * Applies a function to the upstream {@link Single} and returns a {@link SingleSource} with
      * optionally different element type.
-     * @param upstream the upstream Single instance
-     * @return the transformed SingleSource instance
+     * @param upstream the upstream {@code Single} instance
+     * @return the transformed {@code SingleSource} instance
      */
     @NonNull
     SingleSource<Downstream> apply(@NonNull Single<Upstream> upstream);

--- a/src/main/java/io/reactivex/rxjava3/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/disposables/CompositeDisposable.java
@@ -37,7 +37,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
     /**
      * Creates a CompositeDisposables with the given array of initial elements.
      * @param disposables the array of Disposables to start with
-     * @throws NullPointerException if {@code disposables} or any of its array items is null
+     * @throws NullPointerException if {@code disposables} or any of its array items is {@code null}
      */
     public CompositeDisposable(@NonNull Disposable... disposables) {
         Objects.requireNonNull(disposables, "disposables is null");
@@ -51,7 +51,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
     /**
      * Creates a CompositeDisposables with the given Iterable sequence of initial elements.
      * @param disposables the Iterable sequence of Disposables to start with
-     * @throws NullPointerException if {@code disposables} or any of its items is null
+     * @throws NullPointerException if {@code disposables} or any of its items is {@code null}
      */
     public CompositeDisposable(@NonNull Iterable<? extends Disposable> disposables) {
         Objects.requireNonNull(disposables, "disposables is null");
@@ -90,7 +90,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * container has been disposed.
      * @param disposable the disposable to add, not null
      * @return true if successful, false if this container has been disposed
-     * @throws NullPointerException if {@code disposable} is null
+     * @throws NullPointerException if {@code disposable} is {@code null}
      */
     @Override
     public boolean add(@NonNull Disposable disposable) {
@@ -117,7 +117,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * disposes them all if the container has been disposed.
      * @param disposables the array of Disposables
      * @return true if the operation was successful, false if the container has been disposed
-     * @throws NullPointerException if {@code disposables} or any of its array items is null
+     * @throws NullPointerException if {@code disposables} or any of its array items is {@code null}
      */
     public boolean addAll(@NonNull Disposable... disposables) {
         Objects.requireNonNull(disposables, "disposables is null");
@@ -163,7 +163,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      * container.
      * @param disposable the disposable to remove, not null
      * @return true if the operation was successful
-     * @throws NullPointerException if {@code disposable} is null
+     * @throws NullPointerException if {@code disposable} is {@code null}
      */
     @Override
     public boolean delete(@NonNull Disposable disposable) {

--- a/src/main/java/io/reactivex/rxjava3/exceptions/UndeliverableException.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/UndeliverableException.java
@@ -14,7 +14,7 @@
 package io.reactivex.rxjava3.exceptions;
 
 /**
- * Wrapper for Throwable errors that are sent to `RxJavaPlugins.onError`.
+ * Wrapper for Throwable errors that are sent to {@link io.reactivex.rxjava3.plugins.RxJavaPlugins#onError(Throwable) RxJavaPlugins.onError}.
  * <p>History: 2.0.6 - experimental; 2.1 - beta
  * @since 2.2
  */

--- a/src/main/java/io/reactivex/rxjava3/internal/util/BackpressureHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/BackpressureHelper.java
@@ -14,6 +14,7 @@ package io.reactivex.rxjava3.internal.util;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -26,10 +27,10 @@ public final class BackpressureHelper {
     }
 
     /**
-     * Adds two long values and caps the sum at Long.MAX_VALUE.
+     * Adds two long values and caps the sum at {@link Long#MAX_VALUE}.
      * @param a the first value
      * @param b the second value
-     * @return the sum capped at Long.MAX_VALUE
+     * @return the sum capped at {@link Long#MAX_VALUE}
      */
     public static long addCap(long a, long b) {
         long u = a + b;
@@ -40,10 +41,10 @@ public final class BackpressureHelper {
     }
 
     /**
-     * Multiplies two long values and caps the product at Long.MAX_VALUE.
+     * Multiplies two long values and caps the product at {@link Long#MAX_VALUE}.
      * @param a the first value
      * @param b the second value
-     * @return the product capped at Long.MAX_VALUE
+     * @return the product capped at {@link Long#MAX_VALUE}
      */
     public static long multiplyCap(long a, long b) {
         long u = a * b;
@@ -56,13 +57,13 @@ public final class BackpressureHelper {
     }
 
     /**
-     * Atomically adds the positive value n to the requested value in the AtomicLong and
-     * caps the result at Long.MAX_VALUE and returns the previous value.
-     * @param requested the AtomicLong holding the current requested value
+     * Atomically adds the positive value n to the requested value in the {@link AtomicLong} and
+     * caps the result at {@link Long#MAX_VALUE} and returns the previous value.
+     * @param requested the {@code AtomicLong} holding the current requested value
      * @param n the value to add, must be positive (not verified)
      * @return the original value before the add
      */
-    public static long add(AtomicLong requested, long n) {
+    public static long add(@NonNull AtomicLong requested, long n) {
         for (;;) {
             long r = requested.get();
             if (r == Long.MAX_VALUE) {
@@ -76,14 +77,14 @@ public final class BackpressureHelper {
     }
 
     /**
-     * Atomically adds the positive value n to the requested value in the AtomicLong and
-     * caps the result at Long.MAX_VALUE and returns the previous value and
-     * considers Long.MIN_VALUE as a cancel indication (no addition then).
-     * @param requested the AtomicLong holding the current requested value
+     * Atomically adds the positive value n to the requested value in the {@link AtomicLong} and
+     * caps the result at {@link Long#MAX_VALUE} and returns the previous value and
+     * considers {@link Long#MIN_VALUE} as a cancel indication (no addition then).
+     * @param requested the {@code AtomicLong} holding the current requested value
      * @param n the value to add, must be positive (not verified)
      * @return the original value before the add
      */
-    public static long addCancel(AtomicLong requested, long n) {
+    public static long addCancel(@NonNull AtomicLong requested, long n) {
         for (;;) {
             long r = requested.get();
             if (r == Long.MIN_VALUE) {
@@ -100,12 +101,12 @@ public final class BackpressureHelper {
     }
 
     /**
-     * Atomically subtract the given number (positive, not validated) from the target field unless it contains Long.MAX_VALUE.
+     * Atomically subtract the given number (positive, not validated) from the target field unless it contains {@link Long#MAX_VALUE}.
      * @param requested the target field holding the current requested amount
      * @param n the produced element count, positive (not validated)
      * @return the new amount
      */
-    public static long produced(AtomicLong requested, long n) {
+    public static long produced(@NonNull AtomicLong requested, long n) {
         for (;;) {
             long current = requested.get();
             if (current == Long.MAX_VALUE) {
@@ -124,12 +125,12 @@ public final class BackpressureHelper {
 
     /**
      * Atomically subtract the given number (positive, not validated) from the target field if
-     * it doesn't contain Long.MIN_VALUE (indicating some cancelled state) or Long.MAX_VALUE (unbounded mode).
+     * it doesn't contain {@link Long#MIN_VALUE} (indicating some cancelled state) or {@link Long#MAX_VALUE} (unbounded mode).
      * @param requested the target field holding the current requested amount
      * @param n the produced element count, positive (not validated)
      * @return the new amount
      */
-    public static long producedCancel(AtomicLong requested, long n) {
+    public static long producedCancel(@NonNull AtomicLong requested, long n) {
         for (;;) {
             long current = requested.get();
             if (current == Long.MIN_VALUE) {

--- a/src/main/java/io/reactivex/rxjava3/internal/util/QueueDrainHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/QueueDrainHelper.java
@@ -218,7 +218,7 @@ public final class QueueDrainHelper {
     }
 
     /**
-     * Requests Long.MAX_VALUE if prefetch is negative or the exact
+     * Requests {@link Long#MAX_VALUE} if prefetch is negative or the exact
      * amount if prefetch is positive.
      * @param s the Subscription to request from
      * @param prefetch the prefetch value
@@ -383,7 +383,7 @@ public final class QueueDrainHelper {
      * in completed mode, requests no-longer reach the upstream but help in draining the queue.
      * <p>
      * The algorithm utilizes the most significant bit (bit 63) of a long value (AtomicLong) since
-     * request amount only goes up to Long.MAX_VALUE (bits 0-62) and negative values aren't
+     * request amount only goes up to {@link Long#MAX_VALUE} (bits 0-62) and negative values aren't
      * allowed.
      *
      * @param <T> the value type emitted

--- a/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
@@ -16,15 +16,17 @@ package io.reactivex.rxjava3.observers;
 import java.util.*;
 import java.util.concurrent.*;
 
+import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.exceptions.CompositeException;
 import io.reactivex.rxjava3.functions.Predicate;
-import io.reactivex.rxjava3.internal.functions.*;
+import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.internal.util.*;
 
 /**
- * Base class with shared infrastructure to support TestSubscriber and TestObserver.
+ * Base class with shared infrastructure to support
+ * {@link io.reactivex.rxjava3.subscribers.TestSubscriber TestSubscriber} and {@link TestObserver}.
  * @param <T> the value type consumed
- * @param <U> the subclass of this BaseTestConsumer
+ * @param <U> the subclass of this {@code BaseTestConsumer}
  */
 public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     /** The latch that indicates an onError or onComplete has been called. */
@@ -47,26 +49,26 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     protected CharSequence tag;
 
     /**
-     * Indicates that one of the awaitX method has timed out.
+     * Indicates that one of the {@code awaitX} method has timed out.
      * @since 2.0.7
      */
     protected boolean timeout;
 
     public BaseTestConsumer() {
-        this.values = new VolatileSizeArrayList<T>();
-        this.errors = new VolatileSizeArrayList<Throwable>();
+        this.values = new VolatileSizeArrayList<>();
+        this.errors = new VolatileSizeArrayList<>();
         this.done = new CountDownLatch(1);
     }
 
     /**
-     * Returns a shared list of received onNext values.
+     * Returns a shared list of received {@code onNext} values or the single {@code onSuccess} value.
      * <p>
      * Note that accessing the items via certain methods of the {@link List}
      * interface while the upstream is still actively emitting
      * more items may result in a {@code ConcurrentModificationException}.
      * <p>
      * The {@link List#size()} method will return the number of items
-     * already received by this TestObserver/TestSubscriber in a thread-safe
+     * already received by this {@code TestObserver}/{@code TestSubscriber} in a thread-safe
      * manner that can be read via {@link List#get(int)}) method
      * (index range of 0 to {@code List.size() - 1}).
      * <p>
@@ -76,6 +78,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * {@code ConcurrentModificationException}.
      * @return a list of received onNext values
      */
+    @NonNull
     public final List<T> values() {
         return values;
     }
@@ -89,7 +92,8 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @param message the message to use
      * @return AssertionError the prepared AssertionError instance
      */
-    protected final AssertionError fail(String message) {
+    @NonNull
+    protected final AssertionError fail(@NonNull String message) {
         StringBuilder b = new StringBuilder(64 + message.length());
         b.append(message);
 
@@ -131,11 +135,12 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Awaits until this TestObserver/TestSubscriber receives an onError or onComplete events.
+     * Awaits until this {@code TestObserver}/{@code TestSubscriber} receives an {@code onError} or {@code onComplete} events.
      * @return this
      * @throws InterruptedException if the current thread is interrupted while waiting
      */
     @SuppressWarnings("unchecked")
+    @NonNull
     public final U await() throws InterruptedException {
         if (done.getCount() == 0) {
             return (U)this;
@@ -146,14 +151,14 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Awaits the specified amount of time or until this TestObserver/TestSubscriber
-     * receives an onError or onComplete events, whichever happens first.
+     * Awaits the specified amount of time or until this {@code TestObserver}/{@code TestSubscriber}
+     * receives an {@code onError} or {@code onComplete} events, whichever happens first.
      * @param time the waiting time
      * @param unit the time unit of the waiting time
-     * @return true if the TestObserver/TestSubscriber terminated, false if timeout happened
+     * @return true if the {@code TestObserver}/{@code TestSubscriber} terminated, false if timeout happened
      * @throws InterruptedException if the current thread is interrupted while waiting
      */
-    public final boolean await(long time, TimeUnit unit) throws InterruptedException {
+    public final boolean await(long time, @NonNull TimeUnit unit) throws InterruptedException {
         boolean d = done.getCount() == 0 || (done.await(time, unit));
         timeout = !d;
         return d;
@@ -162,10 +167,11 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     // assertion methods
 
     /**
-     * Assert that this TestObserver/TestSubscriber received exactly one onComplete event.
+     * Assert that this {@code TestObserver}/{@code TestSubscriber} received exactly one {@code onComplete} event.
      * @return this
      */
     @SuppressWarnings("unchecked")
+    @NonNull
     public final U assertComplete() {
         long c = completions;
         if (c == 0) {
@@ -178,10 +184,11 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that this TestObserver/TestSubscriber has not received any onComplete event.
+     * Assert that this {@code TestObserver}/{@code TestSubscriber} has not received an {@code onComplete} event.
      * @return this
      */
     @SuppressWarnings("unchecked")
+    @NonNull
     public final U assertNotComplete() {
         long c = completions;
         if (c == 1) {
@@ -194,10 +201,11 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that this TestObserver/TestSubscriber has not received any onError event.
+     * Assert that this {@code TestObserver}/{@code TestSubscriber} has not received an {@code onError} event.
      * @return this
      */
     @SuppressWarnings("unchecked")
+    @NonNull
     public final U assertNoErrors() {
         int s = errors.size();
         if (s != 0) {
@@ -207,9 +215,9 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that this TestObserver/TestSubscriber received exactly the specified onError event value.
+     * Assert that this {@code TestObserver}/{@code TestSubscriber} received exactly the specified {@code onError} event value.
      *
-     * <p>The comparison is performed via Objects.equals(); since most exceptions don't
+     * <p>The comparison is performed via {@link Objects#equals(Object, Object)}; since most exceptions don't
      * implement equals(), this assertion may fail. Use the {@link #assertError(Class)}
      * overload to test against the class of an error instead of an instance of an error
      * or {@link #assertError(Predicate)} to test with different condition.
@@ -218,31 +226,34 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @see #assertError(Class)
      * @see #assertError(Predicate)
      */
-    public final U assertError(Throwable error) {
+    @NonNull
+    public final U assertError(@NonNull Throwable error) {
         return assertError(Functions.equalsWith(error));
     }
 
     /**
-     * Asserts that this TestObserver/TestSubscriber received exactly one onError event which is an
-     * instance of the specified errorClass class.
-     * @param errorClass the error class to expect
+     * Asserts that this {@code TestObserver}/{@code TestSubscriber} received exactly one {@code onError} event which is an
+     * instance of the specified {@code errorClass} {@link Class}.
+     * @param errorClass the error {@code Class} to expect
      * @return this
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public final U assertError(Class<? extends Throwable> errorClass) {
+    @NonNull
+    public final U assertError(@NonNull Class<? extends Throwable> errorClass) {
         return (U)assertError((Predicate)Functions.isInstanceOf(errorClass));
     }
 
     /**
-     * Asserts that this TestObserver/TestSubscriber received exactly one onError event for which
-     * the provided predicate returns true.
+     * Asserts that this {@code TestObserver}/{@code TestSubscriber} received exactly one {@code onError} event for which
+     * the provided predicate returns {@code true}.
      * @param errorPredicate
-     *            the predicate that receives the error Throwable
-     *            and should return true for expected errors.
+     *            the predicate that receives the error {@link Throwable}
+     *            and should return {@code true} for expected errors.
      * @return this
      */
     @SuppressWarnings("unchecked")
-    public final U assertError(Predicate<Throwable> errorPredicate) {
+    @NonNull
+    public final U assertError(@NonNull Predicate<Throwable> errorPredicate) {
         int s = errors.size();
         if (s == 0) {
             throw fail("No errors");
@@ -272,13 +283,14 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that this TestObserver/TestSubscriber received exactly one onNext value which is equal to
-     * the given value with respect to Objects.equals.
+     * Assert that this {@code TestObserver}/{@code TestSubscriber} received exactly one {@code onNext} value which is equal to
+     * the given value with respect to {@link Objects#equals(Object, Object)}.
      * @param value the value to expect
      * @return this
      */
     @SuppressWarnings("unchecked")
-    public final U assertValue(T value) {
+    @NonNull
+    public final U assertValue(@NonNull T value) {
         int s = values.size();
         if (s != 1) {
             throw fail("expected: " + valueAndClass(value) + " but was: " + values);
@@ -291,15 +303,16 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Asserts that this TestObserver/TestSubscriber received exactly one onNext value for which
-     * the provided predicate returns true.
+     * Asserts that this {@code TestObserver}/{@code TestSubscriber} received exactly one {@code onNext} value for which
+     * the provided predicate returns {@code true}.
      * @param valuePredicate
-     *            the predicate that receives the onNext value
-     *            and should return true for the expected value.
+     *            the predicate that receives the {@code onNext} value
+     *            and should return {@code true} for the expected value.
      * @return this
      */
     @SuppressWarnings("unchecked")
-    public final U assertValue(Predicate<T> valuePredicate) {
+    @NonNull
+    public final U assertValue(@NonNull Predicate<T> valuePredicate) {
         assertValueAt(0, valuePredicate);
 
         if (values.size() > 1) {
@@ -310,8 +323,8 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Asserts that this TestObserver/TestSubscriber received an onNext value at the given index
-     * which is equal to the given value with respect to null-safe Object.equals.
+     * Asserts that this {@code TestObserver}/{@code TestSubscriber} received an {@code onNext} value at the given index
+     * which is equal to the given value with respect to {@code null}-safe {@link Objects#equals(Object, Object)}.
      * <p>History: 2.1.3 - experimental
      * @param index the position to assert on
      * @param value the value to expect
@@ -319,7 +332,8 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @since 2.2
      */
     @SuppressWarnings("unchecked")
-    public final U assertValueAt(int index, T value) {
+    @NonNull
+    public final U assertValueAt(int index, @NonNull T value) {
         int s = values.size();
         if (s == 0) {
             throw fail("No values");
@@ -337,16 +351,17 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Asserts that this TestObserver/TestSubscriber received an onNext value at the given index
-     * for the provided predicate returns true.
+     * Asserts that this {@code TestObserver}/{@code TestSubscriber} received an {@code onNext} value at the given index
+     * for the provided predicate returns {@code true}.
      * @param index the position to assert on
      * @param valuePredicate
-     *            the predicate that receives the onNext value
-     *            and should return true for the expected value.
+     *            the predicate that receives the {@code onNext} value
+     *            and should return {@code true} for the expected value.
      * @return this
      */
     @SuppressWarnings("unchecked")
-    public final U assertValueAt(int index, Predicate<T> valuePredicate) {
+    @NonNull
+    public final U assertValueAt(int index, @NonNull Predicate<T> valuePredicate) {
         int s = values.size();
         if (s == 0) {
             throw fail("No values");
@@ -373,11 +388,12 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Appends the class name to a non-null value.
+     * Appends the class name to a non-{@code null} value or returns {@code "null"}.
      * @param o the object
      * @return the string representation
      */
-    public static String valueAndClass(Object o) {
+    @NonNull
+    public static String valueAndClass(@Nullable Object o) {
         if (o != null) {
             return o + " (class: " + o.getClass().getSimpleName() + ")";
         }
@@ -385,11 +401,12 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that this TestObserver/TestSubscriber received the specified number onNext events.
-     * @param count the expected number of onNext events
+     * Assert that this {@code TestObserver}/{@code TestSubscriber} received the specified number {@code onNext} events.
+     * @param count the expected number of {@code onNext} events
      * @return this
      */
     @SuppressWarnings("unchecked")
+    @NonNull
     public final U assertValueCount(int count) {
         int s = values.size();
         if (s != count) {
@@ -399,20 +416,23 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that this TestObserver/TestSubscriber has not received any onNext events.
+     * Assert that this {@code TestObserver}/{@code TestSubscriber} has not received any {@code onNext} events.
      * @return this
      */
+    @NonNull
     public final U assertNoValues() {
         return assertValueCount(0);
     }
 
     /**
-     * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order.
+     * Assert that the {@code TestObserver}/{@code TestSubscriber} received only the specified values in the specified order.
      * @param values the values expected
      * @return this
      */
     @SuppressWarnings("unchecked")
-    public final U assertValues(T... values) {
+    @SafeVarargs
+    @NonNull
+    public final U assertValues(@NonNull T... values) {
         int s = this.values.size();
         if (s != values.length) {
             throw fail("Value count differs; expected: " + values.length + " " + Arrays.toString(values)
@@ -429,14 +449,15 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
+     * Assert that the {@code TestObserver}/{@code TestSubscriber} received only the specified values in the specified order without terminating.
      * <p>History: 2.1.4 - experimental
      * @param values the values expected
      * @return this
      * @since 2.2
      */
     @SafeVarargs
-    public final U assertValuesOnly(T... values) {
+    @NonNull
+    public final U assertValuesOnly(@NonNull T... values) {
         return assertSubscribed()
                 .assertValues(values)
                 .assertNoErrors()
@@ -444,12 +465,13 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that the TestObserver/TestSubscriber received only the specified sequence of values in the same order.
+     * Assert that the {@code TestObserver}/{@code TestSubscriber} received only the specified sequence of values in the same order.
      * @param sequence the sequence of expected values in order
      * @return this
      */
     @SuppressWarnings("unchecked")
-    public final U assertValueSequence(Iterable<? extends T> sequence) {
+    @NonNull
+    public final U assertValueSequence(@NonNull Iterable<? extends T> sequence) {
         int i = 0;
         Iterator<T> actualIterator = values.iterator();
         Iterator<? extends T> expectedIterator = sequence.iterator();
@@ -482,20 +504,22 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that the onSubscribe method was called exactly once.
+     * Assert that the {@code onSubscribe} method was called exactly once.
      * @return this
      */
+    @NonNull
     protected abstract U assertSubscribed();
 
     /**
-     * Assert that the upstream signalled the specified values in order and
+     * Assert that the upstream signaled the specified values in order and
      * completed normally.
      * @param values the expected values, asserted in order
      * @return this
      * @see #assertFailure(Class, Object...)
      */
     @SafeVarargs
-    public final U assertResult(T... values) {
+    @NonNull
+    public final U assertResult(@NonNull T... values) {
         return assertSubscribed()
                 .assertValues(values)
                 .assertNoErrors()
@@ -503,14 +527,15 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that the upstream signalled the specified values in order
-     * and then failed with a specific class or subclass of Throwable.
-     * @param error the expected exception (parent) class
+     * Assert that the upstream signaled the specified values in order
+     * and then failed with a specific class or subclass of {@link Throwable}.
+     * @param error the expected exception (parent) {@link Class}
      * @param values the expected values, asserted in order
      * @return this
      */
     @SafeVarargs
-    public final U assertFailure(Class<? extends Throwable> error, T... values) {
+    @NonNull
+    public final U assertFailure(@NonNull Class<? extends Throwable> error, @NonNull T... values) {
         return assertSubscribed()
                 .assertValues(values)
                 .assertError(error)
@@ -519,14 +544,15 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
 
     /**
      * Awaits until the internal latch is counted down.
-     * <p>If the wait times out or gets interrupted, the TestObserver/TestSubscriber is cancelled.
+     * <p>If the wait times out or gets interrupted, the {@code TestObserver}/{@code TestSubscriber} is cancelled.
      * @param time the waiting time
      * @param unit the time unit of the waiting time
      * @return this
-     * @throws RuntimeException wrapping an InterruptedException if the wait is interrupted
+     * @throws RuntimeException wrapping an {@link InterruptedException} if the wait is interrupted
      */
     @SuppressWarnings("unchecked")
-    public final U awaitDone(long time, TimeUnit unit) {
+    @NonNull
+    public final U awaitDone(long time, @NonNull TimeUnit unit) {
         try {
             if (!done.await(time, unit)) {
                 timeout = true;
@@ -540,9 +566,12 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that the TestObserver/TestSubscriber has received a Disposable but no other events.
+     * Assert that the {@code TestObserver}/{@code TestSubscriber} has received a
+     * {@link io.reactivex.rxjava3.disposables.Disposable Disposable}/{@link org.reactivestreams.Subscription Subscription}
+     * via {@code onSubscribe} but no other events.
      * @return this
      */
+    @NonNull
     public final U assertEmpty() {
         return assertSubscribed()
                 .assertNoValues()
@@ -554,18 +583,19 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * Set the tag displayed along with an assertion failure's
      * other state information.
      * <p>History: 2.0.7 - experimental
-     * @param tag the string to display (null won't print any tag)
+     * @param tag the string to display ({@code null} won't print any tag)
      * @return this
      * @since 2.1
      */
     @SuppressWarnings("unchecked")
-    public final U withTag(CharSequence tag) {
+    @NonNull
+    public final U withTag(@Nullable CharSequence tag) {
         this.tag = tag;
         return (U)this;
     }
 
     /**
-     * Await until the TestObserver/TestSubscriber receives the given
+     * Await until the {@code TestObserver}/{@code TestSubscriber} receives the given
      * number of items or terminates by sleeping 10 milliseconds at a time
      * up to 5000 milliseconds of timeout.
      * <p>History: 2.0.7 - experimental
@@ -574,6 +604,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @since 2.1
      */
     @SuppressWarnings("unchecked")
+    @NonNull
     public final U awaitCount(int atLeast) {
         long start = System.currentTimeMillis();
         long timeoutMillis = 5000;

--- a/src/main/java/io/reactivex/rxjava3/observers/DisposableCompletableObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/DisposableCompletableObserver.java
@@ -53,7 +53,7 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class DisposableCompletableObserver implements CompletableObserver, Disposable {
 
-    final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     @Override
     public final void onSubscribe(@NonNull Disposable d) {
@@ -63,7 +63,7 @@ public abstract class DisposableCompletableObserver implements CompletableObserv
     }
 
     /**
-     * Called once the single upstream Disposable is set via onSubscribe.
+     * Called once the single upstream {@link Disposable} is set via {@link #onSubscribe(Disposable)}.
      */
     protected void onStart() {
     }

--- a/src/main/java/io/reactivex/rxjava3/observers/DisposableMaybeObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/DisposableMaybeObserver.java
@@ -22,7 +22,7 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
 
 /**
- * An abstract {@link MaybeObserver} that allows asynchronous cancellation by implementing Disposable.
+ * An abstract {@link MaybeObserver} that allows asynchronous cancellation by implementing {@link Disposable}.
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
@@ -62,7 +62,7 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class DisposableMaybeObserver<T> implements MaybeObserver<T>, Disposable {
 
-    final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     @Override
     public final void onSubscribe(@NonNull Disposable d) {
@@ -72,7 +72,7 @@ public abstract class DisposableMaybeObserver<T> implements MaybeObserver<T>, Di
     }
 
     /**
-     * Called once the single upstream Disposable is set via onSubscribe.
+     * Called once the single upstream {@link Disposable} is set via {@link #onSubscribe(Disposable)}.
      */
     protected void onStart() {
     }

--- a/src/main/java/io/reactivex/rxjava3/observers/DisposableObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/DisposableObserver.java
@@ -22,7 +22,7 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
 
 /**
- * An abstract {@link Observer} that allows asynchronous cancellation by implementing Disposable.
+ * An abstract {@link Observer} that allows asynchronous cancellation by implementing {@link Disposable}.
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
@@ -66,7 +66,7 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class DisposableObserver<T> implements Observer<T>, Disposable {
 
-    final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     @Override
     public final void onSubscribe(@NonNull Disposable d) {

--- a/src/main/java/io/reactivex/rxjava3/observers/DisposableSingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/DisposableSingleObserver.java
@@ -22,7 +22,7 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
 
 /**
- * An abstract {@link SingleObserver} that allows asynchronous cancellation by implementing Disposable.
+ * An abstract {@link SingleObserver} that allows asynchronous cancellation by implementing {@link Disposable}.
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
@@ -55,7 +55,7 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class DisposableSingleObserver<T> implements SingleObserver<T>, Disposable {
 
-    final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     @Override
     public final void onSubscribe(@NonNull Disposable d) {
@@ -65,7 +65,7 @@ public abstract class DisposableSingleObserver<T> implements SingleObserver<T>, 
     }
 
     /**
-     * Called once the single upstream Disposable is set via onSubscribe.
+     * Called once the single upstream {@link Disposable} is set via {@link #onSubscribe(Disposable)}.
      */
     protected void onStart() {
     }

--- a/src/main/java/io/reactivex/rxjava3/observers/LambdaConsumerIntrospection.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/LambdaConsumerIntrospection.java
@@ -24,8 +24,8 @@ package io.reactivex.rxjava3.observers;
 public interface LambdaConsumerIntrospection {
 
     /**
-     * Returns true or false if a custom onError consumer has been provided.
-     * @return {@code true} if a custom onError consumer implementation was supplied. Returns {@code false} if the
+     * Returns {@code true} or {@code false} if a custom {@code onError} consumer has been provided.
+     * @return {@code true} if a custom {@code onError} consumer implementation was supplied. Returns {@code false} if the
      * implementation is missing an error consumer and thus using a throwing default implementation.
      */
     boolean hasCustomOnError();

--- a/src/main/java/io/reactivex/rxjava3/observers/ResourceCompletableObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/ResourceCompletableObserver.java
@@ -74,17 +74,17 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class ResourceCompletableObserver implements CompletableObserver, Disposable {
     /** The active subscription. */
-    private final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    private final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     /** The resource composite, can never be null. */
     private final ListCompositeDisposable resources = new ListCompositeDisposable();
 
     /**
-     * Adds a resource to this ResourceObserver.
+     * Adds a resource to this {@code ResourceCompletableObserver}.
      *
      * @param resource the resource to add
      *
-     * @throws NullPointerException if resource is null
+     * @throws NullPointerException if resource is {@code null}
      */
     public final void add(@NonNull Disposable resource) {
         Objects.requireNonNull(resource, "resource is null");
@@ -99,7 +99,7 @@ public abstract class ResourceCompletableObserver implements CompletableObserver
     }
 
     /**
-     * Called once the upstream sets a Subscription on this ResourceObserver.
+     * Called once the upstream sets a {@link Disposable} on this {@code ResourceCompletableObserver}.
      *
      * <p>You can perform initialization at this moment. The default
      * implementation does nothing.
@@ -109,10 +109,10 @@ public abstract class ResourceCompletableObserver implements CompletableObserver
 
     /**
      * Cancels the main disposable (if any) and disposes the resources associated with
-     * this ResourceObserver (if any).
+     * this {@code ResourceCompletableObserver} (if any).
      *
-     * <p>This method can be called before the upstream calls onSubscribe at which
-     * case the main Disposable will be immediately disposed.
+     * <p>This method can be called before the upstream calls {@link #onSubscribe(Disposable)} at which
+     * case the main {@link Disposable} will be immediately disposed.
      */
     @Override
     public final void dispose() {
@@ -122,8 +122,8 @@ public abstract class ResourceCompletableObserver implements CompletableObserver
     }
 
     /**
-     * Returns true if this ResourceObserver has been disposed/cancelled.
-     * @return true if this ResourceObserver has been disposed/cancelled
+     * Returns true if this {@code ResourceCompletableObserver} has been disposed/cancelled.
+     * @return true if this {@code ResourceCompletableObserver} has been disposed/cancelled
      */
     @Override
     public final boolean isDisposed() {

--- a/src/main/java/io/reactivex/rxjava3/observers/ResourceMaybeObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/ResourceMaybeObserver.java
@@ -84,17 +84,17 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class ResourceMaybeObserver<T> implements MaybeObserver<T>, Disposable {
     /** The active subscription. */
-    private final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    private final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     /** The resource composite, can never be null. */
     private final ListCompositeDisposable resources = new ListCompositeDisposable();
 
     /**
-     * Adds a resource to this ResourceObserver.
+     * Adds a resource to this {@code ResourceMaybeObserver}.
      *
      * @param resource the resource to add
      *
-     * @throws NullPointerException if resource is null
+     * @throws NullPointerException if resource is {@code null}
      */
     public final void add(@NonNull Disposable resource) {
         Objects.requireNonNull(resource, "resource is null");
@@ -109,7 +109,7 @@ public abstract class ResourceMaybeObserver<T> implements MaybeObserver<T>, Disp
     }
 
     /**
-     * Called once the upstream sets a Subscription on this ResourceObserver.
+     * Called once the upstream sets a {@link Disposable} on this {@code ResourceMaybeObserver}.
      *
      * <p>You can perform initialization at this moment. The default
      * implementation does nothing.
@@ -119,10 +119,10 @@ public abstract class ResourceMaybeObserver<T> implements MaybeObserver<T>, Disp
 
     /**
      * Cancels the main disposable (if any) and disposes the resources associated with
-     * this ResourceObserver (if any).
+     * this {@code ResourceMaybeObserver} (if any).
      *
-     * <p>This method can be called before the upstream calls onSubscribe at which
-     * case the main Disposable will be immediately disposed.
+     * <p>This method can be called before the upstream calls {@link #onSubscribe(Disposable)} at which
+     * case the main {@link Disposable} will be immediately disposed.
      */
     @Override
     public final void dispose() {
@@ -132,8 +132,8 @@ public abstract class ResourceMaybeObserver<T> implements MaybeObserver<T>, Disp
     }
 
     /**
-     * Returns true if this ResourceObserver has been disposed/cancelled.
-     * @return true if this ResourceObserver has been disposed/cancelled
+     * Returns true if this {@code ResourceMaybeObserver} has been disposed/cancelled.
+     * @return true if this {@code ResourceMaybeObserver} has been disposed/cancelled
      */
     @Override
     public final boolean isDisposed() {

--- a/src/main/java/io/reactivex/rxjava3/observers/ResourceObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/ResourceObserver.java
@@ -82,17 +82,17 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class ResourceObserver<T> implements Observer<T>, Disposable {
     /** The active subscription. */
-    private final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    private final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     /** The resource composite, can never be null. */
     private final ListCompositeDisposable resources = new ListCompositeDisposable();
 
     /**
-     * Adds a resource to this ResourceObserver.
+     * Adds a resource to this {@code ResourceObserver}.
      *
      * @param resource the resource to add
      *
-     * @throws NullPointerException if resource is null
+     * @throws NullPointerException if resource is {@code null}
      */
     public final void add(@NonNull Disposable resource) {
         Objects.requireNonNull(resource, "resource is null");
@@ -107,7 +107,7 @@ public abstract class ResourceObserver<T> implements Observer<T>, Disposable {
     }
 
     /**
-     * Called once the upstream sets a Subscription on this ResourceObserver.
+     * Called once the upstream sets a {@link Disposable} on this {@code ResourceObserver}.
      *
      * <p>You can perform initialization at this moment. The default
      * implementation does nothing.
@@ -117,10 +117,10 @@ public abstract class ResourceObserver<T> implements Observer<T>, Disposable {
 
     /**
      * Cancels the main disposable (if any) and disposes the resources associated with
-     * this ResourceObserver (if any).
+     * this {@code ResourceObserver} (if any).
      *
-     * <p>This method can be called before the upstream calls onSubscribe at which
-     * case the main Disposable will be immediately disposed.
+     * <p>This method can be called before the upstream calls {@link #onSubscribe(Disposable)} at which
+     * case the main {@link Disposable} will be immediately disposed.
      */
     @Override
     public final void dispose() {
@@ -130,8 +130,8 @@ public abstract class ResourceObserver<T> implements Observer<T>, Disposable {
     }
 
     /**
-     * Returns true if this ResourceObserver has been disposed/cancelled.
-     * @return true if this ResourceObserver has been disposed/cancelled
+     * Returns true if this {@code ResourceObserver} has been disposed/cancelled.
+     * @return true if this {@code ResourceObserver} has been disposed/cancelled
      */
     @Override
     public final boolean isDisposed() {

--- a/src/main/java/io/reactivex/rxjava3/observers/ResourceSingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/ResourceSingleObserver.java
@@ -77,17 +77,17 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class ResourceSingleObserver<T> implements SingleObserver<T>, Disposable {
     /** The active subscription. */
-    private final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    private final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     /** The resource composite, can never be null. */
     private final ListCompositeDisposable resources = new ListCompositeDisposable();
 
     /**
-     * Adds a resource to this ResourceObserver.
+     * Adds a resource to this {@code ResourceSingleObserver}.
      *
      * @param resource the resource to add
      *
-     * @throws NullPointerException if resource is null
+     * @throws NullPointerException if resource is {@code null}
      */
     public final void add(@NonNull Disposable resource) {
         Objects.requireNonNull(resource, "resource is null");
@@ -102,7 +102,7 @@ public abstract class ResourceSingleObserver<T> implements SingleObserver<T>, Di
     }
 
     /**
-     * Called once the upstream sets a Subscription on this ResourceObserver.
+     * Called once the upstream sets a {@link Disposable} on this {@code ResourceSingleObserver}.
      *
      * <p>You can perform initialization at this moment. The default
      * implementation does nothing.
@@ -112,10 +112,10 @@ public abstract class ResourceSingleObserver<T> implements SingleObserver<T>, Di
 
     /**
      * Cancels the main disposable (if any) and disposes the resources associated with
-     * this ResourceObserver (if any).
+     * this {@code ResourceSingleObserver} (if any).
      *
-     * <p>This method can be called before the upstream calls onSubscribe at which
-     * case the main Disposable will be immediately disposed.
+     * <p>This method can be called before the upstream calls {@link #onSubscribe(Disposable)} at which
+     * case the main {@link Disposable} will be immediately disposed.
      */
     @Override
     public final void dispose() {
@@ -125,8 +125,8 @@ public abstract class ResourceSingleObserver<T> implements SingleObserver<T>, Di
     }
 
     /**
-     * Returns true if this ResourceObserver has been disposed/cancelled.
-     * @return true if this ResourceObserver has been disposed/cancelled
+     * Returns true if this {@code ResourceSingleObserver} has been disposed/cancelled.
+     * @return true if this {@code ResourceSingleObserver} has been disposed/cancelled
      */
     @Override
     public final boolean isDisposed() {

--- a/src/main/java/io/reactivex/rxjava3/observers/SafeObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/SafeObserver.java
@@ -21,7 +21,7 @@ import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
- * Wraps another Subscriber and ensures all onXXX methods conform the protocol
+ * Wraps another {@link Observer} and ensures all {@code onXXX} methods conform the protocol
  * (except the requirement for serialized access).
  *
  * @param <T> the value type
@@ -35,8 +35,8 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
     boolean done;
 
     /**
-     * Constructs a SafeObserver by wrapping the given actual Observer.
-     * @param downstream the actual Observer to wrap, not null (not validated)
+     * Constructs a {@code SafeObserver} by wrapping the given actual {@link Observer}.
+     * @param downstream the actual {@code Observer} to wrap, not {@code null} (not validated)
      */
     public SafeObserver(@NonNull Observer<? super T> downstream) {
         this.downstream = downstream;

--- a/src/main/java/io/reactivex/rxjava3/observers/SerializedObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/SerializedObserver.java
@@ -20,13 +20,14 @@ import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
- * Serializes access to the onNext, onError and onComplete methods of another Observer.
+ * Serializes access to the {@link Observer#onNext(Object)}, {@link Observer#onError(Throwable)} and
+ * {@link Observer#onComplete()} methods of another {@link Observer}.
  *
  * <p>Note that {@link #onSubscribe(Disposable)} is not serialized in respect of the other methods so
- * make sure the {@code onSubscribe()} is called with a non-null {@code Disposable}
+ * make sure the {@code onSubscribe()} is called with a non-null {@link Disposable}
  * before any of the other methods are called.
  *
- * <p>The implementation assumes that the actual Observer's methods don't throw.
+ * <p>The implementation assumes that the actual {@code Observer}'s methods don't throw.
  *
  * @param <T> the value type
  */
@@ -44,19 +45,19 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
     volatile boolean done;
 
     /**
-     * Construct a SerializedObserver by wrapping the given actual Observer.
-     * @param downstream the actual Observer, not null (not verified)
+     * Construct a {@code SerializedObserver} by wrapping the given actual {@link Observer}.
+     * @param downstream the actual {@code Observer}, not {@code null} (not verified)
      */
     public SerializedObserver(@NonNull Observer<? super T> downstream) {
         this(downstream, false);
     }
 
     /**
-     * Construct a SerializedObserver by wrapping the given actual Observer and
+     * Construct a SerializedObserver by wrapping the given actual {@link Observer} and
      * optionally delaying the errors till all regular values have been emitted
      * from the internal buffer.
-     * @param actual the actual Observer, not null (not verified)
-     * @param delayError if true, errors are emitted after regular values have been emitted
+     * @param actual the actual {@code Observer}, not {@code null} (not verified)
+     * @param delayError if {@code true}, errors are emitted after regular values have been emitted
      */
     public SerializedObserver(@NonNull Observer<? super T> actual, boolean delayError) {
         this.downstream = actual;
@@ -100,7 +101,7 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
             if (emitting) {
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(QUEUE_LINK_SIZE);
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
                     queue = q;
                 }
                 q.add(NotificationLite.next(t));
@@ -129,7 +130,7 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
                 done = true;
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(QUEUE_LINK_SIZE);
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
                     queue = q;
                 }
                 Object err = NotificationLite.error(t);
@@ -167,7 +168,7 @@ public final class SerializedObserver<T> implements Observer<T>, Disposable {
             if (emitting) {
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(QUEUE_LINK_SIZE);
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
                     queue = q;
                 }
                 q.add(NotificationLite.complete());

--- a/src/main/java/io/reactivex/rxjava3/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/TestObserver.java
@@ -14,19 +14,24 @@ package io.reactivex.rxjava3.observers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 
 /**
- * An Observer that records events and allows making assertions about them.
+ * An {@link Observer}, {@link MaybeObserver}, {@link SingleObserver} and
+ * {@link CompletableObserver} composite that can record events from
+ * {@link Observable}s, {@link Maybe}s, {@link Single}s and {@link Completable}s
+ *  and allows making assertions about them.
  *
- * <p>You can override the onSubscribe, onNext, onError, onComplete, onSuccess and
- * cancel methods but not the others (this is by design).
+ * <p>You can override the {@link #onSubscribe(Disposable)}, {@link #onNext(Object)}, {@link #onError(Throwable)},
+ * {@link #onComplete()} and {@link #onSuccess(Object)} methods but not the others (this is by design).
  *
- * <p>The TestObserver implements Disposable for convenience where dispose calls cancel.
+ * <p>The {@code TestObserver} implements {@link Disposable} for convenience where dispose calls cancel.
  *
  * @param <T> the value type
+ * @see io.reactivex.rxjava3.subscribers.TestSubscriber
  */
 public class TestObserver<T>
 extends BaseTestConsumer<T, TestObserver<T>>
@@ -35,25 +40,27 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
     private final Observer<? super T> downstream;
 
     /** Holds the current subscription if any. */
-    private final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    private final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     /**
-     * Constructs a non-forwarding TestObserver.
+     * Constructs a non-forwarding {@code TestObserver}.
      * @param <T> the value type received
-     * @return the new TestObserver instance
+     * @return the new {@code TestObserver} instance
      */
+    @NonNull
     public static <T> TestObserver<T> create() {
-        return new TestObserver<T>();
+        return new TestObserver<>();
     }
 
     /**
-     * Constructs a forwarding TestObserver.
+     * Constructs a forwarding {@code TestObserver}.
      * @param <T> the value type received
-     * @param delegate the actual Observer to forward events to
-     * @return the new TestObserver instance
+     * @param delegate the actual {@link Observer} to forward events to
+     * @return the new {@code TestObserver} instance
      */
-    public static <T> TestObserver<T> create(Observer<? super T> delegate) {
-        return new TestObserver<T>(delegate);
+    @NonNull
+    public static <T> TestObserver<T> create(@NonNull Observer<? super T> delegate) {
+        return new TestObserver<>(delegate);
     }
 
     /**
@@ -64,15 +71,15 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
     }
 
     /**
-     * Constructs a forwarding TestObserver.
-     * @param downstream the actual Observer to forward events to
+     * Constructs a forwarding {@code TestObserver}.
+     * @param downstream the actual {@link Observer} to forward events to
      */
-    public TestObserver(Observer<? super T> downstream) {
+    public TestObserver(@NonNull Observer<? super T> downstream) {
         this.downstream = downstream;
     }
 
     @Override
-    public void onSubscribe(Disposable d) {
+    public void onSubscribe(@NonNull Disposable d) {
         lastThread = Thread.currentThread();
 
         if (d == null) {
@@ -91,7 +98,7 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         if (!checkSubscriptionOnce) {
             checkSubscriptionOnce = true;
             if (upstream.get() == null) {
@@ -111,7 +118,7 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         if (!checkSubscriptionOnce) {
             checkSubscriptionOnce = true;
             if (upstream.get() == null) {
@@ -164,18 +171,19 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
 
     // state retrieval methods
     /**
-     * Returns true if this TestObserver received a subscription.
-     * @return true if this TestObserver received a subscription
+     * Returns true if this {@code TestObserver} received a subscription.
+     * @return true if this {@code TestObserver} received a subscription
      */
     public final boolean hasSubscription() {
         return upstream.get() != null;
     }
 
     /**
-     * Assert that the onSubscribe method was called exactly once.
-     * @return this;
+     * Assert that the {@link #onSubscribe(Disposable)} method was called exactly once.
+     * @return this
      */
     @Override
+    @NonNull
     protected final TestObserver<T> assertSubscribed() {
         if (upstream.get() == null) {
             throw fail("Not subscribed!");
@@ -184,7 +192,7 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
     }
 
     @Override
-    public void onSuccess(T value) {
+    public void onSuccess(@NonNull T value) {
         onNext(value);
         onComplete();
     }

--- a/src/main/java/io/reactivex/rxjava3/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/AsyncProcessor.java
@@ -68,7 +68,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  *  <dd>The {@code AsyncProcessor} honors the backpressure of the downstream {@code Subscriber}s and won't emit
  *  its single value to a particular {@code Subscriber} until that {@code Subscriber} has requested an item.
  *  When the {@code AsyncProcessor} is subscribed to a {@link io.reactivex.rxjava3.core.Flowable}, the processor consumes this
- *  {@code Flowable} in an unbounded manner (requesting `Long.MAX_VALUE`) as only the very last upstream item is
+ *  {@code Flowable} in an unbounded manner (requesting {@link Long#MAX_VALUE}) as only the very last upstream item is
  *  retained by it.
  *  </dd>
  *  <dt><b>Scheduler:</b></dt>

--- a/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
@@ -108,7 +108,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  *  that returns true if any of the {@code Subscriber}s is not ready to receive {@code onNext} events. If
  *  there are no {@code Subscriber}s to the processor, {@code offer()} always succeeds.
  *  If the {@code BehaviorProcessor} is (optionally) subscribed to another {@code Publisher}, this upstream
- *  {@code Publisher} is consumed in an unbounded fashion (requesting {@code Long.MAX_VALUE}).</dd>
+ *  {@code Publisher} is consumed in an unbounded fashion (requesting {@link Long#MAX_VALUE}).</dd>
  *  <dt><b>Scheduler:</b></dt>
  *  <dd>{@code BehaviorProcessor} does not operate by default on a particular {@link io.reactivex.rxjava3.core.Scheduler} and
  *  the {@code Subscriber}s get notified on the thread the respective {@code onXXX} methods were invoked.</dd>
@@ -229,7 +229,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     /**
      * Constructs a BehaviorProcessor with the given initial value.
      * @param defaultValue the initial value, not null (verified)
-     * @throws NullPointerException if {@code defaultValue} is null
+     * @throws NullPointerException if {@code defaultValue} is {@code null}
      * @since 2.0
      */
     BehaviorProcessor(T defaultValue) {

--- a/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
@@ -71,7 +71,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  * <dl>
  *  <dt><b>Backpressure:</b></dt>
  *  <dd>The processor does not coordinate backpressure for its subscribers and implements a weaker {@code onSubscribe} which
- *  calls requests Long.MAX_VALUE from the incoming Subscriptions. This makes it possible to subscribe the {@code PublishProcessor}
+ *  calls requests {@link Long#MAX_VALUE} from the incoming Subscriptions. This makes it possible to subscribe the {@code PublishProcessor}
  *  to multiple sources (note on serialization though) unlike the standard {@code Subscriber} contract. Child subscribers, however, are not overflown but receive an
  *  {@link IllegalStateException} in case their requested amount is zero.</dd>
  *  <dt><b>Scheduler:</b></dt>

--- a/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
@@ -66,7 +66,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  * <p>
  * This {@code ReplayProcessor} respects the individual backpressure behavior of its {@code Subscriber}s but
  * does not coordinate their request amounts towards the upstream (because there might not be any) and
- * consumes the upstream in an unbounded manner (requesting {@code Long.MAX_VALUE}).
+ * consumes the upstream in an unbounded manner (requesting {@link Long#MAX_VALUE}).
  * Note that {@code Subscriber}s receive a continuous sequence of values after they subscribed even
  * if an individual item gets delayed due to backpressure.
  * Due to concurrency requirements, a size-bounded {@code ReplayProcessor} may hold strong references to more source
@@ -104,7 +104,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  *  <dt><b>Backpressure:</b></dt>
  *  <dd>This {@code ReplayProcessor} respects the individual backpressure behavior of its {@code Subscriber}s but
  *  does not coordinate their request amounts towards the upstream (because there might not be any) and
- *  consumes the upstream in an unbounded manner (requesting {@code Long.MAX_VALUE}).
+ *  consumes the upstream in an unbounded manner (requesting {@long Long#MAX_VALUE}).
  *  Note that {@code Subscriber}s receive a continuous sequence of values after they subscribed even
  *  if an individual item gets delayed due to backpressure.</dd>
  *  <dt><b>Scheduler:</b></dt>

--- a/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
@@ -104,7 +104,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  *  <dt><b>Backpressure:</b></dt>
  *  <dd>This {@code ReplayProcessor} respects the individual backpressure behavior of its {@code Subscriber}s but
  *  does not coordinate their request amounts towards the upstream (because there might not be any) and
- *  consumes the upstream in an unbounded manner (requesting {@long Long#MAX_VALUE}).
+ *  consumes the upstream in an unbounded manner (requesting {@link Long#MAX_VALUE}).
  *  Note that {@code Subscriber}s receive a continuous sequence of values after they subscribed even
  *  if an individual item gets delayed due to backpressure.</dd>
  *  <dt><b>Scheduler:</b></dt>

--- a/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
@@ -67,7 +67,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  * {@link NullPointerException} being thrown and the processor's state is not changed.
  * <p>
  * Since a {@code UnicastProcessor} is a {@link io.reactivex.rxjava3.core.Flowable} as well as a {@link FlowableProcessor}, it
- * honors the downstream backpressure but consumes an upstream source in an unbounded manner (requesting {@code Long.MAX_VALUE}).
+ * honors the downstream backpressure but consumes an upstream source in an unbounded manner (requesting {@link Long#MAX_VALUE}).
  * <p>
  * When this {@code UnicastProcessor} is terminated via {@link #onError(Throwable)} the current or late single {@code Subscriber}
  * may receive the {@code Throwable} before any available items could be emitted. To make sure an {@code onError} event is delivered
@@ -91,7 +91,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  * <dl>
  *  <dt><b>Backpressure:</b></dt>
  *  <dd>{@code UnicastProcessor} honors the downstream backpressure but consumes an upstream source
- *  (if any) in an unbounded manner (requesting {@code Long.MAX_VALUE}).</dd>
+ *  (if any) in an unbounded manner (requesting {@link Long#MAX_VALUE}).</dd>
  *  <dt><b>Scheduler:</b></dt>
  *  <dd>{@code UnicastProcessor} does not operate by default on a particular {@link io.reactivex.rxjava3.core.Scheduler} and
  *  the single {@code Subscriber} gets notified on the thread the respective {@code onXXX} methods were invoked.</dd>

--- a/src/main/java/io/reactivex/rxjava3/schedulers/Timed.java
+++ b/src/main/java/io/reactivex/rxjava3/schedulers/Timed.java
@@ -29,11 +29,11 @@ public final class Timed<T> {
     final TimeUnit unit;
 
     /**
-     * Constructs a Timed instance with the given value and time information.
+     * Constructs a {@code Timed} instance with the given value and time information.
      * @param value the value to hold
      * @param time the time to hold
      * @param unit the time unit, not null
-     * @throws NullPointerException if unit is null
+     * @throws NullPointerException if unit is {@code null}
      */
     public Timed(@NonNull T value, long time, @NonNull TimeUnit unit) {
         this.value = value;
@@ -69,7 +69,7 @@ public final class Timed<T> {
 
     /**
      * Returns the contained time value in the time unit specified.
-     * @param unit the time unt
+     * @param unit the time unit
      * @return the converted time
      */
     public long time(@NonNull TimeUnit unit) {

--- a/src/main/java/io/reactivex/rxjava3/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/BehaviorSubject.java
@@ -213,7 +213,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
     /**
      * Constructs a BehaviorSubject with the given initial value.
      * @param defaultValue the initial value, not null (verified)
-     * @throws NullPointerException if {@code defaultValue} is null
+     * @throws NullPointerException if {@code defaultValue} is {@code null}
      * @since 2.0
      */
     BehaviorSubject(T defaultValue) {

--- a/src/main/java/io/reactivex/rxjava3/subscribers/DefaultSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/subscribers/DefaultSubscriber.java
@@ -27,7 +27,7 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
- * <p>The default {@link #onStart()} requests Long.MAX_VALUE by default. Override
+ * <p>The default {@link #onStart()} requests {@link Long#MAX_VALUE} by default. Override
  * the method to request a custom <em>positive</em> amount.
  *
  * <p>Note that calling {@link #request(long)} from {@link #onStart()} may trigger
@@ -85,7 +85,7 @@ public abstract class DefaultSubscriber<T> implements FlowableSubscriber<T> {
     }
 
     /**
-     * Requests from the upstream Subscription.
+     * Requests from the upstream {@link Subscription}.
      * @param n the request amount, positive
      */
     protected final void request(long n) {
@@ -96,7 +96,7 @@ public abstract class DefaultSubscriber<T> implements FlowableSubscriber<T> {
     }
 
     /**
-     * Cancels the upstream's Subscription.
+     * Cancels the upstream's {@link Subscription}.
      */
     protected final void cancel() {
         Subscription s = this.upstream;

--- a/src/main/java/io/reactivex/rxjava3/subscribers/DisposableSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/subscribers/DisposableSubscriber.java
@@ -23,11 +23,11 @@ import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
 
 /**
- * An abstract Subscriber that allows asynchronous, external cancellation by implementing Disposable.
+ * An abstract Subscriber that allows asynchronous, external cancellation by implementing {@link Disposable}.
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
- * <p>The default {@link #onStart()} requests Long.MAX_VALUE by default. Override
+ * <p>The default {@link #onStart()} requests {@link Long#MAX_VALUE} by default. Override
  * the method to request a custom <em>positive</em> amount. Use the protected {@link #request(long)}
  * to request more items and {@link #cancel()} to cancel the sequence from within an
  * {@code onNext} implementation.
@@ -74,7 +74,7 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  * @param <T> the received value type.
  */
 public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, Disposable {
-    final AtomicReference<Subscription> upstream = new AtomicReference<Subscription>();
+    final AtomicReference<Subscription> upstream = new AtomicReference<>();
 
     @Override
     public final void onSubscribe(Subscription s) {
@@ -84,18 +84,18 @@ public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, 
     }
 
     /**
-     * Called once the single upstream Subscription is set via onSubscribe.
+     * Called once the single upstream {@link Subscription} is set via {@link #onSubscribe(Subscription)}.
      */
     protected void onStart() {
         upstream.get().request(Long.MAX_VALUE);
     }
 
     /**
-     * Requests the specified amount from the upstream if its Subscription is set via
+     * Requests the specified amount from the upstream if its {@link Subscription} is set via
      * onSubscribe already.
-     * <p>Note that calling this method before a Subscription is set via onSubscribe
-     * leads to NullPointerException and meant to be called from inside onStart or
-     * onNext.
+     * <p>Note that calling this method before a {@link Subscription} is set via {@link #onSubscribe(Subscription)}
+     * leads to {@link NullPointerException} and meant to be called from inside {@link #onStart()} or
+     * {@link #onNext(Object)}.
      * @param n the request amount, positive
      */
     protected final void request(long n) {
@@ -103,8 +103,8 @@ public abstract class DisposableSubscriber<T> implements FlowableSubscriber<T>, 
     }
 
     /**
-     * Cancels the Subscription set via onSubscribe or makes sure a
-     * Subscription set asynchronously (later) is cancelled immediately.
+     * Cancels the Subscription set via {@link #onSubscribe(Subscription)} or makes sure a
+     * {@link Subscription} set asynchronously (later) is cancelled immediately.
      * <p>This method is thread-safe and can be exposed as a public API.
      */
     protected final void cancel() {

--- a/src/main/java/io/reactivex/rxjava3/subscribers/ResourceSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/subscribers/ResourceSubscriber.java
@@ -40,7 +40,7 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  * {@code ResourceSubscriber} and then add/remove resources to/from the {@code CompositeDisposable}
  * freely.
  *
- * <p>The default {@link #onStart()} requests Long.MAX_VALUE by default. Override
+ * <p>The default {@link #onStart()} requests {@link Long#MAX_VALUE} by default. Override
  * the method to request a custom <em>positive</em> amount. Use the protected {@link #request(long)}
  * to request more items and {@link #dispose()} to cancel the sequence from within an
  * {@code onNext} implementation.
@@ -94,7 +94,7 @@ import io.reactivex.rxjava3.internal.util.EndConsumerHelper;
  */
 public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Disposable {
     /** The active subscription. */
-    private final AtomicReference<Subscription> upstream = new AtomicReference<Subscription>();
+    private final AtomicReference<Subscription> upstream = new AtomicReference<>();
 
     /** The resource composite, can never be null. */
     private final ListCompositeDisposable resources = new ListCompositeDisposable();
@@ -103,11 +103,11 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
     private final AtomicLong missedRequested = new AtomicLong();
 
     /**
-     * Adds a resource to this AsyncObserver.
+     * Adds a resource to this {@code ResourceSubscriber}.
      *
      * @param resource the resource to add
      *
-     * @throws NullPointerException if resource is null
+     * @throws NullPointerException if {@code resource} is {@code null}
      */
     public final void add(Disposable resource) {
         Objects.requireNonNull(resource, "resource is null");
@@ -126,10 +126,10 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
     }
 
     /**
-     * Called once the upstream sets a Subscription on this AsyncObserver.
+     * Called once the upstream sets a {@link Subscription} on this {@code ResourceSubscriber}.
      *
      * <p>You can perform initialization at this moment. The default
-     * implementation requests Long.MAX_VALUE from upstream.
+     * implementation requests {@link Long#MAX_VALUE} from upstream.
      */
     protected void onStart() {
         request(Long.MAX_VALUE);
@@ -138,7 +138,7 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
     /**
      * Request the specified amount of elements from upstream.
      *
-     * <p>This method can be called before the upstream calls onSubscribe().
+     * <p>This method can be called before the upstream calls {@link #onSubscribe(Subscription)}.
      * When the subscription happens, all missed requests are requested.
      *
      * @param n the request amount, must be positive
@@ -149,10 +149,10 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
 
     /**
      * Cancels the subscription (if any) and disposes the resources associated with
-     * this AsyncObserver (if any).
+     * this {@code ResourceSubscriber} (if any).
      *
-     * <p>This method can be called before the upstream calls onSubscribe at which
-     * case the Subscription will be immediately cancelled.
+     * <p>This method can be called before the upstream calls {@link #onSubscribe(Subscription)} at which
+     * case the {@link Subscription} will be immediately cancelled.
      */
     @Override
     public final void dispose() {
@@ -162,8 +162,8 @@ public abstract class ResourceSubscriber<T> implements FlowableSubscriber<T>, Di
     }
 
     /**
-     * Returns true if this AsyncObserver has been disposed/cancelled.
-     * @return true if this AsyncObserver has been disposed/cancelled
+     * Returns true if this {@code ResourceSubscriber} has been disposed/cancelled.
+     * @return true if this {@code ResourceSubscriber} has been disposed/cancelled
      */
     @Override
     public final boolean isDisposed() {

--- a/src/main/java/io/reactivex/rxjava3/subscribers/SafeSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/subscribers/SafeSubscriber.java
@@ -14,6 +14,7 @@ package io.reactivex.rxjava3.subscribers;
 
 import org.reactivestreams.*;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.FlowableSubscriber;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.internal.subscriptions.*;
@@ -21,7 +22,7 @@ import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
- * Wraps another Subscriber and ensures all onXXX methods conform the protocol
+ * Wraps another {@link Subscriber} and ensures all {@code onXXX} methods conform the protocol
  * (except the requirement for serialized access).
  *
  * @param <T> the value type
@@ -35,15 +36,15 @@ public final class SafeSubscriber<T> implements FlowableSubscriber<T>, Subscript
     boolean done;
 
     /**
-     * Constructs a SafeSubscriber by wrapping the given actual Subscriber.
-     * @param downstream the actual Subscriber to wrap, not null (not validated)
+     * Constructs a {@code SafeSubscriber} by wrapping the given actual {@link Subscriber}.
+     * @param downstream the actual {@code Subscriber} to wrap, not {@code null} (not validated)
      */
-    public SafeSubscriber(Subscriber<? super T> downstream) {
+    public SafeSubscriber(@NonNull Subscriber<? super T> downstream) {
         this.downstream = downstream;
     }
 
     @Override
-    public void onSubscribe(Subscription s) {
+    public void onSubscribe(@NonNull Subscription s) {
         if (SubscriptionHelper.validate(this.upstream, s)) {
             this.upstream = s;
             try {
@@ -65,7 +66,7 @@ public final class SafeSubscriber<T> implements FlowableSubscriber<T>, Subscript
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         if (done) {
             return;
         }
@@ -124,7 +125,7 @@ public final class SafeSubscriber<T> implements FlowableSubscriber<T>, Subscript
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         if (done) {
             RxJavaPlugins.onError(t);
             return;

--- a/src/main/java/io/reactivex/rxjava3/subscribers/SerializedSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/subscribers/SerializedSubscriber.java
@@ -14,19 +14,21 @@ package io.reactivex.rxjava3.subscribers;
 
 import org.reactivestreams.*;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.FlowableSubscriber;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
- * Serializes access to the onNext, onError and onComplete methods of another Subscriber.
+ * Serializes access to the {@link Subscriber#onNext(Object)}, {@link Subscriber#onError(Throwable)} and
+ * {@link Subscriber#onComplete()} methods of another {@link Subscriber}.
  *
  * <p>Note that {@link #onSubscribe(Subscription)} is not serialized in respect of the other methods so
- * make sure the {@code onSubscribe} is called with a non-null {@code Subscription}
+ * make sure the {@code onSubscribe} is called with a non-{@code null} {@link Subscription}
  * before any of the other methods are called.
  *
- * <p>The implementation assumes that the actual Subscriber's methods don't throw.
+ * <p>The implementation assumes that the actual {@code Subscriber}'s methods don't throw.
  *
  * @param <T> the value type
  */
@@ -44,27 +46,27 @@ public final class SerializedSubscriber<T> implements FlowableSubscriber<T>, Sub
     volatile boolean done;
 
     /**
-     * Construct a SerializedSubscriber by wrapping the given actual Subscriber.
-     * @param downstream the actual Subscriber, not null (not verified)
+     * Construct a {@code SerializedSubscriber} by wrapping the given actual {@link Subscriber}.
+     * @param downstream the actual {@code Subscriber}, not null (not verified)
      */
     public SerializedSubscriber(Subscriber<? super T> downstream) {
         this(downstream, false);
     }
 
     /**
-     * Construct a SerializedSubscriber by wrapping the given actual Observer and
+     * Construct a {@code SerializedSubscriber} by wrapping the given actual {@link Subscriber} and
      * optionally delaying the errors till all regular values have been emitted
      * from the internal buffer.
-     * @param actual the actual Subscriber, not null (not verified)
-     * @param delayError if true, errors are emitted after regular values have been emitted
+     * @param actual the actual {@code Subscriber}, not {@code null} (not verified)
+     * @param delayError if {@code true}, errors are emitted after regular values have been emitted
      */
-    public SerializedSubscriber(Subscriber<? super T> actual, boolean delayError) {
+    public SerializedSubscriber(@NonNull Subscriber<? super T> actual, boolean delayError) {
         this.downstream = actual;
         this.delayError = delayError;
     }
 
     @Override
-    public void onSubscribe(Subscription s) {
+    public void onSubscribe(@NonNull Subscription s) {
         if (SubscriptionHelper.validate(this.upstream, s)) {
             this.upstream = s;
             downstream.onSubscribe(this);
@@ -72,7 +74,7 @@ public final class SerializedSubscriber<T> implements FlowableSubscriber<T>, Sub
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         if (done) {
             return;
         }
@@ -88,7 +90,7 @@ public final class SerializedSubscriber<T> implements FlowableSubscriber<T>, Sub
             if (emitting) {
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(QUEUE_LINK_SIZE);
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
                     queue = q;
                 }
                 q.add(NotificationLite.next(t));
@@ -117,7 +119,7 @@ public final class SerializedSubscriber<T> implements FlowableSubscriber<T>, Sub
                 done = true;
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(QUEUE_LINK_SIZE);
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
                     queue = q;
                 }
                 Object err = NotificationLite.error(t);
@@ -155,7 +157,7 @@ public final class SerializedSubscriber<T> implements FlowableSubscriber<T>, Sub
             if (emitting) {
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(QUEUE_LINK_SIZE);
+                    q = new AppendOnlyLinkedArrayList<>(QUEUE_LINK_SIZE);
                     queue = q;
                 }
                 q.add(NotificationLite.complete());

--- a/src/main/java/io/reactivex/rxjava3/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/subscribers/TestSubscriber.java
@@ -16,20 +16,19 @@ import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.FlowableSubscriber;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.observers.BaseTestConsumer;
 
 /**
- * A subscriber that records events and allows making assertions about them.
+ * A {@link Subscriber} implementation that records events and allows making assertions about them.
  *
- * <p>You can override the onSubscribe, onNext, onError, onComplete, request and
- * cancel methods but not the others (this is by design).
- *
- * <p>The TestSubscriber implements Disposable for convenience where dispose calls cancel.
+ * <p>You can override the {@link #onSubscribe(Subscription)}, {@link #onNext(Object)}, {@link #onError(Throwable)} and
+ * {@link #onComplete()} methods but not the others (this is by design).
  *
  * <p>When calling the default request method, you are requesting on behalf of the
- * wrapped actual subscriber.
+ * wrapped actual {@link Subscriber} if any.
  *
  * @param <T> the value type
  */
@@ -49,78 +48,82 @@ implements FlowableSubscriber<T>, Subscription {
     private final AtomicLong missedRequested;
 
     /**
-     * Creates a TestSubscriber with Long.MAX_VALUE initial request.
+     * Creates a {@code TestSubscriber} with {@link Long#MAX_VALUE} initial request amount.
      * @param <T> the value type
-     * @return the new TestSubscriber instance.
+     * @return the new {@code TestSubscriber} instance.
+     * @see #create(long)
      */
+    @NonNull
     public static <T> TestSubscriber<T> create() {
-        return new TestSubscriber<T>();
+        return new TestSubscriber<>();
     }
 
     /**
-     * Creates a TestSubscriber with the given initial request.
+     * Creates a {@code TestSubscriber} with the given initial request amount.
      * @param <T> the value type
      * @param initialRequested the initial requested amount
-     * @return the new TestSubscriber instance.
+     * @return the new {@code TestSubscriber} instance.
      */
+    @NonNull
     public static <T> TestSubscriber<T> create(long initialRequested) {
-        return new TestSubscriber<T>(initialRequested);
+        return new TestSubscriber<>(initialRequested);
     }
 
     /**
-     * Constructs a forwarding TestSubscriber.
+     * Constructs a forwarding {@code TestSubscriber}.
      * @param <T> the value type received
-     * @param delegate the actual Subscriber to forward events to
+     * @param delegate the actual {@link Subscriber} to forward events to
      * @return the new TestObserver instance
      */
-    public static <T> TestSubscriber<T> create(Subscriber<? super T> delegate) {
-        return new TestSubscriber<T>(delegate);
+    public static <T> TestSubscriber<T> create(@NonNull Subscriber<? super T> delegate) {
+        return new TestSubscriber<>(delegate);
     }
 
     /**
-     * Constructs a non-forwarding TestSubscriber with an initial request value of Long.MAX_VALUE.
+     * Constructs a non-forwarding {@code TestSubscriber} with an initial request value of {@link Long#MAX_VALUE}.
      */
     public TestSubscriber() {
         this(EmptySubscriber.INSTANCE, Long.MAX_VALUE);
     }
 
     /**
-     * Constructs a non-forwarding TestSubscriber with the specified initial request value.
-     * <p>The TestSubscriber doesn't validate the initialRequest value so one can
+     * Constructs a non-forwarding {@code TestSubscriber} with the specified initial request value.
+     * <p>The {@code TestSubscriber} doesn't validate the {@code initialRequest} amount so one can
      * test sources with invalid values as well.
-     * @param initialRequest the initial request value
+     * @param initialRequest the initial request amount
      */
     public TestSubscriber(long initialRequest) {
         this(EmptySubscriber.INSTANCE, initialRequest);
     }
 
     /**
-     * Constructs a forwarding TestSubscriber but leaves the requesting to the wrapped subscriber.
-     * @param downstream the actual Subscriber to forward events to
+     * Constructs a forwarding {@code TestSubscriber} but leaves the requesting to the wrapped {@link Subscriber}.
+     * @param downstream the actual {@code Subscriber} to forward events to
      */
-    public TestSubscriber(Subscriber<? super T> downstream) {
+    public TestSubscriber(@NonNull Subscriber<? super T> downstream) {
         this(downstream, Long.MAX_VALUE);
     }
 
     /**
-     * Constructs a forwarding TestSubscriber with the specified initial request value.
-     * <p>The TestSubscriber doesn't validate the initialRequest value so one can
+     * Constructs a forwarding {@code TestSubscriber} with the specified initial request amount
+     * and an actual {@link Subscriber} to forward events to.
+     * <p>The {@code TestSubscriber} doesn't validate the initialRequest value so one can
      * test sources with invalid values as well.
-     * @param actual the actual Subscriber to forward events to
-     * @param initialRequest the initial request value
+     * @param actual the actual {@code Subscriber} to forward events to
+     * @param initialRequest the initial request amount
      */
-    public TestSubscriber(Subscriber<? super T> actual, long initialRequest) {
+    public TestSubscriber(@NonNull Subscriber<? super T> actual, long initialRequest) {
         super();
         if (initialRequest < 0) {
             throw new IllegalArgumentException("Negative initial request not allowed");
         }
         this.downstream = actual;
-        this.upstream = new AtomicReference<Subscription>();
+        this.upstream = new AtomicReference<>();
         this.missedRequested = new AtomicLong(initialRequest);
     }
 
     @Override
-    public void onSubscribe(Subscription s) {
+    public void onSubscribe(@NonNull Subscription s) {
         lastThread = Thread.currentThread();
 
         if (s == null) {
@@ -153,7 +156,7 @@ implements FlowableSubscriber<T>, Subscription {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         if (!checkSubscriptionOnce) {
             checkSubscriptionOnce = true;
             if (upstream.get() == null) {
@@ -172,7 +175,7 @@ implements FlowableSubscriber<T>, Subscription {
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         if (!checkSubscriptionOnce) {
             checkSubscriptionOnce = true;
             if (upstream.get() == null) {
@@ -225,8 +228,8 @@ implements FlowableSubscriber<T>, Subscription {
     }
 
     /**
-     * Returns true if this TestSubscriber has been cancelled.
-     * @return true if this TestSubscriber has been cancelled
+     * Returns true if this {@code TestSubscriber} has been cancelled.
+     * @return true if this {@code TestSubscriber} has been cancelled
      */
     public final boolean isCancelled() {
         return cancelled;
@@ -245,8 +248,8 @@ implements FlowableSubscriber<T>, Subscription {
     // state retrieval methods
 
     /**
-     * Returns true if this TestSubscriber received a subscription.
-     * @return true if this TestSubscriber received a subscription
+     * Returns true if this {@code TestSubscriber} received a {@link Subscription} via {@link #onSubscribe(Subscription)}.
+     * @return true if this {@code TestSubscriber} received a {@link Subscription} via {@link #onSubscribe(Subscription)}
      */
     public final boolean hasSubscription() {
         return upstream.get() != null;
@@ -255,7 +258,7 @@ implements FlowableSubscriber<T>, Subscription {
     // assertion methods
 
     /**
-     * Assert that the onSubscribe method was called exactly once.
+     * Assert that the {@link #onSubscribe(Subscription)} method was called exactly once.
      * @return this
      */
     @Override

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableSubscriberTest.java
@@ -83,7 +83,7 @@ public class FlowableSubscriberTest {
     }
 
     @Test
-    public void requestFromChainedOperator() throws Exception {
+    public void requestFromChainedOperator() throws Throwable {
         TestSubscriber<String> s = new TestSubscriber<String>(10L);
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
@@ -135,7 +135,7 @@ public class FlowableSubscriberTest {
     }
 
     @Test
-    public void requestFromDecoupledOperator() throws Exception {
+    public void requestFromDecoupledOperator() throws Throwable {
         TestSubscriber<String> s = new TestSubscriber<String>(0L);
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
@@ -188,7 +188,7 @@ public class FlowableSubscriberTest {
     }
 
     @Test
-    public void requestFromDecoupledOperatorThatRequestsN() throws Exception {
+    public void requestFromDecoupledOperatorThatRequestsN() throws Throwable {
         TestSubscriber<String> s = new TestSubscriber<String>(10L);
         final AtomicLong innerR = new AtomicLong();
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {

--- a/src/test/java/io/reactivex/rxjava3/tck/BaseTck.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/BaseTck.java
@@ -51,8 +51,8 @@ public abstract class BaseTck<T> extends PublisherVerification<T> {
 
     /**
      * Creates an Iterable with the specified number of elements or an infinite one if
-     * elements > Integer.MAX_VALUE.
-     * @param elements the number of elements to return, Integer.MAX_VALUE means an infinite sequence
+     * elements > {@link Integer#MAX_VALUE}.
+     * @param elements the number of elements to return, {@link Integer#MAX_VALUE} means an infinite sequence
      * @return the Iterable
      */
     protected Iterable<Long> iterate(long elements) {

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -69,7 +69,7 @@ public enum TestHelper {
     public static final int RACE_LONG_LOOPS = 10000;
 
     /**
-     * Mocks a subscriber and prepares it to request Long.MAX_VALUE.
+     * Mocks a subscriber and prepares it to request {@link Long#MAX_VALUE}.
      * @param <T> the value type
      * @return the mocked subscriber
      */

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberEx.java
@@ -51,7 +51,7 @@ implements FlowableSubscriber<T>, Subscription {
     private QueueSubscription<T> qs;
 
     /**
-     * Constructs a non-forwarding TestSubscriber with an initial request value of Long.MAX_VALUE.
+     * Constructs a non-forwarding TestSubscriber with an initial request value of {@link Long#MAX_VALUE}.
      */
     public TestSubscriberEx() {
         this(EmptySubscriber.INSTANCE, Long.MAX_VALUE);


### PR DESCRIPTION
This PR clears up some javadocs and widens the `throws` on the various `Operator` interfaces:

- Link to `Integer.MAX_VALUE` and `Long.MAX_VALUE`s.
- Add links to types and `{@code TheType}` for other appearances.
- Wrap event type indicators into `{@code }` tags.
- Wrap boolean outcomes into `{@code }` tags.
- Wrap null mentions into `{@code }` tags.
- Apply nullability annotations.
- Fix wording and copy-paste errors.
