### PR TITLE
Diamond operators in unit tests, observable package

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNextTest.java
@@ -63,7 +63,7 @@ public class BlockingObservableNextTest extends RxJavaTest {
     }
 
     static <T> Iterable<T> next(ObservableSource<T> source) {
-        return new BlockingObservableNext<T>(source);
+        return new BlockingObservableNext<>(source);
     }
 
     @Test
@@ -356,7 +356,7 @@ public class BlockingObservableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverError() {
-        NextObserver<Integer> no = new NextObserver<Integer>();
+        NextObserver<Integer> no = new NextObserver<>();
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -370,7 +370,7 @@ public class BlockingObservableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverOnNext() throws Exception {
-        NextObserver<Integer> no = new NextObserver<Integer>();
+        NextObserver<Integer> no = new NextObserver<>();
 
         no.setWaiting();
         no.onNext(Notification.createOnNext(1));
@@ -383,7 +383,7 @@ public class BlockingObservableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverOnCompleteOnNext() throws Exception {
-        NextObserver<Integer> no = new NextObserver<Integer>();
+        NextObserver<Integer> no = new NextObserver<>();
 
         no.setWaiting();
         no.onNext(Notification.<Integer>createOnComplete());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableToIteratorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableToIteratorTest.java
@@ -73,7 +73,7 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<Integer>(128);
+        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<>(128);
 
         assertFalse(it.isDisposed());
 
@@ -84,7 +84,7 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
 
     @Test
     public void interruptWait() {
-        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<Integer>(128);
+        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<>(128);
 
         try {
             Thread.currentThread().interrupt();
@@ -97,14 +97,14 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
 
     @Test(expected = NoSuchElementException.class)
     public void emptyThrowsNoSuch() {
-        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<Integer>(128);
+        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<>(128);
         it.onComplete();
         it.next();
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void remove() {
-        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<Integer>(128);
+        BlockingObservableIterator<Integer> it = new BlockingObservableIterator<>(128);
         it.remove();
     }
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/Burst.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/Burst.java
@@ -53,7 +53,7 @@ public final class Burst<T> extends Observable<T> {
 
     @SafeVarargs
     public static <T> Builder<T> items(T... items) {
-        return new Builder<T>(Arrays.asList(items));
+        return new Builder<>(Arrays.asList(items));
     }
 
     public static final class Builder<T> {
@@ -71,7 +71,7 @@ public final class Burst<T> extends Observable<T> {
         }
 
         public Observable<T> create() {
-            return new Burst<T>(error, items);
+            return new Burst<>(error, items);
         }
 
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAllTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAllTest.java
@@ -146,7 +146,7 @@ public class ObservableAllTest extends RxJavaTest {
 
     @Test
     public void predicateThrowsExceptionAndValueInCauseMessageObservable() {
-        TestObserverEx<Boolean> to = new TestObserverEx<Boolean>();
+        TestObserverEx<Boolean> to = new TestObserverEx<>();
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
@@ -277,7 +277,7 @@ public class ObservableAllTest extends RxJavaTest {
 
     @Test
     public void predicateThrowsExceptionAndValueInCauseMessage() {
-        TestObserverEx<Boolean> to = new TestObserverEx<Boolean>();
+        TestObserverEx<Boolean> to = new TestObserverEx<>();
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
@@ -178,7 +178,7 @@ public class ObservableAmbTest extends RxJavaTest {
         //this stream emits second
         Observable<Integer> o2 = Observable.just(1).doOnSubscribe(incrementer)
                 .delay(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.ambArray(o1, o2).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -212,7 +212,7 @@ public class ObservableAmbTest extends RxJavaTest {
         PublishSubject<Integer> source2 = PublishSubject.create();
         PublishSubject<Integer> source3 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.ambArray(source1, source2, source3).subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAnyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAnyTest.java
@@ -247,7 +247,7 @@ public class ObservableAnyTest extends RxJavaTest {
 
     @Test
     public void predicateThrowsExceptionAndValueInCauseMessageObservable() {
-        TestObserverEx<Boolean> to = new TestObserverEx<Boolean>();
+        TestObserverEx<Boolean> to = new TestObserverEx<>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
         Observable.just("Boo!").any(new Predicate<String>() {
@@ -469,7 +469,7 @@ public class ObservableAnyTest extends RxJavaTest {
 
     @Test
     public void predicateThrowsExceptionAndValueInCauseMessage() {
-        TestObserverEx<Boolean> to = new TestObserverEx<Boolean>();
+        TestObserverEx<Boolean> to = new TestObserverEx<>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
         Observable.just("Boo!").any(new Predicate<String>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBlockingTest.java
@@ -48,7 +48,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeConsumer() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Observable.range(1, 5)
         .subscribeOn(Schedulers.computation())
@@ -64,7 +64,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeConsumerConsumer() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Observable.range(1, 5)
         .subscribeOn(Schedulers.computation())
@@ -80,7 +80,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeConsumerConsumerError() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         TestException ex = new TestException();
 
@@ -100,7 +100,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeConsumerConsumerAction() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Consumer<Object> cons = new Consumer<Object>() {
             @Override
@@ -123,7 +123,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeObserver() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Observable.range(1, 5)
         .subscribeOn(Schedulers.computation())
@@ -156,7 +156,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeObserverError() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         final TestException ex = new TestException();
 
@@ -232,7 +232,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void disposeUpFront() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.dispose();
         Observable.just(1).blockingSubscribe(to);
 
@@ -242,7 +242,7 @@ public class ObservableBlockingTest extends RxJavaTest {
     @SuppressWarnings("rawtypes")
     @Test
     public void delayed() throws Exception {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
         final Observer[] s = { null };
 
         Schedulers.single().scheduleDirect(new Runnable() {
@@ -271,14 +271,14 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void interrupt() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         Thread.currentThread().interrupt();
         Observable.never().blockingSubscribe(to);
     }
 
     @Test
     public void onCompleteDelayed() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         Observable.empty().delay(100, TimeUnit.MILLISECONDS)
         .blockingSubscribe(to);
@@ -288,7 +288,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingCancelUpfront() {
-        BlockingFirstObserver<Integer> o = new BlockingFirstObserver<Integer>();
+        BlockingFirstObserver<Integer> o = new BlockingFirstObserver<>();
 
         assertFalse(o.isDisposed());
         o.dispose();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferTest.java
@@ -273,7 +273,7 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String arg : args) {
             list.add(arg);
         }
@@ -303,7 +303,7 @@ public class ObservableBufferTest extends RxJavaTest {
         Observable<Integer> source = Observable.never();
 
         Observer<List<Integer>> o = TestHelper.mockObserver();
-        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>(o);
+        TestObserver<List<Integer>> to = new TestObserver<>(o);
 
         source.buffer(100, 200, TimeUnit.MILLISECONDS, scheduler)
         .doOnNext(new Consumer<List<Integer>>() {
@@ -781,7 +781,7 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     static HashSet<Integer> set(Integer... values) {
-        return new HashSet<Integer>(Arrays.asList(values));
+        return new HashSet<>(Arrays.asList(values));
     }
 
     @SuppressWarnings("unchecked")
@@ -791,7 +791,7 @@ public class ObservableBufferTest extends RxJavaTest {
         .buffer(3, new Supplier<Collection<Integer>>() {
             @Override
             public Collection<Integer> get() throws Exception {
-                return new HashSet<Integer>();
+                return new HashSet<>();
             }
         })
         .test()
@@ -805,7 +805,7 @@ public class ObservableBufferTest extends RxJavaTest {
         .buffer(3, 3, new Supplier<Collection<Integer>>() {
             @Override
             public Collection<Integer> get() throws Exception {
-                return new HashSet<Integer>();
+                return new HashSet<>();
             }
         })
         .test()
@@ -865,7 +865,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         }, false)
@@ -885,7 +885,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         }, false)
@@ -905,7 +905,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         })
@@ -925,7 +925,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     return null;
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         }, false)
@@ -945,7 +945,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     return null;
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         }, false)
@@ -965,7 +965,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     return null;
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         })
@@ -1016,7 +1016,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (++calls == 2) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         })
         .test()
@@ -1034,7 +1034,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (++calls == 2) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         })
         .test()
@@ -1134,7 +1134,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (++calls == 2) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, true)
         .test();
@@ -1587,7 +1587,7 @@ public class ObservableBufferTest extends RxJavaTest {
                 if (++calls == 2) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }).test();
 
@@ -1609,7 +1609,7 @@ public class ObservableBufferTest extends RxJavaTest {
             }
         };
 
-        final AtomicReference<Observer<? super Integer>> ref = new AtomicReference<Observer<? super Integer>>();
+        final AtomicReference<Observer<? super Integer>> ref = new AtomicReference<>();
         Observable<Integer> b = new Observable<Integer>() {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
@@ -1653,10 +1653,10 @@ public class ObservableBufferTest extends RxJavaTest {
     public void timedInternalState() {
         TestScheduler sch = new TestScheduler();
 
-        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<>();
 
-        BufferExactUnboundedObserver<Integer, List<Integer>> sub = new BufferExactUnboundedObserver<Integer, List<Integer>>(
-                to, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
+        BufferExactUnboundedObserver<Integer, List<Integer>> sub = new BufferExactUnboundedObserver<>(
+                to, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
 
         sub.onSubscribe(Disposable.empty());
 
@@ -1672,7 +1672,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         assertTrue(sub.isDisposed());
 
-        sub.buffer = new ArrayList<Integer>();
+        sub.buffer = new ArrayList<>();
         sub.enter();
         sub.onComplete();
     }
@@ -1703,10 +1703,10 @@ public class ObservableBufferTest extends RxJavaTest {
     public void timedSkipInternalState() {
         TestScheduler sch = new TestScheduler();
 
-        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<>();
 
-        BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<Integer, List<Integer>>(
-                to, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
+        BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<>(
+                to, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(Disposable.empty());
 
@@ -1722,19 +1722,20 @@ public class ObservableBufferTest extends RxJavaTest {
     public void timedSkipCancelWhenSecondBuffer() {
         TestScheduler sch = new TestScheduler();
 
-        final TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+        final TestObserver<List<Integer>> to = new TestObserver<>();
 
-        BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<Integer, List<Integer>>(
+        BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<>(
                 to, new Supplier<List<Integer>>() {
-                    int calls;
-                    @Override
-                    public List<Integer> get() throws Exception {
-                        if (++calls == 2) {
-                            to.dispose();
-                        }
-                        return new ArrayList<Integer>();
-                    }
-                }, 1, 1, TimeUnit.SECONDS, sch.createWorker());
+            int calls;
+
+            @Override
+            public List<Integer> get() throws Exception {
+                if (++calls == 2) {
+                    to.dispose();
+                }
+                return new ArrayList<>();
+            }
+        }, 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(Disposable.empty());
 
@@ -1747,11 +1748,11 @@ public class ObservableBufferTest extends RxJavaTest {
     public void timedSizeBufferAlreadyCleared() {
         TestScheduler sch = new TestScheduler();
 
-        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<>();
 
         BufferExactBoundedObserver<Integer, List<Integer>> sub =
-                new BufferExactBoundedObserver<Integer, List<Integer>>(
-                        to, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()),
+                new BufferExactBoundedObserver<>(
+                        to, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()),
                         1, TimeUnit.SECONDS, 1, false, sch.createWorker())
         ;
 
@@ -1790,10 +1791,10 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferExactState() {
-        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<>();
 
-        BufferExactObserver<Integer, List<Integer>> sub = new BufferExactObserver<Integer, List<Integer>>(
-                to, 1, Functions.justSupplier((List<Integer>)new ArrayList<Integer>())
+        BufferExactObserver<Integer, List<Integer>> sub = new BufferExactObserver<>(
+                to, 1, Functions.justSupplier((List<Integer>) new ArrayList<Integer>())
         );
 
         sub.onComplete();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCacheTest.java
@@ -36,11 +36,11 @@ import io.reactivex.rxjava3.testsupport.*;
 public class ObservableCacheTest extends RxJavaTest {
     @Test
     public void coldReplayNoBackpressure() {
-        ObservableCache<Integer> source = new ObservableCache<Integer>(Observable.range(0, 1000), 16);
+        ObservableCache<Integer> source = new ObservableCache<>(Observable.range(0, 1000), 16);
 
         assertFalse("Source is connected!", source.isConnected());
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         source.subscribe(to);
 
@@ -119,9 +119,9 @@ public class ObservableCacheTest extends RxJavaTest {
 
     @Test
     public void take() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
-        ObservableCache<Integer> cached = new ObservableCache<Integer>(Observable.range(1, 1000), 16);
+        ObservableCache<Integer> cached = new ObservableCache<>(Observable.range(1, 1000), 16);
         cached.take(10).subscribe(to);
 
         to.assertNoErrors();
@@ -135,9 +135,9 @@ public class ObservableCacheTest extends RxJavaTest {
     public void async() {
         Observable<Integer> source = Observable.range(1, 10000);
         for (int i = 0; i < 100; i++) {
-            TestObserver<Integer> to1 = new TestObserver<Integer>();
+            TestObserver<Integer> to1 = new TestObserver<>();
 
-            ObservableCache<Integer> cached = new ObservableCache<Integer>(source, 16);
+            ObservableCache<Integer> cached = new ObservableCache<>(source, 16);
 
             cached.observeOn(Schedulers.computation()).subscribe(to1);
 
@@ -146,7 +146,7 @@ public class ObservableCacheTest extends RxJavaTest {
             to1.assertComplete();
             assertEquals(10000, to1.values().size());
 
-            TestObserver<Integer> to2 = new TestObserver<Integer>();
+            TestObserver<Integer> to2 = new TestObserver<>();
             cached.observeOn(Schedulers.computation()).subscribe(to2);
 
             to2.awaitDone(2, TimeUnit.SECONDS);
@@ -161,18 +161,18 @@ public class ObservableCacheTest extends RxJavaTest {
         Observable<Long> source = Observable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
                 .subscribeOn(Schedulers.io());
-        ObservableCache<Long> cached = new ObservableCache<Long>(source, 16);
+        ObservableCache<Long> cached = new ObservableCache<>(source, 16);
 
         Observable<Long> output = cached.observeOn(Schedulers.computation());
 
-        List<TestObserver<Long>> list = new ArrayList<TestObserver<Long>>(100);
+        List<TestObserver<Long>> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
-            TestObserver<Long> to = new TestObserver<Long>();
+            TestObserver<Long> to = new TestObserver<>();
             list.add(to);
             output.skip(i * 10).take(10).subscribe(to);
         }
 
-        List<Long> expected = new ArrayList<Long>();
+        List<Long> expected = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             expected.add((long)(i - 10));
         }
@@ -206,7 +206,7 @@ public class ObservableCacheTest extends RxJavaTest {
             }
         });
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         firehose.cache().observeOn(Schedulers.computation()).takeLast(100).subscribe(to);
 
         to.awaitDone(3, TimeUnit.SECONDS);
@@ -222,14 +222,14 @@ public class ObservableCacheTest extends RxJavaTest {
                 .concatWith(Observable.<Integer>error(new TestException()))
                 .cache();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         source.subscribe(to);
 
         to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         to.assertNotComplete();
         to.assertError(TestException.class);
 
-        TestObserver<Integer> to2 = new TestObserver<Integer>();
+        TestObserver<Integer> to2 = new TestObserver<>();
         source.subscribe(to2);
 
         to2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -296,7 +296,7 @@ public class ObservableCacheTest extends RxJavaTest {
 
             cache.test();
 
-            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            final TestObserverEx<Integer> to = new TestObserverEx<>();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollectTest.java
@@ -36,7 +36,7 @@ public final class ObservableCollectTest extends RxJavaTest {
         .collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -85,7 +85,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectorFailureDoesNotResultInTwoErrorEmissionsObservable() {
         try {
-            final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+            final List<Throwable> list = new CopyOnWriteArrayList<>();
             RxJavaPlugins.setErrorHandler(addToList(list));
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
@@ -146,14 +146,14 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectIntoObservable() {
         Observable.just(1, 1, 1, 1, 2)
-        .collectInto(new HashSet<Integer>(), new BiConsumer<HashSet<Integer>, Integer>() {
+        .collectInto(new HashSet<>(), new BiConsumer<HashSet<Integer>, Integer>() {
             @Override
             public void accept(HashSet<Integer> s, Integer v) throws Exception {
                 s.add(v);
             }
         }).toObservable()
         .test()
-        .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
+        .assertResult(new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
@@ -162,7 +162,7 @@ public final class ObservableCollectTest extends RxJavaTest {
         .collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -211,7 +211,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectorFailureDoesNotResultInTwoErrorEmissions() {
         try {
-            final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+            final List<Throwable> list = new CopyOnWriteArrayList<>();
             RxJavaPlugins.setErrorHandler(addToList(list));
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
@@ -270,14 +270,14 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectInto() {
         Observable.just(1, 1, 1, 1, 2)
-        .collectInto(new HashSet<Integer>(), new BiConsumer<HashSet<Integer>, Integer>() {
+        .collectInto(new HashSet<>(), new BiConsumer<HashSet<Integer>, Integer>() {
             @Override
             public void accept(HashSet<Integer> s, Integer v) throws Exception {
                 s.add(v);
             }
         })
         .test()
-        .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
+        .assertResult(new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
@@ -285,7 +285,7 @@ public final class ObservableCollectTest extends RxJavaTest {
         TestHelper.checkDisposed(Observable.range(1, 3).collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -297,7 +297,7 @@ public final class ObservableCollectTest extends RxJavaTest {
         TestHelper.checkDisposed(Observable.range(1, 3).collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -315,7 +315,7 @@ public final class ObservableCollectTest extends RxJavaTest {
                 return o.collect(new Supplier<List<Integer>>() {
                     @Override
                     public List<Integer> get() throws Exception {
-                        return new ArrayList<Integer>();
+                        return new ArrayList<>();
                     }
                 }, new BiConsumer<List<Integer>, Integer>() {
                     @Override
@@ -332,7 +332,7 @@ public final class ObservableCollectTest extends RxJavaTest {
                 return o.collect(new Supplier<List<Integer>>() {
                     @Override
                     public List<Integer> get() throws Exception {
-                        return new ArrayList<Integer>();
+                        return new ArrayList<>();
                     }
                 }, new BiConsumer<List<Integer>, Integer>() {
                     @Override
@@ -352,7 +352,7 @@ public final class ObservableCollectTest extends RxJavaTest {
                 return o.collect(new Supplier<List<Integer>>() {
                     @Override
                     public List<Integer> get() throws Exception {
-                        return new ArrayList<Integer>();
+                        return new ArrayList<>();
                     }
                 }, new BiConsumer<List<Integer>, Integer>() {
                     @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
@@ -436,8 +436,8 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         };
         for (int i = 1; i <= n; i++) {
             System.out.println("test1ToNSources: " + i + " sources");
-            List<Observable<Integer>> sources = new ArrayList<Observable<Integer>>();
-            List<Object> values = new ArrayList<Object>();
+            List<Observable<Integer>> sources = new ArrayList<>();
+            List<Object> values = new ArrayList<>();
             for (int j = 0; j < i; j++) {
                 sources.add(Observable.just(j));
                 values.add(j);
@@ -467,8 +467,8 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         };
         for (int i = 1; i <= n; i++) {
             System.out.println("test1ToNSourcesScheduled: " + i + " sources");
-            List<Observable<Integer>> sources = new ArrayList<Observable<Integer>>();
-            List<Object> values = new ArrayList<Object>();
+            List<Observable<Integer>> sources = new ArrayList<>();
+            List<Object> values = new ArrayList<>();
             for (int j = 0; j < i; j++) {
                 sources.add(Observable.just(j).subscribeOn(Schedulers.io()));
                 values.add(j);
@@ -753,7 +753,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
                     }
                 }).take(SIZE);
 
-        TestObserver<Long> to = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<>();
 
         Observable.combineLatest(timer, Observable.<Integer> never(), new BiFunction<Long, Integer, Long>() {
             @Override
@@ -873,7 +873,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void cancelWhileSubscribing() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
 
         Observable.combineLatest(
                 Observable.just(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -197,7 +197,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Before
     public void before() {
-        to = new TestObserver<Object>();
+        to = new TestObserver<>();
     }
 
     @Test
@@ -723,7 +723,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void mapperCancels() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1).hide()
         .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
@@ -837,7 +837,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     public void maxConcurrencyOf2() {
         List<Integer>[] list = new ArrayList[100];
         for (int i = 0; i < 100; i++) {
-            List<Integer> lst = new ArrayList<Integer>();
+            List<Integer> lst = new ArrayList<>();
             list[i] = lst;
             for (int k = 1; k <= 10; k++) {
                 lst.add((i) * 10 + k);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -367,7 +367,7 @@ public class ObservableConcatMapSchedulerTest {
             if (i % 1000 == 0) {
                 System.out.println("concatMapRangeAsyncLoop > " + i);
             }
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.range(0, 1000)
             .concatMap(new Function<Integer, Observable<Integer>>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
@@ -63,7 +63,7 @@ public class ObservableConcatTest extends RxJavaTest {
 
         final Observable<String> odds = Observable.fromArray(o);
         final Observable<String> even = Observable.fromArray(e);
-        final List<Observable<String>> list = new ArrayList<Observable<String>>();
+        final List<Observable<String>> list = new ArrayList<>();
         list.add(odds);
         list.add(even);
         Observable<String> concat = Observable.concat(Observable.fromIterable(list));
@@ -108,8 +108,8 @@ public class ObservableConcatTest extends RxJavaTest {
     public void simpleAsyncConcat() {
         Observer<String> observer = TestHelper.mockObserver();
 
-        TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
-        TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
+        TestObservable<String> o1 = new TestObservable<>("one", "two", "three");
+        TestObservable<String> o2 = new TestObservable<>("four", "five", "six");
 
         Observable.concat(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2)).subscribe(observer);
 
@@ -148,12 +148,12 @@ public class ObservableConcatTest extends RxJavaTest {
     public void nestedAsyncConcat() throws InterruptedException {
         Observer<String> observer = TestHelper.mockObserver();
 
-        final TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
-        final TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
-        final TestObservable<String> o3 = new TestObservable<String>("seven", "eight", "nine");
+        final TestObservable<String> o1 = new TestObservable<>("one", "two", "three");
+        final TestObservable<String> o2 = new TestObservable<>("four", "five", "six");
+        final TestObservable<String> o3 = new TestObservable<>("seven", "eight", "nine");
         final CountDownLatch allowThird = new CountDownLatch(1);
 
-        final AtomicReference<Thread> parent = new AtomicReference<Thread>();
+        final AtomicReference<Thread> parent = new AtomicReference<>();
         final CountDownLatch parentHasStarted = new CountDownLatch(1);
         final CountDownLatch parentHasFinished = new CountDownLatch(1);
 
@@ -272,7 +272,7 @@ public class ObservableConcatTest extends RxJavaTest {
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
         @SuppressWarnings("unchecked")
-        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(callOnce, okToContinue, odds, even);
+        TestObservable<Observable<String>> observableOfObservables = new TestObservable<>(callOnce, okToContinue, odds, even);
         Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
         concatF.subscribe(observer);
         try {
@@ -304,14 +304,14 @@ public class ObservableConcatTest extends RxJavaTest {
 
     @Test
     public void concatConcurrentWithInfinity() {
-        final TestObservable<String> w1 = new TestObservable<String>("one", "two", "three");
+        final TestObservable<String> w1 = new TestObservable<>("one", "two", "three");
         //This Observable will send "hello" MAX_VALUE time.
-        final TestObservable<String> w2 = new TestObservable<String>("hello", Integer.MAX_VALUE);
+        final TestObservable<String> w2 = new TestObservable<>("hello", Integer.MAX_VALUE);
 
         Observer<String> observer = TestHelper.mockObserver();
 
         @SuppressWarnings("unchecked")
-        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
+        TestObservable<Observable<String>> observableOfObservables = new TestObservable<>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
         Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
         concatF.take(50).subscribe(observer);
@@ -339,8 +339,8 @@ public class ObservableConcatTest extends RxJavaTest {
         final CountDownLatch okToContinueW1 = new CountDownLatch(1);
         final CountDownLatch okToContinueW2 = new CountDownLatch(1);
 
-        final TestObservable<String> w1 = new TestObservable<String>(null, okToContinueW1, "one", "two", "three");
-        final TestObservable<String> w2 = new TestObservable<String>(null, okToContinueW2, "four", "five", "six");
+        final TestObservable<String> w1 = new TestObservable<>(null, okToContinueW1, "one", "two", "three");
+        final TestObservable<String> w2 = new TestObservable<>(null, okToContinueW2, "four", "five", "six");
 
         Observer<String> observer = TestHelper.mockObserver();
 
@@ -390,11 +390,11 @@ public class ObservableConcatTest extends RxJavaTest {
     public void concatUnsubscribe() {
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
-        final TestObservable<String> w1 = new TestObservable<String>("one", "two", "three");
-        final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
+        final TestObservable<String> w1 = new TestObservable<>("one", "two", "three");
+        final TestObservable<String> w2 = new TestObservable<>(callOnce, okToContinue, "four", "five", "six");
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
 
         final Observable<String> concat = Observable.concat(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
 
@@ -432,14 +432,14 @@ public class ObservableConcatTest extends RxJavaTest {
     public void concatUnsubscribeConcurrent() {
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
-        final TestObservable<String> w1 = new TestObservable<String>("one", "two", "three");
-        final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
+        final TestObservable<String> w1 = new TestObservable<>("one", "two", "three");
+        final TestObservable<String> w2 = new TestObservable<>(callOnce, okToContinue, "four", "five", "six");
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
 
         @SuppressWarnings("unchecked")
-        TestObservable<Observable<String>> observableOfObservables = new TestObservable<Observable<String>>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
+        TestObservable<Observable<String>> observableOfObservables = new TestObservable<>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
         Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
         concatF.subscribe(to);
@@ -617,7 +617,7 @@ public class ObservableConcatTest extends RxJavaTest {
 
         result.subscribe(o);
 
-        List<Integer> list = new ArrayList<Integer>(n);
+        List<Integer> list = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
             list.add(i);
         }
@@ -642,7 +642,7 @@ public class ObservableConcatTest extends RxJavaTest {
 
         result.subscribe(o);
 
-        List<Integer> list = new ArrayList<Integer>(n);
+        List<Integer> list = new ArrayList<>(n);
         for (int i = 0; i < n / 2; i++) {
             list.add(i);
         }
@@ -674,7 +674,7 @@ public class ObservableConcatTest extends RxJavaTest {
 
         });
 
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
         Observable.concat(o, o).subscribe(to);
         to.awaitDone(500, TimeUnit.MILLISECONDS);
         to.assertTerminated();
@@ -745,7 +745,7 @@ public class ObservableConcatTest extends RxJavaTest {
             if (i % 1000 == 0) {
                 System.out.println("concatMapRangeAsyncLoop > " + i);
             }
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to = new TestObserverEx<>();
 
             Observable.range(0, 1000)
             .concatMap(new Function<Integer, Observable<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithCompletableTest.java
@@ -28,7 +28,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Completable.fromAction(new Action() {
@@ -44,7 +44,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void mainError() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.<Integer>error(new TestException())
         .concatWith(Completable.fromAction(new Action() {
@@ -60,7 +60,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void otherError() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Completable.error(new TestException()))
@@ -71,7 +71,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void takeMain() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Completable.fromAction(new Action() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithMaybeTest.java
@@ -28,7 +28,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void normalEmpty() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Maybe.<Integer>fromAction(new Action() {
@@ -44,7 +44,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void normalNonEmpty() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Maybe.just(100))
@@ -55,7 +55,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void mainError() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.<Integer>error(new TestException())
         .concatWith(Maybe.<Integer>fromAction(new Action() {
@@ -71,7 +71,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void otherError() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Maybe.<Integer>error(new TestException()))
@@ -82,7 +82,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void takeMain() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Maybe.<Integer>fromAction(new Action() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithSingleTest.java
@@ -27,7 +27,7 @@ public class ObservableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Single.just(100))
@@ -38,7 +38,7 @@ public class ObservableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void mainError() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.<Integer>error(new TestException())
         .concatWith(Single.just(100))
@@ -49,7 +49,7 @@ public class ObservableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void otherError() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Single.<Integer>error(new TestException()))
@@ -60,7 +60,7 @@ public class ObservableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void takeMain() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
         .concatWith(Single.just(100))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDebounceTest.java
@@ -288,7 +288,7 @@ public class ObservableDebounceTest extends RxJavaTest {
     @Test
     public void debounceWithTimeBackpressure() throws InterruptedException {
         TestScheduler scheduler = new TestScheduler();
-        TestObserverEx<Integer> observer = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> observer = new TestObserverEx<>();
 
         Observable.merge(
                 Observable.just(1),
@@ -317,7 +317,7 @@ public class ObservableDebounceTest extends RxJavaTest {
 
         TestHelper.checkDisposed(PublishSubject.create().debounce(Functions.justFunction(Observable.never())));
 
-        Disposable d = new ObservableDebounceTimed.DebounceEmitter<Integer>(1, 1, null);
+        Disposable d = new ObservableDebounceTimed.DebounceEmitter<>(1, 1, null);
         assertFalse(d.isDisposed());
 
         d.dispose();
@@ -395,7 +395,7 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void disposeInOnNext() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         BehaviorSubject.createDefault(1)
         .debounce(new Function<Integer, ObservableSource<Object>>() {
@@ -413,7 +413,7 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void disposedInOnComplete() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         new Observable<Integer>() {
             @Override
@@ -430,7 +430,7 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void emitLate() {
-        final AtomicReference<Observer<? super Integer>> ref = new AtomicReference<Observer<? super Integer>>();
+        final AtomicReference<Observer<? super Integer>> ref = new AtomicReference<>();
 
         TestObserver<Integer> to = Observable.range(1, 2)
         .debounce(new Function<Integer, ObservableSource<Integer>>() {
@@ -469,7 +469,7 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void timedDisposedIgnoredBySource() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         new Observable<Integer>() {
             @Override
@@ -487,13 +487,13 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void timedLateEmit() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
-        DebounceTimedObserver<Integer> sub = new DebounceTimedObserver<Integer>(
+        TestObserver<Integer> to = new TestObserver<>();
+        DebounceTimedObserver<Integer> sub = new DebounceTimedObserver<>(
                 to, 1, TimeUnit.SECONDS, new TestScheduler().createWorker());
 
         sub.onSubscribe(Disposable.empty());
 
-        DebounceEmitter<Integer> de = new DebounceEmitter<Integer>(1, 50, sub);
+        DebounceEmitter<Integer> de = new DebounceEmitter<>(1, 50, sub);
         de.run();
         de.run();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
@@ -32,7 +32,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
     public void noPrematureSubscription() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -65,7 +65,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
     public void noMultipleSubscriptions() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -99,7 +99,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
     public void completeTriggersSubscription() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -132,7 +132,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
     public void noPrematureSubscriptionToError() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -165,7 +165,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
     public void noSubscriptionIfOtherErrors() {
         PublishSubject<Object> other = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDelayTest.java
@@ -219,7 +219,7 @@ public class ObservableDelayTest extends RxJavaTest {
         Observable<Integer> result = Observable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
         Observer<Object> o = TestHelper.mockObserver();
-        TestObserver<Object> to = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<>(o);
 
         result.subscribe(to);
         to.dispose();
@@ -233,7 +233,7 @@ public class ObservableDelayTest extends RxJavaTest {
     @Test
     public void delayWithObservableNormal1() {
         PublishSubject<Integer> source = PublishSubject.create();
-        final List<PublishSubject<Integer>> delays = new ArrayList<PublishSubject<Integer>>();
+        final List<PublishSubject<Integer>> delays = new ArrayList<>();
         final int n = 10;
         for (int i = 0; i < n; i++) {
             PublishSubject<Integer> delay = PublishSubject.create();
@@ -584,7 +584,7 @@ public class ObservableDelayTest extends RxJavaTest {
         int n = 3;
 
         PublishSubject<Integer> source = PublishSubject.create();
-        final List<PublishSubject<Integer>> subjects = new ArrayList<PublishSubject<Integer>>();
+        final List<PublishSubject<Integer>> subjects = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             subjects.add(PublishSubject.<Integer> create());
         }
@@ -632,7 +632,7 @@ public class ObservableDelayTest extends RxJavaTest {
             }
 
         });
-        TestObserver<Integer> observer = new TestObserver<Integer>();
+        TestObserver<Integer> observer = new TestObserver<>();
         delayed.subscribe(observer);
         // all will be delivered after 500ms since range does not delay between them
         scheduler.advanceTimeBy(500L, TimeUnit.MILLISECONDS);
@@ -641,7 +641,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
     @Test
     public void backpressureWithTimedDelay() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay(100, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.computation())
@@ -669,7 +669,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
     @Test
     public void backpressureWithSubscriptionTimedDelay() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delaySubscription(100, TimeUnit.MILLISECONDS)
                 .delay(100, TimeUnit.MILLISECONDS)
@@ -698,7 +698,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
     @Test
     public void backpressureWithSelectorDelay() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay(new Function<Integer, Observable<Long>>() {
 
@@ -733,7 +733,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
     @Test
     public void backpressureWithSelectorDelayAndSubscriptionDelay() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay(Observable.timer(500, TimeUnit.MILLISECONDS)
                 , new Function<Integer, Observable<Long>>() {
@@ -773,7 +773,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         ps.delay(1, TimeUnit.SECONDS, test).subscribe(to);
 
@@ -796,7 +796,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         Observable<Integer> source = Observable.range(1, 5);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         source.delaySubscription(ps).subscribe(to);
 
@@ -817,7 +817,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         Observable<Integer> source = Observable.range(1, 5);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         source.delaySubscription(ps).subscribe(to);
 
@@ -839,7 +839,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         Observable<Integer> source = Observable.range(1, 5);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         source.delaySubscription(ps).subscribe(to);
 
@@ -866,7 +866,7 @@ public class ObservableDelayTest extends RxJavaTest {
     @Test
     public void onErrorCalledOnScheduler() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Thread> thread = new AtomicReference<Thread>();
+        final AtomicReference<Thread> thread = new AtomicReference<>();
 
         Observable.<String>error(new Exception())
                 .delay(0, TimeUnit.MILLISECONDS, Schedulers.newThread())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDematerializeTest.java
@@ -140,7 +140,7 @@ public class ObservableDematerializeTest extends RxJavaTest {
 
         Observer<Integer> observer = TestHelper.mockObserver();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(observer);
+        TestObserverEx<Integer> to = new TestObserverEx<>(observer);
         dematerialize.subscribe(to);
 
         System.out.println(to.errors());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDetachTest.java
@@ -33,9 +33,9 @@ public class ObservableDetachTest extends RxJavaTest {
     public void just() throws Exception {
         o = new Object();
 
-        WeakReference<Object> wr = new WeakReference<Object>(o);
+        WeakReference<Object> wr = new WeakReference<>(o);
 
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         Observable.just(o).count().toObservable().onTerminateDetach().subscribe(to);
 
@@ -54,7 +54,7 @@ public class ObservableDetachTest extends RxJavaTest {
 
     @Test
     public void error() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         Observable.error(new TestException()).onTerminateDetach().subscribe(to);
 
@@ -65,7 +65,7 @@ public class ObservableDetachTest extends RxJavaTest {
 
     @Test
     public void empty() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         Observable.empty().onTerminateDetach().subscribe(to);
 
@@ -76,7 +76,7 @@ public class ObservableDetachTest extends RxJavaTest {
 
     @Test
     public void range() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         Observable.range(1, 1000).onTerminateDetach().subscribe(to);
 
@@ -89,7 +89,7 @@ public class ObservableDetachTest extends RxJavaTest {
     public void justUnsubscribed() throws Exception {
         o = new Object();
 
-        WeakReference<Object> wr = new WeakReference<Object>(o);
+        WeakReference<Object> wr = new WeakReference<>(o);
 
         TestObserver<Long> to = Observable.just(o).count().toObservable().onTerminateDetach().test();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctTest.java
@@ -115,7 +115,7 @@ public class ObservableDistinctTest extends RxJavaTest {
 
     @Test
     public void fusedSync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
         .distinct()
@@ -127,7 +127,7 @@ public class ObservableDistinctTest extends RxJavaTest {
 
     @Test
     public void fusedAsync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -148,7 +148,7 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
 
     @Test
     public void fused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.just(1, 2, 2, 3, 3, 4, 5)
         .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
@@ -167,7 +167,7 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
 
     @Test
     public void fusedAsync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoAfterNextTest.java
@@ -31,7 +31,7 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableDoAfterNextTest extends RxJavaTest {
 
-    final List<Integer> values = new ArrayList<Integer>();
+    final List<Integer> values = new ArrayList<>();
 
     final Consumer<Integer> afterNext = new Consumer<Integer>() {
         @Override
@@ -101,7 +101,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     @Test
     public void syncFused() {
-        TestObserverEx<Integer> to0 = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to0 = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .doAfterNext(afterNext)
@@ -115,7 +115,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     @Test
     public void asyncFusedRejected() {
-        TestObserverEx<Integer> to0 = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to0 = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         Observable.range(1, 5)
         .doAfterNext(afterNext)
@@ -129,7 +129,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     @Test
     public void asyncFused() {
-        TestObserverEx<Integer> to0 = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to0 = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
 
@@ -196,7 +196,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     @Test
     public void syncFusedConditional() {
-        TestObserverEx<Integer> to0 = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to0 = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .doAfterNext(afterNext)
@@ -211,7 +211,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     @Test
     public void asyncFusedRejectedConditional() {
-        TestObserverEx<Integer> to0 = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to0 = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         Observable.range(1, 5)
         .doAfterNext(afterNext)
@@ -226,7 +226,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     @Test
     public void asyncFusedConditional() {
-        TestObserverEx<Integer> to0 = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to0 = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoFinallyTest.java
@@ -99,7 +99,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void syncFused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .doFinally(this)
@@ -113,7 +113,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void syncFusedBoundary() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC | QueueFuseable.BOUNDARY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
         .doFinally(this)
@@ -127,7 +127,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void asyncFused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -144,7 +144,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void asyncFusedBoundary() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -206,7 +206,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void syncFusedConditional() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
         .doFinally(this)
@@ -221,7 +221,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void nonFused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Observable.range(1, 5).hide()
         .doFinally(this)
@@ -235,7 +235,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void nonFusedConditional() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Observable.range(1, 5).hide()
         .doFinally(this)
@@ -250,7 +250,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void syncFusedBoundaryConditional() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC | QueueFuseable.BOUNDARY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
         .doFinally(this)
@@ -265,7 +265,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void asyncFusedConditional() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -283,7 +283,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void asyncFusedBoundaryConditional() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -446,7 +446,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void eventOrdering() {
-        final List<String> list = new ArrayList<String>();
+        final List<String> list = new ArrayList<>();
 
         Observable.error(new TestException())
         .doOnDispose(new Action() {
@@ -486,7 +486,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void eventOrdering2() {
-        final List<String> list = new ArrayList<String>();
+        final List<String> list = new ArrayList<>();
 
         Observable.just(1)
         .doOnDispose(new Action() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnEachTest.java
@@ -202,7 +202,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void onErrorThrows() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
 
         Observable.error(new TestException())
         .doOnError(new Consumer<Throwable>() {
@@ -472,7 +472,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -502,7 +502,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedOnErrorCrash() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         final int[] call = { 0 };
 
@@ -531,7 +531,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedConditional() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -562,7 +562,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedOnErrorCrashConditional() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         final int[] call = { 0 };
 
@@ -592,7 +592,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedAsync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -626,7 +626,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedAsyncConditional() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -661,7 +661,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     @Ignore("Fusion not supported yet") // TODO decide/implement fusion
     public void fusedAsyncConditional2() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         final int[] call = { 0, 0 };
 
@@ -695,7 +695,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Observable.just(1).doOnEach(new TestObserver<Integer>()));
+        TestHelper.checkDisposed(Observable.just(1).doOnEach(new TestObserver<>()));
     }
 
     @Test
@@ -703,7 +703,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
             @Override
             public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.doOnEach(new TestObserver<Object>());
+                return o.doOnEach(new TestObserver<>());
             }
         });
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnSubscribeTest.java
@@ -69,7 +69,7 @@ public class ObservableDoOnSubscribeTest extends RxJavaTest {
         final AtomicInteger onSubscribed = new AtomicInteger();
         final AtomicInteger countBefore = new AtomicInteger();
         final AtomicInteger countAfter = new AtomicInteger();
-        final AtomicReference<Observer<? super Integer>> sref = new AtomicReference<Observer<? super Integer>>();
+        final AtomicReference<Observer<? super Integer>> sref = new AtomicReference<>();
         Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
@@ -68,11 +68,11 @@ public class ObservableDoOnUnsubscribeTest extends RxJavaTest {
                     }
                 });
 
-        List<Disposable> subscriptions = new ArrayList<Disposable>();
-        List<TestObserver<Long>> subscribers = new ArrayList<TestObserver<Long>>();
+        List<Disposable> subscriptions = new ArrayList<>();
+        List<TestObserver<Long>> subscribers = new ArrayList<>();
 
         for (int i = 0; i < subCount; ++i) {
-            TestObserver<Long> observer = new TestObserver<Long>();
+            TestObserver<Long> observer = new TestObserver<>();
             subscriptions.add(observer);
             longs.subscribe(observer);
             subscribers.add(observer);
@@ -131,11 +131,11 @@ public class ObservableDoOnUnsubscribeTest extends RxJavaTest {
                 .publish()
                 .refCount();
 
-        List<Disposable> subscriptions = new ArrayList<Disposable>();
-        List<TestObserver<Long>> subscribers = new ArrayList<TestObserver<Long>>();
+        List<Disposable> subscriptions = new ArrayList<>();
+        List<TestObserver<Long>> subscribers = new ArrayList<>();
 
         for (int i = 0; i < subCount; ++i) {
-            TestObserver<Long> observer = new TestObserver<Long>();
+            TestObserver<Long> observer = new TestObserver<>();
             longs.subscribe(observer);
             subscriptions.add(observer);
             subscribers.add(observer);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFilterTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFilterTest.java
@@ -68,7 +68,7 @@ public class ObservableFilterTest extends RxJavaTest {
 
     @Test
     public void fusedSync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.range(1, 5)
         .filter(new Predicate<Integer>() {
@@ -85,7 +85,7 @@ public class ObservableFilterTest extends RxJavaTest {
 
     @Test
     public void fusedAsync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
@@ -106,7 +106,7 @@ public class ObservableFilterTest extends RxJavaTest {
 
     @Test
     public void fusedReject() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
         .filter(new Predicate<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -169,7 +169,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void fusedObservable() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.range(1, 10)
         .flatMapCompletable(new Function<Integer, CompletableSource>() {
@@ -334,7 +334,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void fused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.range(1, 10)
         .flatMapCompletable(new Function<Integer, CompletableSource>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -429,7 +429,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void disposeInner() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
 
         Observable.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Object>>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -344,7 +344,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void disposeInner() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
 
         Observable.just(1).flatMapSingle(new Function<Integer, SingleSource<Object>>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapTest.java
@@ -338,13 +338,13 @@ public class ObservableFlatMapTest extends RxJavaTest {
             }
         }, m);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         source.subscribe(to);
 
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
-        Set<Integer> expected = new HashSet<Integer>(Arrays.asList(
+        Set<Integer> expected = new HashSet<>(Arrays.asList(
                 10, 11, 20, 21, 30, 31, 40, 41, 50, 51, 60, 61, 70, 71, 80, 81, 90, 91, 100, 101
         ));
         Assert.assertEquals(expected.size(), to.values().size());
@@ -369,13 +369,13 @@ public class ObservableFlatMapTest extends RxJavaTest {
             }
         }, m);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         source.subscribe(to);
 
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
-        Set<Integer> expected = new HashSet<Integer>(Arrays.asList(
+        Set<Integer> expected = new HashSet<>(Arrays.asList(
                 1010, 1011, 2020, 2021, 3030, 3031, 4040, 4041, 5050, 5051,
                 6060, 6061, 7070, 7071, 8080, 8081, 9090, 9091, 10100, 10101
         ));
@@ -415,7 +415,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
 
         Observer<Object> o = TestHelper.mockObserver();
-        TestObserverEx<Object> to = new TestObserverEx<Object>(o);
+        TestObserverEx<Object> to = new TestObserverEx<>(o);
 
         Function<Throwable, Observable<Integer>> just = just(onError);
         source.flatMap(just(onNext), just, just0(onComplete), m).subscribe(to);
@@ -440,7 +440,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
             if (i % 10 == 0) {
                 System.out.println("flatMapRangeAsyncLoop > " + i);
             }
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.range(0, 1000)
             .flatMap(new Function<Integer, Observable<Integer>>() {
                 final Random rnd = new Random();
@@ -464,7 +464,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
             to.assertNoErrors();
             List<Integer> list = to.values();
             if (list.size() < 1000) {
-                Set<Integer> set = new HashSet<Integer>(list);
+                Set<Integer> set = new HashSet<>(list);
                 for (int j = 0; j < 1000; j++) {
                     if (!set.contains(j)) {
                         System.out.println(j + " missing");
@@ -478,7 +478,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapIntPassthruAsync() {
         for (int i = 0; i < 1000; i++) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
             Observable.range(1, 1000).flatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
@@ -497,7 +497,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTwoNestedSync() {
         for (final int n : new int[] { 1, 1000, 1000000 }) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
             Observable.just(1, 2).flatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
@@ -972,10 +972,10 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void fusedSourceCrashResumeWithNextSource() {
         final UnicastSubject<Integer> fusedSource = UnicastSubject.create();
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         ObservableFlatMap.MergeObserver<Integer, Integer> merger =
-                new ObservableFlatMap.MergeObserver<Integer, Integer>(to, new Function<Integer, Observable<Integer>>() {
+                new ObservableFlatMap.MergeObserver<>(to, new Function<Integer, Observable<Integer>>() {
                     @Override
                     public Observable<Integer> apply(Integer t)
                             throws Exception {
@@ -984,7 +984,9 @@ public class ObservableFlatMapTest extends RxJavaTest {
                                     .map(new Function<Integer, Integer>() {
                                         @Override
                                         public Integer apply(Integer v)
-                                                throws Exception { throw new TestException(); }
+                                                throws Exception {
+                                            throw new TestException();
+                                        }
                                     })
                                     .compose(TestHelper.<Integer>observableStripBoundary());
                         }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableForEachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableForEachTest.java
@@ -33,7 +33,7 @@ public class ObservableForEachTest extends RxJavaTest {
 
     @Test
     public void forEachWile() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Observable.range(1, 5)
         .doOnNext(new Consumer<Integer>() {
@@ -54,7 +54,7 @@ public class ObservableForEachTest extends RxJavaTest {
 
     @Test
     public void forEachWileWithError() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Observable.range(1, 5).concatWith(Observable.<Integer>error(new TestException()))
         .doOnNext(new Consumer<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromCallableTest.java
@@ -121,7 +121,7 @@ public class ObservableFromCallableTest extends RxJavaTest {
 
         Observer<Object> observer = TestHelper.mockObserver();
 
-        TestObserver<String> outer = new TestObserver<String>(observer);
+        TestObserver<String> outer = new TestObserver<>(observer);
 
         fromCallableObservable
                 .subscribeOn(Schedulers.computation())
@@ -262,7 +262,7 @@ public class ObservableFromCallableTest extends RxJavaTest {
 
     @Test
     public void disposedOnCall() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.fromCallable(new Callable<Integer>() {
             @Override
@@ -280,7 +280,7 @@ public class ObservableFromCallableTest extends RxJavaTest {
     public void disposedOnCallThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestObserver<Integer> to = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<>();
 
             Observable.fromCallable(new Callable<Integer>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromIterableTest.java
@@ -119,7 +119,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
     public void noBackpressure() {
         Observable<Integer> o = Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5));
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         o.subscribe(to);
 
@@ -132,7 +132,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
         Observable<Integer> o = Observable.fromIterable(Arrays.asList(1, 2, 3));
 
         for (int i = 0; i < 10; i++) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
             o.subscribe(to);
 
@@ -235,7 +235,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
 
     @Test
     public void fusionWithConcatMap() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.fromIterable(Arrays.asList(1, 2, 3, 4)).concatMap(
         new Function<Integer, ObservableSource<Integer>>() {
@@ -266,7 +266,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextCancels() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.fromIterable(new Iterable<Integer>() {
             @Override
@@ -303,7 +303,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
 
     @Test
     public void fusionRejected() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         Observable.fromIterable(Arrays.asList(1, 2, 3))
         .subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromSupplierTest.java
@@ -121,7 +121,7 @@ public class ObservableFromSupplierTest extends RxJavaTest {
 
         Observer<Object> observer = TestHelper.mockObserver();
 
-        TestObserver<String> outer = new TestObserver<String>(observer);
+        TestObserver<String> outer = new TestObserver<>(observer);
 
         fromSupplierObservable
                 .subscribeOn(Schedulers.computation())
@@ -262,7 +262,7 @@ public class ObservableFromSupplierTest extends RxJavaTest {
 
     @Test
     public void disposedOnCall() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.fromSupplier(new Supplier<Integer>() {
             @Override
@@ -280,7 +280,7 @@ public class ObservableFromSupplierTest extends RxJavaTest {
     public void disposedOnCallThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestObserver<Integer> to = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<>();
 
             Observable.fromSupplier(new Supplier<Integer>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromTest.java
@@ -77,7 +77,7 @@ public class ObservableFromTest extends RxJavaTest {
 
     @Test
     public void fusionRejected() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         Observable.fromArray(1, 2, 3)
         .subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
@@ -105,7 +105,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
         final AtomicInteger groupCounter = new AtomicInteger();
         final AtomicInteger eventCounter = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         grouped.flatMap(new Function<GroupedObservable<Integer, String>, Observable<String>>() {
 
@@ -148,13 +148,13 @@ public class ObservableGroupByTest extends RxJavaTest {
 
     private static <K, V> Map<K, Collection<V>> toMap(Observable<GroupedObservable<K, V>> observable) {
 
-        final ConcurrentHashMap<K, Collection<V>> result = new ConcurrentHashMap<K, Collection<V>>();
+        final ConcurrentHashMap<K, Collection<V>> result = new ConcurrentHashMap<>();
 
         observable.doOnNext(new Consumer<GroupedObservable<K, V>>() {
 
             @Override
             public void accept(final GroupedObservable<K, V> o) {
-                result.put(o.getKey(), new ConcurrentLinkedQueue<V>());
+                result.put(o.getKey(), new ConcurrentLinkedQueue<>());
                 o.subscribe(new Consumer<V>() {
 
                     @Override
@@ -597,7 +597,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     @Test
     public void firstGroupsCompleteAndParentSlowToThenEmitFinalGroupsAndThenComplete() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
@@ -676,7 +676,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     public void firstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenSubscribesOnAndDelaysAndThenCompletes() throws InterruptedException {
         System.err.println("----------------------------------------------------------------------------------------------");
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
@@ -768,7 +768,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     @Test
     public void firstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenObservesOnAndDelaysAndThenCompletes() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
@@ -845,7 +845,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
     @Test
     public void groupsWithNestedSubscribeOn() throws InterruptedException {
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
@@ -902,7 +902,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
     @Test
     public void groupsWithNestedObserveOn() throws InterruptedException {
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Observable.unsafeCreate(new ObservableSource<Integer>() {
 
             @Override
@@ -1027,7 +1027,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     @Test
     public void groupByBackpressure() throws InterruptedException {
 
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.range(1, 4000)
                 .groupBy(IS_EVEN2)
@@ -1154,7 +1154,7 @@ public class ObservableGroupByTest extends RxJavaTest {
             }
         });
 
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
         m.subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         System.out.println("ts .get " + to.values());
@@ -1170,7 +1170,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
         Observable<Integer> m = source.groupBy(fail(0), dbl).flatMap(FLATTEN_INTEGER);
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         m.subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(1, to.errors().size());
@@ -1182,7 +1182,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         Observable<Integer> source = Observable.just(0, 1, 2, 3, 4, 5, 6);
 
         Observable<Integer> m = source.groupBy(identity, fail(0)).flatMap(FLATTEN_INTEGER);
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         m.subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(1, to.errors().size());
@@ -1196,7 +1196,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
         Observable<Integer> m = source.groupBy(identity, dbl).flatMap(FLATTEN_INTEGER);
 
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         m.subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -1210,7 +1210,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     public void exceptionIfSubscribeToChildMoreThanOnce() {
         Observable<Integer> source = Observable.just(0);
 
-        final AtomicReference<GroupedObservable<Integer, Integer>> inner = new AtomicReference<GroupedObservable<Integer, Integer>>();
+        final AtomicReference<GroupedObservable<Integer, Integer>> inner = new AtomicReference<>();
 
         Observable<GroupedObservable<Integer, Integer>> m = source.groupBy(identity, dbl);
 
@@ -1239,7 +1239,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
         Observable<Integer> m = source.groupBy(identity, dbl).flatMap(FLATTEN_INTEGER);
 
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         m.subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(1, to.errors().size());
@@ -1248,7 +1248,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
     @Test
     public void groupByBackpressure3() throws InterruptedException {
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.range(1, 4000).groupBy(IS_EVEN2).flatMap(new Function<GroupedObservable<Boolean, Integer>, Observable<String>>() {
 
@@ -1305,7 +1305,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     @Test
     public void groupByBackpressure2() throws InterruptedException {
 
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.range(1, 4000).groupBy(IS_EVEN2).flatMap(new Function<GroupedObservable<Boolean, Integer>, Observable<String>>() {
 
@@ -1346,7 +1346,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     @Test
     public void groupByWithNullKey() {
         final String[] key = new String[]{"uninitialized"};
-        final List<String> values = new ArrayList<String>();
+        final List<String> values = new ArrayList<>();
         Observable.just("a", "b", "c").groupBy(new Function<String, String>() {
 
             @Override
@@ -1382,7 +1382,7 @@ public class ObservableGroupByTest extends RxJavaTest {
                     }
                 }
         );
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         o.groupBy(new Function<Integer, Integer>() {
 
@@ -1400,11 +1400,11 @@ public class ObservableGroupByTest extends RxJavaTest {
     @Test
     public void groupByShouldPropagateError() {
         final Throwable e = new RuntimeException("Oops");
-        final TestObserverEx<Integer> inner1 = new TestObserverEx<Integer>();
-        final TestObserverEx<Integer> inner2 = new TestObserverEx<Integer>();
+        final TestObserverEx<Integer> inner1 = new TestObserverEx<>();
+        final TestObserverEx<Integer> inner2 = new TestObserverEx<>();
 
         final TestObserverEx<GroupedObservable<Integer, Integer>> outer
-                = new TestObserverEx<GroupedObservable<Integer, Integer>>(new DefaultObserver<GroupedObservable<Integer, Integer>>() {
+                = new TestObserverEx<>(new DefaultObserver<GroupedObservable<Integer, Integer>>() {
 
             @Override
             public void onComplete() {
@@ -1546,7 +1546,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     public void cancelOverFlatmapRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
 
-            final TestObserver<Integer> to = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<>();
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
@@ -1589,7 +1589,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
     @Test
     public void abandonedGroupsNoDataloss() {
-        final List<GroupedObservable<Integer, Integer>> groups = new ArrayList<GroupedObservable<Integer, Integer>>();
+        final List<GroupedObservable<Integer, Integer>> groups = new ArrayList<>();
 
         Observable.range(1, 1000)
         .groupBy(new Function<Integer, Integer>() {
@@ -1618,8 +1618,8 @@ public class ObservableGroupByTest extends RxJavaTest {
 
     @Test
     public void newGroupValueSelectorFails() {
-        TestObserver<Object> to1 = new TestObserver<Object>();
-        final TestObserver<Object> to2 = new TestObserver<Object>();
+        TestObserver<Object> to1 = new TestObserver<>();
+        final TestObserver<Object> to2 = new TestObserver<>();
 
         Observable.just(1)
         .groupBy(Functions.<Integer>identity(), new Function<Integer, Object>() {
@@ -1645,8 +1645,8 @@ public class ObservableGroupByTest extends RxJavaTest {
 
     @Test
     public void existingGroupValueSelectorFails() {
-        TestObserver<Object> to1 = new TestObserver<Object>();
-        final TestObserver<Object> to2 = new TestObserver<Object>();
+        TestObserver<Object> to1 = new TestObserver<>();
+        final TestObserver<Object> to2 = new TestObserver<>();
 
         Observable.just(1, 2)
         .groupBy(Functions.justFunction(1), new Function<Integer, Object>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableIgnoreElementsTest.java
@@ -58,7 +58,7 @@ public class ObservableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void completedOkObservable() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         Observable.range(1, 10).ignoreElements().toObservable().subscribe(to);
         to.assertNoErrors();
         to.assertNoValues();
@@ -67,7 +67,7 @@ public class ObservableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void errorReceivedObservable() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         TestException ex = new TestException("boo");
         Observable.error(ex).ignoreElements().toObservable().subscribe(to);
         to.assertNoValues();
@@ -120,7 +120,7 @@ public class ObservableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void completedOk() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         Observable.range(1, 10).ignoreElements().subscribe(to);
         to.assertNoErrors();
         to.assertNoValues();
@@ -129,7 +129,7 @@ public class ObservableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void errorReceived() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         TestException ex = new TestException("boo");
         Observable.error(ex).ignoreElements().subscribe(to);
         to.assertNoValues();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableIntervalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableIntervalTest.java
@@ -40,7 +40,7 @@ public class ObservableIntervalTest extends RxJavaTest {
 
     @Test
     public void cancelledOnRun() {
-        TestObserver<Long> to = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<>();
         IntervalObserver is = new IntervalObserver(to);
         to.onSubscribe(is);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMapNotificationTest.java
@@ -27,7 +27,7 @@ import io.reactivex.rxjava3.testsupport.*;
 public class ObservableMapNotificationTest extends RxJavaTest {
     @Test
     public void just() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         Observable.just(1)
         .flatMap(
                 new Function<Integer, Observable<Object>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMapTest.java
@@ -306,7 +306,7 @@ public class ObservableMapTest extends RxJavaTest {
 //    }
 
     private static Map<String, String> getMap(String prefix) {
-        Map<String, String> m = new HashMap<String, String>();
+        Map<String, String> m = new HashMap<>();
         m.put("firstName", prefix + "First");
         m.put("lastName", prefix + "Last");
         return m;
@@ -350,7 +350,7 @@ public class ObservableMapTest extends RxJavaTest {
 
     @Test
     public void fusedSync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.range(1, 5)
         .map(Functions.<Integer>identity())
@@ -362,7 +362,7 @@ public class ObservableMapTest extends RxJavaTest {
 
     @Test
     public void fusedAsync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
@@ -378,7 +378,7 @@ public class ObservableMapTest extends RxJavaTest {
 
     @Test
     public void fusedReject() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
         .map(Functions.<Integer>identity())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMaterializeTest.java
@@ -102,7 +102,7 @@ public class ObservableMaterializeTest extends RxJavaTest {
 
     @Test
     public void withCompletionCausingError() {
-        TestObserverEx<Notification<Integer>> to = new TestObserverEx<Notification<Integer>>();
+        TestObserverEx<Notification<Integer>> to = new TestObserverEx<>();
         final RuntimeException ex = new RuntimeException("boo");
         Observable.<Integer>empty().materialize().doOnNext(new Consumer<Object>() {
             @Override
@@ -119,7 +119,7 @@ public class ObservableMaterializeTest extends RxJavaTest {
 
         boolean onComplete;
         boolean onError;
-        List<Notification<String>> notifications = new Vector<Notification<String>>();
+        List<Notification<String>> notifications = new Vector<>();
 
         @Override
         public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -252,7 +252,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
     public void mergeList() {
         final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
         final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
-        List<Observable<String>> listOfObservables = new ArrayList<Observable<String>>();
+        List<Observable<String>> listOfObservables = new ArrayList<>();
         listOfObservables.add(o1);
         listOfObservables.add(o2);
 
@@ -433,7 +433,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void errorInParentObservable() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         Observable.mergeDelayError(
                 Observable.just(Observable.just(1), Observable.just(2))
                         .startWithItem(Observable.<Integer> error(new RuntimeException()))
@@ -462,7 +462,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
 
             Observer<String> stringObserver = TestHelper.mockObserver();
 
-            TestObserverEx<String> to = new TestObserverEx<String>(stringObserver);
+            TestObserverEx<String> to = new TestObserverEx<>(stringObserver);
             Observable<String> m = Observable.mergeDelayError(parentObservable);
             m.subscribe(to);
             System.out.println("testErrorInParentObservableDelayed | " + i);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
@@ -42,14 +42,14 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void whenMaxConcurrentIsOne() {
         for (int i = 0; i < 100; i++) {
-            List<Observable<String>> os = new ArrayList<Observable<String>>();
+            List<Observable<String>> os = new ArrayList<>();
             os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
             os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
             os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
 
             List<String> expected = Arrays.asList("one", "two", "three", "four", "five", "one", "two", "three", "four", "five", "one", "two", "three", "four", "five");
             Iterator<String> iter = Observable.merge(os, 1).blockingIterable().iterator();
-            List<String> actual = new ArrayList<String>();
+            List<String> actual = new ArrayList<>();
             while (iter.hasNext()) {
                 actual.add(iter.next());
             }
@@ -65,8 +65,8 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
             int maxConcurrent = 2 + (times % 10);
             AtomicInteger subscriptionCount = new AtomicInteger(0);
 
-            List<Observable<String>> os = new ArrayList<Observable<String>>();
-            List<SubscriptionCheckObservable> scos = new ArrayList<SubscriptionCheckObservable>();
+            List<Observable<String>> os = new ArrayList<>();
+            List<SubscriptionCheckObservable> scos = new ArrayList<>();
             for (int i = 0; i < observableCount; i++) {
                 SubscriptionCheckObservable sco = new SubscriptionCheckObservable(subscriptionCount, maxConcurrent);
                 scos.add(sco);
@@ -74,7 +74,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
             }
 
             Iterator<String> iter = Observable.merge(os, maxConcurrent).blockingIterable().iterator();
-            List<String> actual = new ArrayList<String>();
+            List<String> actual = new ArrayList<>();
             while (iter.hasNext()) {
                 actual.add(iter.next());
             }
@@ -126,7 +126,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void mergeALotOfSourcesOneByOneSynchronously() {
         int n = 10000;
-        List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(n);
+        List<Observable<Integer>> sourceList = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
             sourceList.add(Observable.just(i));
         }
@@ -142,7 +142,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void mergeALotOfSourcesOneByOneSynchronouslyTakeHalf() {
         int n = 10000;
-        List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(n);
+        List<Observable<Integer>> sourceList = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
             sourceList.add(Observable.just(i));
         }
@@ -158,9 +158,9 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void simple() {
         for (int i = 1; i < 100; i++) {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
-            List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
-            List<Integer> result = new ArrayList<Integer>(i);
+            TestObserverEx<Integer> to = new TestObserverEx<>();
+            List<Observable<Integer>> sourceList = new ArrayList<>(i);
+            List<Integer> result = new ArrayList<>(i);
             for (int j = 1; j <= i; j++) {
                 sourceList.add(Observable.just(j));
                 result.add(j);
@@ -177,9 +177,9 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void simpleOneLess() {
         for (int i = 2; i < 100; i++) {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
-            List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
-            List<Integer> result = new ArrayList<Integer>(i);
+            TestObserverEx<Integer> to = new TestObserverEx<>();
+            List<Observable<Integer>> sourceList = new ArrayList<>(i);
+            List<Integer> result = new ArrayList<>(i);
             for (int j = 1; j <= i; j++) {
                 sourceList.add(Observable.just(j));
                 result.add(j);
@@ -209,9 +209,9 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void simpleAsync() {
         for (int i = 1; i < 50; i++) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
-            List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
-            Set<Integer> expected = new HashSet<Integer>(i);
+            TestObserver<Integer> to = new TestObserver<>();
+            List<Observable<Integer>> sourceList = new ArrayList<>(i);
+            Set<Integer> expected = new HashSet<>(i);
             for (int j = 1; j <= i; j++) {
                 sourceList.add(Observable.just(j).subscribeOn(Schedulers.io()));
                 expected.add(j);
@@ -221,7 +221,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
 
             to.awaitDone(1, TimeUnit.SECONDS);
             to.assertNoErrors();
-            Set<Integer> actual = new HashSet<Integer>(to.values());
+            Set<Integer> actual = new HashSet<>(to.values());
 
             assertEquals(expected, actual);
         }
@@ -241,9 +241,9 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
             if (System.currentTimeMillis() - t > TimeUnit.SECONDS.toMillis(9)) {
                 break;
             }
-            TestObserver<Integer> to = new TestObserver<Integer>();
-            List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(i);
-            Set<Integer> expected = new HashSet<Integer>(i);
+            TestObserver<Integer> to = new TestObserver<>();
+            List<Observable<Integer>> sourceList = new ArrayList<>(i);
+            Set<Integer> expected = new HashSet<>(i);
             for (int j = 1; j <= i; j++) {
                 sourceList.add(Observable.just(j).subscribeOn(Schedulers.io()));
                 expected.add(j);
@@ -253,7 +253,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
 
             to.awaitDone(1, TimeUnit.SECONDS);
             to.assertNoErrors();
-            Set<Integer> actual = new HashSet<Integer>(to.values());
+            Set<Integer> actual = new HashSet<>(to.values());
 
             assertEquals(expected, actual);
         }
@@ -261,13 +261,13 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
 
     @Test
     public void take() throws Exception {
-        List<Observable<Integer>> sourceList = new ArrayList<Observable<Integer>>(3);
+        List<Observable<Integer>> sourceList = new ArrayList<>(3);
 
         sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
         sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
         sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.merge(sourceList, 2).take(5).subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeTest.java
@@ -112,7 +112,7 @@ public class ObservableMergeTest extends RxJavaTest {
     public void mergeList() {
         final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
         final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
-        List<Observable<String>> listOfObservables = new ArrayList<Observable<String>>();
+        List<Observable<String>> listOfObservables = new ArrayList<>();
         listOfObservables.add(o1);
         listOfObservables.add(o2);
 
@@ -191,7 +191,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final TestASynchronousObservable o2 = new TestASynchronousObservable();
 
         Observable<String> m = Observable.merge(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
-        TestObserver<String> to = new TestObserver<String>(stringObserver);
+        TestObserver<String> to = new TestObserver<>(stringObserver);
         m.subscribe(to);
 
         to.awaitDone(5, TimeUnit.SECONDS);
@@ -408,7 +408,7 @@ public class ObservableMergeTest extends RxJavaTest {
         AtomicBoolean os2 = new AtomicBoolean(false);
         Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
-        TestObserverEx<Long> to = new TestObserverEx<Long>();
+        TestObserverEx<Long> to = new TestObserverEx<>();
         Observable.merge(o1, o2).subscribe(to);
 
         // we haven't incremented time so nothing should be received yet
@@ -450,7 +450,7 @@ public class ObservableMergeTest extends RxJavaTest {
             AtomicBoolean os2 = new AtomicBoolean(false);
             Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
-            TestObserver<Long> to = new TestObserver<Long>();
+            TestObserver<Long> to = new TestObserver<>();
             Observable.merge(o1, o2).subscribe(to);
 
             // we haven't incremented time so nothing should be received yet
@@ -523,7 +523,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
         for (int i = 0; i < 10; i++) {
             Observable<Integer> merge = Observable.merge(o, o, o);
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to = new TestObserverEx<>();
             merge.subscribe(to);
 
             to.awaitDone(3, TimeUnit.SECONDS);
@@ -576,7 +576,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
         for (int i = 0; i < 10; i++) {
             Observable<Integer> merge = Observable.merge(o, o, o);
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
             merge.subscribe(to);
 
             to.awaitDone(5, TimeUnit.SECONDS);
@@ -623,7 +623,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
         for (int i = 0; i < 10; i++) {
             Observable<Integer> merge = Observable.merge(o, o, o);
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
             merge.subscribe(to);
 
             to.awaitDone(5, TimeUnit.SECONDS);
@@ -806,7 +806,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1AsyncStreamOf1() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNAsyncStreamsOfN(1, 1).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -815,7 +815,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1AsyncStreamOf1000() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNAsyncStreamsOfN(1, 1000).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -824,7 +824,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge10AsyncStreamOf1000() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNAsyncStreamsOfN(10, 1000).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -833,7 +833,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1000AsyncStreamOf1000() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNAsyncStreamsOfN(1000, 1000).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -842,7 +842,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge2000AsyncStreamOf100() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNAsyncStreamsOfN(2000, 100).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -851,7 +851,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge100AsyncStreamOf1() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNAsyncStreamsOfN(100, 1).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -873,7 +873,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1SyncStreamOf1() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNSyncStreamsOfN(1, 1).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -882,7 +882,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1SyncStreamOf1000000() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNSyncStreamsOfN(1, 1000000).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -891,7 +891,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1000SyncStreamOf1000() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNSyncStreamsOfN(1000, 1000).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -900,7 +900,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge10000SyncStreamOf10() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNSyncStreamsOfN(10000, 10).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -909,7 +909,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1000000SyncStreamOf1() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         mergeNSyncStreamsOfN(1000000, 1).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -956,7 +956,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void mergeManyAsyncSingle() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable<Observable<Integer>> os = Observable.range(1, 10000)
         .map(new Function<Integer, Observable<Integer>>() {
 
@@ -1004,7 +1004,7 @@ public class ObservableMergeTest extends RxJavaTest {
     ;
 
     void runMerge(Function<Integer, Observable<Integer>> func, TestObserverEx<Integer> to) {
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             list.add(i);
         }
@@ -1022,12 +1022,12 @@ public class ObservableMergeTest extends RxJavaTest {
 
     @Test
     public void fastMergeFullScalar() {
-        runMerge(toScalar, new TestObserverEx<Integer>());
+        runMerge(toScalar, new TestObserverEx<>());
     }
 
     @Test
     public void fastMergeHiddenScalar() {
-        runMerge(toHiddenScalar, new TestObserverEx<Integer>());
+        runMerge(toHiddenScalar, new TestObserverEx<>());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithCompletableTest.java
@@ -29,7 +29,7 @@ public class ObservableMergeWithCompletableTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5).mergeWith(
                 Completable.fromAction(new Action() {
@@ -46,7 +46,7 @@ public class ObservableMergeWithCompletableTest extends RxJavaTest {
 
     @Test
     public void take() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5).mergeWith(
                 Completable.complete()

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithMaybeTest.java
@@ -178,7 +178,7 @@ public class ObservableMergeWithMaybeTest extends RxJavaTest {
     public void onErrorMainOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Observer<?>> observerRef = new AtomicReference<Observer<?>>();
+            final AtomicReference<Observer<?>> observerRef = new AtomicReference<>();
             TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -170,7 +170,7 @@ public class ObservableMergeWithSingleTest extends RxJavaTest {
     public void onErrorMainOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Observer<?>> observerRef = new AtomicReference<Observer<?>>();
+            final AtomicReference<Observer<?>> observerRef = new AtomicReference<>();
             TestObserver<Integer> to = new Observable<Integer>() {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableObserveOnTest.java
@@ -66,7 +66,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
         Observer<String> observer = TestHelper.mockObserver();
 
         InOrder inOrder = inOrder(observer);
-        TestObserverEx<String> to = new TestObserverEx<String>(observer);
+        TestObserverEx<String> to = new TestObserverEx<>(observer);
 
         obs.observeOn(Schedulers.computation()).subscribe(to);
 
@@ -387,7 +387,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
         final TestScheduler testScheduler = new TestScheduler();
 
         final Observer<Integer> observer = TestHelper.mockObserver();
-        TestObserver<Integer> to = new TestObserver<Integer>(observer);
+        TestObserver<Integer> to = new TestObserver<>(observer);
 
         Observable.just(1, 2, 3)
                 .observeOn(testScheduler)
@@ -428,7 +428,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
             }
         });
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         o
                 .take(7)
                 .observeOn(Schedulers.newThread())
@@ -441,7 +441,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
 
     @Test
     public void asyncChild() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(0, 100000).observeOn(Schedulers.newThread()).observeOn(Schedulers.newThread()).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -565,7 +565,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
 
     @Test
     public void outputFused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.range(1, 5).hide()
         .observeOn(Schedulers.single())
@@ -578,7 +578,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
 
     @Test
     public void outputFusedReject() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Observable.range(1, 5).hide()
         .observeOn(Schedulers.single())
@@ -591,7 +591,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
 
     @Test
     public void inputOutputAsyncFusedError() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
@@ -611,7 +611,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
 
     @Test
     public void inputOutputAsyncFusedErrorDelayed() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorResumeNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorResumeNextTest.java
@@ -37,7 +37,7 @@ public class ObservableOnErrorResumeNextTest extends RxJavaTest {
 
     @Test
     public void resumeNextWithSynchronousExecution() {
-        final AtomicReference<Throwable> receivedException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> receivedException = new AtomicReference<>();
         Observable<String> w = Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
@@ -77,7 +77,7 @@ public class ObservableOnErrorResumeNextTest extends RxJavaTest {
 
     @Test
     public void resumeNextWithAsyncExecution() {
-        final AtomicReference<Throwable> receivedException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> receivedException = new AtomicReference<>();
         Subscription s = mock(Subscription.class);
         TestObservable w = new TestObservable(s, "one");
         Function<Throwable, Observable<String>> resume = new Function<Throwable, Observable<String>>() {
@@ -174,7 +174,7 @@ public class ObservableOnErrorResumeNextTest extends RxJavaTest {
 
         Observer<String> observer = TestHelper.mockObserver();
 
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         o.subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
 
@@ -226,7 +226,7 @@ public class ObservableOnErrorResumeNextTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(0, 100000)
                 .onErrorResumeNext(new Function<Throwable, Observable<Integer>>() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorResumeWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorResumeWithTest.java
@@ -146,7 +146,7 @@ public class ObservableOnErrorResumeWithTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(0, 100000)
                 .onErrorResumeWith(Observable.just(1))
                 .observeOn(Schedulers.computation())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorReturnTest.java
@@ -37,7 +37,7 @@ public class ObservableOnErrorReturnTest extends RxJavaTest {
     public void resumeNext() {
         TestObservable f = new TestObservable("one");
         Observable<String> w = Observable.unsafeCreate(f);
-        final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> capturedException = new AtomicReference<>();
 
         Observable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
 
@@ -72,7 +72,7 @@ public class ObservableOnErrorReturnTest extends RxJavaTest {
     public void functionThrowsError() {
         TestObservable f = new TestObservable("one");
         Observable<String> w = Observable.unsafeCreate(f);
-        final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> capturedException = new AtomicReference<>();
 
         Observable<String> observable = w.onErrorReturn(new Function<Throwable, String>() {
 
@@ -130,7 +130,7 @@ public class ObservableOnErrorReturnTest extends RxJavaTest {
         });
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         observable.subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
 
@@ -144,7 +144,7 @@ public class ObservableOnErrorReturnTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(0, 100000)
                 .onErrorReturn(new Function<Throwable, Integer>() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublishTest.java
@@ -126,7 +126,7 @@ public class ObservablePublishTest extends RxJavaTest {
 
         });
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.merge(fast, slow).subscribe(to);
         is.connect();
         to.awaitDone(5, TimeUnit.SECONDS);
@@ -146,7 +146,7 @@ public class ObservablePublishTest extends RxJavaTest {
             }
 
         });
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         xs.publish(new Function<Observable<Integer>, Observable<Integer>>() {
 
             @Override
@@ -173,7 +173,7 @@ public class ObservablePublishTest extends RxJavaTest {
     @Test
     public void takeUntilWithPublishedStream() {
         Observable<Integer> xs = Observable.range(0, Flowable.bufferSize() * 2);
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         ConnectableObservable<Integer> xsp = xs.publish();
         xsp.takeUntil(xsp.skipWhile(new Predicate<Integer>() {
 
@@ -209,7 +209,7 @@ public class ObservablePublishTest extends RxJavaTest {
         final AtomicBoolean child1Unsubscribed = new AtomicBoolean();
         final AtomicBoolean child2Unsubscribed = new AtomicBoolean();
 
-        final TestObserver<Integer> to2 = new TestObserver<Integer>();
+        final TestObserver<Integer> to2 = new TestObserver<>();
 
         final TestObserver<Integer> to1 = new TestObserver<Integer>() {
             @Override
@@ -257,7 +257,7 @@ public class ObservablePublishTest extends RxJavaTest {
         co.connect();
         // Emit 0
         scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
-        TestObserverEx<Long> to = new TestObserverEx<Long>();
+        TestObserverEx<Long> to = new TestObserverEx<>();
         co.subscribe(to);
         // Emit 1 and 2
         scheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);
@@ -270,7 +270,7 @@ public class ObservablePublishTest extends RxJavaTest {
     public void subscribeAfterDisconnectThenConnect() {
         ConnectableObservable<Integer> source = Observable.just(1).publish();
 
-        TestObserverEx<Integer> to1 = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to1 = new TestObserverEx<>();
 
         source.subscribe(to1);
 
@@ -282,7 +282,7 @@ public class ObservablePublishTest extends RxJavaTest {
 
         source.reset();
 
-        TestObserverEx<Integer> to2 = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to2 = new TestObserverEx<>();
 
         source.subscribe(to2);
 
@@ -300,7 +300,7 @@ public class ObservablePublishTest extends RxJavaTest {
     public void noSubscriberRetentionOnCompleted() {
         ObservablePublish<Integer> source = (ObservablePublish<Integer>)Observable.just(1).publish();
 
-        TestObserverEx<Integer> to1 = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to1 = new TestObserverEx<>();
 
         source.subscribe(to1);
 
@@ -382,9 +382,9 @@ public class ObservablePublishTest extends RxJavaTest {
         Observable<Integer> obs = co.observeOn(Schedulers.computation());
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
-                List<TestObserverEx<Integer>> tos = new ArrayList<TestObserverEx<Integer>>();
+                List<TestObserverEx<Integer>> tos = new ArrayList<>();
                 for (int k = 1; k < j; k++) {
-                    TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+                    TestObserverEx<Integer> to = new TestObserverEx<>();
                     tos.add(to);
                     obs.subscribe(to);
                 }
@@ -480,7 +480,7 @@ public class ObservablePublishTest extends RxJavaTest {
 
             final TestObserver<Integer> to = co.test();
 
-            final TestObserver<Integer> to2 = new TestObserver<Integer>();
+            final TestObserver<Integer> to2 = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -628,7 +628,7 @@ public class ObservablePublishTest extends RxJavaTest {
             final ConnectableObservable<Integer> co = ps.publish();
 
             final Disposable d = co.connect();
-            final TestObserver<Integer> to = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -762,7 +762,7 @@ public class ObservablePublishTest extends RxJavaTest {
     @Test
     public void altConnectCrash() {
         try {
-            new ObservablePublish<Integer>(Observable.<Integer>empty())
+            new ObservablePublish<>(Observable.<Integer>empty())
             .connect(new Consumer<Disposable>() {
                 @Override
                 public void accept(Disposable t) throws Exception {
@@ -779,7 +779,7 @@ public class ObservablePublishTest extends RxJavaTest {
     public void altConnectRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             final ConnectableObservable<Integer> co =
-                    new ObservablePublish<Integer>(Observable.<Integer>never());
+                    new ObservablePublish<>(Observable.<Integer>never());
 
             Runnable r = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRangeLongTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRangeLongTest.java
@@ -93,14 +93,14 @@ public class ObservableRangeLongTest extends RxJavaTest {
 
     @Test
     public void noBackpressure() {
-        ArrayList<Long> list = new ArrayList<Long>(Flowable.bufferSize() * 2);
+        ArrayList<Long> list = new ArrayList<>(Flowable.bufferSize() * 2);
         for (long i = 1; i <= Flowable.bufferSize() * 2 + 1; i++) {
             list.add(i);
         }
 
         Observable<Long> o = Observable.rangeLong(1, list.size());
 
-        TestObserverEx<Long> to = new TestObserverEx<Long>();
+        TestObserverEx<Long> to = new TestObserverEx<>();
 
         o.subscribe(to);
 
@@ -137,7 +137,7 @@ public class ObservableRangeLongTest extends RxJavaTest {
 
     @Test
     public void nearMaxValueWithoutBackpressure() {
-        TestObserver<Long> to = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<>();
         Observable.rangeLong(Long.MAX_VALUE - 1L, 2L).subscribe(to);
 
         to.assertComplete();
@@ -171,7 +171,7 @@ public class ObservableRangeLongTest extends RxJavaTest {
 
     @Test
     public void fused() {
-        TestObserverEx<Long> to = new TestObserverEx<Long>(QueueFuseable.ANY);
+        TestObserverEx<Long> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.rangeLong(1, 2).subscribe(to);
 
@@ -181,7 +181,7 @@ public class ObservableRangeLongTest extends RxJavaTest {
 
     @Test
     public void fusedReject() {
-        TestObserverEx<Long> to = new TestObserverEx<Long>(QueueFuseable.ASYNC);
+        TestObserverEx<Long> to = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         Observable.rangeLong(1, 2).subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRangeTest.java
@@ -94,14 +94,14 @@ public class ObservableRangeTest extends RxJavaTest {
 
     @Test
     public void noBackpressure() {
-        ArrayList<Integer> list = new ArrayList<Integer>(Flowable.bufferSize() * 2);
+        ArrayList<Integer> list = new ArrayList<>(Flowable.bufferSize() * 2);
         for (int i = 1; i <= Flowable.bufferSize() * 2 + 1; i++) {
             list.add(i);
         }
 
         Observable<Integer> o = Observable.range(1, list.size());
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         o.subscribe(to);
 
@@ -138,7 +138,7 @@ public class ObservableRangeTest extends RxJavaTest {
 
     @Test
     public void nearMaxValueWithoutBackpressure() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(Integer.MAX_VALUE - 1, 2).subscribe(to);
 
         to.assertComplete();
@@ -158,7 +158,7 @@ public class ObservableRangeTest extends RxJavaTest {
 
     @Test
     public void requestWrongFusion() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC);
 
         Observable.range(1, 5)
         .subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRedoTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRedoTest.java
@@ -24,7 +24,7 @@ public class ObservableRedoTest extends RxJavaTest {
 
     @Test
     public void redoCancel() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1)
         .repeatWhen(new Function<Observable<Object>, ObservableSource<Object>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
@@ -190,8 +190,8 @@ public class ObservableRefCountTest extends RxJavaTest {
                 .publish().refCount();
 
         for (int i = 0; i < 10; i++) {
-            TestObserver<Long> to1 = new TestObserver<Long>();
-            TestObserver<Long> to2 = new TestObserver<Long>();
+            TestObserver<Long> to1 = new TestObserver<>();
+            TestObserver<Long> to2 = new TestObserver<>();
             r.subscribe(to1);
             r.subscribe(to2);
             try {
@@ -233,7 +233,7 @@ public class ObservableRefCountTest extends RxJavaTest {
                     }
                 });
 
-        TestObserverEx<Long> observer = new TestObserverEx<Long>();
+        TestObserverEx<Long> observer = new TestObserverEx<>();
         o.publish().refCount().subscribeOn(Schedulers.newThread()).subscribe(observer);
         System.out.println("send unsubscribe");
         // wait until connected
@@ -278,7 +278,7 @@ public class ObservableRefCountTest extends RxJavaTest {
                     }
                 });
 
-        TestObserverEx<Long> observer = new TestObserverEx<Long>();
+        TestObserverEx<Long> observer = new TestObserverEx<>();
 
         o.publish().refCount().subscribeOn(Schedulers.computation()).subscribe(observer);
         System.out.println("send unsubscribe");
@@ -367,7 +367,7 @@ public class ObservableRefCountTest extends RxJavaTest {
         Observable<Long> interval = Observable.interval(100, TimeUnit.MILLISECONDS, s).publish().refCount();
 
         // subscribe list1
-        final List<Long> list1 = new ArrayList<Long>();
+        final List<Long> list1 = new ArrayList<>();
         Disposable d1 = interval.subscribe(new Consumer<Long>() {
             @Override
             public void accept(Long t1) {
@@ -382,7 +382,7 @@ public class ObservableRefCountTest extends RxJavaTest {
         assertEquals(1L, list1.get(1).longValue());
 
         // subscribe list2
-        final List<Long> list2 = new ArrayList<Long>();
+        final List<Long> list2 = new ArrayList<>();
         Disposable d2 = interval.subscribe(new Consumer<Long>() {
             @Override
             public void accept(Long t1) {
@@ -427,7 +427,7 @@ public class ObservableRefCountTest extends RxJavaTest {
 
         // subscribing a new one should start over because the source should have been unsubscribed
         // subscribe list3
-        final List<Long> list3 = new ArrayList<Long>();
+        final List<Long> list3 = new ArrayList<>();
         interval.subscribe(new Consumer<Long>() {
             @Override
             public void accept(Long t1) {
@@ -498,8 +498,8 @@ public class ObservableRefCountTest extends RxJavaTest {
         })
         .publish().refCount();
 
-        TestObserverEx<Integer> to1 = new TestObserverEx<Integer>();
-        TestObserverEx<Integer> to2 = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to1 = new TestObserverEx<>();
+        TestObserverEx<Integer> to2 = new TestObserverEx<>();
 
         combined.subscribe(to1);
         combined.subscribe(to2);
@@ -1133,7 +1133,7 @@ public class ObservableRefCountTest extends RxJavaTest {
 
             final TestObserver<Integer> to1 = source.test();
 
-            final TestObserver<Integer> to2 = new TestObserver<Integer>();
+            final TestObserver<Integer> to2 = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1337,7 +1337,7 @@ public class ObservableRefCountTest extends RxJavaTest {
 
     @Test
     public void timeoutResetsSource() {
-        TestConnectableObservable<Object> tco = new TestConnectableObservable<Object>();
+        TestConnectableObservable<Object> tco = new TestConnectableObservable<>();
         ObservableRefCount<Object> o = (ObservableRefCount<Object>)tco.refCount();
 
         RefConnection rc = new RefConnection(o);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRepeatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRepeatTest.java
@@ -164,7 +164,7 @@ public class ObservableRepeatTest extends RxJavaTest {
                 .repeat(3)
                 .distinct();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         src.subscribe(to);
 
@@ -176,8 +176,8 @@ public class ObservableRepeatTest extends RxJavaTest {
     /** Issue #2844: wrong target of request. */
     @Test
     public void repeatRetarget() {
-        final List<Integer> concatBase = new ArrayList<Integer>();
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        final List<Integer> concatBase = new ArrayList<>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.just(1, 2)
         .repeat(5)
         .concatMap(new Function<Integer, Observable<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -729,7 +729,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         buf.addLast(new Node(4));
         buf.addLast(new Node(5));
 
-        List<Integer> values = new ArrayList<Integer>();
+        List<Integer> values = new ArrayList<>();
         buf.collect(values);
 
         Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), values);
@@ -753,8 +753,8 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void timedAndSizedTruncation() {
         TestScheduler test = new TestScheduler();
-        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test, false);
-        List<Integer> values = new ArrayList<Integer>();
+        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<>(2, 2000, TimeUnit.MILLISECONDS, test, false);
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
@@ -792,12 +792,12 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void timedAndSizedTruncationError() {
         TestScheduler test = new TestScheduler();
-        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test, false);
+        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<>(2, 2000, TimeUnit.MILLISECONDS, test, false);
 
         Assert.assertFalse(buf.hasCompleted());
         Assert.assertFalse(buf.hasError());
 
-        List<Integer> values = new ArrayList<Integer>();
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
@@ -835,8 +835,8 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void sizedTruncation() {
-        SizeBoundReplayBuffer<Integer> buf = new SizeBoundReplayBuffer<Integer>(2, false);
-        List<Integer> values = new ArrayList<Integer>();
+        SizeBoundReplayBuffer<Integer> buf = new SizeBoundReplayBuffer<>(2, false);
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         buf.next(2);
@@ -871,7 +871,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void coldReplayNoBackpressure() {
         Observable<Integer> source = Observable.range(0, 1000).replay().autoConnect();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         source.subscribe(to);
 
@@ -949,7 +949,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void take() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable<Integer> cached = Observable.range(1, 100).replay().autoConnect();
         cached.take(10).subscribe(to);
@@ -965,7 +965,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void async() {
         Observable<Integer> source = Observable.range(1, 10000);
         for (int i = 0; i < 100; i++) {
-            TestObserverEx<Integer> to1 = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to1 = new TestObserverEx<>();
 
             Observable<Integer> cached = source.replay().autoConnect();
 
@@ -976,7 +976,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
             to1.assertTerminated();
             assertEquals(10000, to1.values().size());
 
-            TestObserverEx<Integer> to2 = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to2 = new TestObserverEx<>();
             cached.observeOn(Schedulers.computation()).subscribe(to2);
 
             to2.awaitDone(2, TimeUnit.SECONDS);
@@ -995,14 +995,14 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
         Observable<Long> output = cached.observeOn(Schedulers.computation());
 
-        List<TestObserverEx<Long>> list = new ArrayList<TestObserverEx<Long>>(100);
+        List<TestObserverEx<Long>> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
-            TestObserverEx<Long> to = new TestObserverEx<Long>();
+            TestObserverEx<Long> to = new TestObserverEx<>();
             list.add(to);
             output.skip(i * 10).take(10).subscribe(to);
         }
 
-        List<Long> expected = new ArrayList<Long>();
+        List<Long> expected = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             expected.add((long)(i - 10));
         }
@@ -1036,7 +1036,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
             }
         });
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         firehose.replay().autoConnect().observeOn(Schedulers.computation()).takeLast(100).subscribe(to);
 
         to.awaitDone(3, TimeUnit.SECONDS);
@@ -1052,14 +1052,14 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
                 .concatWith(Observable.<Integer>error(new TestException()))
                 .replay().autoConnect();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         source.subscribe(to);
 
         to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         to.assertNotComplete();
         Assert.assertEquals(1, to.errors().size());
 
-        TestObserverEx<Integer> to2 = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to2 = new TestObserverEx<>();
         source.subscribe(to2);
 
         to2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -1130,8 +1130,8 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 3).replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
-            final TestObserver<Integer> to2 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
+            final TestObserver<Integer> to2 = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1156,8 +1156,8 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 3).replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
-            final TestObserver<Integer> to2 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
+            final TestObserver<Integer> to2 = new TestObserver<>();
 
             co.subscribe(to1);
 
@@ -1256,7 +1256,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
             final ConnectableObservable<Integer> co = ps.replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1285,7 +1285,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
             final ConnectableObservable<Integer> co = ps.replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
 
             co.subscribe(to1);
 
@@ -1314,7 +1314,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 1000).replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
 
             co.connect();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplayTest.java
@@ -729,7 +729,7 @@ public class ObservableReplayTest extends RxJavaTest {
         buf.addLast(new Node(4));
         buf.addLast(new Node(5));
 
-        List<Integer> values = new ArrayList<Integer>();
+        List<Integer> values = new ArrayList<>();
         buf.collect(values);
 
         Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), values);
@@ -753,8 +753,8 @@ public class ObservableReplayTest extends RxJavaTest {
     @Test
     public void timedAndSizedTruncation() {
         TestScheduler test = new TestScheduler();
-        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test, false);
-        List<Integer> values = new ArrayList<Integer>();
+        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<>(2, 2000, TimeUnit.MILLISECONDS, test, false);
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
@@ -792,12 +792,12 @@ public class ObservableReplayTest extends RxJavaTest {
     @Test
     public void timedAndSizedTruncationError() {
         TestScheduler test = new TestScheduler();
-        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test, false);
+        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<>(2, 2000, TimeUnit.MILLISECONDS, test, false);
 
         Assert.assertFalse(buf.hasCompleted());
         Assert.assertFalse(buf.hasError());
 
-        List<Integer> values = new ArrayList<Integer>();
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
@@ -835,8 +835,8 @@ public class ObservableReplayTest extends RxJavaTest {
 
     @Test
     public void sizedTruncation() {
-        SizeBoundReplayBuffer<Integer> buf = new SizeBoundReplayBuffer<Integer>(2, false);
-        List<Integer> values = new ArrayList<Integer>();
+        SizeBoundReplayBuffer<Integer> buf = new SizeBoundReplayBuffer<>(2, false);
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         buf.next(2);
@@ -871,7 +871,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void coldReplayNoBackpressure() {
         Observable<Integer> source = Observable.range(0, 1000).replay().autoConnect();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         source.subscribe(to);
 
@@ -949,7 +949,7 @@ public class ObservableReplayTest extends RxJavaTest {
 
     @Test
     public void take() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable<Integer> cached = Observable.range(1, 100).replay().autoConnect();
         cached.take(10).subscribe(to);
@@ -965,7 +965,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void async() {
         Observable<Integer> source = Observable.range(1, 10000);
         for (int i = 0; i < 100; i++) {
-            TestObserverEx<Integer> to1 = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to1 = new TestObserverEx<>();
 
             Observable<Integer> cached = source.replay().autoConnect();
 
@@ -976,7 +976,7 @@ public class ObservableReplayTest extends RxJavaTest {
             to1.assertTerminated();
             assertEquals(10000, to1.values().size());
 
-            TestObserverEx<Integer> to2 = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to2 = new TestObserverEx<>();
             cached.observeOn(Schedulers.computation()).subscribe(to2);
 
             to2.awaitDone(2, TimeUnit.SECONDS);
@@ -995,14 +995,14 @@ public class ObservableReplayTest extends RxJavaTest {
 
         Observable<Long> output = cached.observeOn(Schedulers.computation());
 
-        List<TestObserverEx<Long>> list = new ArrayList<TestObserverEx<Long>>(100);
+        List<TestObserverEx<Long>> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
-            TestObserverEx<Long> to = new TestObserverEx<Long>();
+            TestObserverEx<Long> to = new TestObserverEx<>();
             list.add(to);
             output.skip(i * 10).take(10).subscribe(to);
         }
 
-        List<Long> expected = new ArrayList<Long>();
+        List<Long> expected = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             expected.add((long)(i - 10));
         }
@@ -1036,7 +1036,7 @@ public class ObservableReplayTest extends RxJavaTest {
             }
         });
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         firehose.replay().autoConnect().observeOn(Schedulers.computation()).takeLast(100).subscribe(to);
 
         to.awaitDone(3, TimeUnit.SECONDS);
@@ -1052,14 +1052,14 @@ public class ObservableReplayTest extends RxJavaTest {
                 .concatWith(Observable.<Integer>error(new TestException()))
                 .replay().autoConnect();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         source.subscribe(to);
 
         to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         to.assertNotComplete();
         Assert.assertEquals(1, to.errors().size());
 
-        TestObserverEx<Integer> to2 = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to2 = new TestObserverEx<>();
         source.subscribe(to2);
 
         to2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -1130,8 +1130,8 @@ public class ObservableReplayTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 3).replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
-            final TestObserver<Integer> to2 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
+            final TestObserver<Integer> to2 = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1156,8 +1156,8 @@ public class ObservableReplayTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 3).replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
-            final TestObserver<Integer> to2 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
+            final TestObserver<Integer> to2 = new TestObserver<>();
 
             co.subscribe(to1);
 
@@ -1256,7 +1256,7 @@ public class ObservableReplayTest extends RxJavaTest {
 
             final ConnectableObservable<Integer> co = ps.replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1285,7 +1285,7 @@ public class ObservableReplayTest extends RxJavaTest {
 
             final ConnectableObservable<Integer> co = ps.replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
 
             co.subscribe(to1);
 
@@ -1314,7 +1314,7 @@ public class ObservableReplayTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableObservable<Integer> co = Observable.range(1, 1000).replay();
 
-            final TestObserver<Integer> to1 = new TestObserver<Integer>();
+            final TestObserver<Integer> to1 = new TestObserver<>();
 
             co.connect();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableResourceWrapperTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableResourceWrapperTest.java
@@ -27,8 +27,8 @@ public class ObservableResourceWrapperTest extends RxJavaTest {
 
     @Test
     public void disposed() {
-        TestObserver<Object> to = new TestObserver<Object>();
-        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<Object>(to);
+        TestObserver<Object> to = new TestObserver<>();
+        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<>(to);
 
         Disposable d = Disposable.empty();
 
@@ -43,16 +43,16 @@ public class ObservableResourceWrapperTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestObserver<Object> to = new TestObserver<Object>();
-        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<Object>(to);
+        TestObserver<Object> to = new TestObserver<>();
+        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<>(to);
 
         TestHelper.doubleOnSubscribe(orw);
     }
 
     @Test
     public void onErrorDisposes() {
-        TestObserver<Object> to = new TestObserver<Object>();
-        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<Object>(to);
+        TestObserver<Object> to = new TestObserver<>();
+        ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<>(to);
 
         Disposable d = Disposable.empty();
         Disposable d1 = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryTest.java
@@ -64,7 +64,7 @@ public class ObservableRetryTest extends RxJavaTest {
             }
 
         });
-        TestObserver<String> to = new TestObserver<String>(consumer);
+        TestObserver<String> to = new TestObserver<>(consumer);
         producer.retryWhen(new Function<Observable<? extends Throwable>, Observable<Object>>() {
 
             @Override
@@ -117,7 +117,7 @@ public class ObservableRetryTest extends RxJavaTest {
         Observer<String> observer = TestHelper.mockObserver();
         int numRetries = 20;
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(numRetries));
-        origin.retry().subscribe(new TestObserver<String>(observer));
+        origin.retry().subscribe(new TestObserver<>(observer));
 
         InOrder inOrder = inOrder(observer);
         // should show 3 attempts
@@ -136,7 +136,7 @@ public class ObservableRetryTest extends RxJavaTest {
         Observer<String> observer = TestHelper.mockObserver();
         int numRetries = 2;
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(numRetries));
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<Object>>() {
             @Override
             public Observable<Object> apply(Observable<? extends Throwable> t1) {
@@ -205,7 +205,7 @@ public class ObservableRetryTest extends RxJavaTest {
     public void onCompletedFromNotificationHandler() {
         Observer<String> observer = TestHelper.mockObserver();
         Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(1));
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         origin.retryWhen(new Function<Observable<? extends Throwable>, Observable<?>>() {
             @Override
             public Observable<?> apply(Observable<? extends Throwable> t1) {
@@ -455,7 +455,7 @@ public class ObservableRetryTest extends RxJavaTest {
     public void sourceObservableCallsUnsubscribe() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestObserver<String> to = new TestObserver<String>();
+        final TestObserver<String> to = new TestObserver<>();
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
@@ -486,7 +486,7 @@ public class ObservableRetryTest extends RxJavaTest {
     public void sourceObservableRetry1() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestObserver<String> to = new TestObserver<String>();
+        final TestObserver<String> to = new TestObserver<>();
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
@@ -505,7 +505,7 @@ public class ObservableRetryTest extends RxJavaTest {
     public void sourceObservableRetry0() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestObserver<String> to = new TestObserver<String>();
+        final TestObserver<String> to = new TestObserver<>();
 
         ObservableSource<String> onSubscribe = new ObservableSource<String>() {
             @Override
@@ -625,7 +625,7 @@ public class ObservableRetryTest extends RxJavaTest {
         SlowObservable so = new SlowObservable(100, 0, "testUnsubscribeAfterError");
         Observable<Long> o = Observable.unsafeCreate(so).retry(5);
 
-        AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
+        AsyncObserver<Long> async = new AsyncObserver<>(observer);
 
         o.subscribe(async);
 
@@ -649,7 +649,7 @@ public class ObservableRetryTest extends RxJavaTest {
         SlowObservable so = new SlowObservable(100, 10, "testTimeoutWithRetry");
         Observable<Long> o = Observable.unsafeCreate(so).timeout(80, TimeUnit.MILLISECONDS).retry(5);
 
-        AsyncObserver<Long> async = new AsyncObserver<Long>(observer);
+        AsyncObserver<Long> async = new AsyncObserver<>(observer);
 
         o.subscribe(async);
 
@@ -671,7 +671,7 @@ public class ObservableRetryTest extends RxJavaTest {
             for (int i = 0; i < 400; i++) {
                 Observer<String> observer = TestHelper.mockObserver();
                 Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
-                TestObserver<String> to = new TestObserver<String>(observer);
+                TestObserver<String> to = new TestObserver<>(observer);
                 origin.retry().observeOn(Schedulers.computation()).subscribe(to);
                 to.awaitDone(5, TimeUnit.SECONDS);
 
@@ -702,7 +702,7 @@ public class ObservableRetryTest extends RxJavaTest {
                 }
 
                 final AtomicInteger timeouts = new AtomicInteger();
-                final Map<Integer, List<String>> data = new ConcurrentHashMap<Integer, List<String>>();
+                final Map<Integer, List<String>> data = new ConcurrentHashMap<>();
 
                 int m = 5000;
                 final CountDownLatch cdl = new CountDownLatch(m);
@@ -714,11 +714,11 @@ public class ObservableRetryTest extends RxJavaTest {
                             final AtomicInteger nexts = new AtomicInteger();
                             try {
                                 Observable<String> origin = Observable.unsafeCreate(new FuncWithErrors(NUM_RETRIES));
-                                TestObserverEx<String> to = new TestObserverEx<String>();
+                                TestObserverEx<String> to = new TestObserverEx<>();
                                 origin.retry()
                                 .observeOn(Schedulers.computation()).subscribe(to);
                                 to.awaitDone(2500, TimeUnit.MILLISECONDS);
-                                List<String> onNextEvents = new ArrayList<String>(to.values());
+                                List<String> onNextEvents = new ArrayList<>(to.values());
                                 if (onNextEvents.size() != NUM_RETRIES + 2) {
                                     for (Throwable t : to.errors()) {
                                         onNextEvents.add(t.toString());
@@ -816,7 +816,7 @@ public class ObservableRetryTest extends RxJavaTest {
                 return t1.take(1);
             }
         })
-        .subscribe(new TestObserver<String>(observer));
+        .subscribe(new TestObserver<>(observer));
 
         InOrder inOrder = inOrder(observer);
         // should show 3 attempts
@@ -861,7 +861,7 @@ public class ObservableRetryTest extends RxJavaTest {
                 return t1.take(1);
             }
         })
-        .subscribe(new TestObserver<String>(observer));
+        .subscribe(new TestObserver<>(observer));
 
         InOrder inOrder = inOrder(observer);
         // should show 3 attempts

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -235,7 +235,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
                 .unsafeCreate(so)
                 .retry(retry5);
 
-        ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<Long>(observer);
+        ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<>(observer);
 
         o.subscribe(async);
 
@@ -262,7 +262,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
                 .timeout(80, TimeUnit.MILLISECONDS)
                 .retry(retry5);
 
-        ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<Long>(observer);
+        ObservableRetryTest.AsyncObserver<Long> async = new ObservableRetryTest.AsyncObserver<>(observer);
 
         o.subscribe(async);
 
@@ -278,7 +278,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void issue2826() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         final RuntimeException e = new RuntimeException("You shall not pass");
         final AtomicInteger c = new AtomicInteger();
         Observable.just(1).map(new Function<Integer, Integer>() {
@@ -312,7 +312,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void issue3008RetryWithPredicate() {
-        final List<Long> list = new CopyOnWriteArrayList<Long>();
+        final List<Long> list = new CopyOnWriteArrayList<>();
         final AtomicBoolean isFirst = new AtomicBoolean(true);
         Observable.<Long> just(1L, 2L, 3L).map(new Function<Long, Long>() {
             @Override
@@ -340,7 +340,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void issue3008RetryInfinite() {
-        final List<Long> list = new CopyOnWriteArrayList<Long>();
+        final List<Long> list = new CopyOnWriteArrayList<>();
         final AtomicBoolean isFirst = new AtomicBoolean(true);
         Observable.<Long> just(1L, 2L, 3L).map(new Function<Long, Long>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScalarXMapTest.java
@@ -59,7 +59,7 @@ public class ObservableScalarXMapTest extends RxJavaTest {
     static final class OneCallablePublisher implements ObservableSource<Integer>, Supplier<Integer> {
         @Override
         public void subscribe(Observer<? super Integer> observer) {
-            ScalarDisposable<Integer> sd = new ScalarDisposable<Integer>(observer, 1);
+            ScalarDisposable<Integer> sd = new ScalarDisposable<>(observer, 1);
             observer.onSubscribe(sd);
             sd.run();
         }
@@ -72,7 +72,7 @@ public class ObservableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void tryScalarXMap() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new CallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
             public ObservableSource<Integer> apply(Integer f) throws Exception {
@@ -85,7 +85,7 @@ public class ObservableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void emptyXMap() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new EmptyCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
@@ -99,7 +99,7 @@ public class ObservableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void mapperCrashes() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
@@ -113,7 +113,7 @@ public class ObservableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void mapperToJust() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
@@ -127,7 +127,7 @@ public class ObservableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void mapperToEmpty() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
@@ -141,7 +141,7 @@ public class ObservableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void mapperToCrashingCallable() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         assertTrue(ObservableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), to, new Function<Integer, ObservableSource<Integer>>() {
             @Override
@@ -179,8 +179,8 @@ public class ObservableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void scalarDisposableStateCheck() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
-        ScalarDisposable<Integer> sd = new ScalarDisposable<Integer>(to, 1);
+        TestObserver<Integer> to = new TestObserver<>();
+        ScalarDisposable<Integer> sd = new ScalarDisposable<>(to, 1);
         to.onSubscribe(sd);
 
         assertFalse(sd.isDisposed());
@@ -213,8 +213,8 @@ public class ObservableScalarXMapTest extends RxJavaTest {
     @Test
     public void scalarDisposableRunDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
-            final ScalarDisposable<Integer> sd = new ScalarDisposable<Integer>(to, 1);
+            TestObserver<Integer> to = new TestObserver<>();
+            final ScalarDisposable<Integer> sd = new ScalarDisposable<>(to, 1);
             to.onSubscribe(sd);
 
             Runnable r1 = new Runnable() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScanTest.java
@@ -114,7 +114,7 @@ public class ObservableScanTest extends RxJavaTest {
 
     @Test
     public void shouldNotEmitUntilAfterSubscription() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, 100).scan(0, new BiFunction<Integer, Integer, Integer>() {
 
             @Override
@@ -181,7 +181,7 @@ public class ObservableScanTest extends RxJavaTest {
 
                     @Override
                     public List<Integer> get() {
-                        return new ArrayList<Integer>();
+                        return new ArrayList<>();
                     }
 
                 }, new BiConsumer<List<Integer>, Integer>() {
@@ -208,7 +208,7 @@ public class ObservableScanTest extends RxJavaTest {
 
         }).take(1);
 
-        TestObserverEx<Integer> observer = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> observer = new TestObserverEx<>();
 
         o.subscribe(observer);
         observer.assertValue(0);
@@ -220,7 +220,7 @@ public class ObservableScanTest extends RxJavaTest {
     public void initialValueEmittedNoProducer() {
         PublishSubject<Integer> source = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         source.scan(0, new BiFunction<Integer, Integer, Integer>() {
             @Override
@@ -310,7 +310,7 @@ public class ObservableScanTest extends RxJavaTest {
     public void scanFunctionThrowsAndUpstreamErrorsDoesNotResultInTwoTerminalEvents() {
         final RuntimeException err = new RuntimeException();
         final RuntimeException err2 = new RuntimeException();
-        final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+        final List<Throwable> list = new CopyOnWriteArrayList<>();
         final Consumer<Throwable> errorConsumer = new Consumer<Throwable>() {
             @Override
             public void accept(Throwable t) throws Exception {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSingleTest.java
@@ -465,7 +465,7 @@ public class ObservableSingleTest extends RxJavaTest {
     @Test
     public void singleElementOperatorDoNotSwallowExceptionWhenDone() {
         final Throwable exception = new RuntimeException("some error");
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         try {
             RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipLastTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipLastTest.java
@@ -84,7 +84,7 @@ public class ObservableSkipLastTest extends RxJavaTest {
     @Test
     public void skipLastWithBackpressure() {
         Observable<Integer> o = Observable.range(0, Flowable.bufferSize() * 2).skipLast(Flowable.bufferSize() + 10);
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         o.observeOn(Schedulers.computation()).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipTest.java
@@ -138,7 +138,7 @@ public class ObservableSkipTest extends RxJavaTest {
 
     @Test
     public void requestOverflowDoesNotOccur() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.range(1, 10).skip(5).subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSubscribeOnTest.java
@@ -36,7 +36,7 @@ public class ObservableSubscribeOnTest extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable
         .unsafeCreate(new ObservableSource<Integer>() {
@@ -74,7 +74,7 @@ public class ObservableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void onError() {
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
         Observable.unsafeCreate(new ObservableSource<String>() {
 
             @Override
@@ -147,7 +147,7 @@ public class ObservableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void unsubscribeInfiniteStream() throws InterruptedException {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         final AtomicInteger count = new AtomicInteger();
         Observable.unsafeCreate(new ObservableSource<Integer>() {
 
@@ -174,7 +174,7 @@ public class ObservableSubscribeOnTest extends RxJavaTest {
     public void cancelBeforeActualSubscribe() {
         TestScheduler test = new TestScheduler();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(1).hide()
                 .subscribeOn(test).subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchTest.java
@@ -995,7 +995,7 @@ public class ObservableSwitchTest extends RxJavaTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
-                final AtomicReference<Observer<? super Integer>> obs1 = new AtomicReference<Observer<? super Integer>>();
+                final AtomicReference<Observer<? super Integer>> obs1 = new AtomicReference<>();
                 final Observable<Integer> ps1 = new Observable<Integer>() {
                     @Override
                     protected void subscribeActual(
@@ -1003,7 +1003,7 @@ public class ObservableSwitchTest extends RxJavaTest {
                         obs1.set(observer);
                     }
                 };
-                final AtomicReference<Observer<? super Integer>> obs2 = new AtomicReference<Observer<? super Integer>>();
+                final AtomicReference<Observer<? super Integer>> obs2 = new AtomicReference<>();
                 final Observable<Integer> ps2 = new Observable<Integer>() {
                     @Override
                     protected void subscribeActual(
@@ -1203,7 +1203,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void undeliverableUponCancel() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            final TestObserverEx<Integer> to = new TestObserverEx<>();
 
             Observable.just(1)
             .map(new Function<Integer, Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLastOneTest.java
@@ -28,7 +28,7 @@ public class ObservableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void lastOfManyReturnsLast() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         Observable.range(1, 10).takeLast(1).subscribe(to);
         to.assertValue(10);
         to.assertNoErrors();
@@ -37,7 +37,7 @@ public class ObservableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void lastOfEmptyReturnsEmpty() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         Observable.empty().takeLast(1).subscribe(to);
         to.assertNoValues();
         to.assertNoErrors();
@@ -46,7 +46,7 @@ public class ObservableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void lastOfOneReturnsLast() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         Observable.just(1).takeLast(1).subscribe(to);
         to.assertValue(1);
         to.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLastTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLastTest.java
@@ -90,7 +90,7 @@ public class ObservableTakeLastTest extends RxJavaTest {
 
     @Test
     public void backpressure1() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, 100000).takeLast(1)
         .observeOn(Schedulers.newThread())
         .map(newSlowProcessor()).subscribe(to);
@@ -101,7 +101,7 @@ public class ObservableTakeLastTest extends RxJavaTest {
 
     @Test
     public void backpressure2() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, 100000).takeLast(Flowable.bufferSize() * 4)
         .observeOn(Schedulers.newThread()).map(newSlowProcessor()).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeTest.java
@@ -257,7 +257,7 @@ public class ObservableTakeTest extends RxJavaTest {
     @Test
     public void takeObserveOn() {
         Observer<Object> o = TestHelper.mockObserver();
-        TestObserver<Object> to = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<>(o);
 
         INFINITE_OBSERVABLE
         .observeOn(Schedulers.newThread()).take(1).subscribe(to);
@@ -272,7 +272,7 @@ public class ObservableTakeTest extends RxJavaTest {
 
     @Test
     public void interrupt() throws InterruptedException {
-        final AtomicReference<Object> exception = new AtomicReference<Object>();
+        final AtomicReference<Object> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         Observable.just(1).subscribeOn(Schedulers.computation()).take(1)
         .subscribe(new Consumer<Integer>() {
@@ -317,7 +317,7 @@ public class ObservableTakeTest extends RxJavaTest {
     public void reentrantTake() {
         final PublishSubject<Integer> source = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         source.take(1).doOnNext(new Consumer<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeUntilPredicateTest.java
@@ -141,7 +141,7 @@ public class ObservableTakeUntilPredicateTest extends RxJavaTest {
 
     @Test
     public void errorIncludesLastValueAsCause() {
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
         final TestException e = new TestException("Forced failure");
         Predicate<String> predicate = (new Predicate<String>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeUntilTest.java
@@ -190,7 +190,7 @@ public class ObservableTakeUntilTest extends RxJavaTest {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         source.takeUntil(until).subscribe(to);
 
@@ -217,7 +217,7 @@ public class ObservableTakeUntilTest extends RxJavaTest {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         source.takeUntil(until).subscribe(to);
 
@@ -242,7 +242,7 @@ public class ObservableTakeUntilTest extends RxJavaTest {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> until = PublishSubject.create();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         source.takeUntil(until).take(1).subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeWhileTest.java
@@ -223,7 +223,7 @@ public class ObservableTakeWhileTest extends RxJavaTest {
                 return t1 < 2;
             }
         });
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         source.subscribe(to);
 
@@ -236,7 +236,7 @@ public class ObservableTakeWhileTest extends RxJavaTest {
 
     @Test
     public void errorCauseIncludesLastValue() {
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
         Observable.just("abc").takeWhile(new Predicate<String>() {
             @Override
             public boolean test(String t1) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeIntervalTest.java
@@ -60,11 +60,11 @@ public class ObservableTimeIntervalTest extends RxJavaTest {
         subject.onComplete();
 
         inOrder.verify(observer, times(1)).onNext(
-                new Timed<Integer>(1, 1000, TIME_UNIT));
+                new Timed<>(1, 1000, TIME_UNIT));
         inOrder.verify(observer, times(1)).onNext(
-                new Timed<Integer>(2, 2000, TIME_UNIT));
+                new Timed<>(2, 2000, TIME_UNIT));
         inOrder.verify(observer, times(1)).onNext(
-                new Timed<Integer>(3, 3000, TIME_UNIT));
+                new Timed<>(3, 3000, TIME_UNIT));
         inOrder.verify(observer, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutTests.java
@@ -51,7 +51,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldNotTimeoutIfOnNextWithinTimeout() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
 
         withTimeout.subscribe(to);
 
@@ -66,7 +66,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldNotTimeoutIfSecondOnNextWithinTimeout() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
 
         withTimeout.subscribe(to);
 
@@ -82,7 +82,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
 
     @Test
     public void shouldTimeoutIfOnNextNotWithinTimeout() {
-        TestObserverEx<String> observer = new TestObserverEx<String>();
+        TestObserverEx<String> observer = new TestObserverEx<>();
 
         withTimeout.subscribe(observer);
 
@@ -92,7 +92,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
 
     @Test
     public void shouldTimeoutIfSecondOnNextNotWithinTimeout() {
-        TestObserverEx<String> observer = new TestObserverEx<String>();
+        TestObserverEx<String> observer = new TestObserverEx<>();
         withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
@@ -104,7 +104,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldCompleteIfUnderlyingComletes() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onComplete();
@@ -117,7 +117,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldErrorIfUnderlyingErrors() {
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onError(new UnsupportedOperationException());
@@ -132,7 +132,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         source.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -155,7 +155,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         source.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -178,7 +178,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         source.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -201,7 +201,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
         Observable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         source.subscribe(to);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -231,7 +231,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
         final CountDownLatch exit = new CountDownLatch(1);
         final CountDownLatch timeoutSetuped = new CountDownLatch(1);
 
-        final TestObserverEx<String> observer = new TestObserverEx<String>();
+        final TestObserverEx<String> observer = new TestObserverEx<>();
 
         new Thread(new Runnable() {
 
@@ -280,7 +280,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
         TestScheduler testScheduler = new TestScheduler();
         Observable<String> observableWithTimeout = never.timeout(1000, TimeUnit.MILLISECONDS, testScheduler);
 
-        TestObserverEx<String> observer = new TestObserverEx<String>();
+        TestObserverEx<String> observer = new TestObserverEx<>();
         observableWithTimeout.subscribe(observer);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -329,7 +329,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
         }).when(o).onComplete();
 
-        final TestObserver<Integer> to = new TestObserver<Integer>(o);
+        final TestObserver<Integer> to = new TestObserver<>(o);
 
         new Thread(new Runnable() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimerTest.java
@@ -64,7 +64,7 @@ public class ObservableTimerTest extends RxJavaTest {
 
     @Test
     public void timerPeriodically() {
-        TestObserver<Long> to = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<>();
 
         Observable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler).subscribe(to);
 
@@ -92,7 +92,7 @@ public class ObservableTimerTest extends RxJavaTest {
     @Test
     public void interval() {
         Observable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler);
-        TestObserver<Long> to = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<>();
         w.subscribe(to);
 
         to.assertNoValues();
@@ -117,8 +117,8 @@ public class ObservableTimerTest extends RxJavaTest {
     public void withMultipleSubscribersStartingAtSameTime() {
         Observable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler);
 
-        TestObserver<Long> to1 = new TestObserver<Long>();
-        TestObserver<Long> to2 = new TestObserver<Long>();
+        TestObserver<Long> to1 = new TestObserver<>();
+        TestObserver<Long> to2 = new TestObserver<>();
 
         w.subscribe(to1);
         w.subscribe(to2);
@@ -154,7 +154,7 @@ public class ObservableTimerTest extends RxJavaTest {
     public void withMultipleStaggeredSubscribers() {
         Observable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler);
 
-        TestObserver<Long> to1 = new TestObserver<Long>();
+        TestObserver<Long> to1 = new TestObserver<>();
 
         w.subscribe(to1);
 
@@ -162,7 +162,7 @@ public class ObservableTimerTest extends RxJavaTest {
 
         scheduler.advanceTimeTo(2, TimeUnit.SECONDS);
 
-        TestObserver<Long> to2 = new TestObserver<Long>();
+        TestObserver<Long> to2 = new TestObserver<>();
 
         w.subscribe(to2);
 
@@ -194,7 +194,7 @@ public class ObservableTimerTest extends RxJavaTest {
     public void withMultipleStaggeredSubscribersAndPublish() {
         ConnectableObservable<Long> w = Observable.interval(1, TimeUnit.SECONDS, scheduler).publish();
 
-        TestObserver<Long> to1 = new TestObserver<Long>();
+        TestObserver<Long> to1 = new TestObserver<>();
 
         w.subscribe(to1);
         w.connect();
@@ -203,7 +203,7 @@ public class ObservableTimerTest extends RxJavaTest {
 
         scheduler.advanceTimeTo(2, TimeUnit.SECONDS);
 
-        TestObserver<Long> to2 = new TestObserver<Long>();
+        TestObserver<Long> to2 = new TestObserver<>();
         w.subscribe(to2);
 
         to1.assertValues(0L, 1L);
@@ -348,7 +348,7 @@ public class ObservableTimerTest extends RxJavaTest {
 
     @Test
     public void cancelledAndRun() {
-        TestObserver<Long> to = new TestObserver<Long>();
+        TestObserver<Long> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
         TimerObserver tm = new TimerObserver(to);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimestampTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimestampTest.java
@@ -52,9 +52,9 @@ public class ObservableTimestampTest extends RxJavaTest {
 
         InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(2, 100, TimeUnit.MILLISECONDS));
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(2, 100, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(3, 200, TimeUnit.MILLISECONDS));
 
         verify(observer, never()).onError(any(Throwable.class));
         verify(observer, never()).onComplete();
@@ -76,9 +76,9 @@ public class ObservableTimestampTest extends RxJavaTest {
 
         InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(2, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(observer, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(2, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(observer, times(1)).onNext(new Timed<>(3, 200, TimeUnit.MILLISECONDS));
 
         verify(observer, never()).onError(any(Throwable.class));
         verify(observer, never()).onComplete();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToFutureTest.java
@@ -37,7 +37,7 @@ public class ObservableToFutureTest extends RxJavaTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        TestObserver<Object> to = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<>(o);
 
         Observable.fromFuture(future).subscribe(to);
 
@@ -59,7 +59,7 @@ public class ObservableToFutureTest extends RxJavaTest {
         Observer<Object> o = TestHelper.mockObserver();
 
         TestScheduler scheduler = new TestScheduler();
-        TestObserver<Object> to = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<>(o);
 
         Observable.fromFuture(future, scheduler).subscribe(to);
 
@@ -79,7 +79,7 @@ public class ObservableToFutureTest extends RxJavaTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        TestObserver<Object> to = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<>(o);
 
         Observable.fromFuture(future).subscribe(to);
 
@@ -100,7 +100,7 @@ public class ObservableToFutureTest extends RxJavaTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        TestObserver<Object> to = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<>(o);
         to.dispose();
 
         Observable.fromFuture(future).subscribe(to);
@@ -146,7 +146,7 @@ public class ObservableToFutureTest extends RxJavaTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        TestObserver<Object> to = new TestObserver<Object>(o);
+        TestObserver<Object> to = new TestObserver<>(o);
         Observable<Object> futureObservable = Observable.fromFuture(future);
 
         futureObservable.subscribeOn(Schedulers.computation()).subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToMapTest.java
@@ -55,7 +55,7 @@ public class ObservableToMapTest extends RxJavaTest {
 
         Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc).toObservable();
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "a");
         expected.put(2, "bb");
         expected.put(3, "ccc");
@@ -74,7 +74,7 @@ public class ObservableToMapTest extends RxJavaTest {
 
         Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate).toObservable();
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "aa");
         expected.put(2, "bbbb");
         expected.put(3, "cccccc");
@@ -102,7 +102,7 @@ public class ObservableToMapTest extends RxJavaTest {
         };
         Observable<Map<Integer, String>> mapped = source.toMap(lengthFuncErr).toObservable();
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "a");
         expected.put(2, "bb");
         expected.put(3, "ccc");
@@ -132,7 +132,7 @@ public class ObservableToMapTest extends RxJavaTest {
 
         Observable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr).toObservable();
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "aa");
         expected.put(2, "bbbb");
         expected.put(3, "cccccc");
@@ -178,7 +178,7 @@ public class ObservableToMapTest extends RxJavaTest {
             }
         }, mapFactory).toObservable();
 
-        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
         expected.put(3, "ccc");
         expected.put(4, "dddd");
@@ -214,7 +214,7 @@ public class ObservableToMapTest extends RxJavaTest {
             }
         }, mapFactory).toObservable();
 
-        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
         expected.put(3, "ccc");
         expected.put(4, "dddd");
@@ -232,7 +232,7 @@ public class ObservableToMapTest extends RxJavaTest {
 
         Single<Map<Integer, String>> mapped = source.toMap(lengthFunc);
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "a");
         expected.put(2, "bb");
         expected.put(3, "ccc");
@@ -250,7 +250,7 @@ public class ObservableToMapTest extends RxJavaTest {
 
         Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate);
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "aa");
         expected.put(2, "bbbb");
         expected.put(3, "cccccc");
@@ -277,7 +277,7 @@ public class ObservableToMapTest extends RxJavaTest {
         };
         Single<Map<Integer, String>> mapped = source.toMap(lengthFuncErr);
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "a");
         expected.put(2, "bb");
         expected.put(3, "ccc");
@@ -306,7 +306,7 @@ public class ObservableToMapTest extends RxJavaTest {
 
         Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr);
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "aa");
         expected.put(2, "bbbb");
         expected.put(3, "cccccc");
@@ -351,7 +351,7 @@ public class ObservableToMapTest extends RxJavaTest {
             }
         }, mapFactory);
 
-        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
         expected.put(3, "ccc");
         expected.put(4, "dddd");
@@ -386,7 +386,7 @@ public class ObservableToMapTest extends RxJavaTest {
             }
         }, mapFactory);
 
-        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
         expected.put(3, "ccc");
         expected.put(4, "dddd");

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToMultimapTest.java
@@ -55,7 +55,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc).toObservable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
@@ -72,7 +72,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate).toObservable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
@@ -114,11 +114,11 @@ public class ObservableToMultimapTest extends RxJavaTest {
                 mapFactory, new Function<Integer, Collection<String>>() {
                     @Override
                     public Collection<String> apply(Integer v) {
-                        return new ArrayList<String>();
+                        return new ArrayList<>();
                     }
                 }).toObservable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
@@ -137,9 +137,9 @@ public class ObservableToMultimapTest extends RxJavaTest {
             @Override
             public Collection<String> apply(Integer t1) {
                 if (t1 == 2) {
-                    return new ArrayList<String>();
+                    return new ArrayList<>();
                 } else {
-                    return new HashSet<String>();
+                    return new HashSet<>();
                 }
             }
         };
@@ -153,16 +153,16 @@ public class ObservableToMultimapTest extends RxJavaTest {
         Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
             public Map<Integer, Collection<String>> get() {
-                return new HashMap<Integer, Collection<String>>();
+                return new HashMap<>();
             }
         };
 
         Observable<Map<Integer, Collection<String>>> mapped = source
                 .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory).toObservable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
-        expected.put(3, new HashSet<String>(Arrays.asList("eee")));
+        expected.put(3, new HashSet<>(Arrays.asList("eee")));
 
         mapped.subscribe(objectObserver);
 
@@ -187,7 +187,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr).toObservable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
@@ -214,7 +214,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr).toObservable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
@@ -244,7 +244,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
                     }
                 }, mapFactory).toObservable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
@@ -265,7 +265,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
                 if (t1 == 2) {
                     throw new RuntimeException("Forced failure");
                 } else {
-                    return new HashSet<String>();
+                    return new HashSet<>();
                 }
             }
         };
@@ -279,14 +279,14 @@ public class ObservableToMultimapTest extends RxJavaTest {
         Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
             public Map<Integer, Collection<String>> get() {
-                return new HashMap<Integer, Collection<String>>();
+                return new HashMap<>();
             }
         };
 
         Observable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
                 identity, mapSupplier, collectionFactory).toObservable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Collections.singleton("eee"));
 
@@ -303,7 +303,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
@@ -319,7 +319,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
@@ -360,11 +360,11 @@ public class ObservableToMultimapTest extends RxJavaTest {
                 mapFactory, new Function<Integer, Collection<String>>() {
                     @Override
                     public Collection<String> apply(Integer v) {
-                        return new ArrayList<String>();
+                        return new ArrayList<>();
                     }
                 });
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
@@ -382,9 +382,9 @@ public class ObservableToMultimapTest extends RxJavaTest {
             @Override
             public Collection<String> apply(Integer t1) {
                 if (t1 == 2) {
-                    return new ArrayList<String>();
+                    return new ArrayList<>();
                 } else {
-                    return new HashSet<String>();
+                    return new HashSet<>();
                 }
             }
         };
@@ -398,16 +398,16 @@ public class ObservableToMultimapTest extends RxJavaTest {
         Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
             public Map<Integer, Collection<String>> get() {
-                return new HashMap<Integer, Collection<String>>();
+                return new HashMap<>();
             }
         };
 
         Single<Map<Integer, Collection<String>>> mapped = source
                 .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
-        expected.put(3, new HashSet<String>(Arrays.asList("eee")));
+        expected.put(3, new HashSet<>(Arrays.asList("eee")));
 
         mapped.subscribe(singleObserver);
 
@@ -431,7 +431,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
@@ -457,7 +457,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
@@ -486,7 +486,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
                     }
                 }, mapFactory);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
@@ -506,7 +506,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
                 if (t1 == 2) {
                     throw new RuntimeException("Forced failure");
                 } else {
-                    return new HashSet<String>();
+                    return new HashSet<>();
                 }
             }
         };
@@ -520,14 +520,14 @@ public class ObservableToMultimapTest extends RxJavaTest {
         Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
             public Map<Integer, Collection<String>> get() {
-                return new HashMap<Integer, Collection<String>>();
+                return new HashMap<>();
             }
         };
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
                 identity, mapSupplier, collectionFactory);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Collections.singleton("eee"));
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUnsubscribeOnTest.java
@@ -37,7 +37,7 @@ public class ObservableUnsubscribeOnTest extends RxJavaTest {
         UIEventLoopScheduler uiEventLoop = new UIEventLoopScheduler();
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
-            final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
+            final AtomicReference<Thread> subscribeThread = new AtomicReference<>();
             Observable<Integer> w = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
                 @Override
@@ -53,7 +53,7 @@ public class ObservableUnsubscribeOnTest extends RxJavaTest {
                 }
             });
 
-            TestObserverEx<Integer> observer = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> observer = new TestObserverEx<>();
 
             w.subscribeOn(uiEventLoop).observeOn(Schedulers.computation())
             .unsubscribeOn(uiEventLoop)
@@ -87,7 +87,7 @@ public class ObservableUnsubscribeOnTest extends RxJavaTest {
         UIEventLoopScheduler uiEventLoop = new UIEventLoopScheduler();
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
-            final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
+            final AtomicReference<Thread> subscribeThread = new AtomicReference<>();
             Observable<Integer> w = Observable.unsafeCreate(new ObservableSource<Integer>() {
 
                 @Override
@@ -103,7 +103,7 @@ public class ObservableUnsubscribeOnTest extends RxJavaTest {
                 }
             });
 
-            TestObserverEx<Integer> observer = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> observer = new TestObserverEx<>();
 
             w.subscribeOn(Schedulers.newThread()).observeOn(Schedulers.computation())
             .unsubscribeOn(uiEventLoop)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUsingTest.java
@@ -232,7 +232,7 @@ public class ObservableUsingTest extends RxJavaTest {
 
     @Test
     public void usingDisposesEagerlyBeforeCompletion() {
-        final List<String> events = new ArrayList<String>();
+        final List<String> events = new ArrayList<>();
         Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
@@ -259,7 +259,7 @@ public class ObservableUsingTest extends RxJavaTest {
 
     @Test
     public void usingDoesNotDisposesEagerlyBeforeCompletion() {
-        final List<String> events = new ArrayList<String>();
+        final List<String> events = new ArrayList<>();
         Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
@@ -286,7 +286,7 @@ public class ObservableUsingTest extends RxJavaTest {
 
     @Test
     public void usingDisposesEagerlyBeforeError() {
-        final List<String> events = new ArrayList<String>();
+        final List<String> events = new ArrayList<>();
         Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
@@ -314,7 +314,7 @@ public class ObservableUsingTest extends RxJavaTest {
 
     @Test
     public void usingDoesNotDisposesEagerlyBeforeError() {
-        final List<String> events = new ArrayList<String>();
+        final List<String> events = new ArrayList<>();
         final Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
@@ -533,7 +533,7 @@ public class ObservableUsingTest extends RxJavaTest {
 
     @Test
     public void eagerDisposedOnComplete() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.using(Functions.justSupplier(1), Functions.justFunction(new Observable<Integer>() {
             @Override
@@ -548,7 +548,7 @@ public class ObservableUsingTest extends RxJavaTest {
 
     @Test
     public void eagerDisposedOnError() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.using(Functions.justSupplier(1), Functions.justFunction(new Observable<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -44,7 +44,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final Observer<Object> o = TestHelper.mockObserver();
 
-        final List<Observer<Object>> values = new ArrayList<Observer<Object>>();
+        final List<Observer<Object>> values = new ArrayList<>();
 
         Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() {
             @Override
@@ -101,7 +101,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final Observer<Object> o = TestHelper.mockObserver();
 
-        final List<Observer<Object>> values = new ArrayList<Observer<Object>>();
+        final List<Observer<Object>> values = new ArrayList<>();
 
         Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() {
             @Override
@@ -157,7 +157,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final Observer<Object> o = TestHelper.mockObserver();
 
-        final List<Observer<Object>> values = new ArrayList<Observer<Object>>();
+        final List<Observer<Object>> values = new ArrayList<>();
 
         Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() {
             @Override
@@ -207,7 +207,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final Observer<Object> o = TestHelper.mockObserver();
 
-        final List<Observer<Object>> values = new ArrayList<Observer<Object>>();
+        final List<Observer<Object>> values = new ArrayList<>();
 
         Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() {
             @Override
@@ -368,7 +368,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
     public void mainAndBoundaryBothError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Observer<? super Object>> ref = new AtomicReference<Observer<? super Object>>();
+            final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
             TestObserverEx<Observable<Object>> to = Observable.error(new TestException("main"))
             .window(new Observable<Object>() {
@@ -407,8 +407,8 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<Observer<? super Object>>();
-                final AtomicReference<Observer<? super Object>> ref = new AtomicReference<Observer<? super Object>>();
+                final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
+                final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
                 TestObserverEx<Observable<Object>> to = new Observable<Object>() {
                     @Override
@@ -457,8 +457,8 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
     @Test
     public void mainNextBoundaryNextRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<Observer<? super Object>>();
-            final AtomicReference<Observer<? super Object>> ref = new AtomicReference<Observer<? super Object>>();
+            final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
+            final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
             TestObserver<Observable<Object>> to = new Observable<Object>() {
                 @Override
@@ -500,8 +500,8 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
     @Test
     public void takeOneAnotherBoundary() {
-        final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<Observer<? super Object>>();
-        final AtomicReference<Observer<? super Object>> ref = new AtomicReference<Observer<? super Object>>();
+        final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
+        final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
         TestObserverEx<Observable<Object>> to = new Observable<Object>() {
             @Override
@@ -532,8 +532,8 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
     @Test
     public void disposeMainBoundaryCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<Observer<? super Object>>();
-            final AtomicReference<Observer<? super Object>> ref = new AtomicReference<Observer<? super Object>>();
+            final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
+            final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
             final TestObserver<Observable<Object>> to = new Observable<Object>() {
                  @Override
@@ -590,8 +590,8 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
         final TestException ex = new TestException();
 
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-           final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<Observer<? super Object>>();
-           final AtomicReference<Observer<? super Object>> ref = new AtomicReference<Observer<? super Object>>();
+           final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
+           final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
            final TestObserver<Observable<Object>> to = new Observable<Object>() {
                @Override
@@ -671,7 +671,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstream() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<>();
 
         TestObserver<Observable<Integer>> to = ps.window(Observable.<Integer>never())
         .doOnNext(new Consumer<Observable<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -36,7 +36,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
 
     private static <T> List<List<T>> toLists(Observable<Observable<T>> observables) {
 
-        final List<List<T>> lists = new ArrayList<List<T>>();
+        final List<List<T>> lists = new ArrayList<>();
         Observable.concatEager(observables.map(new Function<Observable<T>, Observable<List<T>>>() {
             @Override
             public Observable<List<T>> apply(Observable<T> xs) {
@@ -106,7 +106,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void windowUnsubscribeNonOverlapping() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 10000).doOnNext(new Consumer<Integer>() {
@@ -128,7 +128,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void windowUnsubscribeNonOverlappingAsyncSource() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 100000)
@@ -161,7 +161,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void windowUnsubscribeOverlapping() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 10000).doOnNext(new Consumer<Integer>() {
@@ -183,7 +183,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void windowUnsubscribeOverlappingAsyncSource() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 100000)
@@ -208,7 +208,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String arg : args) {
             list.add(arg);
         }
@@ -241,7 +241,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void takeFlatMapCompletes() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         final int indicator = 999999999;
 
@@ -405,7 +405,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamSize() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<>();
 
         TestObserver<Observable<Integer>> to = ps.window(10)
         .take(1)
@@ -459,7 +459,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamSkip() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<>();
 
         TestObserver<Observable<Integer>> to = ps.window(5, 10)
         .take(1)
@@ -513,7 +513,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamOverlap() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<>();
 
         TestObserver<Observable<Integer>> to = ps.window(5, 3)
         .take(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -47,8 +47,8 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
 
     @Test
     public void observableBasedOpenerAndCloser() {
-        final List<String> list = new ArrayList<String>();
-        final List<List<String>> lists = new ArrayList<List<String>>();
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
 
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
@@ -97,7 +97,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String arg : args) {
             list.add(arg);
         }
@@ -129,7 +129,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
                 stringObservable.subscribe(new DefaultObserver<String>() {
                     @Override
                     public void onComplete() {
-                        lists.add(new ArrayList<String>(list));
+                        lists.add(new ArrayList<>(list));
                         list.clear();
                     }
 
@@ -154,7 +154,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
         PublishSubject<Integer> open = PublishSubject.create();
         final PublishSubject<Integer> close = PublishSubject.create();
 
-        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
+        TestObserver<Observable<Integer>> to = new TestObserver<>();
 
         source.window(open, new Function<Integer, Observable<Integer>>() {
             @Override
@@ -199,7 +199,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
         PublishSubject<Integer> open = PublishSubject.create();
         final PublishSubject<Integer> close = PublishSubject.create();
 
-        TestObserver<Observable<Integer>> to = new TestObserver<Observable<Integer>>();
+        TestObserver<Observable<Integer>> to = new TestObserver<>();
 
         source.window(open, new Function<Integer, Observable<Integer>>() {
             @Override
@@ -464,7 +464,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstream() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<>();
 
         TestObserver<Observable<Integer>> to = ps.window(Observable.<Integer>just(1).concatWith(Observable.<Integer>never()),
                 Functions.justFunction(Observable.never()))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -46,8 +46,8 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
     @Test
     public void timedAndCount() {
-        final List<String> list = new ArrayList<String>();
-        final List<List<String>> lists = new ArrayList<List<String>>();
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
 
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
@@ -82,8 +82,8 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
     @Test
     public void timed() {
-        final List<String> list = new ArrayList<String>();
-        final List<List<String>> lists = new ArrayList<List<String>>();
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
 
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override
@@ -111,7 +111,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String arg : args) {
             list.add(arg);
         }
@@ -143,7 +143,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
                 stringObservable.subscribe(new DefaultObserver<T>() {
                     @Override
                     public void onComplete() {
-                        lists.add(new ArrayList<T>(list));
+                        lists.add(new ArrayList<>(list));
                         list.clear();
                     }
 
@@ -166,8 +166,8 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         Observable<Observable<Integer>> source = Observable.range(1, 10)
                 .window(1, TimeUnit.MINUTES, scheduler, 3);
 
-        final List<Integer> list = new ArrayList<Integer>();
-        final List<List<Integer>> lists = new ArrayList<List<Integer>>();
+        final List<Integer> list = new ArrayList<>();
+        final List<List<Integer>> lists = new ArrayList<>();
 
         source.subscribe(observeWindow(list, lists));
 
@@ -184,7 +184,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
     @Test
     public void takeFlatMapCompletes() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         final AtomicInteger wip = new AtomicInteger();
 
@@ -978,7 +978,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamExactTime() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<>();
 
         TestObserver<Observable<Integer>> to = ps.window(10, TimeUnit.MINUTES)
         .take(1)
@@ -1028,7 +1028,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamExactTimeAndSize() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<>();
 
         TestObserver<Observable<Integer>> to = ps.window(10, TimeUnit.MINUTES, 100)
         .take(1)
@@ -1078,7 +1078,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamExactTimeSkip() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final AtomicReference<Observable<Integer>> inner = new AtomicReference<Observable<Integer>>();
+        final AtomicReference<Observable<Integer>> inner = new AtomicReference<>();
 
         TestObserver<Observable<Integer>> to = ps.window(10, 15, TimeUnit.MINUTES)
         .take(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWithLatestFromTest.java
@@ -91,7 +91,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         result.subscribe(to);
 
@@ -117,7 +117,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         result.subscribe(to);
 
@@ -143,7 +143,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         result.subscribe(to);
 
@@ -170,7 +170,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         result.subscribe(to);
 
@@ -198,7 +198,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         result.subscribe(to);
 
@@ -226,7 +226,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER_ERROR);
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         result.subscribe(to);
 
@@ -252,7 +252,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
         Observable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         result.subscribe(to);
 
@@ -276,7 +276,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
         PublishSubject<String> ps3 = PublishSubject.create();
         PublishSubject<String> main = PublishSubject.create();
 
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         main.withLatestFrom(new Observable[] { ps1, ps2, ps3 }, toArray)
         .subscribe(to);
@@ -323,7 +323,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
         PublishSubject<String> ps3 = PublishSubject.create();
         PublishSubject<String> main = PublishSubject.create();
 
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         main.withLatestFrom(Arrays.<Observable<?>>asList(ps1, ps2, ps3), toArray)
         .subscribe(to);
@@ -368,8 +368,8 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
         for (String val : new String[] { "1" /*, null*/ }) {
             int n = 35;
             for (int i = 0; i < n; i++) {
-                List<Observable<?>> sources = new ArrayList<Observable<?>>();
-                List<String> expected = new ArrayList<String>();
+                List<Observable<?>> sources = new ArrayList<>();
+                List<String> expected = new ArrayList<>();
                 expected.add(val);
 
                 for (int j = 0; j < i; j++) {
@@ -377,7 +377,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
                     expected.add(String.valueOf(val));
                 }
 
-                TestObserver<String> to = new TestObserver<String>();
+                TestObserver<String> to = new TestObserver<>();
 
                 PublishSubject<String> main = PublishSubject.create();
 
@@ -397,7 +397,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
     @Test
     public void withEmpty() {
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.range(1, 3).withLatestFrom(
                 new Observable<?>[] { Observable.just(1), Observable.empty() }, toArray)
@@ -410,7 +410,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
     @Test
     public void withError() {
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.range(1, 3).withLatestFrom(
                 new Observable<?>[] { Observable.just(1), Observable.error(new TestException()) }, toArray)
@@ -423,7 +423,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
 
     @Test
     public void withMainError() {
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.error(new TestException()).withLatestFrom(
                 new Observable<?>[] { Observable.just(1), Observable.just(1) }, toArray)
@@ -438,7 +438,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
     public void with2Others() {
         Observable<Integer> just = Observable.just(1);
 
-        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<>();
 
         just.withLatestFrom(just, just, new Function3<Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -457,7 +457,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
     public void with3Others() {
         Observable<Integer> just = Observable.just(1);
 
-        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<>();
 
         just.withLatestFrom(just, just, just, new Function4<Integer, Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -476,7 +476,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
     public void with4Others() {
         Observable<Integer> just = Observable.just(1);
 
-        TestObserver<List<Integer>> to = new TestObserver<List<Integer>>();
+        TestObserver<List<Integer>> to = new TestObserver<>();
 
         just.withLatestFrom(just, just, just, just, new Function5<Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -511,7 +511,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
     @Test
     public void manyIteratorThrows() {
         Observable.just(1)
-        .withLatestFrom(new CrashingMappedIterable<Observable<Integer>>(1, 100, 100, new Function<Integer, Observable<Integer>>() {
+        .withLatestFrom(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Observable<Integer>>() {
             @Override
             public Observable<Integer> apply(Integer v) throws Exception {
                 return Observable.just(2);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
@@ -350,7 +350,7 @@ public class ObservableZipTest extends RxJavaTest {
         PublishSubject<String> r2 = PublishSubject.create();
         /* define an Observer to receive aggregated events */
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
 
         Observable.zip(r1, r2, zipr2).subscribe(to);
 
@@ -768,7 +768,7 @@ public class ObservableZipTest extends RxJavaTest {
                     }
                 });
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         os.subscribe(new Consumer<String>() {
 
             @Override
@@ -795,7 +795,7 @@ public class ObservableZipTest extends RxJavaTest {
                     }
                 }).take(5);
 
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
         os.subscribe(to);
 
         to.awaitDone(5, TimeUnit.SECONDS);
@@ -820,7 +820,7 @@ public class ObservableZipTest extends RxJavaTest {
                     }
                 });
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         os.subscribe(new DefaultObserver<String>() {
 
             @Override
@@ -884,7 +884,7 @@ public class ObservableZipTest extends RxJavaTest {
 
         });
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         o.subscribe(new Consumer<String>() {
 
             @Override
@@ -913,7 +913,7 @@ public class ObservableZipTest extends RxJavaTest {
 
         });
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         o.subscribe(new Consumer<String>() {
 
             @Override
@@ -940,7 +940,7 @@ public class ObservableZipTest extends RxJavaTest {
             }
         });
 
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         o.subscribe(to);
         to.awaitDone(200, TimeUnit.MILLISECONDS);
         to.assertNoValues();
@@ -974,7 +974,7 @@ public class ObservableZipTest extends RxJavaTest {
         Observable<Integer> o1 = createInfiniteObservable(generatedA).take(Observable.bufferSize() * 2);
         Observable<Integer> o2 = createInfiniteObservable(generatedB).take(Observable.bufferSize() * 2);
 
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
         Observable.zip(o1, o2, new BiFunction<Integer, Integer, String>() {
 
             @Override
@@ -1089,7 +1089,7 @@ public class ObservableZipTest extends RxJavaTest {
                         return i1 + i2;
                     }
                 });
-        List<Integer> expected = new ArrayList<Integer>();
+        List<Integer> expected = new ArrayList<>();
         for (int i = 0; i < 1026; i++) {
             expected.add(i * 3);
         }
@@ -1404,7 +1404,7 @@ public class ObservableZipTest extends RxJavaTest {
     public void firstErrorPreventsSecondSubscription() {
         final AtomicInteger counter = new AtomicInteger();
 
-        List<Observable<?>> observableList = new ArrayList<Observable<?>>();
+        List<Observable<?>> observableList = new ArrayList<>();
         observableList.add(Observable.create(new ObservableOnSubscribe<Object>() {
             @Override
             public void subscribe(ObservableEmitter<Object> e)


### PR DESCRIPTION
Hello, in this pull request i've changed all IDE marked explicit types with diamond operator. Affected package is internal/operators/observable. There is one test fail in CompletableTest.repeatNormal , but diamond is not the cause, there is last stack entry: 
java.lang.AssertionError: expected:<6> but was:<5>
	at org.junit.Assert.fail(Assert.java:88)

This PR is part of  #6767 issue resolving.