### PR TITLE
Diamond operators in unit tests, flowable package

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -352,7 +352,7 @@ public class BlockingFlowableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverError() {
-        NextSubscriber<Integer> no = new NextSubscriber<Integer>();
+        NextSubscriber<Integer> no = new NextSubscriber<>();
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -366,7 +366,7 @@ public class BlockingFlowableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverOnNext() throws Exception {
-        NextSubscriber<Integer> no = new NextSubscriber<Integer>();
+        NextSubscriber<Integer> no = new NextSubscriber<>();
 
         no.setWaiting();
         no.onNext(Notification.createOnNext(1));
@@ -379,7 +379,7 @@ public class BlockingFlowableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverOnCompleteOnNext() throws Exception {
-        NextSubscriber<Integer> no = new NextSubscriber<Integer>();
+        NextSubscriber<Integer> no = new NextSubscriber<>();
 
         no.setWaiting();
         no.onNext(Notification.<Integer>createOnComplete());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableToIteratorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableToIteratorTest.java
@@ -117,13 +117,13 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void remove() {
-        BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<Integer>(128);
+        BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<>(128);
         it.remove();
     }
 
     @Test
     public void dispose() {
-        BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<Integer>(128);
+        BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<>(128);
 
         assertFalse(it.isDisposed());
 
@@ -134,7 +134,7 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test
     public void interruptWait() {
-        BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<Integer>(128);
+        BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<>(128);
 
         try {
             Thread.currentThread().interrupt();
@@ -147,7 +147,7 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test(expected = NoSuchElementException.class)
     public void emptyThrowsNoSuch() {
-        BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<Integer>(128);
+        BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<>(128);
         it.onComplete();
         it.next();
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAllTest.java
@@ -146,7 +146,7 @@ public class FlowableAllTest extends RxJavaTest {
 
     @Test
     public void backpressureIfOneRequestedOneShouldBeDelivered() {
-        TestObserverEx<Boolean> to = new TestObserverEx<Boolean>();
+        TestObserverEx<Boolean> to = new TestObserverEx<>();
 
         Flowable.empty().all(new Predicate<Object>() {
             @Override
@@ -164,7 +164,7 @@ public class FlowableAllTest extends RxJavaTest {
 
     @Test
     public void predicateThrowsExceptionAndValueInCauseMessage() {
-        TestObserverEx<Boolean> to = new TestObserverEx<Boolean>();
+        TestObserverEx<Boolean> to = new TestObserverEx<>();
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
@@ -306,7 +306,7 @@ public class FlowableAllTest extends RxJavaTest {
 
     @Test
     public void backpressureIfNoneRequestedNoneShouldBeDeliveredFlowable() {
-        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(0L);
+        TestSubscriber<Boolean> ts = new TestSubscriber<>(0L);
         Flowable.empty().all(new Predicate<Object>() {
             @Override
             public boolean test(Object t1) {
@@ -323,7 +323,7 @@ public class FlowableAllTest extends RxJavaTest {
 
     @Test
     public void backpressureIfOneRequestedOneShouldBeDeliveredFlowable() {
-        TestSubscriberEx<Boolean> ts = new TestSubscriberEx<Boolean>(1L);
+        TestSubscriberEx<Boolean> ts = new TestSubscriberEx<>(1L);
 
         Flowable.empty().all(new Predicate<Object>() {
             @Override
@@ -343,7 +343,7 @@ public class FlowableAllTest extends RxJavaTest {
 
     @Test
     public void predicateThrowsExceptionAndValueInCauseMessageFlowable() {
-        TestSubscriberEx<Boolean> ts = new TestSubscriberEx<Boolean>();
+        TestSubscriberEx<Boolean> ts = new TestSubscriberEx<>();
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmbTest.java
@@ -174,7 +174,7 @@ public class FlowableAmbTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void producerRequestThroughAmb() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(3);
         final AtomicLong requested1 = new AtomicLong();
         final AtomicLong requested2 = new AtomicLong();
@@ -225,7 +225,7 @@ public class FlowableAmbTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(0, Flowable.bufferSize() * 2)
                 .ambWith(Flowable.range(0, Flowable.bufferSize() * 2))
                 .observeOn(Schedulers.computation()) // observeOn has a backpressured RxRingBuffer
@@ -254,7 +254,7 @@ public class FlowableAmbTest extends RxJavaTest {
         //this stream emits second
         Flowable<Integer> f2 = Flowable.just(1).doOnSubscribe(incrementer)
                 .delay(100, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.ambArray(f1, f2).subscribe(ts);
         ts.request(1);
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -271,7 +271,7 @@ public class FlowableAmbTest extends RxJavaTest {
         //this stream emits second
         Flowable<Integer> f2 = Flowable.fromArray(4, 5, 6)
                 .delay(200, TimeUnit.MILLISECONDS).subscribeOn(Schedulers.computation());
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1L);
 
         Flowable.ambArray(f1, f2).subscribe(ts);
         // before first emission request 20 more
@@ -309,7 +309,7 @@ public class FlowableAmbTest extends RxJavaTest {
         PublishProcessor<Integer> source2 = PublishProcessor.create();
         PublishProcessor<Integer> source3 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.ambArray(source1, source2, source3).subscribe(ts);
 
@@ -327,8 +327,8 @@ public class FlowableAmbTest extends RxJavaTest {
 
     @Test
     public void multipleUse() {
-        TestSubscriber<Long> ts1 = new TestSubscriber<Long>();
-        TestSubscriber<Long> ts2 = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts1 = new TestSubscriber<>();
+        TestSubscriber<Long> ts2 = new TestSubscriber<>();
 
         Flowable<Long> amb = Flowable.timer(100, TimeUnit.MILLISECONDS).ambWith(Flowable.timer(200, TimeUnit.MILLISECONDS));
 
@@ -541,7 +541,7 @@ public class FlowableAmbTest extends RxJavaTest {
 
     @Test
     public void iteratorThrows() {
-        Flowable.amb(new CrashingMappedIterable<Flowable<Integer>>(1, 100, 100, new Function<Integer, Flowable<Integer>>() {
+        Flowable.amb(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
                 return Flowable.never();
@@ -550,7 +550,7 @@ public class FlowableAmbTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
 
-        Flowable.amb(new CrashingMappedIterable<Flowable<Integer>>(100, 1, 100, new Function<Integer, Flowable<Integer>>() {
+        Flowable.amb(new CrashingMappedIterable<>(100, 1, 100, new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
                 return Flowable.never();
@@ -559,7 +559,7 @@ public class FlowableAmbTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
 
-        Flowable.amb(new CrashingMappedIterable<Flowable<Integer>>(100, 100, 1, new Function<Integer, Flowable<Integer>>() {
+        Flowable.amb(new CrashingMappedIterable<>(100, 100, 1, new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
                 return Flowable.never();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAnyTest.java
@@ -239,7 +239,7 @@ public class FlowableAnyTest extends RxJavaTest {
 
     @Test
     public void backpressureIfOneRequestedOneShouldBeDelivered() {
-        TestObserverEx<Boolean> to = new TestObserverEx<Boolean>();
+        TestObserverEx<Boolean> to = new TestObserverEx<>();
         Flowable.just(1).any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
@@ -255,7 +255,7 @@ public class FlowableAnyTest extends RxJavaTest {
 
     @Test
     public void predicateThrowsExceptionAndValueInCauseMessage() {
-        TestObserverEx<Boolean> to = new TestObserverEx<Boolean>();
+        TestObserverEx<Boolean> to = new TestObserverEx<>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
         Flowable.just("Boo!").any(new Predicate<String>() {
@@ -488,7 +488,7 @@ public class FlowableAnyTest extends RxJavaTest {
 
     @Test
     public void backpressureIfNoneRequestedNoneShouldBeDeliveredFlowable() {
-        TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>(0L);
+        TestSubscriber<Boolean> ts = new TestSubscriber<>(0L);
 
         Flowable.just(1).any(new Predicate<Integer>() {
             @Override
@@ -505,7 +505,7 @@ public class FlowableAnyTest extends RxJavaTest {
 
     @Test
     public void backpressureIfOneRequestedOneShouldBeDeliveredFlowable() {
-        TestSubscriberEx<Boolean> ts = new TestSubscriberEx<Boolean>(1L);
+        TestSubscriberEx<Boolean> ts = new TestSubscriberEx<>(1L);
         Flowable.just(1).any(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) {
@@ -521,7 +521,7 @@ public class FlowableAnyTest extends RxJavaTest {
 
     @Test
     public void predicateThrowsExceptionAndValueInCauseMessageFlowable() {
-        TestSubscriberEx<Boolean> ts = new TestSubscriberEx<Boolean>();
+        TestSubscriberEx<Boolean> ts = new TestSubscriberEx<>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
         Flowable.just("Boo!").any(new Predicate<String>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBlockingTest.java
@@ -49,7 +49,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeConsumer() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
@@ -65,7 +65,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void boundedBlockingSubscribeConsumer() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
@@ -81,7 +81,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void boundedBlockingSubscribeConsumerBufferExceed() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
@@ -97,7 +97,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeConsumerConsumer() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
@@ -113,7 +113,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void boundedBlockingSubscribeConsumerConsumer() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
@@ -129,7 +129,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void boundedBlockingSubscribeConsumerConsumerBufferExceed() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
@@ -145,7 +145,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeConsumerConsumerError() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         TestException ex = new TestException();
 
@@ -165,7 +165,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void boundedBlockingSubscribeConsumerConsumerError() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         TestException ex = new TestException();
 
@@ -185,7 +185,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeConsumerConsumerAction() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Consumer<Object> cons = new Consumer<Object>() {
             @Override
@@ -208,7 +208,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void boundedBlockingSubscribeConsumerConsumerAction() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Consumer<Object> cons = new Consumer<Object>() {
             @Override
@@ -233,7 +233,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void boundedBlockingSubscribeConsumerConsumerActionBufferExceed() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Consumer<Object> cons = new Consumer<Object>() {
             @Override
@@ -258,7 +258,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void boundedBlockingSubscribeConsumerConsumerActionBufferExceedMillionItem() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Consumer<Object> cons = new Consumer<Object>() {
             @Override
@@ -283,7 +283,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeObserver() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
@@ -316,7 +316,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingSubscribeObserverError() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         final TestException ex = new TestException();
 
@@ -430,7 +430,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void interrupt() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Thread.currentThread().interrupt();
 
@@ -451,7 +451,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void onCompleteDelayed() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.empty().delay(100, TimeUnit.MILLISECONDS)
         .blockingSubscribe(ts);
@@ -466,7 +466,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void disposeUpFront() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         ts.cancel();
         Flowable.just(1).blockingSubscribe(ts);
 
@@ -476,7 +476,7 @@ public class FlowableBlockingTest extends RxJavaTest {
     @SuppressWarnings("rawtypes")
     @Test
     public void delayed() throws Exception {
-        final TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts = new TestSubscriber<>();
         final Subscriber[] s = { null };
 
         Schedulers.single().scheduleDirect(new Runnable() {
@@ -506,7 +506,7 @@ public class FlowableBlockingTest extends RxJavaTest {
     @Test
     public void blockinsSubscribeCancelAsync() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferTest.java
@@ -272,7 +272,7 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String arg : args) {
             list.add(arg);
         }
@@ -302,7 +302,7 @@ public class FlowableBufferTest extends RxJavaTest {
         Flowable<Integer> source = Flowable.never();
 
         Subscriber<List<Integer>> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(subscriber, 0L);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>(subscriber, 0L);
 
         source.buffer(100, 200, TimeUnit.MILLISECONDS, scheduler)
         .doOnNext(new Consumer<List<Integer>>() {
@@ -730,7 +730,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void producerRequestThroughBufferWithSize1() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(3L);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>(3L);
 
         final AtomicLong requested = new AtomicLong();
         Flowable.unsafeCreate(new Publisher<Integer>() {
@@ -761,7 +761,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void producerRequestThroughBufferWithSize2() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
         final AtomicLong requested = new AtomicLong();
 
         Flowable.unsafeCreate(new Publisher<Integer>() {
@@ -789,7 +789,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void producerRequestThroughBufferWithSize3() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(3L);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>(3L);
         final AtomicLong requested = new AtomicLong();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
@@ -818,7 +818,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void producerRequestThroughBufferWithSize4() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
         final AtomicLong requested = new AtomicLong();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
@@ -845,7 +845,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void producerRequestOverflowThroughBufferWithSize1() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(Long.MAX_VALUE >> 1);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>(Long.MAX_VALUE >> 1);
 
         final AtomicLong requested = new AtomicLong();
 
@@ -874,7 +874,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void producerRequestOverflowThroughBufferWithSize2() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(Long.MAX_VALUE >> 1);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>(Long.MAX_VALUE >> 1);
 
         final AtomicLong requested = new AtomicLong();
 
@@ -1249,7 +1249,7 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     static HashSet<Integer> set(Integer... values) {
-        return new HashSet<Integer>(Arrays.asList(values));
+        return new HashSet<>(Arrays.asList(values));
     }
 
     @SuppressWarnings("unchecked")
@@ -1259,7 +1259,7 @@ public class FlowableBufferTest extends RxJavaTest {
         .buffer(3, new Supplier<Collection<Integer>>() {
             @Override
             public Collection<Integer> get() throws Exception {
-                return new HashSet<Integer>();
+                return new HashSet<>();
             }
         })
         .test()
@@ -1273,7 +1273,7 @@ public class FlowableBufferTest extends RxJavaTest {
         .buffer(3, 3, new Supplier<Collection<Integer>>() {
             @Override
             public Collection<Integer> get() throws Exception {
-                return new HashSet<Integer>();
+                return new HashSet<>();
             }
         })
         .test()
@@ -1317,7 +1317,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     return null;
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         }, false)
@@ -1337,7 +1337,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     return null;
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         }, false)
@@ -1357,7 +1357,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     return null;
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         })
@@ -1419,7 +1419,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         }, false)
@@ -1439,7 +1439,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         }, false)
@@ -1459,7 +1459,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (count++ == 1) {
                     throw new TestException();
                 } else {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             }
         })
@@ -1497,7 +1497,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (++calls == 2) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         })
         .test()
@@ -1515,7 +1515,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (++calls == 1) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         })
         .test()
@@ -1533,7 +1533,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (++calls == 2) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         })
         .test()
@@ -1624,7 +1624,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (++calls == 2) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, true)
         .test();
@@ -2204,7 +2204,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 if (++calls == 2) {
                     throw new TestException();
                 }
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }).test();
 
@@ -2226,7 +2226,7 @@ public class FlowableBufferTest extends RxJavaTest {
             }
         };
 
-        final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<Subscriber<? super Integer>>();
+        final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<>();
         Flowable<Integer> b = new Flowable<Integer>() {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
@@ -2303,10 +2303,10 @@ public class FlowableBufferTest extends RxJavaTest {
     public void timedInternalState() {
         TestScheduler sch = new TestScheduler();
 
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
-        BufferExactUnboundedSubscriber<Integer, List<Integer>> sub = new BufferExactUnboundedSubscriber<Integer, List<Integer>>(
-                ts, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
+        BufferExactUnboundedSubscriber<Integer, List<Integer>> sub = new BufferExactUnboundedSubscriber<>(
+                ts, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2322,7 +2322,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
         assertTrue(sub.isDisposed());
 
-        sub.buffer = new ArrayList<Integer>();
+        sub.buffer = new ArrayList<>();
         sub.enter();
         sub.onComplete();
     }
@@ -2353,10 +2353,10 @@ public class FlowableBufferTest extends RxJavaTest {
     public void timedSkipInternalState() {
         TestScheduler sch = new TestScheduler();
 
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
-        BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<Integer, List<Integer>>(
-                ts, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
+        BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<>(
+                ts, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2372,19 +2372,20 @@ public class FlowableBufferTest extends RxJavaTest {
     public void timedSkipCancelWhenSecondBuffer() {
         TestScheduler sch = new TestScheduler();
 
-        final TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        final TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
-        BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<Integer, List<Integer>>(
+        BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<>(
                 ts, new Supplier<List<Integer>>() {
-                    int calls;
-                    @Override
-                    public List<Integer> get() throws Exception {
-                        if (++calls == 2) {
-                            ts.cancel();
-                        }
-                        return new ArrayList<Integer>();
-                    }
-                }, 1, 1, TimeUnit.SECONDS, sch.createWorker());
+            int calls;
+
+            @Override
+            public List<Integer> get() throws Exception {
+                if (++calls == 2) {
+                    ts.cancel();
+                }
+                return new ArrayList<>();
+            }
+        }, 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2397,11 +2398,11 @@ public class FlowableBufferTest extends RxJavaTest {
     public void timedSizeBufferAlreadyCleared() {
         TestScheduler sch = new TestScheduler();
 
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         BufferExactBoundedSubscriber<Integer, List<Integer>> sub =
-                new BufferExactBoundedSubscriber<Integer, List<Integer>>(
-                        ts, Functions.justSupplier((List<Integer>)new ArrayList<Integer>()),
+                new BufferExactBoundedSubscriber<>(
+                        ts, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()),
                         1, TimeUnit.SECONDS, 1, false, sch.createWorker())
         ;
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCacheTest.java
@@ -35,11 +35,11 @@ import io.reactivex.rxjava3.testsupport.*;
 public class FlowableCacheTest extends RxJavaTest {
     @Test
     public void coldReplayNoBackpressure() {
-        FlowableCache<Integer> source = new FlowableCache<Integer>(Flowable.range(0, 1000), 16);
+        FlowableCache<Integer> source = new FlowableCache<>(Flowable.range(0, 1000), 16);
 
         assertFalse("Source is connected!", source.isConnected());
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         source.subscribe(ts);
 
@@ -58,11 +58,11 @@ public class FlowableCacheTest extends RxJavaTest {
 
     @Test
     public void coldReplayBackpressure() {
-        FlowableCache<Integer> source = new FlowableCache<Integer>(Flowable.range(0, 1000), 16);
+        FlowableCache<Integer> source = new FlowableCache<>(Flowable.range(0, 1000), 16);
 
         assertFalse("Source is connected!", source.isConnected());
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(10);
 
         source.subscribe(ts);
@@ -145,9 +145,9 @@ public class FlowableCacheTest extends RxJavaTest {
 
     @Test
     public void take() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        FlowableCache<Integer> cached = new FlowableCache<Integer>(Flowable.range(1, 100), 16);
+        FlowableCache<Integer> cached = new FlowableCache<>(Flowable.range(1, 100), 16);
         cached.take(10).subscribe(ts);
 
         ts.assertNoErrors();
@@ -160,9 +160,9 @@ public class FlowableCacheTest extends RxJavaTest {
     public void async() {
         Flowable<Integer> source = Flowable.range(1, 10000);
         for (int i = 0; i < 100; i++) {
-            TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-            FlowableCache<Integer> cached = new FlowableCache<Integer>(source, 16);
+            FlowableCache<Integer> cached = new FlowableCache<>(source, 16);
 
             cached.observeOn(Schedulers.computation()).subscribe(ts1);
 
@@ -171,7 +171,7 @@ public class FlowableCacheTest extends RxJavaTest {
             ts1.assertComplete();
             assertEquals(10000, ts1.values().size());
 
-            TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts2 = new TestSubscriber<>();
             cached.observeOn(Schedulers.computation()).subscribe(ts2);
 
             ts2.awaitDone(2, TimeUnit.SECONDS);
@@ -186,18 +186,18 @@ public class FlowableCacheTest extends RxJavaTest {
         Flowable<Long> source = Flowable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
                 .subscribeOn(Schedulers.io());
-        FlowableCache<Long> cached = new FlowableCache<Long>(source, 16);
+        FlowableCache<Long> cached = new FlowableCache<>(source, 16);
 
         Flowable<Long> output = cached.observeOn(Schedulers.computation());
 
-        List<TestSubscriber<Long>> list = new ArrayList<TestSubscriber<Long>>(100);
+        List<TestSubscriber<Long>> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
-            TestSubscriber<Long> ts = new TestSubscriber<Long>();
+            TestSubscriber<Long> ts = new TestSubscriber<>();
             list.add(ts);
             output.skip(i * 10).take(10).subscribe(ts);
         }
 
-        List<Long> expected = new ArrayList<Long>();
+        List<Long> expected = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             expected.add((long)(i - 10));
         }
@@ -231,7 +231,7 @@ public class FlowableCacheTest extends RxJavaTest {
             }
         });
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         firehose.cache().observeOn(Schedulers.computation()).takeLast(100).subscribe(ts);
 
         ts.awaitDone(3, TimeUnit.SECONDS);
@@ -247,14 +247,14 @@ public class FlowableCacheTest extends RxJavaTest {
                 .concatWith(Flowable.<Integer>error(new TestException()))
                 .cache();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         source.subscribe(ts);
 
         ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ts.assertNotComplete();
         ts.assertError(TestException.class);
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>();
         source.subscribe(ts2);
 
         ts2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -294,7 +294,7 @@ public class FlowableCacheTest extends RxJavaTest {
 
             cache.test();
 
-            final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            final TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -432,8 +432,8 @@ public class FlowableCacheTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Flowable<Integer> cache = Flowable.range(1, 500).cache();
 
-            final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
-            final TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>();
+            final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
+            final TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -476,7 +476,7 @@ public class FlowableCacheTest extends RxJavaTest {
 
             cache.test();
 
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -437,8 +437,8 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         };
         for (int i = 1; i <= n; i++) {
             System.out.println("test1ToNSources: " + i + " sources");
-            List<Flowable<Integer>> sources = new ArrayList<Flowable<Integer>>();
-            List<Object> values = new ArrayList<Object>();
+            List<Flowable<Integer>> sources = new ArrayList<>();
+            List<Object> values = new ArrayList<>();
             for (int j = 0; j < i; j++) {
                 sources.add(Flowable.just(j));
                 values.add(j);
@@ -468,8 +468,8 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         };
         for (int i = 1; i <= n; i++) {
             System.out.println("test1ToNSourcesScheduled: " + i + " sources");
-            List<Flowable<Integer>> sources = new ArrayList<Flowable<Integer>>();
-            List<Object> values = new ArrayList<Object>();
+            List<Flowable<Integer>> sources = new ArrayList<>();
+            List<Object> values = new ArrayList<>();
             for (int j = 0; j < i; j++) {
                 sources.add(Flowable.just(j).subscribeOn(Schedulers.io()));
                 values.add(j);
@@ -749,7 +749,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         BiFunction<String, Integer, String> combineLatestFunction = getConcatStringIntegerCombineLatestFunction();
 
         int num = Flowable.bufferSize() * 4;
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Flowable.combineLatest(
                 Flowable.just("one", "two"),
                 Flowable.range(2, num),
@@ -784,7 +784,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
                     }
                 }).take(SIZE);
 
-        TestSubscriber<Long> ts = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts = new TestSubscriber<>();
 
         Flowable.combineLatest(timer, Flowable.<Integer> never(), new BiFunction<Long, Integer, Long>() {
             @Override
@@ -889,7 +889,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     public void combineMany() {
         int n = Flowable.bufferSize() * 3;
 
-        List<Flowable<Integer>> sources = new ArrayList<Flowable<Integer>>();
+        List<Flowable<Integer>> sources = new ArrayList<>();
 
         StringBuilder expected = new StringBuilder(n * 2);
 
@@ -1066,7 +1066,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         for (int i = 1; i < 100; i++) {
             Flowable<Integer>[] sources = new Flowable[i];
             Arrays.fill(sources, Flowable.just(1));
-            List<Object> expected = new ArrayList<Object>(i);
+            List<Object> expected = new ArrayList<>(i);
             for (int j = 1; j <= i; j++) {
                 expected.add(1);
             }
@@ -1207,7 +1207,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void cancelWhileSubscribing() {
-        final TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.combineLatest(
                 Flowable.just(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -232,7 +232,7 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
 
     @Test
     public void concatDelayErrorFlowableError() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.concatDelayError(
                 withError(Flowable.just(withError(Flowable.just(1)), withError(Flowable.just(2)))))
@@ -269,7 +269,7 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void concatDelayErrorIterableError() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.concatDelayError(
                 Arrays.asList(withError(Flowable.just(1)), withError(Flowable.just(2))))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -276,8 +276,8 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Before
     public void before() {
-        ts = new TestSubscriber<Object>();
-        tsBp = new TestSubscriber<Object>(0L);
+        ts = new TestSubscriber<>();
+        tsBp = new TestSubscriber<>(0L);
     }
 
     @Test
@@ -642,7 +642,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void maxConcurrent5() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
         Flowable.range(1, 100).doOnRequest(new LongConsumer() {
             @Override
             public void accept(long reqCount) {
@@ -955,7 +955,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void mapperCancels() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1).hide()
         .concatMapEager(new Function<Integer, Flowable<Integer>>() {
@@ -1097,7 +1097,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             Flowable.just(1)
             .concatMapEager(Functions.justFunction(pp))
@@ -1157,7 +1157,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     public void maxConcurrencyOf2() {
         List<Integer>[] list = new ArrayList[100];
         for (int i = 0; i < 100; i++) {
-            List<Integer> lst = new ArrayList<Integer>();
+            List<Integer> lst = new ArrayList<>();
             list[i] = lst;
             for (int k = 1; k <= 10; k++) {
                 lst.add((i) * 10 + k);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -366,7 +366,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             if (i % 1000 == 0) {
                 System.out.println("concatMapRangeAsyncLoop > " + i);
             }
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.range(0, 1000)
             .concatMap(new Function<Integer, Flowable<Integer>>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapTest.java
@@ -33,8 +33,8 @@ public class FlowableConcatMapTest extends RxJavaTest {
 
     @Test
     public void weakSubscriptionRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
-        WeakScalarSubscription<Integer> ws = new WeakScalarSubscription<Integer>(1, ts);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        WeakScalarSubscription<Integer> ws = new WeakScalarSubscription<>(1, ts);
         ts.onSubscribe(ws);
 
         ws.request(0);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
@@ -65,7 +65,7 @@ public class FlowableConcatTest {
 
         final Flowable<String> odds = Flowable.fromArray(o);
         final Flowable<String> even = Flowable.fromArray(e);
-        final List<Flowable<String>> list = new ArrayList<Flowable<String>>();
+        final List<Flowable<String>> list = new ArrayList<>();
         list.add(odds);
         list.add(even);
         Flowable<String> concat = Flowable.concat(Flowable.fromIterable(list));
@@ -110,8 +110,8 @@ public class FlowableConcatTest {
     public void simpleAsyncConcat() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
-        TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
+        TestObservable<String> o1 = new TestObservable<>("one", "two", "three");
+        TestObservable<String> o2 = new TestObservable<>("four", "five", "six");
 
         Flowable.concat(Flowable.unsafeCreate(o1), Flowable.unsafeCreate(o2)).subscribe(subscriber);
 
@@ -150,12 +150,12 @@ public class FlowableConcatTest {
     public void nestedAsyncConcat() throws InterruptedException {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        final TestObservable<String> o1 = new TestObservable<String>("one", "two", "three");
-        final TestObservable<String> o2 = new TestObservable<String>("four", "five", "six");
-        final TestObservable<String> o3 = new TestObservable<String>("seven", "eight", "nine");
+        final TestObservable<String> o1 = new TestObservable<>("one", "two", "three");
+        final TestObservable<String> o2 = new TestObservable<>("four", "five", "six");
+        final TestObservable<String> o3 = new TestObservable<>("seven", "eight", "nine");
         final CountDownLatch allowThird = new CountDownLatch(1);
 
-        final AtomicReference<Thread> parent = new AtomicReference<Thread>();
+        final AtomicReference<Thread> parent = new AtomicReference<>();
         final CountDownLatch parentHasStarted = new CountDownLatch(1);
         final CountDownLatch parentHasFinished = new CountDownLatch(1);
 
@@ -284,7 +284,7 @@ public class FlowableConcatTest {
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
         @SuppressWarnings("unchecked")
-        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(callOnce, okToContinue, odds, even);
+        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<>(callOnce, okToContinue, odds, even);
         Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
         concatF.subscribe(subscriber);
         try {
@@ -316,14 +316,14 @@ public class FlowableConcatTest {
 
     @Test
     public void concatConcurrentWithInfinity() {
-        final TestObservable<String> w1 = new TestObservable<String>("one", "two", "three");
+        final TestObservable<String> w1 = new TestObservable<>("one", "two", "three");
         //This observable will send "hello" MAX_VALUE time.
-        final TestObservable<String> w2 = new TestObservable<String>("hello", Integer.MAX_VALUE);
+        final TestObservable<String> w2 = new TestObservable<>("hello", Integer.MAX_VALUE);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         @SuppressWarnings("unchecked")
-        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
+        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
         Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
 
         concatF.take(50).subscribe(subscriber);
@@ -351,8 +351,8 @@ public class FlowableConcatTest {
         final CountDownLatch okToContinueW1 = new CountDownLatch(1);
         final CountDownLatch okToContinueW2 = new CountDownLatch(1);
 
-        final TestObservable<String> w1 = new TestObservable<String>(null, okToContinueW1, "one", "two", "three");
-        final TestObservable<String> w2 = new TestObservable<String>(null, okToContinueW2, "four", "five", "six");
+        final TestObservable<String> w1 = new TestObservable<>(null, okToContinueW1, "one", "two", "three");
+        final TestObservable<String> w2 = new TestObservable<>(null, okToContinueW2, "four", "five", "six");
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -402,11 +402,11 @@ public class FlowableConcatTest {
     public void concatUnsubscribe() {
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
-        final TestObservable<String> w1 = new TestObservable<String>("one", "two", "three");
-        final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
+        final TestObservable<String> w1 = new TestObservable<>("one", "two", "three");
+        final TestObservable<String> w2 = new TestObservable<>(callOnce, okToContinue, "four", "five", "six");
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, 0L);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber, 0L);
 
         final Flowable<String> concat = Flowable.concat(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
 
@@ -444,14 +444,14 @@ public class FlowableConcatTest {
     public void concatUnsubscribeConcurrent() {
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
-        final TestObservable<String> w1 = new TestObservable<String>("one", "two", "three");
-        final TestObservable<String> w2 = new TestObservable<String>(callOnce, okToContinue, "four", "five", "six");
+        final TestObservable<String> w1 = new TestObservable<>("one", "two", "three");
+        final TestObservable<String> w2 = new TestObservable<>(callOnce, okToContinue, "four", "five", "six");
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, 0L);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber, 0L);
 
         @SuppressWarnings("unchecked")
-        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<Flowable<String>>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
+        TestObservable<Flowable<String>> observableOfObservables = new TestObservable<>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
         Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
 
         concatF.subscribe(ts);
@@ -630,7 +630,7 @@ public class FlowableConcatTest {
 
         result.subscribe(o);
 
-        List<Integer> list = new ArrayList<Integer>(n);
+        List<Integer> list = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
             list.add(i);
         }
@@ -655,7 +655,7 @@ public class FlowableConcatTest {
 
         result.subscribe(o);
 
-        List<Integer> list = new ArrayList<Integer>(n);
+        List<Integer> list = new ArrayList<>(n);
         for (int i = 0; i < n / 2; i++) {
             list.add(i);
         }
@@ -674,7 +674,7 @@ public class FlowableConcatTest {
 
     @Test
     public void innerBackpressureWithAlignedBoundaries() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(0, Flowable.bufferSize() * 2)
                 .concatWith(Flowable.range(0, Flowable.bufferSize() * 2))
                 .observeOn(Schedulers.computation()) // observeOn has a backpressured RxRingBuffer
@@ -693,7 +693,7 @@ public class FlowableConcatTest {
      */
     @Test
     public void innerBackpressureWithoutAlignedBoundaries() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(0, (Flowable.bufferSize() * 2) + 10)
                 .concatWith(Flowable.range(0, (Flowable.bufferSize() * 2) + 10))
                 .observeOn(Schedulers.computation()) // observeOn has a backpressured RxRingBuffer
@@ -719,7 +719,7 @@ public class FlowableConcatTest {
 
         });
 
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
         Flowable.concat(f, f).subscribe(ts);
         ts.awaitDone(500, TimeUnit.MILLISECONDS);
         ts.assertTerminated();
@@ -815,7 +815,7 @@ public class FlowableConcatTest {
             if (i % 1000 == 0) {
                 System.out.println("concatMapRangeAsyncLoop > " + i);
             }
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.range(0, 1000)
             .concatMap(new Function<Integer, Flowable<Integer>>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithCompletableTest.java
@@ -33,7 +33,7 @@ public class FlowableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Completable.fromAction(new Action() {
@@ -49,7 +49,7 @@ public class FlowableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void mainError() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.<Integer>error(new TestException())
         .concatWith(Completable.fromAction(new Action() {
@@ -65,7 +65,7 @@ public class FlowableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void otherError() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Completable.error(new TestException()))
@@ -76,7 +76,7 @@ public class FlowableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void takeMain() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Completable.fromAction(new Action() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithMaybeTest.java
@@ -27,7 +27,7 @@ public class FlowableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void normalEmpty() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Maybe.<Integer>fromAction(new Action() {
@@ -43,7 +43,7 @@ public class FlowableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void normalNonEmpty() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Maybe.just(100))
@@ -68,7 +68,7 @@ public class FlowableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void mainError() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.<Integer>error(new TestException())
         .concatWith(Maybe.<Integer>fromAction(new Action() {
@@ -84,7 +84,7 @@ public class FlowableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void otherError() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Maybe.<Integer>error(new TestException()))
@@ -95,7 +95,7 @@ public class FlowableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void takeMain() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Maybe.<Integer>fromAction(new Action() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithSingleTest.java
@@ -26,7 +26,7 @@ public class FlowableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Single.just(100))
@@ -51,7 +51,7 @@ public class FlowableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void mainError() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.<Integer>error(new TestException())
         .concatWith(Single.just(100))
@@ -62,7 +62,7 @@ public class FlowableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void otherError() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Single.<Integer>error(new TestException()))
@@ -73,7 +73,7 @@ public class FlowableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void takeMain() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
         .concatWith(Single.just(100))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCreateTest.java
@@ -1063,7 +1063,7 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void emittersHasToString() {
         Map<BackpressureStrategy, Class<? extends FlowableEmitter>> emitterMap =
-                new HashMap<BackpressureStrategy, Class<? extends FlowableEmitter>>();
+                new HashMap<>();
 
         emitterMap.put(BackpressureStrategy.MISSING, FlowableCreate.MissingEmitter.class);
         emitterMap.put(BackpressureStrategy.ERROR, FlowableCreate.ErrorAsyncEmitter.class);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounceTest.java
@@ -289,7 +289,7 @@ public class FlowableDebounceTest extends RxJavaTest {
     @Test
     public void debounceWithTimeBackpressure() throws InterruptedException {
         TestScheduler scheduler = new TestScheduler();
-        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>();
         Flowable.merge(
                 Flowable.just(1),
                 Flowable.just(2).delay(10, TimeUnit.MILLISECONDS, scheduler)
@@ -305,7 +305,7 @@ public class FlowableDebounceTest extends RxJavaTest {
     @Test
     public void debounceDefaultScheduler() throws Exception {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 1000).debounce(1, TimeUnit.SECONDS).subscribe(ts);
 
@@ -330,7 +330,7 @@ public class FlowableDebounceTest extends RxJavaTest {
 
         TestHelper.checkDisposed(PublishProcessor.create().debounce(Functions.justFunction(Flowable.never())));
 
-        Disposable d = new FlowableDebounceTimed.DebounceEmitter<Integer>(1, 1, null);
+        Disposable d = new FlowableDebounceTimed.DebounceEmitter<>(1, 1, null);
         assertFalse(d.isDisposed());
 
         d.dispose();
@@ -426,7 +426,7 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void disposeInOnNext() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         BehaviorProcessor.createDefault(1)
         .debounce(new Function<Integer, Flowable<Object>>() {
@@ -444,7 +444,7 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void disposedInOnComplete() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         new Flowable<Integer>() {
             @Override
@@ -461,7 +461,7 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void emitLate() {
-        final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<Subscriber<? super Integer>>();
+        final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<>();
 
         TestSubscriber<Integer> ts = Flowable.range(1, 2)
         .debounce(new Function<Integer, Flowable<Integer>>() {
@@ -505,7 +505,7 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void timedDisposedIgnoredBySource() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         new Flowable<Integer>() {
             @Override
@@ -528,13 +528,13 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void timedLateEmit() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        DebounceTimedSubscriber<Integer> sub = new DebounceTimedSubscriber<Integer>(
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        DebounceTimedSubscriber<Integer> sub = new DebounceTimedSubscriber<>(
                 ts, 1, TimeUnit.SECONDS, new TestScheduler().createWorker());
 
         sub.onSubscribe(new BooleanSubscription());
 
-        DebounceEmitter<Integer> de = new DebounceEmitter<Integer>(1, 50, sub);
+        DebounceEmitter<Integer> de = new DebounceEmitter<>(1, 50, sub);
         de.emit();
         de.emit();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDefaultIfEmptyTest.java
@@ -57,7 +57,7 @@ public class FlowableDefaultIfEmptyTest extends RxJavaTest {
 
     @Test
     public void backpressureEmpty() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
         Flowable.<Integer>empty().defaultIfEmpty(1).subscribe(ts);
         ts.assertNoValues();
         ts.assertNotTerminated();
@@ -69,7 +69,7 @@ public class FlowableDefaultIfEmptyTest extends RxJavaTest {
 
     @Test
     public void backpressureNonEmpty() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
         Flowable.just(1, 2, 3).defaultIfEmpty(1).subscribe(ts);
         ts.assertNoValues();
         ts.assertNotTerminated();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -31,7 +31,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
     public void noPrematureSubscription() {
         PublishProcessor<Object> other = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -64,7 +64,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
     public void noMultipleSubscriptions() {
         PublishProcessor<Object> other = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -98,7 +98,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
     public void completeTriggersSubscription() {
         PublishProcessor<Object> other = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -131,7 +131,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
     public void noPrematureSubscriptionToError() {
         PublishProcessor<Object> other = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -164,7 +164,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
     public void noSubscriptionIfOtherErrors() {
         PublishProcessor<Object> other = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -198,7 +198,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
 
         PublishProcessor<Object> other = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         final AtomicInteger subscribed = new AtomicInteger();
 
@@ -249,7 +249,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> other = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.delaySubscription(other).subscribe(ts);
 
@@ -267,7 +267,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> other = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.delaySubscription(other).subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelayTest.java
@@ -218,7 +218,7 @@ public class FlowableDelayTest extends RxJavaTest {
         Flowable<Integer> result = Flowable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
+        TestSubscriber<Object> ts = new TestSubscriber<>(subscriber);
 
         result.subscribe(ts);
         ts.cancel();
@@ -232,7 +232,7 @@ public class FlowableDelayTest extends RxJavaTest {
     @Test
     public void delayWithFlowableNormal1() {
         PublishProcessor<Integer> source = PublishProcessor.create();
-        final List<PublishProcessor<Integer>> delays = new ArrayList<PublishProcessor<Integer>>();
+        final List<PublishProcessor<Integer>> delays = new ArrayList<>();
         final int n = 10;
         for (int i = 0; i < n; i++) {
             PublishProcessor<Integer> delay = PublishProcessor.create();
@@ -577,7 +577,7 @@ public class FlowableDelayTest extends RxJavaTest {
         int n = 3;
 
         PublishProcessor<Integer> source = PublishProcessor.create();
-        final List<PublishProcessor<Integer>> subjects = new ArrayList<PublishProcessor<Integer>>();
+        final List<PublishProcessor<Integer>> subjects = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             subjects.add(PublishProcessor.<Integer> create());
         }
@@ -625,7 +625,7 @@ public class FlowableDelayTest extends RxJavaTest {
             }
 
         });
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         delayed.subscribe(ts);
         // all will be delivered after 500ms since range does not delay between them
         scheduler.advanceTimeBy(500L, TimeUnit.MILLISECONDS);
@@ -634,7 +634,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
     @Test
     public void backpressureWithTimedDelay() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, Flowable.bufferSize() * 2)
                 .delay(100, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.computation())
@@ -662,7 +662,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
     @Test
     public void backpressureWithSubscriptionTimedDelay() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, Flowable.bufferSize() * 2)
                 .delaySubscription(100, TimeUnit.MILLISECONDS)
                 .delay(100, TimeUnit.MILLISECONDS)
@@ -691,7 +691,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
     @Test
     public void backpressureWithSelectorDelay() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, Flowable.bufferSize() * 2)
                 .delay(new Function<Integer, Flowable<Long>>() {
 
@@ -726,7 +726,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
     @Test
     public void backpressureWithSelectorDelayAndSubscriptionDelay() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, Flowable.bufferSize() * 2)
                 .delay(Flowable.defer(new Supplier<Flowable<Long>>() {
 
@@ -771,7 +771,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         pp.delay(1, TimeUnit.SECONDS, test).subscribe(ts);
 
@@ -794,7 +794,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         Flowable<Integer> source = Flowable.range(1, 5);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
             @Override
@@ -820,7 +820,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         Flowable<Integer> source = Flowable.range(1, 5);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
             @Override
@@ -847,7 +847,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         Flowable<Integer> source = Flowable.range(1, 5);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
             @Override
@@ -904,7 +904,7 @@ public class FlowableDelayTest extends RxJavaTest {
         Flowable<Integer> result = Flowable.just(1, 2, 3).delaySubscription(100, TimeUnit.MILLISECONDS, scheduler);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
+        TestSubscriber<Object> ts = new TestSubscriber<>(subscriber);
 
         result.subscribe(ts);
         ts.cancel();
@@ -918,7 +918,7 @@ public class FlowableDelayTest extends RxJavaTest {
     @Test
     public void onErrorCalledOnScheduler() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Thread> thread = new AtomicReference<Thread>();
+        final AtomicReference<Thread> thread = new AtomicReference<>();
 
         Flowable.<String>error(new Exception())
                 .delay(0, TimeUnit.MILLISECONDS, Schedulers.newThread())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDematerializeTest.java
@@ -141,7 +141,7 @@ public class FlowableDematerializeTest extends RxJavaTest {
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(subscriber);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(subscriber);
         dematerialize.subscribe(ts);
 
         System.out.println(ts.errors());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDetachTest.java
@@ -35,9 +35,9 @@ public class FlowableDetachTest extends RxJavaTest {
     public void just() throws Exception {
         o = new Object();
 
-        WeakReference<Object> wr = new WeakReference<Object>(o);
+        WeakReference<Object> wr = new WeakReference<>(o);
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.just(o).count().toFlowable().onTerminateDetach().subscribe(ts);
 
@@ -56,7 +56,7 @@ public class FlowableDetachTest extends RxJavaTest {
 
     @Test
     public void error() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.error(new TestException()).onTerminateDetach().subscribe(ts);
 
@@ -67,7 +67,7 @@ public class FlowableDetachTest extends RxJavaTest {
 
     @Test
     public void empty() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.empty().onTerminateDetach().subscribe(ts);
 
@@ -78,7 +78,7 @@ public class FlowableDetachTest extends RxJavaTest {
 
     @Test
     public void range() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.range(1, 1000).onTerminateDetach().subscribe(ts);
 
@@ -91,9 +91,9 @@ public class FlowableDetachTest extends RxJavaTest {
     public void backpressured() throws Exception {
         o = new Object();
 
-        WeakReference<Object> wr = new WeakReference<Object>(o);
+        WeakReference<Object> wr = new WeakReference<>(o);
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
+        TestSubscriber<Object> ts = new TestSubscriber<>(0L);
 
         Flowable.just(o).count().toFlowable().onTerminateDetach().subscribe(ts);
 
@@ -117,9 +117,9 @@ public class FlowableDetachTest extends RxJavaTest {
     public void justUnsubscribed() throws Exception {
         o = new Object();
 
-        WeakReference<Object> wr = new WeakReference<Object>(o);
+        WeakReference<Object> wr = new WeakReference<>(o);
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
+        TestSubscriber<Object> ts = new TestSubscriber<>(0);
 
         Flowable.just(o).count().toFlowable().onTerminateDetach().subscribe(ts);
 
@@ -135,9 +135,9 @@ public class FlowableDetachTest extends RxJavaTest {
 
     @Test
     public void deferredUpstreamProducer() {
-        final AtomicReference<Subscriber<? super Object>> subscriber = new AtomicReference<Subscriber<? super Object>>();
+        final AtomicReference<Subscriber<? super Object>> subscriber = new AtomicReference<>();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
+        TestSubscriber<Object> ts = new TestSubscriber<>(0);
 
         Flowable.unsafeCreate(new Publisher<Object>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoAfterNextTest.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableDoAfterNextTest extends RxJavaTest {
 
-    final List<Integer> values = new ArrayList<Integer>();
+    final List<Integer> values = new ArrayList<>();
 
     final Consumer<Integer> afterNext = new Consumer<Integer>() {
         @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoAfterTerminateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoAfterTerminateTest.java
@@ -91,7 +91,7 @@ public class FlowableDoAfterTerminateTest extends RxJavaTest {
             Action finallyAction = Mockito.mock(Action.class);
             doThrow(new IllegalStateException()).when(finallyAction).run();
 
-            TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
+            TestSubscriber<String> testSubscriber = new TestSubscriber<>();
 
             Flowable
                     .just("value")

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoFinallyTest.java
@@ -440,7 +440,7 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void eventOrdering() {
-        final List<String> list = new ArrayList<String>();
+        final List<String> list = new ArrayList<>();
 
         Flowable.error(new TestException())
         .doOnCancel(new Action() {
@@ -480,7 +480,7 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void eventOrdering2() {
-        final List<String> list = new ArrayList<String>();
+        final List<String> list = new ArrayList<>();
 
         Flowable.just(1)
         .doOnCancel(new Action() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -173,7 +173,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void onErrorThrows() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
         Flowable.error(new TestException())
         .doOnError(new Consumer<Throwable>() {
@@ -691,7 +691,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Flowable.just(1).doOnEach(new TestSubscriber<Integer>()));
+        TestHelper.checkDisposed(Flowable.just(1).doOnEach(new TestSubscriber<>()));
     }
 
     @Test
@@ -699,7 +699,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.doOnEach(new TestSubscriber<Object>());
+                return f.doOnEach(new TestSubscriber<>());
             }
         });
     }
@@ -736,7 +736,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
                 .compose(new FlowableTransformer<Integer, Integer>() {
                     @Override
                     public Publisher<Integer> apply(Flowable<Integer> v) {
-                        return new FlowableDoOnEach<Integer>(v,
+                        return new FlowableDoOnEach<>(v,
                                 new Consumer<Integer>() {
                                     @Override
                                     public void accept(Integer v) throws Exception {
@@ -752,7 +752,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
                                 Functions.EMPTY_ACTION
                                 ,
                                 Functions.EMPTY_ACTION
-                                );
+                        );
                     }
                 })
         .publish();
@@ -866,7 +866,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
                 .compose(new FlowableTransformer<Integer, Integer>() {
                     @Override
                     public Publisher<Integer> apply(Flowable<Integer> v) {
-                        return new FlowableDoOnEach<Integer>(v,
+                        return new FlowableDoOnEach<>(v,
                                 new Consumer<Integer>() {
                                     @Override
                                     public void accept(Integer v) throws Exception {
@@ -882,7 +882,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
                                 Functions.EMPTY_ACTION
                                 ,
                                 Functions.EMPTY_ACTION
-                                );
+                        );
                     }
                 })
         .filter(Functions.alwaysTrue())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnRequestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnRequestTest.java
@@ -51,7 +51,7 @@ public class FlowableDoOnRequestTest extends RxJavaTest {
 
     @Test
     public void doRequest() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
         Flowable.range(1, 5)
         //
                 .doOnRequest(new LongConsumer() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnSubscribeTest.java
@@ -66,7 +66,7 @@ public class FlowableDoOnSubscribeTest extends RxJavaTest {
         final AtomicInteger onSubscribed = new AtomicInteger();
         final AtomicInteger countBefore = new AtomicInteger();
         final AtomicInteger countAfter = new AtomicInteger();
-        final AtomicReference<Subscriber<? super Integer>> sref = new AtomicReference<Subscriber<? super Integer>>();
+        final AtomicReference<Subscriber<? super Integer>> sref = new AtomicReference<>();
         Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
@@ -67,11 +67,11 @@ public class FlowableDoOnUnsubscribeTest extends RxJavaTest {
                     }
                 });
 
-        List<Disposable> subscriptions = new ArrayList<Disposable>();
-        List<TestSubscriber<Long>> subscribers = new ArrayList<TestSubscriber<Long>>();
+        List<Disposable> subscriptions = new ArrayList<>();
+        List<TestSubscriber<Long>> subscribers = new ArrayList<>();
 
         for (int i = 0; i < subCount; ++i) {
-            TestSubscriber<Long> subscriber = new TestSubscriber<Long>();
+            TestSubscriber<Long> subscriber = new TestSubscriber<>();
             subscriptions.add(Disposable.fromSubscription(subscriber));
             longs.subscribe(subscriber);
             subscribers.add(subscriber);
@@ -128,11 +128,11 @@ public class FlowableDoOnUnsubscribeTest extends RxJavaTest {
                 .publish()
                 .refCount();
 
-        List<Disposable> subscriptions = new ArrayList<Disposable>();
-        List<TestSubscriber<Long>> subscribers = new ArrayList<TestSubscriber<Long>>();
+        List<Disposable> subscriptions = new ArrayList<>();
+        List<TestSubscriber<Long>> subscribers = new ArrayList<>();
 
         for (int i = 0; i < subCount; ++i) {
-            TestSubscriber<Long> subscriber = new TestSubscriber<Long>();
+            TestSubscriber<Long> subscriber = new TestSubscriber<>();
             longs.subscribe(subscriber);
             subscriptions.add(Disposable.fromSubscription(subscriber));
             subscribers.add(subscriber);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableElementAtTest.java
@@ -72,7 +72,7 @@ public class FlowableElementAtTest extends RxJavaTest {
 
     @Test
     public void elementAtConstrainsUpstreamRequests() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
         Flowable.fromArray(1, 2, 3, 4)
             .doOnRequest(new LongConsumer() {
                 @Override
@@ -88,7 +88,7 @@ public class FlowableElementAtTest extends RxJavaTest {
 
     @Test
     public void elementAtWithDefaultConstrainsUpstreamRequests() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
         Flowable.fromArray(1, 2, 3, 4)
             .doOnRequest(new LongConsumer() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFilterTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFilterTest.java
@@ -158,7 +158,7 @@ public class FlowableFilterTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         pp.filter(new Predicate<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -523,7 +523,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void disposeInner() {
-        final TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Object>>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -408,7 +408,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void disposeInner() {
-        final TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.just(1).flatMapSingle(new Function<Integer, SingleSource<Object>>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapTest.java
@@ -343,13 +343,13 @@ public class FlowableFlatMapTest extends RxJavaTest {
             }
         }, m);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
-        Set<Integer> expected = new HashSet<Integer>(Arrays.asList(
+        Set<Integer> expected = new HashSet<>(Arrays.asList(
                 10, 11, 20, 21, 30, 31, 40, 41, 50, 51, 60, 61, 70, 71, 80, 81, 90, 91, 100, 101
         ));
         Assert.assertEquals(expected.size(), ts.values().size());
@@ -374,13 +374,13 @@ public class FlowableFlatMapTest extends RxJavaTest {
             }
         }, m);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
-        Set<Integer> expected = new HashSet<Integer>(Arrays.asList(
+        Set<Integer> expected = new HashSet<>(Arrays.asList(
                 1010, 1011, 2020, 2021, 3030, 3031, 4040, 4041, 5050, 5051,
                 6060, 6061, 7070, 7071, 8080, 8081, 9090, 9091, 10100, 10101
         ));
@@ -420,7 +420,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>(subscriber);
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>(subscriber);
 
         Function<Integer, Flowable<Integer>> just = just(onNext);
         Function<Throwable, Flowable<Integer>> just2 = just(onError);
@@ -447,7 +447,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
             if (i % 10 == 0) {
                 System.out.println("flatMapRangeAsyncLoop > " + i);
             }
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.range(0, 1000)
             .flatMap(new Function<Integer, Flowable<Integer>>() {
                 final Random rnd = new Random();
@@ -471,7 +471,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
             ts.assertNoErrors();
             List<Integer> list = ts.values();
             if (list.size() < 1000) {
-                Set<Integer> set = new HashSet<Integer>(list);
+                Set<Integer> set = new HashSet<>(list);
                 for (int j = 0; j < 1000; j++) {
                     if (!set.contains(j)) {
                         System.out.println(j + " missing");
@@ -485,7 +485,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapIntPassthruAsync() {
         for (int i = 0; i < 1000; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.range(1, 1000).flatMap(new Function<Integer, Flowable<Integer>>() {
                 @Override
@@ -504,7 +504,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTwoNestedSync() {
         for (final int n : new int[] { 1, 1000, 1000000 }) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).flatMap(new Function<Integer, Flowable<Integer>>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -40,7 +40,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     @Test
     public void normal0() {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 2)
         .reduce(new BiFunction<Integer, Integer, Integer>() {
@@ -72,7 +72,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5).concatMapIterable(mapper)
         .subscribe(ts);
@@ -84,7 +84,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void normalViaFlatMap() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5).flatMapIterable(mapper)
         .subscribe(ts);
@@ -96,7 +96,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void normalBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
 
         Flowable.range(1, 5).concatMapIterable(mapper)
         .subscribe(ts);
@@ -126,7 +126,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void longRunning() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         int n = 1000 * 1000;
 
@@ -140,7 +140,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void asIntermediate() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         int n = 1000 * 1000;
 
@@ -159,7 +159,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void just() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1).concatMapIterable(mapper)
         .subscribe(ts);
@@ -171,7 +171,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void justHidden() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1).hide().concatMapIterable(mapper)
         .subscribe(ts);
@@ -183,7 +183,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void empty() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.<Integer>empty().concatMapIterable(mapper)
         .subscribe(ts);
@@ -195,7 +195,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void error() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.<Integer>just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .concatMapIterable(mapper)
@@ -208,7 +208,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorHasNextThrowsImmediately() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final Iterable<Integer> it = new Iterable<Integer>() {
             @Override
@@ -248,7 +248,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorHasNextThrowsImmediatelyJust() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final Iterable<Integer> it = new Iterable<Integer>() {
             @Override
@@ -288,7 +288,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorHasNextThrowsSecondCall() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final Iterable<Integer> it = new Iterable<Integer>() {
             @Override
@@ -332,7 +332,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorNextThrows() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final Iterable<Integer> it = new Iterable<Integer>() {
             @Override
@@ -372,7 +372,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorNextThrowsAndUnsubscribes() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final Iterable<Integer> it = new Iterable<Integer>() {
             @Override
@@ -418,7 +418,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void mixture() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(0, 1000)
         .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
@@ -436,7 +436,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void emptyInnerThenSingleBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
 
         Flowable.range(1, 2)
         .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
@@ -454,7 +454,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void manyEmptyInnerThenSingleBackpressured() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
 
         Flowable.range(1, 1000)
         .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
@@ -472,7 +472,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextIsNotCalledAfterChildUnsubscribedOnNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final AtomicInteger counter = new AtomicInteger();
 
@@ -523,7 +523,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void normalPrefetchViaFlatMap() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5).flatMapIterable(mapper, 2)
         .subscribe(ts);
@@ -827,7 +827,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void cancelAfterHasNext() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 3).hide()
         .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
@@ -974,8 +974,8 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void upstreamFusionRejected() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<Integer, Integer>(ts,
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<>(ts,
                 Functions.justFunction(Collections.<Integer>emptyList()), 128);
 
         final AtomicLong requested = new AtomicLong();
@@ -1031,8 +1031,8 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void onErrorLate() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
-            FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<Integer, Integer>(ts,
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+            FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<>(ts,
                     Functions.justFunction(Collections.<Integer>emptyList()), 128);
 
             f.onSubscribe(new BooleanSubscription());
@@ -1059,8 +1059,8 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void fusedCurrentIteratorEmpty() throws Throwable {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
-        FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<Integer, Integer>(ts,
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<>(ts,
                 Functions.justFunction(Arrays.<Integer>asList(1, 2)), 128);
 
         f.onSubscribe(new BooleanSubscription());
@@ -1080,8 +1080,8 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void fusionRequestedState() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
-        FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<Integer, Integer>(ts,
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
+        FlattenIterableSubscriber<Integer, Integer> f = new FlattenIterableSubscriber<>(ts,
                 Functions.justFunction(Arrays.<Integer>asList(1, 2)), 128);
 
         f.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableForEachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableForEachTest.java
@@ -27,7 +27,7 @@ public class FlowableForEachTest extends RxJavaTest {
 
     @Test
     public void forEachWile() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Flowable.range(1, 5)
         .doOnNext(new Consumer<Integer>() {
@@ -48,7 +48,7 @@ public class FlowableForEachTest extends RxJavaTest {
 
     @Test
     public void forEachWileWithError() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(new TestException()))
         .doOnNext(new Consumer<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromArrayTest.java
@@ -37,7 +37,7 @@ public class FlowableFromArrayTest extends RxJavaTest {
 
     @Test
     public void simple() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         create(1000).subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromCallableTest.java
@@ -121,7 +121,7 @@ public class FlowableFromCallableTest extends RxJavaTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<String> outer = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> outer = new TestSubscriber<>(subscriber);
 
         fromCallableFlowable
                 .subscribeOn(Schedulers.computation())
@@ -248,7 +248,7 @@ public class FlowableFromCallableTest extends RxJavaTest {
     public void undeliverableUponCancellation() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.fromCallable(new Callable<Integer>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromIterableTest.java
@@ -119,13 +119,13 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void backpressureViaRequest() {
-        ArrayList<Integer> list = new ArrayList<Integer>(Flowable.bufferSize());
+        ArrayList<Integer> list = new ArrayList<>(Flowable.bufferSize());
         for (int i = 1; i <= Flowable.bufferSize() + 1; i++) {
             list.add(i);
         }
         Flowable<Integer> f = Flowable.fromIterable(list);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
 
         ts.assertNoValues();
         ts.request(1);
@@ -145,7 +145,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void noBackpressure() {
         Flowable<Integer> f = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5));
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
 
         ts.assertNoValues();
         ts.request(Long.MAX_VALUE); // infinite
@@ -161,7 +161,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
         Flowable<Integer> f = Flowable.fromIterable(Arrays.asList(1, 2, 3));
 
         for (int i = 0; i < 10; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             f.subscribe(ts);
 
@@ -333,7 +333,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.fromIterable(it).subscribe(ts);
 
@@ -366,7 +366,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.fromIterable(it).subscribe(ts);
 
@@ -403,7 +403,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.fromIterable(it).subscribe(ts);
 
@@ -440,7 +440,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(5);
 
         Flowable.fromIterable(it).subscribe(ts);
 
@@ -473,7 +473,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.fromIterable(it).subscribe(ts);
 
@@ -506,7 +506,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(5);
 
         Flowable.fromIterable(it).subscribe(ts);
 
@@ -539,7 +539,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(5);
         ts.cancel();
 
         Flowable.fromIterable(it).subscribe(ts);
@@ -552,7 +552,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void fusionWithConcatMap() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.fromIterable(Arrays.asList(1, 2, 3, 4)).concatMap(
         new Function<Integer, Flowable  <Integer>>() {
@@ -724,7 +724,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void requestRaceConditional() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             Runnable r = new Runnable() {
                 @Override
@@ -744,7 +744,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void requestRaceConditional2() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             Runnable r = new Runnable() {
                 @Override
@@ -764,7 +764,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void requestCancelConditionalRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -791,7 +791,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void requestCancelConditionalRace2() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -818,7 +818,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void requestCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -844,7 +844,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void requestCancelRace2() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -933,7 +933,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextCancels() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.fromIterable(new Iterable<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSourceTest.java
@@ -38,7 +38,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
     public void before() {
         source = new PublishAsyncEmitter();
         sourceNoCancel = new PublishAsyncEmitterNoCancel();
-        ts = new TestSubscriberEx<Integer>(0L);
+        ts = new TestSubscriberEx<>(0L);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSupplierTest.java
@@ -121,7 +121,7 @@ public class FlowableFromSupplierTest extends RxJavaTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<String> outer = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> outer = new TestSubscriber<>(subscriber);
 
         fromSupplierFlowable
                 .subscribeOn(Schedulers.computation())
@@ -248,7 +248,7 @@ public class FlowableFromSupplierTest extends RxJavaTest {
     public void undeliverableUponCancellation() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.fromSupplier(new Supplier<Integer>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -111,7 +111,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         final AtomicInteger groupCounter = new AtomicInteger();
         final AtomicInteger eventCounter = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         grouped.flatMap(new Function<GroupedFlowable<Integer, String>, Flowable<String>>() {
 
@@ -156,13 +156,13 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     private static <K, V> Map<K, Collection<V>> toMap(Flowable<GroupedFlowable<K, V>> flowable) {
 
-        final ConcurrentHashMap<K, Collection<V>> result = new ConcurrentHashMap<K, Collection<V>>();
+        final ConcurrentHashMap<K, Collection<V>> result = new ConcurrentHashMap<>();
 
         flowable.doOnNext(new Consumer<GroupedFlowable<K, V>>() {
 
             @Override
             public void accept(final GroupedFlowable<K, V> f) {
-                result.put(f.getKey(), new ConcurrentLinkedQueue<V>());
+                result.put(f.getKey(), new ConcurrentLinkedQueue<>());
                 f.subscribe(new Consumer<V>() {
 
                     @Override
@@ -605,7 +605,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void firstGroupsCompleteAndParentSlowToThenEmitFinalGroupsAndThenComplete() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
@@ -684,7 +684,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void firstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenSubscribesOnAndDelaysAndThenCompletes() throws InterruptedException {
         System.err.println("----------------------------------------------------------------------------------------------");
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
@@ -776,7 +776,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void firstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenObservesOnAndDelaysAndThenCompletes() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
@@ -853,7 +853,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void groupsWithNestedSubscribeOn() throws InterruptedException {
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
@@ -910,7 +910,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void groupsWithNestedObserveOn() throws InterruptedException {
-        final ArrayList<String> results = new ArrayList<String>();
+        final ArrayList<String> results = new ArrayList<>();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
@@ -1035,7 +1035,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void groupByBackpressure() throws InterruptedException {
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
 
         Flowable.range(1, 4000)
                 .groupBy(IS_EVEN2)
@@ -1162,7 +1162,7 @@ public class FlowableGroupByTest extends RxJavaTest {
             }
         });
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         m.subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         System.out.println("ts .get " + ts.values());
@@ -1178,7 +1178,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         Flowable<Integer> m = source.groupBy(fail(0), dbl).flatMap(FLATTEN_INTEGER);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         m.subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(1, ts.errors().size());
@@ -1190,7 +1190,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         Flowable<Integer> source = Flowable.just(0, 1, 2, 3, 4, 5, 6);
 
         Flowable<Integer> m = source.groupBy(identity, fail(0)).flatMap(FLATTEN_INTEGER);
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         m.subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(1, ts.errors().size());
@@ -1204,7 +1204,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         Flowable<Integer> m = source.groupBy(identity, dbl).flatMap(FLATTEN_INTEGER);
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         m.subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1218,7 +1218,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void exceptionIfSubscribeToChildMoreThanOnce() {
         Flowable<Integer> source = Flowable.just(0);
 
-        final AtomicReference<GroupedFlowable<Integer, Integer>> inner = new AtomicReference<GroupedFlowable<Integer, Integer>>();
+        final AtomicReference<GroupedFlowable<Integer, Integer>> inner = new AtomicReference<>();
 
         Flowable<GroupedFlowable<Integer, Integer>> m = source.groupBy(identity, dbl);
 
@@ -1247,7 +1247,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         Flowable<Integer> m = source.groupBy(identity, dbl).flatMap(FLATTEN_INTEGER);
 
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
         m.subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(1, ts.errors().size());
@@ -1256,7 +1256,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void groupByBackpressure3() throws InterruptedException {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
 
         Flowable.range(1, 4000).groupBy(IS_EVEN2).flatMap(new Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>() {
 
@@ -1313,7 +1313,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void groupByBackpressure2() throws InterruptedException {
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
 
         Flowable.range(1, 4000)
             .doOnNext(new Consumer<Integer>() {
@@ -1362,7 +1362,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void groupByWithNullKey() {
         final String[] key = new String[]{"uninitialized"};
-        final List<String> values = new ArrayList<String>();
+        final List<String> values = new ArrayList<>();
         Flowable.just("a", "b", "c").groupBy(new Function<String, String>() {
 
             @Override
@@ -1398,7 +1398,7 @@ public class FlowableGroupByTest extends RxJavaTest {
                     }
                 }
         );
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         f.groupBy(new Function<Integer, Integer>() {
 
@@ -1416,11 +1416,11 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void groupByShouldPropagateError() {
         final Throwable e = new RuntimeException("Oops");
-        final TestSubscriberEx<Integer> inner1 = new TestSubscriberEx<Integer>();
-        final TestSubscriberEx<Integer> inner2 = new TestSubscriberEx<Integer>();
+        final TestSubscriberEx<Integer> inner1 = new TestSubscriberEx<>();
+        final TestSubscriberEx<Integer> inner2 = new TestSubscriberEx<>();
 
         final TestSubscriberEx<GroupedFlowable<Integer, Integer>> outer
-                = new TestSubscriberEx<GroupedFlowable<Integer, Integer>>(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() {
+                = new TestSubscriberEx<>(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() {
 
             @Override
             public void onComplete() {
@@ -1557,7 +1557,7 @@ public class FlowableGroupByTest extends RxJavaTest {
      */
     @Test
     public void backpressureInnerDoesntOverflowOuter() {
-        TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<GroupedFlowable<Integer, Integer>>(0L);
+        TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<>(0L);
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -1586,7 +1586,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void backpressureInnerDoesntOverflowOuterMissingBackpressure() {
-        TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<GroupedFlowable<Integer, Integer>>(1);
+        TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<>(1);
 
         Flowable.fromArray(1, 2)
                 .groupBy(new Function<Integer, Integer>() {
@@ -1611,9 +1611,9 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void oneGroupInnerRequestsTwiceBuffer() {
         // FIXME: delayed requesting in groupBy results in group abandonment
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>(1L);
+        TestSubscriber<Object> ts1 = new TestSubscriber<>(1L);
 
-        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>(0L);
+        final TestSubscriber<Object> ts2 = new TestSubscriber<>(0L);
 
         Flowable.range(1, Flowable.bufferSize() * 2)
         .groupBy(new Function<Integer, Object>() {
@@ -1886,7 +1886,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void mapFactoryExpiryCompletesGroupedFlowable() {
-        final List<Integer> completed = new CopyOnWriteArrayList<Integer>();
+        final List<Integer> completed = new CopyOnWriteArrayList<>();
         Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory = createEvictingMapFactorySynchronousOnly(1);
         PublishSubject<Integer> subject = PublishSubject.create();
         TestSubscriberEx<Integer> ts = subject.toFlowable(BackpressureStrategy.BUFFER)
@@ -1916,7 +1916,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void mapFactoryWithExpiringGuavaCacheDemonstrationCodeForUseInJavadoc() {
         //javadoc will be a version of this using lambdas and without assertions
-        final List<Integer> completed = new CopyOnWriteArrayList<Integer>();
+        final List<Integer> completed = new CopyOnWriteArrayList<>();
         //size should be less than 5 to notice the effect
         Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory = createEvictingMapFactoryGuava(3);
         int numValues = 1000;
@@ -1999,7 +1999,7 @@ public class FlowableGroupByTest extends RxJavaTest {
             }
         };
 
-        final List<String> list = new CopyOnWriteArrayList<String>();
+        final List<String> list = new CopyOnWriteArrayList<>();
         Flowable<Integer> stream = source //
                 .doOnCancel(new Action() {
                     @Override
@@ -2091,8 +2091,8 @@ public class FlowableGroupByTest extends RxJavaTest {
     //not thread safe
     private static final class SingleThreadEvictingHashMap<K, V> implements Map<K, V> {
 
-        private final List<K> list = new ArrayList<K>();
-        private final Map<K, V> map = new HashMap<K, V>();
+        private final List<K> list = new ArrayList<>();
+        private final Map<K, V> map = new HashMap<>();
         private final int maxSize;
         private final Consumer<V> evictedListener;
 
@@ -2214,15 +2214,16 @@ public class FlowableGroupByTest extends RxJavaTest {
 
                     @Override
                     public Map<Integer, Object> apply(final Consumer<Object> notify) throws Exception {
-                        return new SingleThreadEvictingHashMap<Integer, Object>(maxSize, new Consumer<Object>() {
-                                    @Override
-                                    public void accept(Object object) {
-                                        try {
-                                            notify.accept(object);
-                                        } catch (Throwable e) {
-                                            throw new RuntimeException(e);
-                                        }
-                                    }});
+                        return new SingleThreadEvictingHashMap<>(maxSize, new Consumer<Object>() {
+                            @Override
+                            public void accept(Object object) {
+                                try {
+                                    notify.accept(object);
+                                } catch (Throwable e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
+                        });
                     }};
         return evictingMapFactory;
     }
@@ -2231,7 +2232,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void cancelOverFlatmapRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
 
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -2274,7 +2275,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void abandonedGroupsNoDataloss() {
-        final List<GroupedFlowable<Integer, Integer>> groups = new ArrayList<GroupedFlowable<Integer, Integer>>();
+        final List<GroupedFlowable<Integer, Integer>> groups = new ArrayList<>();
 
         Flowable.range(1, 1000)
         .groupBy(new Function<Integer, Integer>() {
@@ -2303,8 +2304,8 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void newGroupValueSelectorFails() {
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>();
-        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts1 = new TestSubscriber<>();
+        final TestSubscriber<Object> ts2 = new TestSubscriber<>();
 
         Flowable.just(1)
         .groupBy(Functions.<Integer>identity(), new Function<Integer, Object>() {
@@ -2330,8 +2331,8 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void existingGroupValueSelectorFails() {
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>();
-        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts1 = new TestSubscriber<>();
+        final TestSubscriber<Object> ts2 = new TestSubscriber<>();
 
         Flowable.just(1, 2)
         .groupBy(Functions.justFunction(1), new Function<Integer, Object>() {
@@ -2399,7 +2400,7 @@ public class FlowableGroupByTest extends RxJavaTest {
                 throw new TestException();
             }
         })
-        .subscribeWith(new TestSubscriberEx<GroupedFlowable<Integer, Integer>>(0L));
+        .subscribeWith(new TestSubscriberEx<>(0L));
 
         assertTrue(pp.offer(1));
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -61,7 +61,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void completedOkFlowable() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
         Flowable.range(1, 10).ignoreElements().toFlowable().subscribe(ts);
         ts.assertNoErrors();
         ts.assertNoValues();
@@ -70,7 +70,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void errorReceivedFlowable() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
         TestException ex = new TestException("boo");
         Flowable.error(ex).ignoreElements().toFlowable().subscribe(ts);
         ts.assertNoValues();
@@ -173,7 +173,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void completedOk() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         Flowable.range(1, 10).ignoreElements().subscribe(to);
         to.assertNoErrors();
         to.assertNoValues();
@@ -182,7 +182,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void errorReceived() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         TestException ex = new TestException("boo");
         Flowable.error(ex).ignoreElements().subscribe(to);
         to.assertNoValues();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIntervalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIntervalTest.java
@@ -40,7 +40,7 @@ public class FlowableIntervalTest extends RxJavaTest {
 
     @Test
     public void cancelledOnRun() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts = new TestSubscriber<>();
         IntervalSubscriber is = new IntervalSubscriber(ts);
         ts.onSubscribe(is);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMapNotificationTest.java
@@ -29,7 +29,7 @@ import io.reactivex.rxjava3.testsupport.*;
 public class FlowableMapNotificationTest extends RxJavaTest {
     @Test
     public void just() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         Flowable.just(1)
         .flatMap(
                 new Function<Integer, Flowable<Object>>() {
@@ -61,7 +61,7 @@ public class FlowableMapNotificationTest extends RxJavaTest {
     public void backpressure() {
         TestSubscriber<Object> ts = TestSubscriber.create(0L);
 
-        new FlowableMapNotification<Integer, Integer>(Flowable.range(1, 3),
+        new FlowableMapNotification<>(Flowable.range(1, 3),
                 new Function<Integer, Integer>() {
                     @Override
                     public Integer apply(Integer item) {
@@ -105,7 +105,7 @@ public class FlowableMapNotificationTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        new FlowableMapNotification<Integer, Integer>(pp,
+        new FlowableMapNotification<>(pp,
                 new Function<Integer, Integer>() {
                     @Override
                     public Integer apply(Integer item) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMapTest.java
@@ -155,7 +155,7 @@ public class FlowableMapTest extends RxJavaTest {
 
     @Test
     public void mapWithError() {
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         Flowable<String> w = Flowable.just("one", "fail", "two", "three", "fail");
         Flowable<String> m = w.map(new Function<String, String>() {
@@ -261,7 +261,7 @@ public class FlowableMapTest extends RxJavaTest {
     }
 
     private static Map<String, String> getMap(String prefix) {
-        Map<String, String> m = new HashMap<String, String>();
+        Map<String, String> m = new HashMap<>();
         m.put("firstName", prefix + "First");
         m.put("lastName", prefix + "Last");
         return m;
@@ -272,7 +272,7 @@ public class FlowableMapTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         pp.map(new Function<Integer, Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMaterializeTest.java
@@ -102,7 +102,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void backpressureOnEmptyStream() {
-        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<Notification<Integer>>(0L);
+        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<>(0L);
         Flowable.<Integer> empty().materialize().subscribe(ts);
         ts.assertNoValues();
         ts.request(1);
@@ -113,7 +113,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void backpressureNoError() {
-        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<Notification<Integer>>(0L);
+        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<>(0L);
         Flowable.just(1, 2, 3).materialize().subscribe(ts);
         ts.assertNoValues();
         ts.request(1);
@@ -127,7 +127,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void backpressureNoErrorAsync() throws InterruptedException {
-        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<Notification<Integer>>(0L);
+        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<>(0L);
         Flowable.just(1, 2, 3)
             .materialize()
             .subscribeOn(Schedulers.computation())
@@ -148,7 +148,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void backpressureWithError() {
-        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<Notification<Integer>>(0L);
+        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<>(0L);
         Flowable.<Integer> error(new IllegalArgumentException()).materialize().subscribe(ts);
         ts.assertNoValues();
         ts.request(1);
@@ -158,7 +158,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void backpressureWithEmissionThenError() {
-        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<Notification<Integer>>(0L);
+        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<>(0L);
         IllegalArgumentException ex = new IllegalArgumentException();
         Flowable.fromIterable(Arrays.asList(1)).concatWith(Flowable.<Integer> error(ex)).materialize()
                 .subscribe(ts);
@@ -175,7 +175,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void withCompletionCausingError() {
-        TestSubscriberEx<Notification<Integer>> ts = new TestSubscriberEx<Notification<Integer>>();
+        TestSubscriberEx<Notification<Integer>> ts = new TestSubscriberEx<>();
         final RuntimeException ex = new RuntimeException("boo");
         Flowable.<Integer>empty().materialize().doOnNext(new Consumer<Object>() {
             @Override
@@ -190,7 +190,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void unsubscribeJustBeforeCompletionNotificationShouldPreventThatNotificationArriving() {
-        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<Notification<Integer>>(0L);
+        TestSubscriber<Notification<Integer>> ts = new TestSubscriber<>(0L);
 
         Flowable.<Integer>empty().materialize()
                 .subscribe(ts);
@@ -204,7 +204,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
         boolean onComplete;
         boolean onError;
-        List<Notification<String>> notifications = new Vector<Notification<String>>();
+        List<Notification<String>> notifications = new Vector<>();
 
         @Override
         public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -257,7 +257,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
     public void mergeList() {
         final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
+        List<Flowable<String>> listOfFlowables = new ArrayList<>();
         listOfFlowables.add(f1);
         listOfFlowables.add(f2);
 
@@ -438,7 +438,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void errorInParentFlowable() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         Flowable.mergeDelayError(
                 Flowable.just(Flowable.just(1), Flowable.just(2))
                         .startWithItem(Flowable.<Integer> error(new RuntimeException()))
@@ -467,7 +467,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
 
             stringSubscriber = TestHelper.mockSubscriber();
 
-            TestSubscriberEx<String> ts = new TestSubscriberEx<String>(stringSubscriber);
+            TestSubscriberEx<String> ts = new TestSubscriberEx<>(stringSubscriber);
             Flowable<String> m = Flowable.mergeDelayError(parentFlowable);
             m.subscribe(ts);
             System.out.println("testErrorInParentFlowableDelayed | " + i);
@@ -506,7 +506,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void delayErrorMaxConcurrent() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(
                 Flowable.just(1).hide(),
                 Flowable.<Integer>error(new TestException()))
@@ -517,7 +517,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
                     }
                 }), 1);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         source.subscribe(ts);
 
@@ -532,7 +532,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
     public void mergeIterable() {
         final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
+        List<Flowable<String>> listOfFlowables = new ArrayList<>();
         listOfFlowables.add(f1);
         listOfFlowables.add(f2);
 
@@ -574,7 +574,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void iterableMaxConcurrentError() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -34,14 +34,14 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void whenMaxConcurrentIsOne() {
         for (int i = 0; i < 100; i++) {
-            List<Flowable<String>> os = new ArrayList<Flowable<String>>();
+            List<Flowable<String>> os = new ArrayList<>();
             os.add(Flowable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
             os.add(Flowable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
             os.add(Flowable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
 
             List<String> expected = Arrays.asList("one", "two", "three", "four", "five", "one", "two", "three", "four", "five", "one", "two", "three", "four", "five");
             Iterator<String> iter = Flowable.merge(os, 1).blockingIterable().iterator();
-            List<String> actual = new ArrayList<String>();
+            List<String> actual = new ArrayList<>();
             while (iter.hasNext()) {
                 actual.add(iter.next());
             }
@@ -57,8 +57,8 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
             int maxConcurrent = 2 + (times % 10);
             AtomicInteger subscriptionCount = new AtomicInteger(0);
 
-            List<Flowable<String>> os = new ArrayList<Flowable<String>>();
-            List<SubscriptionCheckObservable> scos = new ArrayList<SubscriptionCheckObservable>();
+            List<Flowable<String>> os = new ArrayList<>();
+            List<SubscriptionCheckObservable> scos = new ArrayList<>();
             for (int i = 0; i < observableCount; i++) {
                 SubscriptionCheckObservable sco = new SubscriptionCheckObservable(subscriptionCount, maxConcurrent);
                 scos.add(sco);
@@ -66,7 +66,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
             }
 
             Iterator<String> iter = Flowable.merge(os, maxConcurrent).blockingIterable().iterator();
-            List<String> actual = new ArrayList<String>();
+            List<String> actual = new ArrayList<>();
             while (iter.hasNext()) {
                 actual.add(iter.next());
             }
@@ -118,7 +118,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void mergeALotOfSourcesOneByOneSynchronously() {
         int n = 10000;
-        List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(n);
+        List<Flowable<Integer>> sourceList = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
             sourceList.add(Flowable.just(i));
         }
@@ -134,7 +134,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void mergeALotOfSourcesOneByOneSynchronouslyTakeHalf() {
         int n = 10000;
-        List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(n);
+        List<Flowable<Integer>> sourceList = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
             sourceList.add(Flowable.just(i));
         }
@@ -150,9 +150,9 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void simple() {
         for (int i = 1; i < 100; i++) {
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
-            List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(i);
-            List<Integer> result = new ArrayList<Integer>(i);
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+            List<Flowable<Integer>> sourceList = new ArrayList<>(i);
+            List<Integer> result = new ArrayList<>(i);
             for (int j = 1; j <= i; j++) {
                 sourceList.add(Flowable.just(j));
                 result.add(j);
@@ -169,9 +169,9 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void simpleOneLess() {
         for (int i = 2; i < 100; i++) {
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
-            List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(i);
-            List<Integer> result = new ArrayList<Integer>(i);
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+            List<Flowable<Integer>> sourceList = new ArrayList<>(i);
+            List<Integer> result = new ArrayList<>(i);
             for (int j = 1; j <= i; j++) {
                 sourceList.add(Flowable.just(j));
                 result.add(j);
@@ -201,9 +201,9 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
     @Test
     public void simpleAsync() {
         for (int i = 1; i < 50; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-            List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(i);
-            Set<Integer> expected = new HashSet<Integer>(i);
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            List<Flowable<Integer>> sourceList = new ArrayList<>(i);
+            Set<Integer> expected = new HashSet<>(i);
             for (int j = 1; j <= i; j++) {
                 sourceList.add(Flowable.just(j).subscribeOn(Schedulers.io()));
                 expected.add(j);
@@ -213,7 +213,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
 
             ts.awaitDone(1, TimeUnit.SECONDS);
             ts.assertNoErrors();
-            Set<Integer> actual = new HashSet<Integer>(ts.values());
+            Set<Integer> actual = new HashSet<>(ts.values());
 
             assertEquals(expected, actual);
         }
@@ -233,9 +233,9 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
             if (System.currentTimeMillis() - t > TimeUnit.SECONDS.toMillis(9)) {
                 break;
             }
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-            List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(i);
-            Set<Integer> expected = new HashSet<Integer>(i);
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            List<Flowable<Integer>> sourceList = new ArrayList<>(i);
+            Set<Integer> expected = new HashSet<>(i);
             for (int j = 1; j <= i; j++) {
                 sourceList.add(Flowable.just(j).subscribeOn(Schedulers.io()));
                 expected.add(j);
@@ -245,7 +245,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
 
             ts.awaitDone(1, TimeUnit.SECONDS);
             ts.assertNoErrors();
-            Set<Integer> actual = new HashSet<Integer>(ts.values());
+            Set<Integer> actual = new HashSet<>(ts.values());
 
             assertEquals(expected, actual);
         }
@@ -253,7 +253,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
 
     @Test
     public void backpressureHonored() throws Exception {
-        List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(3);
+        List<Flowable<Integer>> sourceList = new ArrayList<>(3);
 
         sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
         sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
@@ -284,13 +284,13 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
 
     @Test
     public void take() throws Exception {
-        List<Flowable<Integer>> sourceList = new ArrayList<Flowable<Integer>>(3);
+        List<Flowable<Integer>> sourceList = new ArrayList<>(3);
 
         sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
         sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
         sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.merge(sourceList, 2).take(5).subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeTest.java
@@ -115,7 +115,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void mergeList() {
         final Flowable<String> f1 = Flowable.unsafeCreate(new TestSynchronousFlowable());
         final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
-        List<Flowable<String>> listOfFlowables = new ArrayList<Flowable<String>>();
+        List<Flowable<String>> listOfFlowables = new ArrayList<>();
         listOfFlowables.add(f1);
         listOfFlowables.add(f2);
 
@@ -201,7 +201,7 @@ public class FlowableMergeTest extends RxJavaTest {
         final TestASynchronousFlowable f2 = new TestASynchronousFlowable();
 
         Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(f1), Flowable.unsafeCreate(f2));
-        TestSubscriber<String> ts = new TestSubscriber<String>(stringSubscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(stringSubscriber);
         m.subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -231,7 +231,7 @@ public class FlowableMergeTest extends RxJavaTest {
         final AtomicInteger concurrentCounter = new AtomicInteger();
         final AtomicInteger totalCounter = new AtomicInteger();
 
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(f1), Flowable.unsafeCreate(f2));
         m.subscribe(new DefaultSubscriber<String>() {
@@ -424,7 +424,7 @@ public class FlowableMergeTest extends RxJavaTest {
         AtomicBoolean os2 = new AtomicBoolean(false);
         Flowable<Long> f2 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
-        TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>();
+        TestSubscriberEx<Long> ts = new TestSubscriberEx<>();
         Flowable.merge(f1, f2).subscribe(ts);
 
         // we haven't incremented time so nothing should be received yet
@@ -466,7 +466,7 @@ public class FlowableMergeTest extends RxJavaTest {
             AtomicBoolean os2 = new AtomicBoolean(false);
             Flowable<Long> f2 = createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
-            TestSubscriber<Long> ts = new TestSubscriber<Long>();
+            TestSubscriber<Long> ts = new TestSubscriber<>();
             Flowable.merge(f1, f2).subscribe(ts);
 
             // we haven't incremented time so nothing should be received yet
@@ -542,7 +542,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
         for (int i = 0; i < 10; i++) {
             Flowable<Integer> merge = Flowable.merge(f.onBackpressureBuffer(), f.onBackpressureBuffer(), f.onBackpressureBuffer());
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             merge.subscribe(ts);
 
             ts.awaitDone(3, TimeUnit.SECONDS);
@@ -595,7 +595,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
         for (int i = 0; i < 10; i++) {
             Flowable<Integer> merge = Flowable.merge(f, f, f);
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
             merge.subscribe(ts);
 
             ts.awaitDone(5, TimeUnit.SECONDS);
@@ -642,7 +642,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
         for (int i = 0; i < 10; i++) {
             Flowable<Integer> merge = Flowable.merge(f.onBackpressureBuffer(), f.onBackpressureBuffer(), f.onBackpressureBuffer());
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
             merge.subscribe(ts);
 
             ts.awaitDone(5, TimeUnit.SECONDS);
@@ -866,7 +866,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1AsyncStreamOf1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNAsyncStreamsOfN(1, 1).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -875,7 +875,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1AsyncStreamOf1000() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNAsyncStreamsOfN(1, 1000).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -884,7 +884,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge10AsyncStreamOf1000() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNAsyncStreamsOfN(10, 1000).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -893,7 +893,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1000AsyncStreamOf1000() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNAsyncStreamsOfN(1000, 1000).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -902,7 +902,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge2000AsyncStreamOf100() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNAsyncStreamsOfN(2000, 100).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -911,7 +911,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge100AsyncStreamOf1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNAsyncStreamsOfN(100, 1).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -933,7 +933,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1SyncStreamOf1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNSyncStreamsOfN(1, 1).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -942,7 +942,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1SyncStreamOf1000000() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNSyncStreamsOfN(1, 1000000).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -951,7 +951,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1000SyncStreamOf1000() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNSyncStreamsOfN(1000, 1000).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -960,7 +960,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge10000SyncStreamOf10() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNSyncStreamsOfN(10000, 10).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -969,7 +969,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void merge1000000SyncStreamOf1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         mergeNSyncStreamsOfN(1000000, 1).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1016,7 +1016,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void mergeManyAsyncSingle() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable<Flowable<Integer>> os = Flowable.range(1, 10000)
         .map(new Function<Integer, Flowable<Integer>>() {
 
@@ -1051,7 +1051,7 @@ public class FlowableMergeTest extends RxJavaTest {
     @Test
     public void shouldCompleteAfterApplyingBackpressure_NormalPath() {
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(Flowable.range(1, 2)));
-        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>(0L);
         source.subscribe(subscriber);
         subscriber.request(3); // 1, 2, <complete> - with request(2) we get the 1 and 2 but not the <complete>
         subscriber.assertValues(1, 2);
@@ -1061,7 +1061,7 @@ public class FlowableMergeTest extends RxJavaTest {
     @Test
     public void shouldCompleteAfterApplyingBackpressure_FastPath() {
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(Flowable.just(1)));
-        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>(0L);
         source.subscribe(subscriber);
         subscriber.request(2); // 1, <complete> - should work as per .._NormalPath above
         subscriber.assertValue(1);
@@ -1072,7 +1072,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void shouldNotCompleteIfThereArePendingScalarSynchronousEmissionsWhenTheLastInnerSubscriberCompletes() {
         TestScheduler scheduler = new TestScheduler();
         Flowable<Long> source = Flowable.mergeDelayError(Flowable.just(1L), Flowable.timer(1, TimeUnit.SECONDS, scheduler).skip(1));
-        TestSubscriberEx<Long> subscriber = new TestSubscriberEx<Long>(0L);
+        TestSubscriberEx<Long> subscriber = new TestSubscriberEx<>(0L);
         source.subscribe(subscriber);
         scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
         subscriber.assertNoValues();
@@ -1089,7 +1089,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void delayedErrorsShouldBeEmittedWhenCompleteAfterApplyingBackpressure_NormalPath() {
         Throwable exception = new Throwable();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.range(1, 2), Flowable.<Integer>error(exception));
-        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>(0L);
         source.subscribe(subscriber);
         subscriber.request(3); // 1, 2, <error>
         subscriber.assertValues(1, 2);
@@ -1101,7 +1101,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void delayedErrorsShouldBeEmittedWhenCompleteAfterApplyingBackpressure_FastPath() {
         Throwable exception = new Throwable();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(1), Flowable.<Integer>error(exception));
-        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>(0L);
         source.subscribe(subscriber);
         subscriber.request(2); // 1, <error>
         subscriber.assertValue(1);
@@ -1112,7 +1112,7 @@ public class FlowableMergeTest extends RxJavaTest {
     @Test
     public void shouldNotCompleteWhileThereAreStillScalarSynchronousEmissionsInTheQueue() {
         Flowable<Integer> source = Flowable.merge(Flowable.just(1), Flowable.just(2));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>(1L);
         source.subscribe(subscriber);
         subscriber.assertValue(1);
         subscriber.request(1);
@@ -1123,7 +1123,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void shouldNotReceivedDelayedErrorWhileThereAreStillScalarSynchronousEmissionsInTheQueue() {
         Throwable exception = new Throwable();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.just(1), Flowable.just(2), Flowable.<Integer>error(exception));
-        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>(0L);
         subscriber.request(1);
         source.subscribe(subscriber);
         subscriber.assertValue(1);
@@ -1137,7 +1137,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void shouldNotReceivedDelayedErrorWhileThereAreStillNormalEmissionsInTheQueue() {
         Throwable exception = new Throwable();
         Flowable<Integer> source = Flowable.mergeDelayError(Flowable.range(1, 2), Flowable.range(3, 2), Flowable.<Integer>error(exception));
-        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>(0L);
         subscriber.request(3);
         source.subscribe(subscriber);
         subscriber.assertValues(1, 2, 3);
@@ -1152,7 +1152,7 @@ public class FlowableMergeTest extends RxJavaTest {
         //for (int i = 0; i < 5000; i++) {
             //System.out.println(i + ".......................................................................");
             final CountDownLatch latch = new CountDownLatch(1);
-            final ConcurrentLinkedQueue<String> messages = new ConcurrentLinkedQueue<String>();
+            final ConcurrentLinkedQueue<String> messages = new ConcurrentLinkedQueue<>();
 
             Flowable.range(1, 2)
                     // produce many integers per second
@@ -1280,7 +1280,7 @@ public class FlowableMergeTest extends RxJavaTest {
     ;
 
     void runMerge(Function<Integer, Flowable<Integer>> func, TestSubscriberEx<Integer> ts) {
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             list.add(i);
         }
@@ -1298,12 +1298,12 @@ public class FlowableMergeTest extends RxJavaTest {
 
     @Test
     public void fastMergeFullScalar() {
-        runMerge(toScalar, new TestSubscriberEx<Integer>());
+        runMerge(toScalar, new TestSubscriberEx<>());
     }
 
     @Test
     public void fastMergeHiddenScalar() {
-        runMerge(toHiddenScalar, new TestSubscriberEx<Integer>());
+        runMerge(toHiddenScalar, new TestSubscriberEx<>());
     }
 
     @Test
@@ -1466,7 +1466,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void noInnerReordering() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
         FlowableFlatMap.MergeSubscriber<Publisher<Integer>, Integer> ms =
-                new FlowableFlatMap.MergeSubscriber<Publisher<Integer>, Integer>(ts, Functions.<Publisher<Integer>>identity(), false, 128, 128);
+                new FlowableFlatMap.MergeSubscriber<>(ts, Functions.<Publisher<Integer>>identity(), false, 128, 128);
         ms.onSubscribe(new BooleanSubscription());
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -1488,7 +1488,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void noOuterScalarReordering() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
         FlowableFlatMap.MergeSubscriber<Publisher<Integer>, Integer> ms =
-                new FlowableFlatMap.MergeSubscriber<Publisher<Integer>, Integer>(ts, Functions.<Publisher<Integer>>identity(), false, 128, 128);
+                new FlowableFlatMap.MergeSubscriber<>(ts, Functions.<Publisher<Integer>>identity(), false, 128, 128);
         ms.onSubscribe(new BooleanSubscription());
 
         ms.onNext(Flowable.just(1));

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -29,7 +29,7 @@ public class FlowableMergeWithCompletableTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5).mergeWith(
                 Completable.fromAction(new Action() {
@@ -71,7 +71,7 @@ public class FlowableMergeWithCompletableTest extends RxJavaTest {
 
     @Test
     public void normalBackpressured() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Flowable.range(1, 5).mergeWith(
                 Completable.fromAction(new Action() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithMaybeTest.java
@@ -230,7 +230,7 @@ public class FlowableMergeWithMaybeTest extends RxJavaTest {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final MaybeSubject<Integer> cs = MaybeSubject.create();
 
-            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>(0));
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<>(0));
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -259,7 +259,7 @@ public class FlowableMergeWithMaybeTest extends RxJavaTest {
     public void onErrorMainOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Subscriber<?>> subscriber = new AtomicReference<Subscriber<?>>();
+            final AtomicReference<Subscriber<?>> subscriber = new AtomicReference<>();
             TestSubscriber<Integer> ts = new Flowable<Integer>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -87,7 +87,7 @@ public class FlowableMergeWithSingleTest extends RxJavaTest {
 
     @Test
     public void normalBackpressured() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Flowable.range(1, 5).mergeWith(
                 Single.just(100)
@@ -226,7 +226,7 @@ public class FlowableMergeWithSingleTest extends RxJavaTest {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final SingleSubject<Integer> cs = SingleSubject.create();
 
-            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<Integer>(0));
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<>(0));
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -255,7 +255,7 @@ public class FlowableMergeWithSingleTest extends RxJavaTest {
     public void onErrorMainOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Subscriber<?>> subscriber = new AtomicReference<Subscriber<?>>();
+            final AtomicReference<Subscriber<?>> subscriber = new AtomicReference<>();
             TestSubscriber<Integer> ts = new Flowable<Integer>() {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOnTest.java
@@ -65,7 +65,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
         InOrder inOrder = inOrder(subscriber);
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>(subscriber);
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>(subscriber);
 
         obs.observeOn(Schedulers.computation()).subscribe(ts);
 
@@ -384,7 +384,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
         final TestScheduler testScheduler = new TestScheduler();
 
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(subscriber);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(subscriber);
 
         Flowable.just(1, 2, 3)
                 .observeOn(testScheduler)
@@ -519,7 +519,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             }
         });
 
-        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         flowable
                 .take(7)
                 .observeOn(Schedulers.newThread())
@@ -547,7 +547,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
         });
 
-        TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<Integer>(new DefaultSubscriber<Integer>() {
+        TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {
@@ -590,7 +590,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void asyncChild() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(0, 100000).observeOn(Schedulers.newThread()).observeOn(Schedulers.newThread()).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -602,7 +602,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             final PublishProcessor<Long> processor = PublishProcessor.create();
 
             final AtomicLong counter = new AtomicLong();
-            TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>(new DefaultSubscriber<Long>() {
+            TestSubscriberEx<Long> ts = new TestSubscriberEx<>(new DefaultSubscriber<Long>() {
 
                 @Override
                 public void onComplete() {
@@ -649,7 +649,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
      */
     @Test
     public void hotOperatorBackpressure() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
         Flowable.interval(0, 1, TimeUnit.MICROSECONDS)
                 .observeOn(Schedulers.computation())
                 .map(new Function<Long, String>() {
@@ -697,7 +697,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
                 });
 
-        TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>();
+        TestSubscriberEx<Long> ts = new TestSubscriberEx<>();
 
         Flowable.combineLatest(timer, Flowable.<Integer> never(), new BiFunction<Long, Integer, Long>() {
 
@@ -757,7 +757,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
     @Test
     public void noMoreRequestsAfterUnsubscribe() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final List<Long> requests = Collections.synchronizedList(new ArrayList<Long>());
+        final List<Long> requests = Collections.synchronizedList(new ArrayList<>());
         Flowable.range(1, 1000000)
                 .doOnRequest(new LongConsumer() {
 
@@ -873,7 +873,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
         TestScheduler test = new TestScheduler();
 
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
 
         Flowable.range(1, 100)
         .doOnRequest(new LongConsumer() {
@@ -918,9 +918,9 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void synchronousRebatching() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 50)
         .doOnRequest(new LongConsumer() {
@@ -1594,7 +1594,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void syncFusedCancelAfterRequest2() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(2L);
 
         Flowable.range(1, 2)
         .observeOn(Schedulers.single())
@@ -1630,7 +1630,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void syncFusedCancelAfterRequestConditional2() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(2L);
 
         Flowable.range(1, 2)
         .observeOn(Schedulers.single())
@@ -1644,7 +1644,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void nonFusedCancelAfterRequestConditional2() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(2L);
 
         Flowable.range(1, 2).hide()
         .observeOn(Schedulers.single())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBufferStrategyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBufferStrategyTest.java
@@ -58,7 +58,7 @@ public class FlowableOnBackpressureBufferStrategyTest extends RxJavaTest {
     }
 
     private TestSubscriber<Long> createTestSubscriber() {
-        return new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
+        return new TestSubscriber<>(new DefaultSubscriber<Long>() {
 
             @Override
             protected void onStart() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -39,7 +39,7 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
 
     @Test
     public void noBackpressureSupport() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
+        TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         // this will be ignored
         ts.request(100);
         // we take 500 so it unsubscribes
@@ -53,7 +53,7 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
     public void fixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<>(new DefaultSubscriber<Long>() {
 
             @Override
             protected void onStart() {
@@ -110,17 +110,19 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
     public void fixBackpressureBoundedBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch backpressureCallback = new CountDownLatch(1);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<>(new DefaultSubscriber<Long>() {
 
             @Override
             protected void onStart() {
             }
 
             @Override
-            public void onComplete() { }
+            public void onComplete() {
+            }
 
             @Override
-            public void onError(Throwable e) { }
+            public void onError(Throwable e) {
+            }
 
             @Override
             public void onNext(Long t) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -32,7 +32,7 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
 
     @Test
     public void noBackpressureSupport() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
+        TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         // this will be ignored
         ts.request(100);
         // we take 500 so it unsubscribes
@@ -44,7 +44,7 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
 
     @Test
     public void withObserveOn() throws InterruptedException {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(0, Flowable.bufferSize() * 10).onBackpressureDrop().observeOn(Schedulers.io()).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
     }
@@ -53,7 +53,7 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
     public void fixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(new DefaultSubscriber<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<>(new DefaultSubscriber<Long>() {
 
             @Override
             protected void onStart() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureErrorTest.java
@@ -37,7 +37,7 @@ public class FlowableOnBackpressureErrorTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
             @Override
             public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                return new FlowableOnBackpressureError<Object>(f);
+                return new FlowableOnBackpressureError<>(f);
             }
         });
     }
@@ -47,7 +47,7 @@ public class FlowableOnBackpressureErrorTest extends RxJavaTest {
         TestHelper.<Integer>checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
             @Override
             public Object apply(Flowable<Integer> f) throws Exception {
-                return new FlowableOnBackpressureError<Integer>(f);
+                return new FlowableOnBackpressureError<>(f);
             }
         }, false, 1, 1, 1);
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.testsupport.*;
 public class FlowableOnBackpressureLatestTest extends RxJavaTest {
     @Test
     public void simple() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.range(1, 5).onBackpressureLatest().subscribe(ts);
 
@@ -41,7 +41,7 @@ public class FlowableOnBackpressureLatestTest extends RxJavaTest {
 
     @Test
     public void simpleError() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(new TestException()))
         .onBackpressureLatest().subscribe(ts);
@@ -53,7 +53,7 @@ public class FlowableOnBackpressureLatestTest extends RxJavaTest {
 
     @Test
     public void simpleBackpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(2L);
 
         Flowable.range(1, 5).onBackpressureLatest().subscribe(ts);
 
@@ -65,7 +65,7 @@ public class FlowableOnBackpressureLatestTest extends RxJavaTest {
     @Test
     public void synchronousDrop() {
         PublishProcessor<Integer> source = PublishProcessor.create();
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
 
         source.onBackpressureLatest().subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
@@ -148,7 +148,7 @@ public class FlowableOnErrorResumeNextViaFlowableTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(0, 100000)
                 .onErrorResumeWith(Flowable.just(1))
                 .observeOn(Schedulers.computation())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
@@ -39,7 +39,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
 
     @Test
     public void resumeNextWithSynchronousExecution() {
-        final AtomicReference<Throwable> receivedException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> receivedException = new AtomicReference<>();
         Flowable<String> w = Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
@@ -79,7 +79,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
 
     @Test
     public void resumeNextWithAsyncExecution() {
-        final AtomicReference<Throwable> receivedException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> receivedException = new AtomicReference<>();
         Subscription s = mock(Subscription.class);
         TestFlowable w = new TestFlowable(s, "one");
         Function<Throwable, Flowable<String>> resume = new Function<Throwable, Flowable<String>>() {
@@ -176,7 +176,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber, Long.MAX_VALUE);
         flowable.subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
 
@@ -228,7 +228,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(0, 100000)
                 .onErrorResumeNext(new Function<Throwable, Flowable<Integer>>() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -39,7 +39,7 @@ public class FlowableOnErrorReturnTest extends RxJavaTest {
     public void resumeNext() {
         TestFlowable f = new TestFlowable("one");
         Flowable<String> w = Flowable.unsafeCreate(f);
-        final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> capturedException = new AtomicReference<>();
 
         Flowable<String> flowable = w.onErrorReturn(new Function<Throwable, String>() {
 
@@ -74,7 +74,7 @@ public class FlowableOnErrorReturnTest extends RxJavaTest {
     public void functionThrowsError() {
         TestFlowable f = new TestFlowable("one");
         Flowable<String> w = Flowable.unsafeCreate(f);
-        final AtomicReference<Throwable> capturedException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> capturedException = new AtomicReference<>();
 
         Flowable<String> flowable = w.onErrorReturn(new Function<Throwable, String>() {
 
@@ -132,7 +132,7 @@ public class FlowableOnErrorReturnTest extends RxJavaTest {
         });
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber, Long.MAX_VALUE);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber, Long.MAX_VALUE);
         flowable.subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
 
@@ -146,7 +146,7 @@ public class FlowableOnErrorReturnTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(0, 100000)
                 .onErrorReturn(new Function<Throwable, Integer>() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -37,7 +37,7 @@ import io.reactivex.rxjava3.testsupport.*;
 public class FlowablePublishFunctionTest extends RxJavaTest {
     @Test
     public void concatTakeFirstLastCompletes() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 3).publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
@@ -210,7 +210,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
 
     @Test
     public void overflowMissingBackpressureException() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0);
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -236,11 +236,11 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
 
     @Test
     public void overflowMissingBackpressureExceptionDelayed() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0);
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        new FlowablePublishMulticast<Integer, Integer>(pp, new Function<Flowable<Integer>, Flowable<Integer>>() {
+        new FlowablePublishMulticast<>(pp, new Function<Flowable<Integer>, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Flowable<Integer> f) {
                 return f;
@@ -349,7 +349,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
 
     @Test
     public void error() {
-        new FlowablePublishMulticast<Integer, Integer>(Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException())),
+        new FlowablePublishMulticast<>(Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException())),
                 Functions.<Flowable<Integer>>identity(), 16, true)
         .test()
         .assertFailure(TestException.class, 1);
@@ -428,7 +428,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
     @Test
     public void sourceSubscriptionDelayed() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>(0L);
 
             Flowable.just(1)
             .publish(new Function<Flowable<Integer>, Publisher<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticastTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticastTest.java
@@ -32,7 +32,7 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void asyncFusedInput() {
-        MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+        MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -51,7 +51,7 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void fusionRejectedInput() {
-        MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+        MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
         mp.onSubscribe(new QueueSubscription<Integer>() {
 
@@ -106,10 +106,10 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
     public void addRemoveRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
 
-            final MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+            final MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
-            final MulticastSubscription<Integer> ms1 = new MulticastSubscription<Integer>(null, mp);
-            final MulticastSubscription<Integer> ms2 = new MulticastSubscription<Integer>(null, mp);
+            final MulticastSubscription<Integer> ms1 = new MulticastSubscription<>(null, mp);
+            final MulticastSubscription<Integer> ms2 = new MulticastSubscription<>(null, mp);
 
             assertTrue(mp.add(ms1));
 
@@ -133,9 +133,9 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void removeNotFound() {
-        MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+        MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
-        MulticastSubscription<Integer> ms1 = new MulticastSubscription<Integer>(null, mp);
+        MulticastSubscription<Integer> ms1 = new MulticastSubscription<>(null, mp);
         assertTrue(mp.add(ms1));
 
         mp.remove(null);
@@ -143,9 +143,9 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void errorAllCancelled() {
-        MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+        MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
-        MulticastSubscription<Integer> ms1 = new MulticastSubscription<Integer>(null, mp);
+        MulticastSubscription<Integer> ms1 = new MulticastSubscription<>(null, mp);
         assertTrue(mp.add(ms1));
 
         ms1.set(Long.MIN_VALUE);
@@ -155,9 +155,9 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void completeAllCancelled() {
-        MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+        MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
-        MulticastSubscription<Integer> ms1 = new MulticastSubscription<Integer>(null, mp);
+        MulticastSubscription<Integer> ms1 = new MulticastSubscription<>(null, mp);
         assertTrue(mp.add(ms1));
 
         ms1.set(Long.MIN_VALUE);
@@ -167,9 +167,9 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void cancelledWhileFindingRequests() {
-        final MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+        final MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
-        final MulticastSubscription<Integer> ms1 = new MulticastSubscription<Integer>(null, mp);
+        final MulticastSubscription<Integer> ms1 = new MulticastSubscription<>(null, mp);
 
         assertTrue(mp.add(ms1));
 
@@ -182,9 +182,9 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void negativeRequest() {
-        final MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+        final MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
-        final MulticastSubscription<Integer> ms1 = new MulticastSubscription<Integer>(null, mp);
+        final MulticastSubscription<Integer> ms1 = new MulticastSubscription<>(null, mp);
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -198,19 +198,19 @@ public class FlowablePublishMulticastTest extends RxJavaTest {
 
     @Test
     public void outputCancellerDoubleOnSubscribe() {
-        TestHelper.doubleOnSubscribe(new OutputCanceller<Object>(new TestSubscriber<Object>(), null));
+        TestHelper.doubleOnSubscribe(new OutputCanceller<>(new TestSubscriber<>(), null));
     }
 
     @Test
     public void dontDropItemsWhenNoReadyConsumers() {
-        final MulticastProcessor<Integer> mp = new MulticastProcessor<Integer>(128, true);
+        final MulticastProcessor<Integer> mp = new MulticastProcessor<>(128, true);
 
         mp.onSubscribe(new BooleanSubscription());
 
         mp.onNext(1);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        final MulticastSubscription<Integer> ms1 = new MulticastSubscription<Integer>(ts, mp);
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        final MulticastSubscription<Integer> ms1 = new MulticastSubscription<>(ts, mp);
         ts.onSubscribe(ms1);
 
         assertTrue(mp.add(ms1));

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishTest.java
@@ -128,7 +128,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         });
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.merge(fast, slow).subscribe(ts);
         is.connect();
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -148,7 +148,7 @@ public class FlowablePublishTest extends RxJavaTest {
             }
 
         });
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         xs.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
 
             @Override
@@ -175,7 +175,7 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void takeUntilWithPublishedStream() {
         Flowable<Integer> xs = Flowable.range(0, Flowable.bufferSize() * 2);
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ConnectableFlowable<Integer> xsp = xs.publish();
         xsp.takeUntil(xsp.skipWhile(new Predicate<Integer>() {
 
@@ -211,7 +211,7 @@ public class FlowablePublishTest extends RxJavaTest {
         final AtomicBoolean child1Unsubscribed = new AtomicBoolean();
         final AtomicBoolean child2Unsubscribed = new AtomicBoolean();
 
-        final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
             @Override
@@ -259,7 +259,7 @@ public class FlowablePublishTest extends RxJavaTest {
         cf.connect();
         // Emit 0
         scheduler.advanceTimeBy(15, TimeUnit.MILLISECONDS);
-        TestSubscriber<Long> subscriber = new TestSubscriber<Long>();
+        TestSubscriber<Long> subscriber = new TestSubscriber<>();
         cf.subscribe(subscriber);
         // Emit 1 and 2
         scheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS);
@@ -271,7 +271,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void subscribeAfterDisconnectThenConnect() {
         ConnectableFlowable<Integer> source = Flowable.just(1).publish();
 
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
 
         source.subscribe(ts1);
 
@@ -283,7 +283,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         source.reset();
 
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
 
         source.subscribe(ts2);
 
@@ -301,7 +301,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void noSubscriberRetentionOnCompleted() {
         FlowablePublish<Integer> source = (FlowablePublish<Integer>)Flowable.just(1).publish();
 
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
 
         source.subscribe(ts1);
 
@@ -353,7 +353,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void zeroRequested() {
         ConnectableFlowable<Integer> source = Flowable.just(1).publish();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
 
         source.subscribe(ts);
 
@@ -408,9 +408,9 @@ public class FlowablePublishTest extends RxJavaTest {
         Flowable<Integer> obs = cf.observeOn(Schedulers.computation());
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
-                List<TestSubscriberEx<Integer>> tss = new ArrayList<TestSubscriberEx<Integer>>();
+                List<TestSubscriberEx<Integer>> tss = new ArrayList<>();
                 for (int k = 1; k < j; k++) {
-                    TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+                    TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
                     tss.add(ts);
                     obs.subscribe(ts);
                 }
@@ -435,9 +435,9 @@ public class FlowablePublishTest extends RxJavaTest {
         Flowable<Integer> obs = cf.observeOn(ImmediateThinScheduler.INSTANCE);
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
-                List<TestSubscriberEx<Integer>> tss = new ArrayList<TestSubscriberEx<Integer>>();
+                List<TestSubscriberEx<Integer>> tss = new ArrayList<>();
                 for (int k = 1; k < j; k++) {
-                    TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+                    TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
                     tss.add(ts);
                     obs.subscribe(ts);
                 }
@@ -461,9 +461,9 @@ public class FlowablePublishTest extends RxJavaTest {
         ConnectableFlowable<Integer> cf = Flowable.range(0, 1000).observeOn(ImmediateThinScheduler.INSTANCE).publish();
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
-                List<TestSubscriberEx<Integer>> tss = new ArrayList<TestSubscriberEx<Integer>>();
+                List<TestSubscriberEx<Integer>> tss = new ArrayList<>();
                 for (int k = 1; k < j; k++) {
-                    TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+                    TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
                     tss.add(ts);
                     cf.subscribe(ts);
                 }
@@ -488,9 +488,9 @@ public class FlowablePublishTest extends RxJavaTest {
         Flowable<Integer> obs = cf.observeOn(Schedulers.computation());
         for (int i = 0; i < 1000; i++) {
             for (int j = 1; j < 6; j++) {
-                List<TestSubscriberEx<Integer>> tss = new ArrayList<TestSubscriberEx<Integer>>();
+                List<TestSubscriberEx<Integer>> tss = new ArrayList<>();
                 for (int k = 1; k < j; k++) {
-                    TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+                    TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
                     tss.add(ts);
                     obs.subscribe(ts);
                 }
@@ -539,7 +539,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = cf.test();
 
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -694,7 +694,7 @@ public class FlowablePublishTest extends RxJavaTest {
             final ConnectableFlowable<Integer> cf = pp.publish();
 
             final Disposable d = cf.connect();
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -938,7 +938,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void disposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final AtomicReference<Disposable> ref = new AtomicReference<Disposable>();
+            final AtomicReference<Disposable> ref = new AtomicReference<>();
 
             final ConnectableFlowable<Integer> cf = new Flowable<Integer>() {
                 @Override
@@ -963,7 +963,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void removeNotPresent() {
-        final AtomicReference<PublishConnection<Integer>> ref = new AtomicReference<PublishConnection<Integer>>();
+        final AtomicReference<PublishConnection<Integer>> ref = new AtomicReference<>();
 
         final ConnectableFlowable<Integer> cf = new Flowable<Integer>() {
             @Override
@@ -976,7 +976,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         cf.connect();
 
-        ref.get().add(new InnerSubscription<Integer>(new TestSubscriber<Integer>(), ref.get()));
+        ref.get().add(new InnerSubscription<>(new TestSubscriber<>(), ref.get()));
         ref.get().remove(null);
     }
 
@@ -999,7 +999,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         ts1.assertResult(1);
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(0);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
         cf.subscribe(ts2);
 
         ts2
@@ -1012,7 +1012,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void subscriberLiveSwap() {
         final ConnectableFlowable<Integer> cf = Flowable.range(1, 5).publish();
 
-        final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(0);
+        final TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
 
         TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
             @Override
@@ -1038,7 +1038,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void selectorSubscriberSwap() {
-        final AtomicReference<Flowable<Integer>> ref = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> ref = new AtomicReference<>();
 
         Flowable.range(1, 5).publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
             @Override
@@ -1061,7 +1061,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void leavingSubscriberOverrequests() {
-        final AtomicReference<Flowable<Integer>> ref = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> ref = new AtomicReference<>();
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -1205,7 +1205,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void publishFunctionCancelOuterAfterOneInner() {
-        final AtomicReference<Flowable<Integer>> ref = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> ref = new AtomicReference<>();
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -1231,7 +1231,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void publishFunctionCancelOuterAfterOneInnerBackpressured() {
-        final AtomicReference<Flowable<Integer>> ref = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> ref = new AtomicReference<>();
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -1261,7 +1261,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final AtomicReference<Flowable<Integer>> ref = new AtomicReference<Flowable<Integer>>();
+            final AtomicReference<Flowable<Integer>> ref = new AtomicReference<>();
 
             pp.publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
                 @Override
@@ -1300,9 +1300,9 @@ public class FlowablePublishTest extends RxJavaTest {
 
         ConnectableFlowable<Integer> cf = pp.publish();
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-        final AtomicReference<InnerSubscription<Integer>> ref = new AtomicReference<InnerSubscription<Integer>>();
+        final AtomicReference<InnerSubscription<Integer>> ref = new AtomicReference<>();
 
         cf.subscribe(new FlowableSubscriber<Integer>() {
             @SuppressWarnings("unchecked")
@@ -1500,7 +1500,7 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void altConnectCrash() {
         try {
-            new FlowablePublish<Integer>(Flowable.<Integer>empty(), 128)
+            new FlowablePublish<>(Flowable.<Integer>empty(), 128)
             .connect(new Consumer<Disposable>() {
                 @Override
                 public void accept(Disposable t) throws Exception {
@@ -1517,7 +1517,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void altConnectRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf =
-                    new FlowablePublish<Integer>(Flowable.<Integer>never(), 128);
+                    new FlowablePublish<>(Flowable.<Integer>never(), 128);
 
             Runnable r = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRangeLongTest.java
@@ -98,7 +98,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
     public void backpressureViaRequest() {
         Flowable<Long> f = Flowable.rangeLong(1, Flowable.bufferSize());
 
-        TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>(0L);
+        TestSubscriberEx<Long> ts = new TestSubscriberEx<>(0L);
 
         ts.assertNoValues();
         ts.request(1);
@@ -119,14 +119,14 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void noBackpressure() {
-        ArrayList<Long> list = new ArrayList<Long>(Flowable.bufferSize() * 2);
+        ArrayList<Long> list = new ArrayList<>(Flowable.bufferSize() * 2);
         for (long i = 1; i <= Flowable.bufferSize() * 2 + 1; i++) {
             list.add(i);
         }
 
         Flowable<Long> f = Flowable.rangeLong(1, list.size());
 
-        TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>(0L);
+        TestSubscriberEx<Long> ts = new TestSubscriberEx<>(0L);
 
         ts.assertNoValues();
         ts.request(Long.MAX_VALUE); // infinite
@@ -139,11 +139,11 @@ public class FlowableRangeLongTest extends RxJavaTest {
     void withBackpressureOneByOne(long start) {
         Flowable<Long> source = Flowable.rangeLong(start, 100);
 
-        TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>(0L);
+        TestSubscriberEx<Long> ts = new TestSubscriberEx<>(0L);
         ts.request(1);
         source.subscribe(ts);
 
-        List<Long> list = new ArrayList<Long>(100);
+        List<Long> list = new ArrayList<>(100);
         for (long i = 0; i < 100; i++) {
             list.add(i + start);
             ts.request(1);
@@ -154,11 +154,11 @@ public class FlowableRangeLongTest extends RxJavaTest {
     void withBackpressureAllAtOnce(long start) {
         Flowable<Long> source = Flowable.rangeLong(start, 100);
 
-        TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>(0L);
+        TestSubscriberEx<Long> ts = new TestSubscriberEx<>(0L);
         ts.request(100);
         source.subscribe(ts);
 
-        List<Long> list = new ArrayList<Long>(100);
+        List<Long> list = new ArrayList<>(100);
         for (long i = 0; i < 100; i++) {
             list.add(i + start);
         }
@@ -184,11 +184,11 @@ public class FlowableRangeLongTest extends RxJavaTest {
     public void withBackpressureRequestWayMore() {
         Flowable<Long> source = Flowable.rangeLong(50, 100);
 
-        TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>(0L);
+        TestSubscriberEx<Long> ts = new TestSubscriberEx<>(0L);
         ts.request(150);
         source.subscribe(ts);
 
-        List<Long> list = new ArrayList<Long>(100);
+        List<Long> list = new ArrayList<>(100);
         for (long i = 0; i < 100; i++) {
             list.add(i + 50);
         }
@@ -257,7 +257,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void nearMaxValueWithoutBackpressure() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts = new TestSubscriber<>();
         Flowable.rangeLong(Long.MAX_VALUE - 1L, 2L).subscribe(ts);
 
         ts.assertComplete();
@@ -267,7 +267,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void nearMaxValueWithBackpressure() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(3L);
+        TestSubscriber<Long> ts = new TestSubscriber<>(3L);
         Flowable.rangeLong(Long.MAX_VALUE - 1L, 2L).subscribe(ts);
 
         ts.assertComplete();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRangeTest.java
@@ -98,7 +98,7 @@ public class FlowableRangeTest extends RxJavaTest {
     public void backpressureViaRequest() {
         Flowable<Integer> f = Flowable.range(1, Flowable.bufferSize());
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
 
         ts.assertNoValues();
         ts.request(1);
@@ -119,14 +119,14 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void noBackpressure() {
-        ArrayList<Integer> list = new ArrayList<Integer>(Flowable.bufferSize() * 2);
+        ArrayList<Integer> list = new ArrayList<>(Flowable.bufferSize() * 2);
         for (int i = 1; i <= Flowable.bufferSize() * 2 + 1; i++) {
             list.add(i);
         }
 
         Flowable<Integer> f = Flowable.range(1, list.size());
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
 
         ts.assertNoValues();
         ts.request(Long.MAX_VALUE); // infinite
@@ -139,11 +139,11 @@ public class FlowableRangeTest extends RxJavaTest {
     void withBackpressureOneByOne(int start) {
         Flowable<Integer> source = Flowable.range(start, 100);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
         ts.request(1);
         source.subscribe(ts);
 
-        List<Integer> list = new ArrayList<Integer>(100);
+        List<Integer> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
             list.add(i + start);
             ts.request(1);
@@ -154,11 +154,11 @@ public class FlowableRangeTest extends RxJavaTest {
     void withBackpressureAllAtOnce(int start) {
         Flowable<Integer> source = Flowable.range(start, 100);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
         ts.request(100);
         source.subscribe(ts);
 
-        List<Integer> list = new ArrayList<Integer>(100);
+        List<Integer> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
             list.add(i + start);
         }
@@ -184,11 +184,11 @@ public class FlowableRangeTest extends RxJavaTest {
     public void withBackpressureRequestWayMore() {
         Flowable<Integer> source = Flowable.range(50, 100);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
         ts.request(150);
         source.subscribe(ts);
 
-        List<Integer> list = new ArrayList<Integer>(100);
+        List<Integer> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
             list.add(i + 50);
         }
@@ -257,7 +257,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void nearMaxValueWithoutBackpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(Integer.MAX_VALUE - 1, 2).subscribe(ts);
 
         ts.assertComplete();
@@ -267,7 +267,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void nearMaxValueWithBackpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(3L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(3L);
         Flowable.range(Integer.MAX_VALUE - 1, 2).subscribe(ts);
 
         ts.assertComplete();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRefCountTest.java
@@ -205,8 +205,8 @@ public class FlowableRefCountTest extends RxJavaTest {
                 .publish().refCount();
 
         for (int i = 0; i < 10; i++) {
-            TestSubscriber<Long> ts1 = new TestSubscriber<Long>();
-            TestSubscriber<Long> ts2 = new TestSubscriber<Long>();
+            TestSubscriber<Long> ts1 = new TestSubscriber<>();
+            TestSubscriber<Long> ts2 = new TestSubscriber<>();
             r.subscribe(ts1);
             r.subscribe(ts2);
             try {
@@ -248,7 +248,7 @@ public class FlowableRefCountTest extends RxJavaTest {
                     }
                 });
 
-        TestSubscriberEx<Long> s = new TestSubscriberEx<Long>();
+        TestSubscriberEx<Long> s = new TestSubscriberEx<>();
         f.publish().refCount().subscribeOn(Schedulers.newThread()).subscribe(s);
         System.out.println("send unsubscribe");
         // wait until connected
@@ -293,7 +293,7 @@ public class FlowableRefCountTest extends RxJavaTest {
                     }
                 });
 
-        TestSubscriberEx<Long> s = new TestSubscriberEx<Long>();
+        TestSubscriberEx<Long> s = new TestSubscriberEx<>();
 
         f.publish().refCount().subscribeOn(Schedulers.computation()).subscribe(s);
         System.out.println("send unsubscribe");
@@ -386,7 +386,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         Flowable<Long> interval = Flowable.interval(100, TimeUnit.MILLISECONDS, s).publish().refCount();
 
         // subscribe list1
-        final List<Long> list1 = new ArrayList<Long>();
+        final List<Long> list1 = new ArrayList<>();
         Disposable d1 = interval.subscribe(new Consumer<Long>() {
             @Override
             public void accept(Long t1) {
@@ -401,7 +401,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         assertEquals(1L, list1.get(1).longValue());
 
         // subscribe list2
-        final List<Long> list2 = new ArrayList<Long>();
+        final List<Long> list2 = new ArrayList<>();
         Disposable d2 = interval.subscribe(new Consumer<Long>() {
             @Override
             public void accept(Long t1) {
@@ -446,7 +446,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         // subscribing a new one should start over because the source should have been unsubscribed
         // subscribe list3
-        final List<Long> list3 = new ArrayList<Long>();
+        final List<Long> list3 = new ArrayList<>();
         interval.subscribe(new Consumer<Long>() {
             @Override
             public void accept(Long t1) {
@@ -517,8 +517,8 @@ public class FlowableRefCountTest extends RxJavaTest {
         })
         .publish().refCount();
 
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
 
         combined.subscribe(ts1);
         combined.subscribe(ts2);
@@ -1184,7 +1184,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts1 = source.test(0);
 
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(0);
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1388,7 +1388,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
     @Test
     public void timeoutResetsSource() {
-        TestConnectableFlowable<Object> tcf = new TestConnectableFlowable<Object>();
+        TestConnectableFlowable<Object> tcf = new TestConnectableFlowable<>();
         FlowableRefCount<Object> o = (FlowableRefCount<Object>)tcf.refCount();
 
         RefConnection rc = new RefConnection(o);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRepeatTest.java
@@ -164,7 +164,7 @@ public class FlowableRepeatTest {
                 .repeat(3)
                 .distinct();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         src.subscribe(ts);
 
@@ -176,8 +176,8 @@ public class FlowableRepeatTest {
     /** Issue #2844: wrong target of request. */
     @Test
     public void repeatRetarget() {
-        final List<Integer> concatBase = new ArrayList<Integer>();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final List<Integer> concatBase = new ArrayList<>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.just(1, 2)
         .repeat(5)
         .concatMap(new Function<Integer, Flowable<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -732,14 +732,14 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(true);
+        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<>(true);
         buf.addLast(new Node(1, 0));
         buf.addLast(new Node(2, 1));
         buf.addLast(new Node(3, 2));
         buf.addLast(new Node(4, 3));
         buf.addLast(new Node(5, 4));
 
-        List<Integer> values = new ArrayList<Integer>();
+        List<Integer> values = new ArrayList<>();
         buf.collect(values);
 
         Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), values);
@@ -762,8 +762,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void timedAndSizedTruncation() {
         TestScheduler test = new TestScheduler();
-        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test, true);
-        List<Integer> values = new ArrayList<Integer>();
+        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<>(2, 2000, TimeUnit.MILLISECONDS, test, true);
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
@@ -808,8 +808,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
                 });
         ConnectableFlowable<Integer> cf = source.replay();
 
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>(10L);
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>(90L);
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>(10L);
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>(90L);
 
         cf.subscribe(ts1);
         cf.subscribe(ts2);
@@ -839,8 +839,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
                 });
         ConnectableFlowable<Integer> cf = source.replay(50, true);
 
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>(10L);
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>(90L);
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>(10L);
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>(90L);
 
         cf.subscribe(ts1);
         cf.subscribe(ts2);
@@ -862,7 +862,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void coldReplayNoBackpressure() {
         Flowable<Integer> source = Flowable.range(0, 1000).replay().autoConnect();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         source.subscribe(ts);
 
@@ -880,7 +880,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void coldReplayBackpressure() {
         Flowable<Integer> source = Flowable.range(0, 1000).replay().autoConnect();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(10);
 
         source.subscribe(ts);
@@ -961,7 +961,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void take() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable<Integer> cached = Flowable.range(1, 100).replay().autoConnect();
         cached.take(10).subscribe(ts);
@@ -975,7 +975,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void async() {
         Flowable<Integer> source = Flowable.range(1, 10000);
         for (int i = 0; i < 100; i++) {
-            TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
 
             Flowable<Integer> cached = source.replay().autoConnect();
 
@@ -986,7 +986,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
             ts1.assertTerminated();
             assertEquals(10000, ts1.values().size());
 
-            TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
             cached.observeOn(Schedulers.computation()).subscribe(ts2);
 
             ts2.awaitDone(2, TimeUnit.SECONDS);
@@ -1005,14 +1005,14 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
         Flowable<Long> output = cached.observeOn(Schedulers.computation(), false, 1024);
 
-        List<TestSubscriberEx<Long>> list = new ArrayList<TestSubscriberEx<Long>>(100);
+        List<TestSubscriberEx<Long>> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
-            TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>();
+            TestSubscriberEx<Long> ts = new TestSubscriberEx<>();
             list.add(ts);
             output.skip(i * 10).take(10).subscribe(ts);
         }
 
-        List<Long> expected = new ArrayList<Long>();
+        List<Long> expected = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             expected.add((long)(i - 10));
         }
@@ -1046,7 +1046,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
             }
         });
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         firehose.replay().autoConnect().observeOn(Schedulers.computation()).takeLast(100).subscribe(ts);
 
         ts.awaitDone(3, TimeUnit.SECONDS);
@@ -1062,14 +1062,14 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
                 .concatWith(Flowable.<Integer>error(new TestException()))
                 .replay().autoConnect();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         source.subscribe(ts);
 
         ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ts.assertNotComplete();
         Assert.assertEquals(1, ts.errors().size());
 
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
         source.subscribe(ts2);
 
         ts2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -1110,7 +1110,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void unboundedLeavesEarly() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
 
         Flowable<Integer> out = source
                 .doOnRequest(new LongConsumer() {
@@ -1120,8 +1120,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
                     }
                 }).replay().autoConnect();
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(5L);
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(10L);
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>(5L);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(10L);
 
         out.subscribe(ts1);
         out.subscribe(ts2);
@@ -1135,7 +1135,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ConnectableFlowable<Integer> source = Flowable.range(1, 10).replay(1, true);
         source.connect();
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>(2L);
 
         source.subscribe(ts1);
 
@@ -1143,7 +1143,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts1.assertNoErrors();
         ts1.cancel();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(2L);
 
         source.subscribe(ts2);
 
@@ -1151,7 +1151,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts2.assertNoErrors();
         ts2.cancel();
 
-        TestSubscriber<Integer> ts21 = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts21 = new TestSubscriber<>(1L);
 
         source.subscribe(ts21);
 
@@ -1159,7 +1159,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts21.assertNoErrors();
         ts21.cancel();
 
-        TestSubscriber<Integer> ts22 = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts22 = new TestSubscriber<>(1L);
 
         source.subscribe(ts22);
 
@@ -1167,7 +1167,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts22.assertNoErrors();
         ts22.cancel();
 
-        TestSubscriber<Integer> ts3 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts3 = new TestSubscriber<>();
 
         source.subscribe(ts3);
 
@@ -1182,7 +1182,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ConnectableFlowable<Integer> source = Flowable.range(1, 10).replay(2, true);
         source.connect();
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>(2L);
 
         source.subscribe(ts1);
 
@@ -1190,7 +1190,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts1.assertNoErrors();
         ts1.cancel();
 
-        TestSubscriber<Integer> ts11 = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts11 = new TestSubscriber<>(2L);
 
         source.subscribe(ts11);
 
@@ -1198,7 +1198,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts11.assertNoErrors();
         ts11.cancel();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(3L);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(3L);
 
         source.subscribe(ts2);
 
@@ -1206,7 +1206,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts2.assertNoErrors();
         ts2.cancel();
 
-        TestSubscriber<Integer> ts21 = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts21 = new TestSubscriber<>(1L);
 
         source.subscribe(ts21);
 
@@ -1214,7 +1214,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts21.assertNoErrors();
         ts21.cancel();
 
-        TestSubscriber<Integer> ts22 = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts22 = new TestSubscriber<>(1L);
 
         source.subscribe(ts22);
 
@@ -1222,7 +1222,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         ts22.assertNoErrors();
         ts22.cancel();
 
-        TestSubscriber<Integer> ts3 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts3 = new TestSubscriber<>();
 
         source.subscribe(ts3);
 
@@ -1286,8 +1286,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1312,8 +1312,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
             cf.subscribe(ts1);
 
@@ -1412,7 +1412,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
             final ConnectableFlowable<Integer> cf = pp.replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1441,7 +1441,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
             final ConnectableFlowable<Integer> cf = pp.replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
             cf.subscribe(ts1);
 
@@ -1470,7 +1470,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf = Flowable.range(1, 1000).replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
             cf.connect();
 
@@ -1592,12 +1592,12 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void timedAndSizedTruncationError() {
         TestScheduler test = new TestScheduler();
-        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test, true);
+        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<>(2, 2000, TimeUnit.MILLISECONDS, test, true);
 
         Assert.assertFalse(buf.hasCompleted());
         Assert.assertFalse(buf.hasError());
 
-        List<Integer> values = new ArrayList<Integer>();
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
@@ -1635,8 +1635,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void sizedTruncation() {
-        SizeBoundReplayBuffer<Integer> buf = new SizeBoundReplayBuffer<Integer>(2, true);
-        List<Integer> values = new ArrayList<Integer>();
+        SizeBoundReplayBuffer<Integer> buf = new SizeBoundReplayBuffer<>(2, true);
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         buf.next(2);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplayTest.java
@@ -732,14 +732,14 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false);
+        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<>(false);
         buf.addLast(new Node(1, 0));
         buf.addLast(new Node(2, 1));
         buf.addLast(new Node(3, 2));
         buf.addLast(new Node(4, 3));
         buf.addLast(new Node(5, 4));
 
-        List<Integer> values = new ArrayList<Integer>();
+        List<Integer> values = new ArrayList<>();
         buf.collect(values);
 
         Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), values);
@@ -763,8 +763,8 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void timedAndSizedTruncation() {
         TestScheduler test = new TestScheduler();
-        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test, false);
-        List<Integer> values = new ArrayList<Integer>();
+        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<>(2, 2000, TimeUnit.MILLISECONDS, test, false);
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
@@ -809,8 +809,8 @@ public class FlowableReplayTest extends RxJavaTest {
                 });
         ConnectableFlowable<Integer> cf = source.replay();
 
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>(10L);
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>(90L);
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>(10L);
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>(90L);
 
         cf.subscribe(ts1);
         cf.subscribe(ts2);
@@ -840,8 +840,8 @@ public class FlowableReplayTest extends RxJavaTest {
                 });
         ConnectableFlowable<Integer> cf = source.replay(50);
 
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>(10L);
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>(90L);
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>(10L);
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>(90L);
 
         cf.subscribe(ts1);
         cf.subscribe(ts2);
@@ -863,7 +863,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void coldReplayNoBackpressure() {
         Flowable<Integer> source = Flowable.range(0, 1000).replay().autoConnect();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         source.subscribe(ts);
 
@@ -881,7 +881,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void coldReplayBackpressure() {
         Flowable<Integer> source = Flowable.range(0, 1000).replay().autoConnect();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(10);
 
         source.subscribe(ts);
@@ -962,7 +962,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void take() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable<Integer> cached = Flowable.range(1, 100).replay().autoConnect();
         cached.take(10).subscribe(ts);
@@ -976,7 +976,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void async() {
         Flowable<Integer> source = Flowable.range(1, 10000);
         for (int i = 0; i < 100; i++) {
-            TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
 
             Flowable<Integer> cached = source.replay().autoConnect();
 
@@ -987,7 +987,7 @@ public class FlowableReplayTest extends RxJavaTest {
             ts1.assertTerminated();
             assertEquals(10000, ts1.values().size());
 
-            TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
             cached.observeOn(Schedulers.computation()).subscribe(ts2);
 
             ts2.awaitDone(2, TimeUnit.SECONDS);
@@ -1006,14 +1006,14 @@ public class FlowableReplayTest extends RxJavaTest {
 
         Flowable<Long> output = cached.observeOn(Schedulers.computation(), false, 1024);
 
-        List<TestSubscriberEx<Long>> list = new ArrayList<TestSubscriberEx<Long>>(100);
+        List<TestSubscriberEx<Long>> list = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
-            TestSubscriberEx<Long> ts = new TestSubscriberEx<Long>();
+            TestSubscriberEx<Long> ts = new TestSubscriberEx<>();
             list.add(ts);
             output.skip(i * 10).take(10).subscribe(ts);
         }
 
-        List<Long> expected = new ArrayList<Long>();
+        List<Long> expected = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             expected.add((long)(i - 10));
         }
@@ -1047,7 +1047,7 @@ public class FlowableReplayTest extends RxJavaTest {
             }
         });
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         firehose.replay().autoConnect().observeOn(Schedulers.computation()).takeLast(100).subscribe(ts);
 
         ts.awaitDone(3, TimeUnit.SECONDS);
@@ -1063,14 +1063,14 @@ public class FlowableReplayTest extends RxJavaTest {
                 .concatWith(Flowable.<Integer>error(new TestException()))
                 .replay().autoConnect();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         source.subscribe(ts);
 
         ts.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ts.assertNotComplete();
         Assert.assertEquals(1, ts.errors().size());
 
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
         source.subscribe(ts2);
 
         ts2.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -1111,7 +1111,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void unboundedLeavesEarly() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
 
         Flowable<Integer> out = source
                 .doOnRequest(new LongConsumer() {
@@ -1121,8 +1121,8 @@ public class FlowableReplayTest extends RxJavaTest {
                     }
                 }).replay().autoConnect();
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(5L);
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(10L);
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>(5L);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(10L);
 
         out.subscribe(ts1);
         out.subscribe(ts2);
@@ -1136,7 +1136,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ConnectableFlowable<Integer> source = Flowable.range(1, 10).replay(1);
         source.connect();
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>(2L);
 
         source.subscribe(ts1);
 
@@ -1144,7 +1144,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts1.assertNoErrors();
         ts1.cancel();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(2L);
 
         source.subscribe(ts2);
 
@@ -1152,7 +1152,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts2.assertNoErrors();
         ts2.cancel();
 
-        TestSubscriber<Integer> ts21 = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts21 = new TestSubscriber<>(1L);
 
         source.subscribe(ts21);
 
@@ -1160,7 +1160,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts21.assertNoErrors();
         ts21.cancel();
 
-        TestSubscriber<Integer> ts22 = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts22 = new TestSubscriber<>(1L);
 
         source.subscribe(ts22);
 
@@ -1168,7 +1168,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts22.assertNoErrors();
         ts22.cancel();
 
-        TestSubscriber<Integer> ts3 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts3 = new TestSubscriber<>();
 
         source.subscribe(ts3);
 
@@ -1183,7 +1183,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ConnectableFlowable<Integer> source = Flowable.range(1, 10).replay(2);
         source.connect();
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>(2L);
 
         source.subscribe(ts1);
 
@@ -1191,7 +1191,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts1.assertNoErrors();
         ts1.cancel();
 
-        TestSubscriber<Integer> ts11 = new TestSubscriber<Integer>(2L);
+        TestSubscriber<Integer> ts11 = new TestSubscriber<>(2L);
 
         source.subscribe(ts11);
 
@@ -1199,7 +1199,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts11.assertNoErrors();
         ts11.cancel();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(3L);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(3L);
 
         source.subscribe(ts2);
 
@@ -1207,7 +1207,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts2.assertNoErrors();
         ts2.cancel();
 
-        TestSubscriber<Integer> ts21 = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts21 = new TestSubscriber<>(1L);
 
         source.subscribe(ts21);
 
@@ -1215,7 +1215,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts21.assertNoErrors();
         ts21.cancel();
 
-        TestSubscriber<Integer> ts22 = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts22 = new TestSubscriber<>(1L);
 
         source.subscribe(ts22);
 
@@ -1223,7 +1223,7 @@ public class FlowableReplayTest extends RxJavaTest {
         ts22.assertNoErrors();
         ts22.cancel();
 
-        TestSubscriber<Integer> ts3 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts3 = new TestSubscriber<>();
 
         source.subscribe(ts3);
 
@@ -1287,8 +1287,8 @@ public class FlowableReplayTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1313,8 +1313,8 @@ public class FlowableReplayTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
             cf.subscribe(ts1);
 
@@ -1413,7 +1413,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
             final ConnectableFlowable<Integer> cf = pp.replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -1442,7 +1442,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
             final ConnectableFlowable<Integer> cf = pp.replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
             cf.subscribe(ts1);
 
@@ -1471,7 +1471,7 @@ public class FlowableReplayTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf = Flowable.range(1, 1000).replay();
 
-            final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
             cf.connect();
 
@@ -1593,12 +1593,12 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void timedAndSizedTruncationError() {
         TestScheduler test = new TestScheduler();
-        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<Integer>(2, 2000, TimeUnit.MILLISECONDS, test, false);
+        SizeAndTimeBoundReplayBuffer<Integer> buf = new SizeAndTimeBoundReplayBuffer<>(2, 2000, TimeUnit.MILLISECONDS, test, false);
 
         Assert.assertFalse(buf.hasCompleted());
         Assert.assertFalse(buf.hasError());
 
-        List<Integer> values = new ArrayList<Integer>();
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
@@ -1636,8 +1636,8 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void sizedTruncation() {
-        SizeBoundReplayBuffer<Integer> buf = new SizeBoundReplayBuffer<Integer>(2, false);
-        List<Integer> values = new ArrayList<Integer>();
+        SizeBoundReplayBuffer<Integer> buf = new SizeBoundReplayBuffer<>(2, false);
+        List<Integer> values = new ArrayList<>();
 
         buf.next(1);
         buf.next(2);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryTest.java
@@ -63,7 +63,7 @@ public class FlowableRetryTest extends RxJavaTest {
             }
 
         });
-        TestSubscriber<String> ts = new TestSubscriber<String>(consumer);
+        TestSubscriber<String> ts = new TestSubscriber<>(consumer);
         producer.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
 
             @Override
@@ -117,7 +117,7 @@ public class FlowableRetryTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         int numRetries = 20;
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-        origin.retry().subscribe(new TestSubscriber<String>(subscriber));
+        origin.retry().subscribe(new TestSubscriber<>(subscriber));
 
         InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
@@ -136,7 +136,7 @@ public class FlowableRetryTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         int numRetries = 2;
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
@@ -203,7 +203,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void onCompletedFromNotificationHandler() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(1));
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
@@ -498,7 +498,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void sourceFlowableCallsUnsubscribe() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestSubscriber<String> ts = new TestSubscriber<String>();
+        final TestSubscriber<String> ts = new TestSubscriber<>();
 
         Publisher<String> onSubscribe = new Publisher<String>() {
             @Override
@@ -529,7 +529,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void sourceFlowableRetry1() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestSubscriber<String> ts = new TestSubscriber<String>();
+        final TestSubscriber<String> ts = new TestSubscriber<>();
 
         Publisher<String> onSubscribe = new Publisher<String>() {
             @Override
@@ -548,7 +548,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void sourceFlowableRetry0() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
 
-        final TestSubscriber<String> ts = new TestSubscriber<String>();
+        final TestSubscriber<String> ts = new TestSubscriber<>();
 
         Publisher<String> onSubscribe = new Publisher<String>() {
             @Override
@@ -674,7 +674,7 @@ public class FlowableRetryTest extends RxJavaTest {
         SlowFlowable so = new SlowFlowable(100, 0, "testUnsubscribeAfterError");
         Flowable<Long> f = Flowable.unsafeCreate(so).retry(5);
 
-        AsyncSubscriber<Long> async = new AsyncSubscriber<Long>(subscriber);
+        AsyncSubscriber<Long> async = new AsyncSubscriber<>(subscriber);
 
         f.subscribe(async);
 
@@ -698,7 +698,7 @@ public class FlowableRetryTest extends RxJavaTest {
         SlowFlowable sf = new SlowFlowable(100, 10, "testTimeoutWithRetry");
         Flowable<Long> f = Flowable.unsafeCreate(sf).timeout(80, TimeUnit.MILLISECONDS).retry(5);
 
-        AsyncSubscriber<Long> async = new AsyncSubscriber<Long>(subscriber);
+        AsyncSubscriber<Long> async = new AsyncSubscriber<>(subscriber);
 
         f.subscribe(async);
 
@@ -720,7 +720,7 @@ public class FlowableRetryTest extends RxJavaTest {
             for (int i = 0; i < 400; i++) {
                 Subscriber<String> subscriber = TestHelper.mockSubscriber();
                 Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-                TestSubscriberEx<String> ts = new TestSubscriberEx<String>(subscriber);
+                TestSubscriberEx<String> ts = new TestSubscriberEx<>(subscriber);
                 origin.retry().observeOn(Schedulers.computation()).subscribe(ts);
                 ts.awaitDone(5, TimeUnit.SECONDS);
 
@@ -751,7 +751,7 @@ public class FlowableRetryTest extends RxJavaTest {
                 }
 
                 final AtomicInteger timeouts = new AtomicInteger();
-                final Map<Integer, List<String>> data = new ConcurrentHashMap<Integer, List<String>>();
+                final Map<Integer, List<String>> data = new ConcurrentHashMap<>();
 
                 int m = 5000;
                 final CountDownLatch cdl = new CountDownLatch(m);
@@ -763,11 +763,11 @@ public class FlowableRetryTest extends RxJavaTest {
                             final AtomicInteger nexts = new AtomicInteger();
                             try {
                                 Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-                                TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+                                TestSubscriberEx<String> ts = new TestSubscriberEx<>();
                                 origin.retry()
                                 .observeOn(Schedulers.computation()).subscribe(ts);
                                 ts.awaitDone(2500, TimeUnit.MILLISECONDS);
-                                List<String> onNextEvents = new ArrayList<String>(ts.values());
+                                List<String> onNextEvents = new ArrayList<>(ts.values());
                                 if (onNextEvents.size() != numRetries + 2) {
                                     for (Throwable t : ts.errors()) {
                                         onNextEvents.add(t.toString());
@@ -865,7 +865,7 @@ public class FlowableRetryTest extends RxJavaTest {
                 return t1.take(1);
             }
         }, NUM_MSG) // Must request as many groups as groupBy produces to avoid MBE
-        .subscribe(new TestSubscriber<String>(subscriber));
+        .subscribe(new TestSubscriber<>(subscriber));
 
         InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
@@ -910,7 +910,7 @@ public class FlowableRetryTest extends RxJavaTest {
                 return t1.take(1);
             }
         })
-        .subscribe(new TestSubscriber<String>(subscriber));
+        .subscribe(new TestSubscriber<>(subscriber));
 
         InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -236,7 +236,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
                 .unsafeCreate(so)
                 .retry(retry5);
 
-        FlowableRetryTest.AsyncSubscriber<Long> async = new FlowableRetryTest.AsyncSubscriber<Long>(subscriber);
+        FlowableRetryTest.AsyncSubscriber<Long> async = new FlowableRetryTest.AsyncSubscriber<>(subscriber);
 
         f.subscribe(async);
 
@@ -263,7 +263,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
                 .timeout(80, TimeUnit.MILLISECONDS)
                 .retry(retry5);
 
-        FlowableRetryTest.AsyncSubscriber<Long> async = new FlowableRetryTest.AsyncSubscriber<Long>(subscriber);
+        FlowableRetryTest.AsyncSubscriber<Long> async = new FlowableRetryTest.AsyncSubscriber<>(subscriber);
 
         f.subscribe(async);
 
@@ -279,7 +279,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void issue2826() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         final RuntimeException e = new RuntimeException("You shall not pass");
         final AtomicInteger c = new AtomicInteger();
         Flowable.just(1).map(new Function<Integer, Integer>() {
@@ -313,7 +313,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void issue3008RetryWithPredicate() {
-        final List<Long> list = new CopyOnWriteArrayList<Long>();
+        final List<Long> list = new CopyOnWriteArrayList<>();
         final AtomicBoolean isFirst = new AtomicBoolean(true);
         Flowable.<Long> just(1L, 2L, 3L).map(new Function<Long, Long>() {
             @Override
@@ -341,7 +341,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void issue3008RetryInfinite() {
-        final List<Long> list = new CopyOnWriteArrayList<Long>();
+        final List<Long> list = new CopyOnWriteArrayList<>();
         final AtomicBoolean isFirst = new AtomicBoolean(true);
         Flowable.<Long> just(1L, 2L, 3L).map(new Function<Long, Long>() {
             @Override
@@ -365,7 +365,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
 
         Flowable<Integer> source = Flowable
                 .just(1)
@@ -377,7 +377,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
                     }
                 });
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(3L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(3L);
         source
         .retry(new BiPredicate<Integer, Throwable>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScalarXMapTest.java
@@ -59,7 +59,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
     static final class OneCallablePublisher implements Publisher<Integer>, Supplier<Integer> {
         @Override
         public void subscribe(Subscriber<? super Integer> s) {
-            s.onSubscribe(new ScalarSubscription<Integer>(s, 1));
+            s.onSubscribe(new ScalarSubscription<>(s, 1));
         }
 
         @Override
@@ -70,7 +70,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void tryScalarXMap() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new CallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer f) throws Exception {
@@ -83,7 +83,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void emptyXMap() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new EmptyCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
             @Override
@@ -97,7 +97,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void mapperCrashes() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
             @Override
@@ -111,7 +111,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void mapperToJust() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
             @Override
@@ -125,7 +125,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void mapperToEmpty() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
             @Override
@@ -139,7 +139,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void mapperToCrashingCallable() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
             @Override
@@ -177,8 +177,8 @@ public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void scalarDisposableStateCheck() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ScalarSubscription<Integer> sd = new ScalarSubscription<Integer>(ts, 1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ScalarSubscription<Integer> sd = new ScalarSubscription<>(ts, 1);
         ts.onSubscribe(sd);
 
         assertFalse(sd.isCancelled());
@@ -211,8 +211,8 @@ public class FlowableScalarXMapTest extends RxJavaTest {
     @Test
     public void scalarDisposableRunDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-            final ScalarSubscription<Integer> sd = new ScalarSubscription<Integer>(ts, 1);
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            final ScalarSubscription<Integer> sd = new ScalarSubscription<>(ts, 1);
             ts.onSubscribe(sd);
 
             Runnable r1 = new Runnable() {
@@ -235,7 +235,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
 
     @Test
     public void cancelled() {
-        ScalarSubscription<Integer> scalar = new ScalarSubscription<Integer>(new TestSubscriber<Integer>(), 1);
+        ScalarSubscription<Integer> scalar = new ScalarSubscription<>(new TestSubscriber<>(), 1);
 
         assertFalse(scalar.isCancelled());
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScanTest.java
@@ -114,7 +114,7 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void shouldNotEmitUntilAfterSubscription() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, 100).scan(0, new BiFunction<Integer, Integer, Integer>() {
 
             @Override
@@ -263,7 +263,7 @@ public class FlowableScanTest extends RxJavaTest {
 
                     @Override
                     public List<Integer> get() {
-                        return new ArrayList<Integer>();
+                        return new ArrayList<>();
                     }
 
                 }, new BiConsumer<List<Integer>, Integer>() {
@@ -289,7 +289,7 @@ public class FlowableScanTest extends RxJavaTest {
 
                     @Override
                     public List<Integer> get() {
-                        return new ArrayList<Integer>();
+                        return new ArrayList<>();
                     }
 
                 }, new BiConsumer<List<Integer>, Integer>() {
@@ -315,7 +315,7 @@ public class FlowableScanTest extends RxJavaTest {
             }
 
         }).take(1);
-        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>();
         f.subscribe(subscriber);
         subscriber.assertValue(0);
         subscriber.assertTerminated();
@@ -324,7 +324,7 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void scanShouldNotRequestZero() {
-        final AtomicReference<Subscription> producer = new AtomicReference<Subscription>();
+        final AtomicReference<Subscription> producer = new AtomicReference<>();
         Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(final Subscriber<? super Integer> subscriber) {
@@ -445,7 +445,7 @@ public class FlowableScanTest extends RxJavaTest {
     public void unsubscribeScan() {
 
         FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
-        .scan(new HashMap<String, String>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
+        .scan(new HashMap<>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
             @Override
             public HashMap<String, String> apply(HashMap<String, String> accum, Event perInstanceEvent) {
                 accum.put("instance", perInstanceEvent.instanceId);
@@ -463,7 +463,7 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void scanWithSeedDoesNotEmitErrorTwiceIfScanFunctionThrows() {
-        final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+        final List<Throwable> list = new CopyOnWriteArrayList<>();
         Consumer<Throwable> errorConsumer = new Consumer<Throwable>() {
             @Override
             public void accept(Throwable t) throws Exception {
@@ -543,7 +543,7 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void scanNoSeedDoesNotEmitErrorTwiceIfScanFunctionThrows() {
-        final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+        final List<Throwable> list = new CopyOnWriteArrayList<>();
         Consumer<Throwable> errorConsumer = new Consumer<Throwable>() {
             @Override
             public void accept(Throwable t) throws Exception {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -384,7 +384,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
         };
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Boolean> ts = new TestSubscriber<Boolean>();
+            final TestSubscriber<Boolean> ts = new TestSubscriber<>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -487,7 +487,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
         };
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestObserver<Boolean> to = new TestObserver<Boolean>();
+            final TestObserver<Boolean> to = new TestObserver<>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSingleTest.java
@@ -74,7 +74,7 @@ public class FlowableSingleTest extends RxJavaTest {
 
     @Test
     public void singleDoesNotRequestMoreThanItNeedsIf1Then2RequestedFlowable() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
         Flowable.just(1)
         //
                 .doOnRequest(new LongConsumer() {
@@ -115,7 +115,7 @@ public class FlowableSingleTest extends RxJavaTest {
 
     @Test
     public void singleDoesNotRequestMoreThanItNeedsIf3RequestedFlowable() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
         Flowable.just(1)
         //
                 .doOnRequest(new LongConsumer() {
@@ -155,7 +155,7 @@ public class FlowableSingleTest extends RxJavaTest {
 
     @Test
     public void singleRequestsExactlyWhatItNeedsIf1RequestedFlowable() {
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
         Flowable.just(1)
         //
                 .doOnRequest(new LongConsumer() {
@@ -705,7 +705,7 @@ public class FlowableSingleTest extends RxJavaTest {
     @Test
     public void singleElementOperatorDoNotSwallowExceptionWhenDone() {
         final Throwable exception = new RuntimeException("some error");
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         try {
             RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipLastTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipLastTest.java
@@ -89,7 +89,7 @@ public class FlowableSkipLastTest extends RxJavaTest {
     @Test
     public void skipLastWithBackpressure() {
         Flowable<Integer> f = Flowable.range(0, Flowable.bufferSize() * 2).skipLast(Flowable.bufferSize() + 10);
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         f.observeOn(Schedulers.computation()).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipTest.java
@@ -143,7 +143,7 @@ public class FlowableSkipTest extends RxJavaTest {
     @Test
     public void backpressureMultipleSmallAsyncRequests() throws InterruptedException {
         final AtomicLong requests = new AtomicLong(0);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
+        TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.interval(100, TimeUnit.MILLISECONDS)
                 .doOnRequest(new LongConsumer() {
                     @Override
@@ -162,7 +162,7 @@ public class FlowableSkipTest extends RxJavaTest {
 
     @Test
     public void requestOverflowDoesNotOccur() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(Long.MAX_VALUE - 1);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(Long.MAX_VALUE - 1);
         Flowable.range(1, 10).skip(5).subscribe(ts);
         ts.assertTerminated();
         ts.assertComplete();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -41,7 +41,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable
         .unsafeCreate(new Publisher<Integer>() {
@@ -79,7 +79,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void onError() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
         Flowable.unsafeCreate(new Publisher<String>() {
 
             @Override
@@ -152,7 +152,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void unsubscribeInfiniteStream() throws InterruptedException {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         final AtomicInteger count = new AtomicInteger();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
@@ -178,7 +178,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
     @Test
     public void backpressureReschedulesCorrectly() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(10);
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(new DefaultSubscriber<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {
@@ -208,7 +208,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void setProducerSynchronousRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.just(1, 2, 3).lift(new FlowableOperator<Integer, Integer>() {
 
             @Override
@@ -283,11 +283,11 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
     public void deferredRequestRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             Worker w = Schedulers.computation().createWorker();
 
-            final SubscribeOnSubscriber<Integer> so = new SubscribeOnSubscriber<Integer>(ts, w, Flowable.<Integer>never(), true);
+            final SubscribeOnSubscriber<Integer> so = new SubscribeOnSubscriber<>(ts, w, Flowable.<Integer>never(), true);
             ts.onSubscribe(so);
 
             final BooleanSubscription bs = new BooleanSubscription();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -142,7 +142,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
     @Test
     public void switchRequestAlternativeObservableWithBackpressure() {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1L);
 
         Flowable.<Integer>empty().switchIfEmpty(Flowable.just(1, 2, 3)).subscribe(ts);
 
@@ -156,7 +156,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
 
     @Test
     public void backpressureNoRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         Flowable.<Integer>empty().switchIfEmpty(Flowable.just(1, 2, 3)).subscribe(ts);
         ts.assertNoValues();
         ts.assertNoErrors();
@@ -164,7 +164,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
 
     @Test
     public void backpressureOnFirstObservable() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         Flowable.just(1, 2, 3).switchIfEmpty(Flowable.just(4, 5, 6)).subscribe(ts);
         ts.assertNotComplete();
         ts.assertNoErrors();
@@ -173,7 +173,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
 
     @Test
     public void requestsNotLost() throws InterruptedException {
-        final TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
+        final TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.unsafeCreate(new Publisher<Long>() {
 
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchTest.java
@@ -450,7 +450,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         publishCompleted(o2, 50);
         publishCompleted(o3, 55);
 
-        final TestSubscriberEx<String> testSubscriber = new TestSubscriberEx<String>();
+        final TestSubscriberEx<String> testSubscriber = new TestSubscriberEx<>();
         Flowable.switchOnNext(o).subscribe(new DefaultSubscriber<String>() {
 
             private int requested;
@@ -549,7 +549,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void initialRequestsAreAdditive() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
+        TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
                           .map(
@@ -568,7 +568,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void initialRequestsDontOverflow() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
+        TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
                         .map(new Function<Long, Flowable<Long>>() {
@@ -585,7 +585,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void secondaryRequestsDontOverflow() throws InterruptedException {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
+        TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
                         .map(new Function<Long, Flowable<Long>>() {
@@ -639,7 +639,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchOnNextPrefetch() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(new Consumer<Integer>() {
             @Override
@@ -656,7 +656,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchOnNextDelayError() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(new Consumer<Integer>() {
             @Override
@@ -673,7 +673,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchOnNextDelayErrorPrefetch() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(new Consumer<Integer>() {
             @Override
@@ -1082,7 +1082,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     @Test
     public void drainCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -1176,7 +1176,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void undeliverableUponCancel() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            final TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
             Flowable.just(1)
             .map(new Function<Integer, Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastOneTest.java
@@ -30,7 +30,7 @@ public class FlowableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void lastOfManyReturnsLast() {
-        TestSubscriberEx<Integer> s = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> s = new TestSubscriberEx<>();
         Flowable.range(1, 10).takeLast(1).subscribe(s);
         s.assertValue(10);
         s.assertNoErrors();
@@ -41,7 +41,7 @@ public class FlowableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void lastOfEmptyReturnsEmpty() {
-        TestSubscriberEx<Object> s = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> s = new TestSubscriberEx<>();
         Flowable.empty().takeLast(1).subscribe(s);
         s.assertNoValues();
         s.assertNoErrors();
@@ -52,7 +52,7 @@ public class FlowableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void lastOfOneReturnsLast() {
-        TestSubscriberEx<Integer> s = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> s = new TestSubscriberEx<>();
         Flowable.just(1).takeLast(1).subscribe(s);
         s.assertValue(1);
         s.assertNoErrors();
@@ -81,7 +81,7 @@ public class FlowableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void lastWithBackpressure() {
-        MySubscriber<Integer> s = new MySubscriber<Integer>(0);
+        MySubscriber<Integer> s = new MySubscriber<>(0);
         Flowable.just(1).takeLast(1).subscribe(s);
         assertEquals(0, s.list.size());
         s.requestMore(1);
@@ -111,7 +111,7 @@ public class FlowableTakeLastOneTest extends RxJavaTest {
             this.initialRequest = initialRequest;
         }
 
-        final List<T> list = new ArrayList<T>();
+        final List<T> list = new ArrayList<>();
 
         public void requestMore(long n) {
             request(n);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastTest.java
@@ -96,7 +96,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
 
     @Test
     public void backpressure1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, 100000).takeLast(1)
         .observeOn(Schedulers.newThread())
         .map(newSlowProcessor()).subscribe(ts);
@@ -107,7 +107,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
 
     @Test
     public void backpressure2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, 100000).takeLast(Flowable.bufferSize() * 4)
         .observeOn(Schedulers.newThread()).map(newSlowProcessor()).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -283,7 +283,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
 
     @Test
     public void requestOverflow() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
         Flowable.range(1, 100).takeLast(50).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -208,7 +208,7 @@ public class FlowableTakeLastTimedTest extends RxJavaTest {
     public void continuousDelivery() {
         TestScheduler scheduler = new TestScheduler();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeTest.java
@@ -290,7 +290,7 @@ public class FlowableTakeTest extends RxJavaTest {
     @Test
     public void takeObserveOn() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
+        TestSubscriber<Object> ts = new TestSubscriber<>(subscriber);
 
         INFINITE_OBSERVABLE.onBackpressureDrop()
         .observeOn(Schedulers.newThread()).take(1).subscribe(ts);
@@ -305,7 +305,7 @@ public class FlowableTakeTest extends RxJavaTest {
 
     @Test
     public void producerRequestThroughTake() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(3);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(3);
         final AtomicLong requested = new AtomicLong();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
@@ -331,7 +331,7 @@ public class FlowableTakeTest extends RxJavaTest {
 
     @Test
     public void producerRequestThroughTakeIsModified() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(3);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(3);
         final AtomicLong requested = new AtomicLong();
         Flowable.unsafeCreate(new Publisher<Integer>() {
 
@@ -358,7 +358,7 @@ public class FlowableTakeTest extends RxJavaTest {
 
     @Test
     public void interrupt() throws InterruptedException {
-        final AtomicReference<Object> exception = new AtomicReference<Object>();
+        final AtomicReference<Object> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         Flowable.just(1).subscribeOn(Schedulers.computation()).take(1)
         .subscribe(new Consumer<Integer>() {
@@ -384,7 +384,7 @@ public class FlowableTakeTest extends RxJavaTest {
     @Test
     public void doesntRequestMoreThanNeededFromUpstream() throws InterruptedException {
         final AtomicLong requests = new AtomicLong();
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(0L);
+        TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.interval(100, TimeUnit.MILLISECONDS)
             //
             .doOnRequest(new LongConsumer() {
@@ -429,7 +429,7 @@ public class FlowableTakeTest extends RxJavaTest {
     public void reentrantTake() {
         final PublishProcessor<Integer> source = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.take(1).doOnNext(new Consumer<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeTest2.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeTest2.java
@@ -32,7 +32,7 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 // moved tests from FlowableLimitTest to here (limit removed as operator)
 public class FlowableTakeTest2 extends RxJavaTest implements LongConsumer, Action {
 
-    final List<Long> requests = new ArrayList<Long>();
+    final List<Long> requests = new ArrayList<>();
 
     static final Long CANCELLED = -100L;
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
@@ -142,7 +142,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(5L);
 
         Flowable.range(1, 1000).takeUntil(new Predicate<Integer>() {
             @Override
@@ -158,7 +158,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
 
     @Test
     public void errorIncludesLastValueAsCause() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
         final TestException e = new TestException("Forced failure");
         Predicate<String> predicate = new Predicate<String>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -190,7 +190,7 @@ public class FlowableTakeUntilTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> until = PublishProcessor.create();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         source.takeUntil(until).subscribe(ts);
 
@@ -216,7 +216,7 @@ public class FlowableTakeUntilTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> until = PublishProcessor.create();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         source.takeUntil(until).subscribe(ts);
 
@@ -240,7 +240,7 @@ public class FlowableTakeUntilTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> until = PublishProcessor.create();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         source.takeUntil(until).take(1).subscribe(ts);
 
@@ -262,7 +262,7 @@ public class FlowableTakeUntilTest extends RxJavaTest {
     public void backpressure() {
         PublishProcessor<Integer> until = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Flowable.range(1, 10).takeUntil(until).subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -236,7 +236,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
                 return t1 < 100;
             }
         });
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(5L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(5L);
 
         source.subscribe(ts);
 
@@ -257,7 +257,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
                 return t1 < 2;
             }
         });
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.subscribe(ts);
 
@@ -269,7 +269,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
 
     @Test
     public void errorCauseIncludesLastValue() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
         Flowable.just("abc").takeWhile(new Predicate<String>() {
             @Override
             public boolean test(String t1) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeIntervalTest.java
@@ -61,11 +61,11 @@ public class FlowableTimeIntervalTest extends RxJavaTest {
         processor.onComplete();
 
         inOrder.verify(subscriber, times(1)).onNext(
-                new Timed<Integer>(1, 1000, TIME_UNIT));
+                new Timed<>(1, 1000, TIME_UNIT));
         inOrder.verify(subscriber, times(1)).onNext(
-                new Timed<Integer>(2, 2000, TIME_UNIT));
+                new Timed<>(2, 2000, TIME_UNIT));
         inOrder.verify(subscriber, times(1)).onNext(
-                new Timed<Integer>(3, 3000, TIME_UNIT));
+                new Timed<>(3, 3000, TIME_UNIT));
         inOrder.verify(subscriber, times(1)).onComplete();
         inOrder.verifyNoMoreInteractions();
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeoutTests.java
@@ -52,7 +52,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldNotTimeoutIfOnNextWithinTimeout() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
 
         withTimeout.subscribe(ts);
 
@@ -67,7 +67,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldNotTimeoutIfSecondOnNextWithinTimeout() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
 
         withTimeout.subscribe(ts);
 
@@ -83,7 +83,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
 
     @Test
     public void shouldTimeoutIfOnNextNotWithinTimeout() {
-        TestSubscriberEx<String> subscriber = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> subscriber = new TestSubscriberEx<>();
 
         withTimeout.subscribe(subscriber);
 
@@ -93,8 +93,8 @@ public class FlowableTimeoutTests extends RxJavaTest {
 
     @Test
     public void shouldTimeoutIfSecondOnNextNotWithinTimeout() {
-        TestSubscriberEx<String> subscriber = new TestSubscriberEx<String>();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriberEx<String> subscriber = new TestSubscriberEx<>();
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         withTimeout.subscribe(subscriber);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onNext("One");
@@ -107,7 +107,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldCompleteIfUnderlyingComletes() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         withTimeout.subscribe(subscriber);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onComplete();
@@ -120,7 +120,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldErrorIfUnderlyingErrors() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         withTimeout.subscribe(subscriber);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
         underlyingSubject.onError(new UnsupportedOperationException());
@@ -135,7 +135,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
         Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -158,7 +158,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
         Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -181,7 +181,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
         Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -204,7 +204,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
         Flowable<String> source = underlyingSubject.timeout(TIMEOUT, TIME_UNIT, testScheduler, other);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         source.subscribe(ts);
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -234,7 +234,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
         final CountDownLatch exit = new CountDownLatch(1);
         final CountDownLatch timeoutSetuped = new CountDownLatch(1);
 
-        final TestSubscriberEx<String> subscriber = new TestSubscriberEx<String>();
+        final TestSubscriberEx<String> subscriber = new TestSubscriberEx<>();
 
         new Thread(new Runnable() {
 
@@ -283,7 +283,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
         TestScheduler testScheduler = new TestScheduler();
         Flowable<String> observableWithTimeout = never.timeout(1000, TimeUnit.MILLISECONDS, testScheduler);
 
-        TestSubscriberEx<String> subscriber = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> subscriber = new TestSubscriberEx<>();
         observableWithTimeout.subscribe(subscriber);
 
         testScheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -329,7 +329,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
         }).when(subscriber).onComplete();
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(subscriber);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(subscriber);
 
         new Thread(new Runnable() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimerTest.java
@@ -63,7 +63,7 @@ public class FlowableTimerTest extends RxJavaTest {
 
     @Test
     public void timerPeriodically() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts = new TestSubscriber<>();
 
         Flowable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler).subscribe(ts);
 
@@ -91,7 +91,7 @@ public class FlowableTimerTest extends RxJavaTest {
     @Test
     public void interval() {
         Flowable<Long> w = Flowable.interval(1, TimeUnit.SECONDS, scheduler);
-        TestSubscriber<Long> ts = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts = new TestSubscriber<>();
         w.subscribe(ts);
 
         ts.assertNoValues();
@@ -116,8 +116,8 @@ public class FlowableTimerTest extends RxJavaTest {
     public void withMultipleSubscribersStartingAtSameTime() {
         Flowable<Long> w = Flowable.interval(1, TimeUnit.SECONDS, scheduler);
 
-        TestSubscriber<Long> ts1 = new TestSubscriber<Long>();
-        TestSubscriber<Long> ts2 = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts1 = new TestSubscriber<>();
+        TestSubscriber<Long> ts2 = new TestSubscriber<>();
 
         w.subscribe(ts1);
         w.subscribe(ts2);
@@ -153,7 +153,7 @@ public class FlowableTimerTest extends RxJavaTest {
     public void withMultipleStaggeredSubscribers() {
         Flowable<Long> w = Flowable.interval(1, TimeUnit.SECONDS, scheduler);
 
-        TestSubscriber<Long> ts1 = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts1 = new TestSubscriber<>();
 
         w.subscribe(ts1);
 
@@ -161,7 +161,7 @@ public class FlowableTimerTest extends RxJavaTest {
 
         scheduler.advanceTimeTo(2, TimeUnit.SECONDS);
 
-        TestSubscriber<Long> ts2 = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts2 = new TestSubscriber<>();
 
         w.subscribe(ts2);
 
@@ -193,7 +193,7 @@ public class FlowableTimerTest extends RxJavaTest {
     public void withMultipleStaggeredSubscribersAndPublish() {
         ConnectableFlowable<Long> w = Flowable.interval(1, TimeUnit.SECONDS, scheduler).publish();
 
-        TestSubscriber<Long> ts1 = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts1 = new TestSubscriber<>();
 
         w.subscribe(ts1);
         w.connect();
@@ -202,7 +202,7 @@ public class FlowableTimerTest extends RxJavaTest {
 
         scheduler.advanceTimeTo(2, TimeUnit.SECONDS);
 
-        TestSubscriber<Long> ts2 = new TestSubscriber<Long>();
+        TestSubscriber<Long> ts2 = new TestSubscriber<>();
         w.subscribe(ts2);
 
         ts1.assertValues(0L, 1L);
@@ -309,7 +309,7 @@ public class FlowableTimerTest extends RxJavaTest {
     @Test
     public void timerCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Long> ts = new TestSubscriber<Long>();
+            final TestSubscriber<Long> ts = new TestSubscriber<>();
 
             final TestScheduler scheduler = new TestScheduler();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimestampTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimestampTest.java
@@ -53,9 +53,9 @@ public class FlowableTimestampTest extends RxJavaTest {
 
         InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(2, 100, TimeUnit.MILLISECONDS));
-        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<>(2, 100, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<>(3, 200, TimeUnit.MILLISECONDS));
 
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber, never()).onComplete();
@@ -77,9 +77,9 @@ public class FlowableTimestampTest extends RxJavaTest {
 
         InOrder inOrder = inOrder(subscriber);
 
-        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(1, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(2, 0, TimeUnit.MILLISECONDS));
-        inOrder.verify(subscriber, times(1)).onNext(new Timed<Integer>(3, 200, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<>(1, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<>(2, 0, TimeUnit.MILLISECONDS));
+        inOrder.verify(subscriber, times(1)).onNext(new Timed<>(3, 200, TimeUnit.MILLISECONDS));
 
         verify(subscriber, never()).onError(any(Throwable.class));
         verify(subscriber, never()).onComplete();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToCompletableTest.java
@@ -73,7 +73,7 @@ public class FlowableToCompletableTest extends RxJavaTest {
 
     @Test
     public void neverObservable() {
-        TestSubscriberEx<String> subscriber = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> subscriber = new TestSubscriberEx<>();
         Completable cmp = Flowable.<String>never().ignoreElements();
         cmp.<String>toFlowable().subscribe(subscriber);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToFutureTest.java
@@ -38,7 +38,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
+        TestSubscriber<Object> ts = new TestSubscriber<>(subscriber);
 
         Flowable.fromFuture(future).subscribe(ts);
 
@@ -60,7 +60,7 @@ public class FlowableToFutureTest extends RxJavaTest {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         TestScheduler scheduler = new TestScheduler();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
+        TestSubscriber<Object> ts = new TestSubscriber<>(subscriber);
 
         Flowable.fromFuture(future, scheduler).subscribe(ts);
 
@@ -80,7 +80,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
+        TestSubscriber<Object> ts = new TestSubscriber<>(subscriber);
 
         Flowable.fromFuture(future).subscribe(ts);
 
@@ -101,7 +101,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
+        TestSubscriber<Object> ts = new TestSubscriber<>(subscriber);
         ts.cancel();
 
         Flowable.fromFuture(future).subscribe(ts);
@@ -147,7 +147,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(subscriber);
+        TestSubscriber<Object> ts = new TestSubscriber<>(subscriber);
         Flowable<Object> futureObservable = Flowable.fromFuture(future);
 
         futureObservable.subscribeOn(Schedulers.computation()).subscribe(ts);
@@ -163,9 +163,9 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
 
-        FutureTask<Integer> f = new FutureTask<Integer>(new Runnable() {
+        FutureTask<Integer> f = new FutureTask<>(new Runnable() {
             @Override
             public void run() {
 
@@ -187,7 +187,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void withTimeoutNoTimeout() {
-        FutureTask<Integer> task = new FutureTask<Integer>(new Runnable() {
+        FutureTask<Integer> task = new FutureTask<>(new Runnable() {
             @Override
             public void run() {
 
@@ -207,7 +207,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void withTimeoutTimeout() {
-        FutureTask<Integer> task = new FutureTask<Integer>(new Runnable() {
+        FutureTask<Integer> task = new FutureTask<>(new Runnable() {
             @Override
             public void run() {
 
@@ -225,7 +225,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void withTimeoutNoTimeoutScheduler() {
-        FutureTask<Integer> task = new FutureTask<Integer>(new Runnable() {
+        FutureTask<Integer> task = new FutureTask<>(new Runnable() {
             @Override
             public void run() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListTest.java
@@ -92,7 +92,7 @@ public class FlowableToListTest extends RxJavaTest {
     @Test
     public void backpressureHonoredFlowable() {
         Flowable<List<Integer>> w = Flowable.just(1, 2, 3, 4, 5).toList().toFlowable();
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(0L);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>(0L);
 
         w.subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToMapTest.java
@@ -54,7 +54,7 @@ public class FlowableToMapTest extends RxJavaTest {
 
         Flowable<Map<Integer, String>> mapped = source.toMap(lengthFunc).toFlowable();
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "a");
         expected.put(2, "bb");
         expected.put(3, "ccc");
@@ -73,7 +73,7 @@ public class FlowableToMapTest extends RxJavaTest {
 
         Flowable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate).toFlowable();
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "aa");
         expected.put(2, "bbbb");
         expected.put(3, "cccccc");
@@ -101,7 +101,7 @@ public class FlowableToMapTest extends RxJavaTest {
         };
         Flowable<Map<Integer, String>> mapped = source.toMap(lengthFuncErr).toFlowable();
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "a");
         expected.put(2, "bb");
         expected.put(3, "ccc");
@@ -131,7 +131,7 @@ public class FlowableToMapTest extends RxJavaTest {
 
         Flowable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr).toFlowable();
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "aa");
         expected.put(2, "bbbb");
         expected.put(3, "cccccc");
@@ -177,7 +177,7 @@ public class FlowableToMapTest extends RxJavaTest {
             }
         }, mapFactory).toFlowable();
 
-        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
         expected.put(3, "ccc");
         expected.put(4, "dddd");
@@ -213,7 +213,7 @@ public class FlowableToMapTest extends RxJavaTest {
             }
         }, mapFactory).toFlowable();
 
-        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
         expected.put(3, "ccc");
         expected.put(4, "dddd");
@@ -231,7 +231,7 @@ public class FlowableToMapTest extends RxJavaTest {
 
         Single<Map<Integer, String>> mapped = source.toMap(lengthFunc);
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "a");
         expected.put(2, "bb");
         expected.put(3, "ccc");
@@ -249,7 +249,7 @@ public class FlowableToMapTest extends RxJavaTest {
 
         Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicate);
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "aa");
         expected.put(2, "bbbb");
         expected.put(3, "cccccc");
@@ -276,7 +276,7 @@ public class FlowableToMapTest extends RxJavaTest {
         };
         Single<Map<Integer, String>> mapped = source.toMap(lengthFuncErr);
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "a");
         expected.put(2, "bb");
         expected.put(3, "ccc");
@@ -305,7 +305,7 @@ public class FlowableToMapTest extends RxJavaTest {
 
         Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr);
 
-        Map<Integer, String> expected = new HashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "aa");
         expected.put(2, "bbbb");
         expected.put(3, "cccccc");
@@ -350,7 +350,7 @@ public class FlowableToMapTest extends RxJavaTest {
             }
         }, mapFactory);
 
-        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
         expected.put(3, "ccc");
         expected.put(4, "dddd");
@@ -385,7 +385,7 @@ public class FlowableToMapTest extends RxJavaTest {
             }
         }, mapFactory);
 
-        Map<Integer, String> expected = new LinkedHashMap<Integer, String>();
+        Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
         expected.put(3, "ccc");
         expected.put(4, "dddd");

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToMultimapTest.java
@@ -55,7 +55,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc).toFlowable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
@@ -72,7 +72,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate).toFlowable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
@@ -114,11 +114,11 @@ public class FlowableToMultimapTest extends RxJavaTest {
                 mapFactory, new Function<Integer, Collection<String>>() {
                     @Override
                     public Collection<String> apply(Integer e) {
-                        return new ArrayList<String>();
+                        return new ArrayList<>();
                     }
                 }).toFlowable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
@@ -137,9 +137,9 @@ public class FlowableToMultimapTest extends RxJavaTest {
             @Override
             public Collection<String> apply(Integer t1) {
                 if (t1 == 2) {
-                    return new ArrayList<String>();
+                    return new ArrayList<>();
                 } else {
-                    return new HashSet<String>();
+                    return new HashSet<>();
                 }
             }
         };
@@ -153,16 +153,16 @@ public class FlowableToMultimapTest extends RxJavaTest {
         Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
             public Map<Integer, Collection<String>> get() {
-                return new HashMap<Integer, Collection<String>>();
+                return new HashMap<>();
             }
         };
 
         Flowable<Map<Integer, Collection<String>>> mapped = source
                 .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory).toFlowable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
-        expected.put(3, new HashSet<String>(Arrays.asList("eee")));
+        expected.put(3, new HashSet<>(Arrays.asList("eee")));
 
         mapped.subscribe(objectSubscriber);
 
@@ -187,7 +187,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr).toFlowable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
@@ -214,7 +214,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr).toFlowable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
@@ -244,7 +244,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
                     }
                 }, mapFactory).toFlowable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
@@ -265,7 +265,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
                 if (t1 == 2) {
                     throw new RuntimeException("Forced failure");
                 } else {
-                    return new HashSet<String>();
+                    return new HashSet<>();
                 }
             }
         };
@@ -279,14 +279,14 @@ public class FlowableToMultimapTest extends RxJavaTest {
         Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
             public Map<Integer, Collection<String>> get() {
-                return new HashMap<Integer, Collection<String>>();
+                return new HashMap<>();
             }
         };
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
                 identity, mapSupplier, collectionFactory).toFlowable();
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Collections.singleton("eee"));
 
@@ -303,7 +303,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
@@ -319,7 +319,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicate);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
@@ -360,11 +360,11 @@ public class FlowableToMultimapTest extends RxJavaTest {
                 mapFactory, new Function<Integer, Collection<String>>() {
                     @Override
                     public Collection<String> apply(Integer e) {
-                        return new ArrayList<String>();
+                        return new ArrayList<>();
                     }
                 });
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
@@ -382,9 +382,9 @@ public class FlowableToMultimapTest extends RxJavaTest {
             @Override
             public Collection<String> apply(Integer t1) {
                 if (t1 == 2) {
-                    return new ArrayList<String>();
+                    return new ArrayList<>();
                 } else {
-                    return new HashSet<String>();
+                    return new HashSet<>();
                 }
             }
         };
@@ -398,16 +398,16 @@ public class FlowableToMultimapTest extends RxJavaTest {
         Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
             public Map<Integer, Collection<String>> get() {
-                return new HashMap<Integer, Collection<String>>();
+                return new HashMap<>();
             }
         };
 
         Single<Map<Integer, Collection<String>>> mapped = source
                 .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
-        expected.put(3, new HashSet<String>(Arrays.asList("eee")));
+        expected.put(3, new HashSet<>(Arrays.asList("eee")));
 
         mapped.subscribe(singleObserver);
 
@@ -431,7 +431,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("a", "b"));
         expected.put(2, Arrays.asList("cc", "dd"));
 
@@ -457,7 +457,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(1, Arrays.asList("aa", "bb"));
         expected.put(2, Arrays.asList("cccc", "dddd"));
 
@@ -486,7 +486,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
                     }
                 }, mapFactory);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Arrays.asList("eee", "fff"));
 
@@ -506,7 +506,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
                 if (t1 == 2) {
                     throw new RuntimeException("Forced failure");
                 } else {
-                    return new HashSet<String>();
+                    return new HashSet<>();
                 }
             }
         };
@@ -520,14 +520,14 @@ public class FlowableToMultimapTest extends RxJavaTest {
         Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
             @Override
             public Map<Integer, Collection<String>> get() {
-                return new HashMap<Integer, Collection<String>>();
+                return new HashMap<>();
             }
         };
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
                 identity, mapSupplier, collectionFactory);
 
-        Map<Integer, Collection<String>> expected = new HashMap<Integer, Collection<String>>();
+        Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
         expected.put(3, Collections.singleton("eee"));
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToSortedListTest.java
@@ -72,7 +72,7 @@ public class FlowableToSortedListTest extends RxJavaTest {
     @Test
     public void backpressureHonoredFlowable() {
         Flowable<List<Integer>> w = Flowable.just(1, 3, 2, 5, 4).toSortedList().toFlowable();
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(0L);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>(0L);
 
         w.subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -38,7 +38,7 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
         UIEventLoopScheduler uiEventLoop = new UIEventLoopScheduler();
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
-            final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
+            final AtomicReference<Thread> subscribeThread = new AtomicReference<>();
             Flowable<Integer> w = Flowable.unsafeCreate(new Publisher<Integer>() {
 
                 @Override
@@ -54,7 +54,7 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
                 }
             });
 
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             w.subscribeOn(uiEventLoop).observeOn(Schedulers.computation())
             .unsubscribeOn(uiEventLoop)
             .take(2)
@@ -87,7 +87,7 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
         UIEventLoopScheduler uiEventLoop = new UIEventLoopScheduler();
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
-            final AtomicReference<Thread> subscribeThread = new AtomicReference<Thread>();
+            final AtomicReference<Thread> subscribeThread = new AtomicReference<>();
             Flowable<Integer> w = Flowable.unsafeCreate(new Publisher<Integer>() {
 
                 @Override
@@ -103,7 +103,7 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
                 }
             });
 
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             w.subscribeOn(Schedulers.newThread()).observeOn(Schedulers.computation())
             .unsubscribeOn(uiEventLoop)
             .take(2)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUsingTest.java
@@ -233,7 +233,7 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void usingDisposesEagerlyBeforeCompletion() {
-        final List<String> events = new ArrayList<String>();
+        final List<String> events = new ArrayList<>();
         Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
@@ -260,7 +260,7 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void usingDoesNotDisposesEagerlyBeforeCompletion() {
-        final List<String> events = new ArrayList<String>();
+        final List<String> events = new ArrayList<>();
         Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
@@ -287,7 +287,7 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void usingDisposesEagerlyBeforeError() {
-        final List<String> events = new ArrayList<String>();
+        final List<String> events = new ArrayList<>();
         Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
@@ -315,7 +315,7 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void usingDoesNotDisposesEagerlyBeforeError() {
-        final List<String> events = new ArrayList<String>();
+        final List<String> events = new ArrayList<>();
         final Supplier<Resource> resourceFactory = createResourceFactory(events);
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
@@ -604,7 +604,7 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void eagerDisposedOnComplete() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.using(Functions.justSupplier(1), Functions.justFunction(new Flowable<Integer>() {
             @Override
@@ -619,7 +619,7 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void eagerDisposedOnError() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.using(Functions.justSupplier(1), Functions.justFunction(new Flowable<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -43,7 +43,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
+        final List<Subscriber<Object>> values = new ArrayList<>();
 
         Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
             @Override
@@ -100,7 +100,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
+        final List<Subscriber<Object>> values = new ArrayList<>();
 
         Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
             @Override
@@ -156,7 +156,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
+        final List<Subscriber<Object>> values = new ArrayList<>();
 
         Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
             @Override
@@ -206,7 +206,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        final List<Subscriber<Object>> values = new ArrayList<Subscriber<Object>>();
+        final List<Subscriber<Object>> values = new ArrayList<>();
 
         Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
             @Override
@@ -408,7 +408,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
     public void mainAndBoundaryBothError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
+            final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
             TestSubscriberEx<Flowable<Object>> ts = Flowable.error(new TestException("main"))
             .window(new Flowable<Object>() {
@@ -447,8 +447,8 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
-                final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
+                final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
+                final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
                 TestSubscriberEx<Flowable<Object>> ts = new Flowable<Object>() {
                     @Override
@@ -497,8 +497,8 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
     @Test
     public void mainNextBoundaryNextRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
-            final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
+            final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
+            final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
             TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                 @Override
@@ -540,8 +540,8 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
     @Test
     public void takeOneAnotherBoundary() {
-        final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
-        final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
+        final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
+        final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
         TestSubscriberEx<Flowable<Object>> ts = new Flowable<Object>() {
             @Override
@@ -572,8 +572,8 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
     @Test
     public void disposeMainBoundaryCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
-            final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
+            final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
+            final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
             final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                  @Override
@@ -629,8 +629,8 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         final TestException ex = new TestException();
 
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-           final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<Subscriber<? super Object>>();
-           final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<Subscriber<? super Object>>();
+           final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
+           final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
                @Override
@@ -709,7 +709,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstream() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(Flowable.<Integer>never())
         .doOnNext(new Consumer<Flowable<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -99,7 +99,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void windowUnsubscribeNonOverlapping() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         final AtomicInteger count = new AtomicInteger();
         Flowable.merge(Flowable.range(1, 10000).doOnNext(new Consumer<Integer>() {
@@ -121,7 +121,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void windowUnsubscribeNonOverlappingAsyncSource() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         final AtomicInteger count = new AtomicInteger();
         Flowable.merge(Flowable.range(1, 100000)
                 .doOnNext(new Consumer<Integer>() {
@@ -145,7 +145,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void windowUnsubscribeOverlapping() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         final AtomicInteger count = new AtomicInteger();
         Flowable.merge(Flowable.range(1, 10000).doOnNext(new Consumer<Integer>() {
 
@@ -164,7 +164,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void windowUnsubscribeOverlappingAsyncSource() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         final AtomicInteger count = new AtomicInteger();
         Flowable.merge(Flowable.range(1, 100000)
                 .doOnNext(new Consumer<Integer>() {
@@ -187,7 +187,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String arg : args) {
             list.add(arg);
         }
@@ -198,7 +198,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
     public void backpressureOuter() {
         Flowable<Flowable<Integer>> source = Flowable.range(1, 10).window(3);
 
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
@@ -271,7 +271,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void takeFlatMapCompletes() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final int indicator = 999999999;
 
@@ -293,7 +293,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void backpressureOuterInexact() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>(0L);
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>(0L);
 
         Flowable.range(1, 5)
         .window(2, 1)
@@ -476,7 +476,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamSize() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(10)
         .take(1)
@@ -530,7 +530,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamSkip() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(5, 10)
         .take(1)
@@ -584,7 +584,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamOverlap() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(5, 3)
         .take(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -46,8 +46,8 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
     @Test
     public void flowableBasedOpenerAndCloser() {
-        final List<String> list = new ArrayList<String>();
-        final List<List<String>> lists = new ArrayList<List<String>>();
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
 
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
@@ -96,7 +96,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String arg : args) {
             list.add(arg);
         }
@@ -128,7 +128,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
                 stringFlowable.subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onComplete() {
-                        lists.add(new ArrayList<String>(list));
+                        lists.add(new ArrayList<>(list));
                         list.clear();
                     }
 
@@ -153,7 +153,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         PublishProcessor<Integer> open = PublishProcessor.create();
         final PublishProcessor<Integer> close = PublishProcessor.create();
 
-        TestSubscriber<Flowable<Integer>> ts = new TestSubscriber<Flowable<Integer>>();
+        TestSubscriber<Flowable<Integer>> ts = new TestSubscriber<>();
 
         source.window(open, new Function<Integer, Flowable<Integer>>() {
             @Override
@@ -197,7 +197,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         PublishProcessor<Integer> open = PublishProcessor.create();
         final PublishProcessor<Integer> close = PublishProcessor.create();
 
-        TestSubscriber<Flowable<Integer>> ts = new TestSubscriber<Flowable<Integer>>();
+        TestSubscriber<Flowable<Integer>> ts = new TestSubscriber<>();
 
         source.window(open, new Function<Integer, Flowable<Integer>>() {
             @Override
@@ -481,7 +481,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstream() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(Flowable.<Integer>just(1).concatWith(Flowable.<Integer>never()),
                 Functions.justFunction(Flowable.never()))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -46,8 +46,8 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
     @Test
     public void timedAndCount() {
-        final List<String> list = new ArrayList<String>();
-        final List<List<String>> lists = new ArrayList<List<String>>();
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
 
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
@@ -82,8 +82,8 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
     @Test
     public void timed() {
-        final List<String> list = new ArrayList<String>();
-        final List<List<String>> lists = new ArrayList<List<String>>();
+        final List<String> list = new ArrayList<>();
+        final List<List<String>> lists = new ArrayList<>();
 
         Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
             @Override
@@ -111,7 +111,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String arg : args) {
             list.add(arg);
         }
@@ -143,7 +143,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
                 stringFlowable.subscribe(new DefaultSubscriber<T>() {
                     @Override
                     public void onComplete() {
-                        lists.add(new ArrayList<T>(list));
+                        lists.add(new ArrayList<>(list));
                         list.clear();
                     }
 
@@ -166,8 +166,8 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         Flowable<Flowable<Integer>> source = Flowable.range(1, 10)
                 .window(1, TimeUnit.MINUTES, scheduler, 3);
 
-        final List<Integer> list = new ArrayList<Integer>();
-        final List<List<Integer>> lists = new ArrayList<List<Integer>>();
+        final List<Integer> list = new ArrayList<>();
+        final List<List<Integer>> lists = new ArrayList<>();
 
         source.subscribe(observeWindow(list, lists));
 
@@ -184,7 +184,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
     @Test
     public void takeFlatMapCompletes() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final AtomicInteger wip = new AtomicInteger();
 
@@ -514,7 +514,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> tsInner = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> tsInner = new TestSubscriber<>();
 
             TestSubscriber<Flowable<Integer>> ts = pp.window(2, 1, TimeUnit.SECONDS, scheduler)
             .doOnNext(new Consumer<Flowable<Integer>>() {
@@ -1204,7 +1204,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamExactTime() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(10, TimeUnit.MINUTES)
         .take(1)
@@ -1254,7 +1254,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamExactTimeAndSize() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(10, TimeUnit.MINUTES, 100)
         .take(1)
@@ -1304,7 +1304,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     public void windowAbandonmentCancelsUpstreamExactTimeSkip() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<Flowable<Integer>>();
+        final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(10, 15, TimeUnit.MINUTES)
         .take(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -90,7 +90,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         result.subscribe(ts);
 
@@ -116,7 +116,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         result.subscribe(ts);
 
@@ -142,7 +142,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         result.subscribe(ts);
 
@@ -169,7 +169,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         result.subscribe(ts);
 
@@ -197,7 +197,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         result.subscribe(ts);
 
@@ -225,7 +225,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER_ERROR);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         result.subscribe(ts);
 
@@ -251,7 +251,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         result.subscribe(ts);
 
@@ -267,7 +267,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         result.subscribe(ts);
 
@@ -319,7 +319,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         PublishProcessor<String> pp3 = PublishProcessor.create();
         PublishProcessor<String> main = PublishProcessor.create();
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
 
         main.withLatestFrom(new Flowable[] { pp1, pp2, pp3 }, toArray)
         .subscribe(ts);
@@ -366,7 +366,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         PublishProcessor<String> pp3 = PublishProcessor.create();
         PublishProcessor<String> main = PublishProcessor.create();
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
 
         main.withLatestFrom(Arrays.<Flowable<?>>asList(pp1, pp2, pp3), toArray)
         .subscribe(ts);
@@ -411,8 +411,8 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         for (String val : new String[] { "1" /*, null*/ }) {
             int n = 35;
             for (int i = 0; i < n; i++) {
-                List<Flowable<?>> sources = new ArrayList<Flowable<?>>();
-                List<String> expected = new ArrayList<String>();
+                List<Flowable<?>> sources = new ArrayList<>();
+                List<String> expected = new ArrayList<>();
                 expected.add(val);
 
                 for (int j = 0; j < i; j++) {
@@ -420,7 +420,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
                     expected.add(String.valueOf(val));
                 }
 
-                TestSubscriber<String> ts = new TestSubscriber<String>();
+                TestSubscriber<String> ts = new TestSubscriber<>();
 
                 PublishProcessor<String> main = PublishProcessor.create();
 
@@ -443,7 +443,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         PublishProcessor<String> pp1 = PublishProcessor.create();
         PublishProcessor<String> pp2 = PublishProcessor.create();
 
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
 
         Flowable.range(1, 10).withLatestFrom(new Flowable<?>[] { pp1, pp2 }, toArray)
         .subscribe(ts);
@@ -465,7 +465,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         PublishProcessor<String> pp1 = PublishProcessor.create();
         PublishProcessor<String> pp2 = PublishProcessor.create();
 
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
 
         Flowable.range(1, 3).withLatestFrom(new Flowable<?>[] { pp1, pp2 }, toArray)
         .subscribe(ts);
@@ -495,7 +495,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
     @Test
     public void withEmpty() {
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
 
         Flowable.range(1, 3).withLatestFrom(
                 new Flowable<?>[] { Flowable.just(1), Flowable.empty() }, toArray)
@@ -508,7 +508,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
     @Test
     public void withError() {
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
 
         Flowable.range(1, 3).withLatestFrom(
                 new Flowable<?>[] { Flowable.just(1), Flowable.error(new TestException()) }, toArray)
@@ -521,7 +521,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
     @Test
     public void withMainError() {
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
 
         Flowable.error(new TestException()).withLatestFrom(
                 new Flowable<?>[] { Flowable.just(1), Flowable.just(1) }, toArray)
@@ -536,7 +536,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     public void with2Others() {
         Flowable<Integer> just = Flowable.just(1);
 
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         just.withLatestFrom(just, just, new Function3<Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -555,7 +555,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     public void with3Others() {
         Flowable<Integer> just = Flowable.just(1);
 
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         just.withLatestFrom(just, just, just, new Function4<Integer, Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -574,7 +574,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     public void with4Others() {
         Flowable<Integer> just = Flowable.just(1);
 
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         just.withLatestFrom(just, just, just, just, new Function5<Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
             @Override
@@ -609,7 +609,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     @Test
     public void manyIteratorThrows() {
         Flowable.just(1)
-        .withLatestFrom(new CrashingMappedIterable<Flowable<Integer>>(1, 100, 100, new Function<Integer, Flowable<Integer>>() {
+        .withLatestFrom(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
                 return Flowable.just(2);
@@ -733,7 +733,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         Flowable<Integer> result = source.withLatestFrom(other, COMBINER);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         result.subscribe(ts);
 
@@ -794,7 +794,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
                 }
             });
 
-            final TestSubscriber<Object> ts = new TestSubscriber<Object>();
+            final TestSubscriber<Object> ts = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -837,7 +837,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
                 }
             });
 
-            final TestSubscriber<Object> ts = new TestSubscriber<Object>();
+            final TestSubscriber<Object> ts = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
@@ -352,7 +352,7 @@ public class FlowableZipTest extends RxJavaTest {
         PublishProcessor<String> r2 = PublishProcessor.create();
         /* define a Subscriber to receive aggregated events */
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
 
         Flowable.zip(r1, r2, zipr2).subscribe(ts);
 
@@ -770,7 +770,7 @@ public class FlowableZipTest extends RxJavaTest {
                     }
                 });
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         os.subscribe(new Consumer<String>() {
 
             @Override
@@ -797,7 +797,7 @@ public class FlowableZipTest extends RxJavaTest {
                     }
                 }).take(5);
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         os.subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -822,7 +822,7 @@ public class FlowableZipTest extends RxJavaTest {
                     }
                 });
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         os.subscribe(new DefaultSubscriber<String>() {
 
             @Override
@@ -886,7 +886,7 @@ public class FlowableZipTest extends RxJavaTest {
 
         });
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         f.subscribe(new Consumer<String>() {
 
             @Override
@@ -915,7 +915,7 @@ public class FlowableZipTest extends RxJavaTest {
 
         });
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         f.subscribe(new Consumer<String>() {
 
             @Override
@@ -942,7 +942,7 @@ public class FlowableZipTest extends RxJavaTest {
             }
         });
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         f.subscribe(ts);
         ts.awaitDone(200, TimeUnit.MILLISECONDS);
         ts.assertNoValues();
@@ -976,7 +976,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f1 = createInfiniteFlowable(generatedA);
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB);
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
@@ -1000,7 +1000,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f1 = createInfiniteFlowable(generatedA).subscribeOn(Schedulers.computation());
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
@@ -1024,7 +1024,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f1 = createInfiniteFlowable(generatedA).take(Flowable.bufferSize() * 2);
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB).take(Flowable.bufferSize() * 2);
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
@@ -1049,7 +1049,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f1 = createInfiniteFlowable(generatedA).subscribeOn(Schedulers.computation());
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
@@ -1074,7 +1074,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f1 = createInfiniteFlowable(generatedA);
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB);
 
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
 
             @Override
@@ -1189,7 +1189,7 @@ public class FlowableZipTest extends RxJavaTest {
                         return i1 + i2;
                     }
                 });
-        List<Integer> expected = new ArrayList<Integer>();
+        List<Integer> expected = new ArrayList<>();
         for (int i = 0; i < 1026; i++) {
             expected.add(i * 3);
         }
@@ -1247,7 +1247,7 @@ public class FlowableZipTest extends RxJavaTest {
     @Test
     public void zipRequest1() {
         Flowable<Integer> src = Flowable.just(1).subscribeOn(Schedulers.computation());
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1L);
 
         Flowable.zip(src, src, new BiFunction<Integer, Integer, Integer>() {
             @Override
@@ -1871,7 +1871,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void firstErrorPreventsSecondSubscription() {
         final AtomicInteger counter = new AtomicInteger();
 
-        List<Flowable<?>> flowableList = new ArrayList<Flowable<?>>();
+        List<Flowable<?>> flowableList = new ArrayList<>();
         flowableList.add(Flowable.create(new FlowableOnSubscribe<Object>() {
             @Override
             public void subscribe(FlowableEmitter<Object> e)


### PR DESCRIPTION
Hello, in this pull request i've changed all IDE marked explicit types with diamond operator. Affected package is internal/operators/flowable. 

There is one test fail in CompletableTest.repeatNormal , but diamond is not the cause, there is last stack entry: 
java.lang.AssertionError: expected:<6> but was:<5>
	at org.junit.Assert.fail(Assert.java:88)

This PR is part of  #6767 issue resolving.