### PR TITLE
Diamond operators in tests

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/SubscribeWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/SubscribeWithTest.java
@@ -27,14 +27,14 @@ public class SubscribeWithTest extends RxJavaTest {
     @Test
     public void withFlowable() {
         Flowable.range(1, 10)
-        .subscribeWith(new TestSubscriber<Integer>())
+        .subscribeWith(new TestSubscriber<>())
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 
     @Test
     public void withObservable() {
         Observable.range(1, 10)
-        .subscribeWith(new TestObserver<Integer>())
+        .subscribeWith(new TestObserver<>())
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 

--- a/src/test/java/io/reactivex/rxjava3/internal/disposables/DisposableHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/disposables/DisposableHelperTest.java
@@ -54,7 +54,7 @@ public class DisposableHelperTest extends RxJavaTest {
     @Test
     public void disposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
+            final AtomicReference<Disposable> d = new AtomicReference<>();
 
             Runnable r = new Runnable() {
                 @Override
@@ -70,7 +70,7 @@ public class DisposableHelperTest extends RxJavaTest {
     @Test
     public void setReplace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
+            final AtomicReference<Disposable> d = new AtomicReference<>();
 
             Runnable r = new Runnable() {
                 @Override
@@ -86,7 +86,7 @@ public class DisposableHelperTest extends RxJavaTest {
     @Test
     public void setRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
+            final AtomicReference<Disposable> d = new AtomicReference<>();
 
             Runnable r = new Runnable() {
                 @Override
@@ -101,7 +101,7 @@ public class DisposableHelperTest extends RxJavaTest {
 
     @Test
     public void setReplaceNull() {
-        final AtomicReference<Disposable> d = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> d = new AtomicReference<>();
 
         DisposableHelper.dispose(d);
 
@@ -112,7 +112,7 @@ public class DisposableHelperTest extends RxJavaTest {
     @Test
     public void dispose() {
         Disposable u = Disposable.empty();
-        final AtomicReference<Disposable> d = new AtomicReference<Disposable>(u);
+        final AtomicReference<Disposable> d = new AtomicReference<>(u);
 
         DisposableHelper.dispose(d);
 
@@ -121,7 +121,7 @@ public class DisposableHelperTest extends RxJavaTest {
 
     @Test
     public void trySet() {
-        AtomicReference<Disposable> ref = new AtomicReference<Disposable>();
+        AtomicReference<Disposable> ref = new AtomicReference<>();
 
         Disposable d1 = Disposable.empty();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/BasicFuseableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/BasicFuseableObserverTest.java
@@ -25,7 +25,7 @@ public class BasicFuseableObserverTest extends RxJavaTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void offer() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(to) {
             @Nullable
             @Override
@@ -57,7 +57,7 @@ public class BasicFuseableObserverTest extends RxJavaTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void offer2() {
-        BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(new TestObserver<Integer>()) {
+        BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(new TestObserver<>()) {
             @Nullable
             @Override
             public Integer poll() throws Exception {

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/BlockingFirstObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/BlockingFirstObserverTest.java
@@ -25,7 +25,7 @@ public class BlockingFirstObserverTest extends RxJavaTest {
 
     @Test
     public void firstValueOnly() {
-        BlockingFirstObserver<Integer> bf = new BlockingFirstObserver<Integer>();
+        BlockingFirstObserver<Integer> bf = new BlockingFirstObserver<>();
         Disposable d = Disposable.empty();
         bf.onSubscribe(d);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/BlockingMultiObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/BlockingMultiObserverTest.java
@@ -27,7 +27,7 @@ public class BlockingMultiObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+        BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<>();
         bmo.dispose();
 
         Disposable d = Disposable.empty();
@@ -37,7 +37,7 @@ public class BlockingMultiObserverTest extends RxJavaTest {
 
     @Test
     public void blockingGetDefault() {
-        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<>();
 
         Schedulers.single().scheduleDirect(new Runnable() {
             @Override
@@ -51,7 +51,7 @@ public class BlockingMultiObserverTest extends RxJavaTest {
 
     @Test
     public void blockingAwait() {
-        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<>();
 
         Schedulers.single().scheduleDirect(new Runnable() {
             @Override
@@ -65,7 +65,7 @@ public class BlockingMultiObserverTest extends RxJavaTest {
 
     @Test
     public void blockingGetDefaultInterrupt() {
-        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<Integer>();
+        final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<>();
 
         Thread.currentThread().interrupt();
         try {

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/BlockingObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/BlockingObserverTest.java
@@ -25,9 +25,9 @@ public class BlockingObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        Queue<Object> q = new ArrayDeque<Object>();
+        Queue<Object> q = new ArrayDeque<>();
 
-        BlockingObserver<Object> bo = new BlockingObserver<Object>(q);
+        BlockingObserver<Object> bo = new BlockingObserver<>(q);
 
         bo.dispose();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/ConsumerSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/ConsumerSingleObserverTest.java
@@ -24,7 +24,7 @@ public final class ConsumerSingleObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        ConsumerSingleObserver<Integer> o = new ConsumerSingleObserver<Integer>(Functions.<Integer>emptyConsumer(),
+        ConsumerSingleObserver<Integer> o = new ConsumerSingleObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING);
 
         assertFalse(o.hasCustomOnError());
@@ -32,7 +32,7 @@ public final class ConsumerSingleObserverTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        ConsumerSingleObserver<Integer> o = new ConsumerSingleObserver<Integer>(Functions.<Integer>emptyConsumer(),
+        ConsumerSingleObserver<Integer> o = new ConsumerSingleObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer());
 
         assertTrue(o.hasCustomOnError());

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/DeferredScalarObserverTest.java
@@ -50,7 +50,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void normal() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
             TakeFirst source = new TakeFirst(to);
 
@@ -73,7 +73,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void error() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         TakeFirst source = new TakeFirst(to);
 
@@ -85,7 +85,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void complete() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         TakeFirst source = new TakeFirst(to);
 
@@ -97,7 +97,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         TakeFirst source = new TakeFirst(to);
 
@@ -118,7 +118,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void fused() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+            TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
             TakeFirst source = new TakeFirst(to);
 
@@ -148,7 +148,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void fusedReject() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+            TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
             TakeFirst source = new TakeFirst(to);
 
@@ -193,7 +193,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void nonfusedTerminateMore() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.NONE);
+            TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
             TakeLast source = new TakeLast(to);
 
@@ -218,7 +218,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void nonfusedError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.NONE);
+            TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
             TakeLast source = new TakeLast(to);
 
@@ -243,7 +243,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void fusedTerminateMore() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+            TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
             TakeLast source = new TakeLast(to);
 
@@ -268,7 +268,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void fusedError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+            TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
             TakeLast source = new TakeLast(to);
 
@@ -291,7 +291,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void disposed() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.NONE);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
         TakeLast source = new TakeLast(to);
 
@@ -309,7 +309,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void disposedAfterOnNext() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         TakeLast source = new TakeLast(new Observer<Integer>() {
             Disposable upstream;
@@ -346,7 +346,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void fusedEmpty() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         TakeLast source = new TakeLast(to);
 
@@ -361,7 +361,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void nonfusedEmpty() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.NONE);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
         TakeLast source = new TakeLast(to);
 
@@ -376,7 +376,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void customFusion() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         TakeLast source = new TakeLast(new Observer<Integer>() {
             QueueDisposable<Integer> d;
@@ -426,7 +426,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void customFusionClear() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         TakeLast source = new TakeLast(new Observer<Integer>() {
             QueueDisposable<Integer> d;
@@ -465,7 +465,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void offerThrow() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.NONE);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
         TakeLast source = new TakeLast(to);
 
@@ -474,7 +474,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void customFusionDontConsume() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         TakeFirst source = new TakeFirst(new Observer<Integer>() {
             QueueDisposable<Integer> d;

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/DisposableLambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/DisposableLambdaObserverTest.java
@@ -32,8 +32,8 @@ public class DisposableLambdaObserverTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.doubleOnSubscribe(new DisposableLambdaObserver<Integer>(
-                new TestObserver<Integer>(), Functions.emptyConsumer(), Functions.EMPTY_ACTION
+        TestHelper.doubleOnSubscribe(new DisposableLambdaObserver<>(
+                new TestObserver<>(), Functions.emptyConsumer(), Functions.EMPTY_ACTION
         ));
     }
 
@@ -41,8 +41,8 @@ public class DisposableLambdaObserverTest extends RxJavaTest {
     public void disposeCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            DisposableLambdaObserver<Integer> o = new DisposableLambdaObserver<Integer>(
-                    new TestObserver<Integer>(), Functions.emptyConsumer(),
+            DisposableLambdaObserver<Integer> o = new DisposableLambdaObserver<>(
+                    new TestObserver<>(), Functions.emptyConsumer(),
                     new Action() {
                         @Override
                         public void run() throws Exception {

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/FutureObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/FutureObserverTest.java
@@ -36,7 +36,7 @@ public class FutureObserverTest extends RxJavaTest {
 
     @Before
     public void before() {
-        fo = new FutureObserver<Integer>();
+        fo = new FutureObserver<>();
     }
 
     @Test
@@ -157,7 +157,7 @@ public class FutureObserverTest extends RxJavaTest {
     @Test
     public void cancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final FutureSubscriber<Integer> fo = new FutureSubscriber<Integer>();
+            final FutureSubscriber<Integer> fo = new FutureSubscriber<>();
 
             Runnable r = new Runnable() {
                 @Override
@@ -188,7 +188,7 @@ public class FutureObserverTest extends RxJavaTest {
         RxJavaPlugins.setErrorHandler(Functions.emptyConsumer());
         try {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                final FutureSubscriber<Integer> fo = new FutureSubscriber<Integer>();
+                final FutureSubscriber<Integer> fo = new FutureSubscriber<>();
 
                 final TestException ex = new TestException();
 
@@ -218,7 +218,7 @@ public class FutureObserverTest extends RxJavaTest {
         RxJavaPlugins.setErrorHandler(Functions.emptyConsumer());
         try {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                final FutureSubscriber<Integer> fo = new FutureSubscriber<Integer>();
+                final FutureSubscriber<Integer> fo = new FutureSubscriber<>();
 
                 if (i % 3 == 0) {
                     fo.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/LambdaObserverTest.java
@@ -35,20 +35,20 @@ public class LambdaObserverTest extends RxJavaTest {
 
     @Test
     public void onSubscribeThrows() {
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+        LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
             }
         },
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
+                new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable e) throws Exception {
+                        received.add(e);
+                    }
+                }, new Action() {
             @Override
             public void run() throws Exception {
                 received.add(100);
@@ -72,20 +72,20 @@ public class LambdaObserverTest extends RxJavaTest {
 
     @Test
     public void onNextThrows() {
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+        LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 throw new TestException();
             }
         },
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
+                new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable e) throws Exception {
+                        received.add(e);
+                    }
+                }, new Action() {
             @Override
             public void run() throws Exception {
                 received.add(100);
@@ -111,20 +111,20 @@ public class LambdaObserverTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<>();
 
-            LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+            LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) throws Exception {
                     received.add(v);
                 }
             },
-            new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    throw new TestException("Inner");
-                }
-            }, new Action() {
+                    new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable e) throws Exception {
+                            throw new TestException("Inner");
+                        }
+                    }, new Action() {
                 @Override
                 public void run() throws Exception {
                     received.add(100);
@@ -157,20 +157,20 @@ public class LambdaObserverTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<>();
 
-            LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+            LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) throws Exception {
                     received.add(v);
                 }
             },
-            new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    received.add(e);
-                }
-            }, new Action() {
+                    new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable e) throws Exception {
+                            received.add(e);
+                        }
+                    }, new Action() {
                 @Override
                 public void run() throws Exception {
                     throw new TestException();
@@ -215,20 +215,20 @@ public class LambdaObserverTest extends RxJavaTest {
                 }
             };
 
-            final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<>();
 
-            LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+            LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) throws Exception {
                     received.add(v);
                 }
             },
-            new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    received.add(e);
-                }
-            }, new Action() {
+                    new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable e) throws Exception {
+                            received.add(e);
+                        }
+                    }, new Action() {
                 @Override
                 public void run() throws Exception {
                     received.add(100);
@@ -266,20 +266,20 @@ public class LambdaObserverTest extends RxJavaTest {
                 }
             };
 
-            final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<>();
 
-            LambdaObserver<Object> o = new LambdaObserver<Object>(new Consumer<Object>() {
+            LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) throws Exception {
                     received.add(v);
                 }
             },
-            new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    received.add(e);
-                }
-            }, new Action() {
+                    new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable e) throws Exception {
+                            received.add(e);
+                        }
+                    }, new Action() {
                 @Override
                 public void run() throws Exception {
                     received.add(100);
@@ -304,7 +304,7 @@ public class LambdaObserverTest extends RxJavaTest {
     public void onNextThrowsCancelsUpstream() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         ps.subscribe(new Consumer<Integer>() {
             @Override
@@ -333,9 +333,9 @@ public class LambdaObserverTest extends RxJavaTest {
     public void onSubscribeThrowsCancelsUpstream() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
-        ps.subscribe(new LambdaObserver<Integer>(new Consumer<Integer>() {
+        ps.subscribe(new LambdaObserver<>(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
             }
@@ -363,7 +363,7 @@ public class LambdaObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        LambdaObserver<Integer> o = new LambdaObserver<Integer>(Functions.<Integer>emptyConsumer(),
+        LambdaObserver<Integer> o = new LambdaObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION,
                 Functions.<Disposable>emptyConsumer());
@@ -373,7 +373,7 @@ public class LambdaObserverTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        LambdaObserver<Integer> o = new LambdaObserver<Integer>(Functions.<Integer>emptyConsumer(),
+        LambdaObserver<Integer> o = new LambdaObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,
                 Functions.<Disposable>emptyConsumer());
@@ -385,9 +385,9 @@ public class LambdaObserverTest extends RxJavaTest {
     public void disposedObserverShouldReportErrorOnGlobalErrorHandler() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final List<Throwable> observerErrors = Collections.synchronizedList(new ArrayList<Throwable>());
+            final List<Throwable> observerErrors = Collections.synchronizedList(new ArrayList<>());
 
-            LambdaObserver<Integer> o = new LambdaObserver<Integer>(Functions.<Integer>emptyConsumer(),
+            LambdaObserver<Integer> o = new LambdaObserver<>(Functions.<Integer>emptyConsumer(),
                     new Consumer<Throwable>() {
                         @Override
                         public void accept(Throwable t) {

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/QueueDrainObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/QueueDrainObserverTest.java
@@ -24,7 +24,7 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 public class QueueDrainObserverTest extends RxJavaTest {
 
     static final QueueDrainObserver<Integer, Integer, Integer> createUnordered(TestObserver<Integer> to, final Disposable d) {
-        return new QueueDrainObserver<Integer, Integer, Integer>(to, new SpscArrayQueue<Integer>(4)) {
+        return new QueueDrainObserver<Integer, Integer, Integer>(to, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathEmit(t, false, d);
@@ -51,7 +51,7 @@ public class QueueDrainObserverTest extends RxJavaTest {
     }
 
     static final QueueDrainObserver<Integer, Integer, Integer> createOrdered(TestObserver<Integer> to, final Disposable d) {
-        return new QueueDrainObserver<Integer, Integer, Integer>(to, new SpscArrayQueue<Integer>(4)) {
+        return new QueueDrainObserver<Integer, Integer, Integer>(to, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathOrderedEmit(t, false, d);
@@ -79,7 +79,7 @@ public class QueueDrainObserverTest extends RxJavaTest {
 
     @Test
     public void unorderedSlowPath() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Disposable d = Disposable.empty();
         QueueDrainObserver<Integer, Integer, Integer> qd = createUnordered(to, d);
         to.onSubscribe(Disposable.empty());
@@ -92,7 +92,7 @@ public class QueueDrainObserverTest extends RxJavaTest {
 
     @Test
     public void orderedSlowPath() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Disposable d = Disposable.empty();
         QueueDrainObserver<Integer, Integer, Integer> qd = createOrdered(to, d);
         to.onSubscribe(Disposable.empty());
@@ -105,7 +105,7 @@ public class QueueDrainObserverTest extends RxJavaTest {
 
     @Test
     public void orderedSlowPathNonEmptyQueue() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Disposable d = Disposable.empty();
         QueueDrainObserver<Integer, Integer, Integer> qd = createOrdered(to, d);
         to.onSubscribe(Disposable.empty());
@@ -120,7 +120,7 @@ public class QueueDrainObserverTest extends RxJavaTest {
     public void unorderedOnNextRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
 
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
             Disposable d = Disposable.empty();
             final QueueDrainObserver<Integer, Integer, Integer> qd = createUnordered(to, d);
             to.onSubscribe(Disposable.empty());
@@ -142,7 +142,7 @@ public class QueueDrainObserverTest extends RxJavaTest {
     public void orderedOnNextRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
 
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
             Disposable d = Disposable.empty();
             final QueueDrainObserver<Integer, Integer, Integer> qd = createOrdered(to, d);
             to.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableAmbTest.java
@@ -38,7 +38,7 @@ public class CompletableAmbTest extends RxJavaTest {
 
     @Test
     public void ambLots() {
-        List<Completable> ms = new ArrayList<Completable>();
+        List<Completable> ms = new ArrayList<>();
 
         for (int i = 0; i < 32; i++) {
             ms.add(Completable.never());
@@ -172,7 +172,7 @@ public class CompletableAmbTest extends RxJavaTest {
 
     @Test
     public void ambRace() {
-        TestObserver<Void> to = new TestObserver<Void>();
+        TestObserver<Void> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         CompositeDisposable cd = new CompositeDisposable();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableAndThenCompletableabTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableAndThenCompletableabTest.java
@@ -113,7 +113,7 @@ public class CompletableAndThenCompletableabTest extends RxJavaTest {
 
     @Test
     public void andThenFirstCancels() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
         Completable.fromRunnable(new Runnable() {
             @Override
             public void run() {
@@ -129,7 +129,7 @@ public class CompletableAndThenCompletableabTest extends RxJavaTest {
 
     @Test
     public void andThenSecondCancels() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
         Completable.complete()
                 .andThen(Completable.fromRunnable(new Runnable() {
                     @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableCacheTest.java
@@ -86,7 +86,7 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
     public void crossDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserver<Void> to1 = new TestObserver<Void>();
+        final TestObserver<Void> to1 = new TestObserver<>();
 
         final TestObserver<Void> to2 = new TestObserver<Void>() {
             @Override
@@ -111,7 +111,7 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
     public void crossDisposeOnError() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserver<Void> to1 = new TestObserver<Void>();
+        final TestObserver<Void> to1 = new TestObserver<>();
 
         final TestObserver<Void> to2 = new TestObserver<Void>() {
             @Override
@@ -174,9 +174,9 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
 
             final Completable c = ps.ignoreElements().cache();
 
-            final TestObserver<Void> to1 = new TestObserver<Void>();
+            final TestObserver<Void> to1 = new TestObserver<>();
 
-            final TestObserver<Void> to2 = new TestObserver<Void>();
+            final TestObserver<Void> to2 = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -209,7 +209,7 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
 
             final TestObserver<Void> to1 = c.test();
 
-            final TestObserver<Void> to2 = new TestObserver<Void>();
+            final TestObserver<Void> to2 = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -237,7 +237,7 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
     public void doubleDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         ps.ignoreElements().cache()
         .subscribe(new CompletableObserver() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcatTest.java
@@ -167,7 +167,7 @@ public class CompletableConcatTest extends RxJavaTest {
 
     @Test
     public void arrayFirstCancels() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.concatArray(new Completable() {
             @Override
@@ -191,7 +191,7 @@ public class CompletableConcatTest extends RxJavaTest {
 
     @Test
     public void iterableFirstCancels() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.concat(Arrays.asList(new Completable() {
             @Override
@@ -215,7 +215,7 @@ public class CompletableConcatTest extends RxJavaTest {
 
             final Completable c = Completable.concatArray(a);
 
-            final TestObserver<Void> to = new TestObserver<Void>();
+            final TestObserver<Void> to = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -244,7 +244,7 @@ public class CompletableConcatTest extends RxJavaTest {
 
             final Completable c = Completable.concat(Arrays.asList(a));
 
-            final TestObserver<Void> to = new TestObserver<Void>();
+            final TestObserver<Void> to = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableDelayTest.java
@@ -41,7 +41,7 @@ public class CompletableDelayTest extends RxJavaTest {
     @Test
     public void onErrorCalledOnScheduler() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Thread> thread = new AtomicReference<Thread>();
+        final AtomicReference<Thread> thread = new AtomicReference<>();
 
         Completable.error(new Exception())
                 .delay(0, TimeUnit.MILLISECONDS, Schedulers.newThread())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableDetachTest.java
@@ -65,7 +65,7 @@ public class CompletableDetachTest extends RxJavaTest {
     @Test
     public void cancelDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Void> to = new Completable() {
             @Override
@@ -91,7 +91,7 @@ public class CompletableDetachTest extends RxJavaTest {
     @Test
     public void completeDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Void> to = new Completable() {
             @Override
@@ -117,7 +117,7 @@ public class CompletableDetachTest extends RxJavaTest {
     @Test
     public void errorDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Void> to = new Completable() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromCallableTest.java
@@ -142,7 +142,7 @@ public class CompletableFromCallableTest extends RxJavaTest {
 
         Observer<Object> observer = TestHelper.mockObserver();
 
-        TestObserver<String> outer = new TestObserver<String>(observer);
+        TestObserver<String> outer = new TestObserver<>(observer);
 
         fromCallableObservable
                 .subscribeOn(Schedulers.computation())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromSupplierTest.java
@@ -144,7 +144,7 @@ public class CompletableFromSupplierTest extends RxJavaTest {
 
         Observer<Object> observer = TestHelper.mockObserver();
 
-        TestObserver<String> outer = new TestObserver<String>(observer);
+        TestObserver<String> outer = new TestObserver<>(observer);
 
         fromSupplierObservable
                 .subscribeOn(Schedulers.computation())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableMergeIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableMergeIterableTest.java
@@ -67,7 +67,7 @@ public class CompletableMergeIterableTest extends RxJavaTest {
 
     @Test
     public void cancelAfterHasNext() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.merge(new Iterable<Completable>() {
             @Override
@@ -97,7 +97,7 @@ public class CompletableMergeIterableTest extends RxJavaTest {
 
     @Test
     public void cancelAfterNext() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.merge(new Iterable<Completable>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableMergeTest.java
@@ -43,7 +43,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
     @Test
     public void cancelAfterFirst() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.mergeArray(new Completable() {
             @Override
@@ -60,7 +60,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
     @Test
     public void cancelAfterFirstDelayError() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.mergeArrayDelayError(new Completable() {
             @Override
@@ -428,7 +428,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
     @Test
     public void innerIsDisposed() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.mergeDelayError(Flowable.just(new Completable() {
             @Override
@@ -494,7 +494,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
     @Test
     public void delayErrorIterableCancelAfterHasNext() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.mergeDelayError(new Iterable<Completable>() {
             @Override
@@ -525,7 +525,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
     @Test
     public void delayErrorIterableCancelAfterNext() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Completable.mergeDelayError(new Iterable<Completable>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableTakeUntilTest.java
@@ -186,7 +186,7 @@ public class CompletableTakeUntilTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            final AtomicReference<CompletableObserver> ref = new AtomicReference<CompletableObserver>();
+            final AtomicReference<CompletableObserver> ref = new AtomicReference<>();
 
             Completable.complete()
             .takeUntil(new Completable() {
@@ -213,7 +213,7 @@ public class CompletableTakeUntilTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            final AtomicReference<CompletableObserver> ref = new AtomicReference<CompletableObserver>();
+            final AtomicReference<CompletableObserver> ref = new AtomicReference<>();
 
             Completable.complete()
             .takeUntil(new Completable() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableTimeoutTest.java
@@ -155,7 +155,7 @@ public class CompletableTimeoutTest extends RxJavaTest {
 
     @Test
     public void ambRace() {
-        TestObserver<Void> to = new TestObserver<Void>();
+        TestObserver<Void> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         CompositeDisposable cd = new CompositeDisposable();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableToObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableToObservableTest.java
@@ -39,7 +39,7 @@ public class CompletableToObservableTest extends RxJavaTest {
 
     @Test
     public void fusion() throws Exception {
-        TestObserver<Void> to = new TestObserver<Void>();
+        TestObserver<Void> to = new TestObserver<>();
 
         ObserverCompletableObserver co = new ObserverCompletableObserver(to);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeAmbTest.java
@@ -37,7 +37,7 @@ public class MaybeAmbTest extends RxJavaTest {
 
     @Test
     public void ambLots() {
-        List<Maybe<Integer>> ms = new ArrayList<Maybe<Integer>>();
+        List<Maybe<Integer>> ms = new ArrayList<>();
 
         for (int i = 0; i < 32; i++) {
             ms.add(Maybe.<Integer>never());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCacheTest.java
@@ -154,7 +154,7 @@ public class MaybeCacheTest extends RxJavaTest {
     @Test
     public void crossCancelOnSuccess() {
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -178,7 +178,7 @@ public class MaybeCacheTest extends RxJavaTest {
     @Test
     public void crossCancelOnError() {
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
@@ -201,7 +201,7 @@ public class MaybeCacheTest extends RxJavaTest {
     @Test
     public void crossCancelOnComplete() {
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -31,7 +31,7 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<Object>(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_ACTION);
+        MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_ACTION);
 
         Disposable d = Disposable.empty();
 
@@ -50,7 +50,7 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
     public void onSuccessCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<Object>(
+            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
                     new Consumer<Object>() {
                         @Override
                         public void accept(Object v) throws Exception {
@@ -74,7 +74,7 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
     public void onErrorCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<Object>(
+            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
                     Functions.emptyConsumer(),
                     new Consumer<Object>() {
                         @Override
@@ -103,7 +103,7 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
     public void onCompleteCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<Object>(
+            MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
                     Functions.emptyConsumer(),
                     Functions.emptyConsumer(),
                     new Action() {
@@ -125,7 +125,7 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        MaybeCallbackObserver<Integer> o = new MaybeCallbackObserver<Integer>(Functions.<Integer>emptyConsumer(),
+        MaybeCallbackObserver<Integer> o = new MaybeCallbackObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION);
 
@@ -134,7 +134,7 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        MaybeCallbackObserver<Integer> o = new MaybeCallbackObserver<Integer>(Functions.<Integer>emptyConsumer(),
+        MaybeCallbackObserver<Integer> o = new MaybeCallbackObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -90,7 +90,7 @@ public class MaybeConcatIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrows() {
-        Maybe.concat(new CrashingMappedIterable<Maybe<Integer>>(100, 1, 100, new Function<Integer, Maybe<Integer>>() {
+        Maybe.concat(new CrashingMappedIterable<>(100, 1, 100, new Function<Integer, Maybe<Integer>>() {
             @Override
             public Maybe<Integer> apply(Integer v) throws Exception {
                 return Maybe.just(1);
@@ -102,7 +102,7 @@ public class MaybeConcatIterableTest extends RxJavaTest {
 
     @Test
     public void nextThrows() {
-        Maybe.concat(new CrashingMappedIterable<Maybe<Integer>>(100, 100, 1, new Function<Integer, Maybe<Integer>>() {
+        Maybe.concat(new CrashingMappedIterable<>(100, 100, 1, new Function<Integer, Maybe<Integer>>() {
             @Override
             public Maybe<Integer> apply(Integer v) throws Exception {
                 return Maybe.just(1);
@@ -114,7 +114,7 @@ public class MaybeConcatIterableTest extends RxJavaTest {
 
     @Test
     public void nextReturnsNull() {
-        Maybe.concat(new CrashingMappedIterable<Maybe<Integer>>(100, 100, 100, new Function<Integer, Maybe<Integer>>() {
+        Maybe.concat(new CrashingMappedIterable<>(100, 100, 100, new Function<Integer, Maybe<Integer>>() {
             @Override
             public Maybe<Integer> apply(Integer v) throws Exception {
                 return null;

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDetachTest.java
@@ -65,7 +65,7 @@ public class MaybeDetachTest extends RxJavaTest {
     @Test
     public void cancelDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Object> to = new Maybe<Object>() {
             @Override
@@ -91,7 +91,7 @@ public class MaybeDetachTest extends RxJavaTest {
     @Test
     public void completeDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Integer> to = new Maybe<Integer>() {
             @Override
@@ -117,7 +117,7 @@ public class MaybeDetachTest extends RxJavaTest {
     @Test
     public void errorDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Integer> to = new Maybe<Integer>() {
             @Override
@@ -143,7 +143,7 @@ public class MaybeDetachTest extends RxJavaTest {
     @Test
     public void successDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Integer> to = new Maybe<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDoAfterSuccessTest.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class MaybeDoAfterSuccessTest extends RxJavaTest {
 
-    final List<Integer> values = new ArrayList<Integer>();
+    final List<Integer> values = new ArrayList<>();
 
     final Consumer<Integer> afterSuccess = new Consumer<Integer>() {
         @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapBiSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapBiSelectorTest.java
@@ -215,7 +215,7 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
 
     @Test
     public void mapperCancels() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Maybe.just(1)
         .flatMap(new Function<Integer, MaybeSource<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -480,7 +480,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
         final Integer[] a = new Integer[1000];
         Arrays.fill(a, 1);
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.just(1)
         .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
@@ -524,7 +524,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
         final Integer[] a = new Integer[1000];
         Arrays.fill(a, 1);
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.just(1)
         .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
@@ -99,7 +99,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
 
     @Test
     public void fused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -117,7 +117,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
 
     @Test
     public void fusedNoSync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromActionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromActionTest.java
@@ -170,7 +170,7 @@ public class MaybeFromActionTest extends RxJavaTest {
 
     @Test
     public void cancelWhileRunning() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
 
         Maybe.fromAction(new Action() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromCallableTest.java
@@ -196,7 +196,7 @@ public class MaybeFromCallableTest extends RxJavaTest {
 
         Observer<Object> observer = TestHelper.mockObserver();
 
-        TestObserver<String> outer = new TestObserver<String>(observer);
+        TestObserver<String> outer = new TestObserver<>(observer);
 
         fromCallableObservable
                 .subscribeOn(Schedulers.computation())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromFutureTest.java
@@ -29,7 +29,7 @@ public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void cancelImmediately() {
-        FutureTask<Integer> ft = new FutureTask<Integer>(Functions.justCallable(1));
+        FutureTask<Integer> ft = new FutureTask<>(Functions.justCallable(1));
 
         Maybe.fromFuture(ft).test(true)
         .assertEmpty();
@@ -37,7 +37,7 @@ public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void timeout() {
-        FutureTask<Integer> ft = new FutureTask<Integer>(Functions.justCallable(1));
+        FutureTask<Integer> ft = new FutureTask<>(Functions.justCallable(1));
 
         Maybe.fromFuture(ft, 1, TimeUnit.MILLISECONDS).test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -46,7 +46,7 @@ public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void timedWait() {
-        FutureTask<Integer> ft = new FutureTask<Integer>(Functions.justCallable(1));
+        FutureTask<Integer> ft = new FutureTask<>(Functions.justCallable(1));
         ft.run();
 
         Maybe.fromFuture(ft, 1, TimeUnit.MILLISECONDS).test()
@@ -56,7 +56,7 @@ public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void interrupt() {
-        FutureTask<Integer> ft = new FutureTask<Integer>(Functions.justCallable(1));
+        FutureTask<Integer> ft = new FutureTask<>(Functions.justCallable(1));
 
         Thread.currentThread().interrupt();
 
@@ -66,9 +66,9 @@ public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void cancelWhileRunning() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
 
-        FutureTask<Object> ft = new FutureTask<Object>(new Runnable() {
+        FutureTask<Object> ft = new FutureTask<>(new Runnable() {
             @Override
             public void run() {
                 to.dispose();
@@ -86,9 +86,9 @@ public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void cancelAndCrashWhileRunning() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
 
-        FutureTask<Object> ft = new FutureTask<Object>(new Runnable() {
+        FutureTask<Object> ft = new FutureTask<>(new Runnable() {
             @Override
             public void run() {
                 to.dispose();
@@ -107,7 +107,7 @@ public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void futureNull() {
-        FutureTask<Object> ft = new FutureTask<Object>(new Runnable() {
+        FutureTask<Object> ft = new FutureTask<>(new Runnable() {
             @Override
             public void run() {
             }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -175,7 +175,7 @@ public class MaybeFromRunnableTest extends RxJavaTest {
 
     @Test
     public void cancelWhileRunning() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
 
         Maybe.fromRunnable(new Runnable() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromSupplierTest.java
@@ -197,7 +197,7 @@ public class MaybeFromSupplierTest extends RxJavaTest {
 
         Observer<Object> observer = TestHelper.mockObserver();
 
-        TestObserver<String> outer = new TestObserver<String>(observer);
+        TestObserver<String> outer = new TestObserver<>(observer);
 
         fromSupplierObservable
                 .subscribeOn(Schedulers.computation())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -95,7 +95,7 @@ public class MaybeMergeArrayTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void cancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.mergeArray(Maybe.just(1), Maybe.<Integer>empty(), Maybe.just(2))
         .subscribe(ts);
@@ -109,7 +109,7 @@ public class MaybeMergeArrayTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void firstErrors() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.mergeArray(Maybe.<Integer>error(new TestException()), Maybe.<Integer>empty(), Maybe.just(2))
         .subscribe(ts);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterableTest.java
@@ -156,7 +156,7 @@ public class MaybeZipIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorThrows() {
-        Maybe.zip(new CrashingMappedIterable<Maybe<Integer>>(1, 100, 100, new Function<Integer, Maybe<Integer>>() {
+        Maybe.zip(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Maybe<Integer>>() {
             @Override
             public Maybe<Integer> apply(Integer v) throws Exception {
                 return Maybe.just(v);
@@ -168,7 +168,7 @@ public class MaybeZipIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrows() {
-        Maybe.zip(new CrashingMappedIterable<Maybe<Integer>>(100, 20, 100, new Function<Integer, Maybe<Integer>>() {
+        Maybe.zip(new CrashingMappedIterable<>(100, 20, 100, new Function<Integer, Maybe<Integer>>() {
             @Override
             public Maybe<Integer> apply(Integer v) throws Exception {
                 return Maybe.just(v);
@@ -180,7 +180,7 @@ public class MaybeZipIterableTest extends RxJavaTest {
 
     @Test
     public void nextThrows() {
-        Maybe.zip(new CrashingMappedIterable<Maybe<Integer>>(100, 100, 5, new Function<Integer, Maybe<Integer>>() {
+        Maybe.zip(new CrashingMappedIterable<>(100, 100, 5, new Function<Integer, Maybe<Integer>>() {
             @Override
             public Maybe<Integer> apply(Integer v) throws Exception {
                 return Maybe.just(v);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -291,7 +291,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
         try {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<MaybeObserver<? super Integer>>();
+            final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = pp.concatMapMaybe(
                     new Function<Integer, MaybeSource<Integer>>() {
@@ -368,9 +368,9 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void cancelNoConcurrentClean() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ConcatMapMaybeSubscriber<Integer, Integer> operator =
-                new ConcatMapMaybeSubscriber<Integer, Integer>(
+                new ConcatMapMaybeSubscriber<>(
                         ts, Functions.justFunction(Maybe.<Integer>never()), 16, ErrorMode.IMMEDIATE);
 
         operator.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -209,7 +209,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
         try {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<SingleObserver<? super Integer>>();
+            final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = pp.concatMapSingle(
                     new Function<Integer, SingleSource<Integer>>() {
@@ -286,9 +286,9 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void cancelNoConcurrentClean() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ConcatMapSingleSubscriber<Integer, Integer> operator =
-                new ConcatMapSingleSubscriber<Integer, Integer>(
+                new ConcatMapSingleSubscriber<>(
                         ts, Functions.justFunction(Single.<Integer>never()), 16, ErrorMode.IMMEDIATE);
 
         operator.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
@@ -174,7 +174,7 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
     @Test
     public void mapperCancels() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Flowable.range(1, 5).switchMapCompletable(new Function<Integer, CompletableSource>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
@@ -307,7 +307,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void disposeBeforeSwitchInOnNext() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1)
         .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
@@ -324,7 +324,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void disposeOnNextAfterFirst() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1, 2)
         .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
@@ -404,7 +404,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
     public void innerErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<MaybeObserver<? super Integer>> moRef = new AtomicReference<MaybeObserver<? super Integer>>();
+            final AtomicReference<MaybeObserver<? super Integer>> moRef = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = new Flowable<Integer>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -255,7 +255,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void disposeBeforeSwitchInOnNext() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1)
         .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
@@ -272,7 +272,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void disposeOnNextAfterFirst() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1, 2)
         .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
@@ -352,7 +352,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
     public void innerErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<SingleObserver<? super Integer>> moRef = new AtomicReference<SingleObserver<? super Integer>>();
+            final AtomicReference<SingleObserver<? super Integer>> moRef = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = new Flowable<Integer>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -262,7 +262,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
         try {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<MaybeObserver<? super Integer>>();
+            final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestObserverEx<Integer> to = ps.concatMapMaybe(
                     new Function<Integer, MaybeSource<Integer>>() {
@@ -373,9 +373,9 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void cancelNoConcurrentClean() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         ConcatMapMaybeMainObserver<Integer, Integer> operator =
-                new ConcatMapMaybeMainObserver<Integer, Integer>(
+                new ConcatMapMaybeMainObserver<>(
                         to, Functions.justFunction(Maybe.<Integer>never()), 16, ErrorMode.IMMEDIATE);
 
         operator.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -180,7 +180,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
         try {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<SingleObserver<? super Integer>>();
+            final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestObserverEx<Integer> to = ps.concatMapSingle(
                     new Function<Integer, SingleSource<Integer>>() {
@@ -313,9 +313,9 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void cancelNoConcurrentClean() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         ConcatMapSingleMainObserver<Integer, Integer> operator =
-                new ConcatMapSingleMainObserver<Integer, Integer>(
+                new ConcatMapSingleMainObserver<>(
                         to, Functions.justFunction(Single.<Integer>never()), 16, ErrorMode.IMMEDIATE);
 
         operator.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
@@ -172,7 +172,7 @@ public class ObservableSwitchMapCompletableTest extends RxJavaTest {
 
     @Test
     public void mapperCancels() {
-        final TestObserver<Void> to = new TestObserver<Void>();
+        final TestObserver<Void> to = new TestObserver<>();
 
         Observable.range(1, 5).switchMapCompletable(new Function<Integer, CompletableSource>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -283,7 +283,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void disposeBeforeSwitchInOnNext() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1)
         .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
@@ -300,7 +300,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void disposeOnNextAfterFirst() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1, 2)
         .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
@@ -380,7 +380,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
     public void innerErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<MaybeObserver<? super Integer>> moRef = new AtomicReference<MaybeObserver<? super Integer>>();
+            final AtomicReference<MaybeObserver<? super Integer>> moRef = new AtomicReference<>();
 
             TestObserverEx<Integer> to = new Observable<Integer>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -252,7 +252,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void disposeBeforeSwitchInOnNext() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1).hide()
         .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
@@ -269,7 +269,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void disposeOnNextAfterFirst() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1, 2)
         .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
@@ -349,7 +349,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
     public void innerErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<SingleObserver<? super Integer>> moRef = new AtomicReference<SingleObserver<? super Integer>>();
+            final AtomicReference<SingleObserver<? super Integer>> moRef = new AtomicReference<>();
 
             TestObserverEx<Integer> to = new Observable<Integer>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayTest.java
@@ -138,7 +138,7 @@ public class SingleDelayTest extends RxJavaTest {
     @Test
     public void onErrorCalledOnScheduler() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Thread> thread = new AtomicReference<Thread>();
+        final AtomicReference<Thread> thread = new AtomicReference<>();
 
         Single.<String>error(new Exception())
                 .delay(0, TimeUnit.MILLISECONDS, Schedulers.newThread())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleDetachTest.java
@@ -65,7 +65,7 @@ public class SingleDetachTest extends RxJavaTest {
     @Test
     public void cancelDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Object> to = new Single<Object>() {
             @Override
@@ -91,7 +91,7 @@ public class SingleDetachTest extends RxJavaTest {
     @Test
     public void errorDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Integer> to = new Single<Integer>() {
             @Override
@@ -117,7 +117,7 @@ public class SingleDetachTest extends RxJavaTest {
     @Test
     public void successDetaches() throws Exception {
         Disposable d = Disposable.empty();
-        final WeakReference<Disposable> wr = new WeakReference<Disposable>(d);
+        final WeakReference<Disposable> wr = new WeakReference<>(d);
 
         TestObserver<Integer> to = new Single<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleDoAfterSuccessTest.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class SingleDoAfterSuccessTest extends RxJavaTest {
 
-    final List<Integer> values = new ArrayList<Integer>();
+    final List<Integer> values = new ArrayList<>();
 
     final Consumer<Integer> afterSuccess = new Consumer<Integer>() {
         @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleDoAfterTerminateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleDoAfterTerminateTest.java
@@ -39,7 +39,7 @@ public class SingleDoAfterTerminateTest extends RxJavaTest {
         }
     };
 
-    private final TestObserver<Integer> to = new TestObserver<Integer>();
+    private final TestObserver<Integer> to = new TestObserver<>();
 
     @Test
     public void just() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -467,7 +467,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         final Integer[] a = new Integer[1000];
         Arrays.fill(a, 1);
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Single.just(1)
         .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
@@ -511,7 +511,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         final Integer[] a = new Integer[1000];
         Arrays.fill(a, 1);
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Single.just(1)
         .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapIterableObservableTest.java
@@ -86,7 +86,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
 
     @Test
     public void fused() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
             @Override
@@ -104,7 +104,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
 
     @Test
     public void fusedNoSync() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.SYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
         Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFromCallableTest.java
@@ -169,7 +169,7 @@ public class SingleFromCallableTest extends RxJavaTest {
 
         Observer<Object> observer = TestHelper.mockObserver();
 
-        TestObserver<String> outer = new TestObserver<String>(observer);
+        TestObserver<String> outer = new TestObserver<>(observer);
 
         fromCallableObservable
                 .subscribeOn(Schedulers.computation())
@@ -230,7 +230,7 @@ public class SingleFromCallableTest extends RxJavaTest {
 
     @Test
     public void disposedOnCall() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Single.fromCallable(new Callable<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleFromSupplierTest.java
@@ -170,7 +170,7 @@ public class SingleFromSupplierTest extends RxJavaTest {
 
         Observer<Object> observer = TestHelper.mockObserver();
 
-        TestObserver<String> outer = new TestObserver<String>(observer);
+        TestObserver<String> outer = new TestObserver<>(observer);
 
         fromSupplierObservable
                 .subscribeOn(Schedulers.computation())
@@ -231,7 +231,7 @@ public class SingleFromSupplierTest extends RxJavaTest {
 
     @Test
     public void disposedOnCall() {
-        final TestObserver<Integer> to = new TestObserver<Integer>();
+        final TestObserver<Integer> to = new TestObserver<>();
 
         Single.fromSupplier(new Supplier<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipIterableTest.java
@@ -156,7 +156,7 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorThrows() {
-        Single.zip(new CrashingMappedIterable<Single<Integer>>(1, 100, 100, new Function<Integer, Single<Integer>>() {
+        Single.zip(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Single<Integer>>() {
             @Override
             public Single<Integer> apply(Integer v) throws Exception {
                 return Single.just(v);
@@ -168,7 +168,7 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrows() {
-        Single.zip(new CrashingMappedIterable<Single<Integer>>(100, 20, 100, new Function<Integer, Single<Integer>>() {
+        Single.zip(new CrashingMappedIterable<>(100, 20, 100, new Function<Integer, Single<Integer>>() {
             @Override
             public Single<Integer> apply(Integer v) throws Exception {
                 return Single.just(v);
@@ -180,7 +180,7 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void nextThrows() {
-        Single.zip(new CrashingMappedIterable<Single<Integer>>(100, 100, 5, new Function<Integer, Single<Integer>>() {
+        Single.zip(new CrashingMappedIterable<>(100, 100, 5, new Function<Integer, Single<Integer>>() {
             @Override
             public Single<Integer> apply(Integer v) throws Exception {
                 return Single.just(v);

--- a/src/test/java/io/reactivex/rxjava3/internal/queue/SimpleQueueTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/queue/SimpleQueueTest.java
@@ -30,25 +30,25 @@ public class SimpleQueueTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void spscArrayQueueNull() {
-        SpscArrayQueue<Object> q = new SpscArrayQueue<Object>(16);
+        SpscArrayQueue<Object> q = new SpscArrayQueue<>(16);
         q.offer(null);
     }
 
     @Test(expected = NullPointerException.class)
     public void spscLinkedArrayQueueNull() {
-        SpscLinkedArrayQueue<Object> q = new SpscLinkedArrayQueue<Object>(16);
+        SpscLinkedArrayQueue<Object> q = new SpscLinkedArrayQueue<>(16);
         q.offer(null);
     }
 
     @Test(expected = NullPointerException.class)
     public void mpscLinkedQueueNull() {
-        MpscLinkedQueue<Object> q = new MpscLinkedQueue<Object>();
+        MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
         q.offer(null);
     }
 
     @Test
     public void spscArrayQueueBiOffer() {
-        SpscArrayQueue<Object> q = new SpscArrayQueue<Object>(16);
+        SpscArrayQueue<Object> q = new SpscArrayQueue<>(16);
         q.offer(1, 2);
 
         assertEquals(1, q.poll());
@@ -58,7 +58,7 @@ public class SimpleQueueTest extends RxJavaTest {
 
     @Test
     public void spscLinkedArrayQueueBiOffer() {
-        SpscLinkedArrayQueue<Object> q = new SpscLinkedArrayQueue<Object>(16);
+        SpscLinkedArrayQueue<Object> q = new SpscLinkedArrayQueue<>(16);
         q.offer(1, 2);
 
         assertEquals(1, q.poll());
@@ -68,7 +68,7 @@ public class SimpleQueueTest extends RxJavaTest {
 
     @Test
     public void mpscLinkedQueueBiOffer() {
-        MpscLinkedQueue<Object> q = new MpscLinkedQueue<Object>();
+        MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
         q.offer(1, 2);
 
         assertEquals(1, q.poll());
@@ -78,7 +78,7 @@ public class SimpleQueueTest extends RxJavaTest {
 
     @Test
     public void spscBiOfferCapacity() {
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(8);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(8);
         assertTrue(q.offer(1, 2));
         assertTrue(q.offer(3, 4));
         assertTrue(q.offer(5, 6));
@@ -90,7 +90,7 @@ public class SimpleQueueTest extends RxJavaTest {
 
     @Test
     public void spscLinkedNewBufferPeek() {
-        SpscLinkedArrayQueue<Integer> q = new SpscLinkedArrayQueue<Integer>(8);
+        SpscLinkedArrayQueue<Integer> q = new SpscLinkedArrayQueue<>(8);
         assertTrue(q.offer(1, 2));
         assertTrue(q.offer(3, 4));
         assertTrue(q.offer(5, 6));
@@ -107,7 +107,7 @@ public class SimpleQueueTest extends RxJavaTest {
 
     @Test
     public void mpscOfferPollRace() throws Exception {
-        final MpscLinkedQueue<Integer> q = new MpscLinkedQueue<Integer>();
+        final MpscLinkedQueue<Integer> q = new MpscLinkedQueue<>();
 
         final AtomicInteger c = new AtomicInteger(3);
 
@@ -160,7 +160,7 @@ public class SimpleQueueTest extends RxJavaTest {
 
     @Test
     public void spscLinkedArrayQueueNoNepotism() {
-        SpscLinkedArrayQueue<Integer> q = new SpscLinkedArrayQueue<Integer>(16);
+        SpscLinkedArrayQueue<Integer> q = new SpscLinkedArrayQueue<>(16);
 
         AtomicReferenceArray<Object> ara = q.producerBuffer;
 

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTaskTest.java
@@ -156,12 +156,12 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
             task.dispose();
 
-            FutureTask<Void> f1 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            FutureTask<Void> f1 = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
             task.setFirst(f1);
 
             assertTrue(f1.isCancelled());
 
-            FutureTask<Void> f2 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            FutureTask<Void> f2 = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
             task.setRest(f2);
 
             assertTrue(f2.isCancelled());
@@ -187,12 +187,12 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
             task.dispose();
 
-            FutureTask<Void> f1 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            FutureTask<Void> f1 = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
             task.setFirst(f1);
 
             assertTrue(f1.isCancelled());
 
-            FutureTask<Void> f2 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            FutureTask<Void> f2 = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
             task.setRest(f2);
 
             assertTrue(f2.isCancelled());
@@ -214,7 +214,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
                     }
                 }, exec);
 
-                final FutureTask<Void> f1 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+                final FutureTask<Void> f1 = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {
@@ -251,7 +251,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
                     }
                 }, exec);
 
-                final FutureTask<Void> f1 = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+                final FutureTask<Void> f1 = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
                 Runnable r1 = new Runnable() {
                     @Override
                     public void run() {

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnableTest.java
@@ -65,7 +65,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
 
-            final FutureTask<Object> ft = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, 0);
+            final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, 0);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -94,7 +94,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
 
-            final FutureTask<Object> ft = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, 0);
+            final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, 0);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -266,7 +266,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
 
-            final FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+            final FutureTask<Void> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -316,7 +316,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
             final ScheduledRunnable run = new ScheduledRunnable(r0, set);
             set.add(run);
 
-            final FutureTask<Void> ft = new FutureTask<Void>(run, null);
+            final FutureTask<Void> ft = new FutureTask<>(run, null);
 
             Runnable r2 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/SchedulerMultiWorkerSupportTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/SchedulerMultiWorkerSupportTest.java
@@ -33,7 +33,7 @@ public class SchedulerMultiWorkerSupportTest extends RxJavaTest {
 
     @Test
     public void moreThanMaxWorkers() {
-        final List<Worker> list = new ArrayList<Worker>();
+        final List<Worker> list = new ArrayList<>();
 
         SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
 
@@ -49,7 +49,7 @@ public class SchedulerMultiWorkerSupportTest extends RxJavaTest {
 
     @Test
     public void getShutdownWorkers() {
-        final List<Worker> list = new ArrayList<Worker>();
+        final List<Worker> list = new ArrayList<>();
 
         ComputationScheduler.NONE.createWorkers(max * 2, new WorkerCallback() {
             @Override
@@ -74,14 +74,14 @@ public class SchedulerMultiWorkerSupportTest extends RxJavaTest {
             try {
                 final CountDownLatch cdl = new CountDownLatch(max * 2);
 
-                final Set<String> threads1 = Collections.synchronizedSet(new HashSet<String>());
+                final Set<String> threads1 = Collections.synchronizedSet(new HashSet<>());
 
-                final Set<String> threads2 = Collections.synchronizedSet(new HashSet<String>());
+                final Set<String> threads2 = Collections.synchronizedSet(new HashSet<>());
 
                 Runnable parallel1 = new Runnable() {
                     @Override
                     public void run() {
-                        final List<Worker> list1 = new ArrayList<Worker>();
+                        final List<Worker> list1 = new ArrayList<>();
 
                         SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
 
@@ -110,7 +110,7 @@ public class SchedulerMultiWorkerSupportTest extends RxJavaTest {
                 Runnable parallel2 = new Runnable() {
                     @Override
                     public void run() {
-                        final List<Worker> list2 = new ArrayList<Worker>();
+                        final List<Worker> list2 = new ArrayList<>();
 
                         SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
@@ -75,7 +75,7 @@ public class BasicFuseableConditionalSubscriberTest extends RxJavaTest {
             }
         };
 
-        fcs.onSubscribe(new ScalarSubscription<Integer>(fcs, 1));
+        fcs.onSubscribe(new ScalarSubscription<>(fcs, 1));
 
         TestHelper.assertNoOffer(fcs);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/BasicFuseableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/BasicFuseableSubscriberTest.java
@@ -27,7 +27,7 @@ public class BasicFuseableSubscriberTest extends RxJavaTest {
 
     @Test
     public void offerThrows() {
-        BasicFuseableSubscriber<Integer, Integer> fcs = new BasicFuseableSubscriber<Integer, Integer>(new TestSubscriber<Integer>(0L)) {
+        BasicFuseableSubscriber<Integer, Integer> fcs = new BasicFuseableSubscriber<Integer, Integer>(new TestSubscriber<>(0L)) {
 
             @Override
             public void onNext(Integer t) {
@@ -45,7 +45,7 @@ public class BasicFuseableSubscriberTest extends RxJavaTest {
             }
         };
 
-        fcs.onSubscribe(new ScalarSubscription<Integer>(fcs, 1));
+        fcs.onSubscribe(new ScalarSubscription<>(fcs, 1));
 
         TestHelper.assertNoOffer(fcs);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/BlockingSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/BlockingSubscriberTest.java
@@ -29,12 +29,12 @@ public class BlockingSubscriberTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.doubleOnSubscribe(new BlockingSubscriber<Integer>(new ArrayDeque<Object>()));
+        TestHelper.doubleOnSubscribe(new BlockingSubscriber<Integer>(new ArrayDeque<>()));
     }
 
     @Test
     public void cancel() {
-        BlockingSubscriber<Integer> bq = new BlockingSubscriber<Integer>(new ArrayDeque<Object>());
+        BlockingSubscriber<Integer> bq = new BlockingSubscriber<>(new ArrayDeque<>());
 
         assertFalse(bq.isCancelled());
 
@@ -54,7 +54,7 @@ public class BlockingSubscriberTest extends RxJavaTest {
 
     @Test
     public void blockingFirstTimeout() {
-        BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<Integer>();
+        BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<>();
 
         Thread.currentThread().interrupt();
 
@@ -68,7 +68,7 @@ public class BlockingSubscriberTest extends RxJavaTest {
 
     @Test
     public void blockingFirstTimeout2() {
-        BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<Integer>();
+        BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<>();
 
         bf.onSubscribe(new BooleanSubscription());
 
@@ -85,7 +85,7 @@ public class BlockingSubscriberTest extends RxJavaTest {
     @Test
     public void cancelOnRequest() {
 
-        final BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<Integer>();
+        final BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<>();
 
         final AtomicBoolean b = new AtomicBoolean();
 
@@ -109,7 +109,7 @@ public class BlockingSubscriberTest extends RxJavaTest {
     @Test
     public void cancelUpfront() {
 
-        final BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<Integer>();
+        final BlockingFirstSubscriber<Integer> bf = new BlockingFirstSubscriber<>();
 
         final AtomicBoolean b = new AtomicBoolean();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/BoundedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/BoundedSubscriberTest.java
@@ -33,9 +33,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void onSubscribeThrows() {
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
             @Override
             public void accept(Object o) throws Exception {
                 received.add(o);
@@ -69,9 +69,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void onNextThrows() {
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
             @Override
             public void accept(Object o) throws Exception {
                 throw new TestException();
@@ -108,9 +108,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<>();
 
-            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
+            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
                 @Override
                 public void accept(Object o) throws Exception {
                     received.add(o);
@@ -154,9 +154,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<>();
 
-            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
+            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
                 @Override
                 public void accept(Object o) throws Exception {
                     received.add(o);
@@ -196,9 +196,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
     public void onNextThrowsCancelsUpstream() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
-        BoundedSubscriber<Integer> s = new BoundedSubscriber<Integer>(new Consumer<Integer>() {
+        BoundedSubscriber<Integer> s = new BoundedSubscriber<>(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
                 throw new TestException();
@@ -237,9 +237,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
     public void onSubscribeThrowsCancelsUpstream() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
-        BoundedSubscriber<Integer> s = new BoundedSubscriber<Integer>(new Consumer<Integer>() {
+        BoundedSubscriber<Integer> s = new BoundedSubscriber<>(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
             }
@@ -285,9 +285,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
             }
         });
 
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
@@ -330,9 +330,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
             }
         });
 
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<Object>(new Consumer<Object>() {
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
@@ -361,7 +361,7 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+        BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION,
                 Functions.<Subscription>boundedConsumer(128), 128);
@@ -371,7 +371,7 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+        BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,
                 Functions.<Subscription>boundedConsumer(128), 128);

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -427,7 +427,7 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.doubleOnSubscribe(new DeferredScalarSubscriber<Integer, Integer>(new TestSubscriber<Integer>()) {
+        TestHelper.doubleOnSubscribe(new DeferredScalarSubscriber<Integer, Integer>(new TestSubscriber<>()) {
             private static final long serialVersionUID = -4445381578878059054L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/FutureSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/FutureSubscriberTest.java
@@ -34,7 +34,7 @@ public class FutureSubscriberTest extends RxJavaTest {
 
     @Before
     public void before() {
-        fs = new FutureSubscriber<Integer>();
+        fs = new FutureSubscriber<>();
     }
 
     @Test
@@ -128,7 +128,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     @Test
     public void cancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
+            final FutureSubscriber<Integer> fs = new FutureSubscriber<>();
 
             Runnable r = new Runnable() {
                 @Override
@@ -157,7 +157,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     @Test
     public void onErrorCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
+            final FutureSubscriber<Integer> fs = new FutureSubscriber<>();
 
             final TestException ex = new TestException();
 
@@ -182,7 +182,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     @Test
     public void onCompleteCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final FutureSubscriber<Integer> fs = new FutureSubscriber<Integer>();
+            final FutureSubscriber<Integer> fs = new FutureSubscriber<>();
 
             if (i % 3 == 0) {
                 fs.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/InnerQueuedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/InnerQueuedSubscriberTest.java
@@ -44,9 +44,9 @@ public class InnerQueuedSubscriberTest extends RxJavaTest {
             }
         };
 
-        InnerQueuedSubscriber<Integer> inner = new InnerQueuedSubscriber<Integer>(support, 4);
+        InnerQueuedSubscriber<Integer> inner = new InnerQueuedSubscriber<>(support, 4);
 
-        final List<Long> requests = new ArrayList<Long>();
+        final List<Long> requests = new ArrayList<>();
 
         inner.onSubscribe(new Subscription() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/LambdaSubscriberTest.java
@@ -34,20 +34,20 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
     @Test
     public void onSubscribeThrows() {
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
             }
         },
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
+                new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable e) throws Exception {
+                        received.add(e);
+                    }
+                }, new Action() {
             @Override
             public void run() throws Exception {
                 received.add(100);
@@ -71,20 +71,20 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
     @Test
     public void onNextThrows() {
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 throw new TestException();
             }
         },
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
+                new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable e) throws Exception {
+                        received.add(e);
+                    }
+                }, new Action() {
             @Override
             public void run() throws Exception {
                 received.add(100);
@@ -111,20 +111,20 @@ public class LambdaSubscriberTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<>();
 
-            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
+            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) throws Exception {
                     received.add(v);
                 }
             },
-            new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    throw new TestException("Inner");
-                }
-            }, new Action() {
+                    new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable e) throws Exception {
+                            throw new TestException("Inner");
+                        }
+                    }, new Action() {
                 @Override
                 public void run() throws Exception {
                     received.add(100);
@@ -158,20 +158,20 @@ public class LambdaSubscriberTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            final List<Object> received = new ArrayList<Object>();
+            final List<Object> received = new ArrayList<>();
 
-            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
+            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) throws Exception {
                     received.add(v);
                 }
             },
-            new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    received.add(e);
-                }
-            }, new Action() {
+                    new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable e) throws Exception {
+                            received.add(e);
+                        }
+                    }, new Action() {
                 @Override
                 public void run() throws Exception {
                     throw new TestException();
@@ -215,20 +215,20 @@ public class LambdaSubscriberTest extends RxJavaTest {
             }
         });
 
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
             }
         },
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
+                new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable e) throws Exception {
+                        received.add(e);
+                    }
+                }, new Action() {
             @Override
             public void run() throws Exception {
                 received.add(100);
@@ -261,20 +261,20 @@ public class LambdaSubscriberTest extends RxJavaTest {
             }
         });
 
-        final List<Object> received = new ArrayList<Object>();
+        final List<Object> received = new ArrayList<>();
 
-        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<Object>(new Consumer<Object>() {
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
             @Override
             public void accept(Object v) throws Exception {
                 received.add(v);
             }
         },
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
+                new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable e) throws Exception {
+                        received.add(e);
+                    }
+                }, new Action() {
             @Override
             public void run() throws Exception {
                 received.add(100);
@@ -295,7 +295,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
     public void onNextThrowsCancelsUpstream() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         pp.subscribe(new Consumer<Integer>() {
             @Override
@@ -324,9 +324,9 @@ public class LambdaSubscriberTest extends RxJavaTest {
     public void onSubscribeThrowsCancelsUpstream() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
-        pp.subscribe(new LambdaSubscriber<Integer>(new Consumer<Integer>() {
+        pp.subscribe(new LambdaSubscriber<>(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
             }
@@ -354,7 +354,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+        LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION,
                 FlowableInternalHelper.RequestMax.INSTANCE);
@@ -364,7 +364,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+        LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,
                 FlowableInternalHelper.RequestMax.INSTANCE);

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/QueueDrainSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/QueueDrainSubscriberTest.java
@@ -32,7 +32,7 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 public class QueueDrainSubscriberTest extends RxJavaTest {
 
     static final QueueDrainSubscriber<Integer, Integer, Integer> createUnordered(TestSubscriber<Integer> ts, final Disposable d) {
-        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<Integer>(4)) {
+        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathEmitMax(t, false, d);
@@ -60,7 +60,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
     }
 
     static final QueueDrainSubscriber<Integer, Integer, Integer> createOrdered(TestSubscriber<Integer> ts, final Disposable d) {
-        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<Integer>(4)) {
+        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathOrderedEmitMax(t, false, d);
@@ -88,7 +88,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
     }
 
     static final QueueDrainSubscriber<Integer, Integer, Integer> createUnorderedReject(TestSubscriber<Integer> ts, final Disposable d) {
-        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<Integer>(4)) {
+        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathEmitMax(t, false, d);
@@ -116,7 +116,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
     }
 
     static final QueueDrainSubscriber<Integer, Integer, Integer> createOrderedReject(TestSubscriber<Integer> ts, final Disposable d) {
-        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<Integer>(4)) {
+        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathOrderedEmitMax(t, false, d);
@@ -145,7 +145,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void unorderedFastPathNoRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -159,7 +159,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void orderedFastPathNoRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -173,7 +173,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void acceptBadRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -191,7 +191,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void unorderedFastPathRequest1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -205,7 +205,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void orderedFastPathRequest1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -219,7 +219,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void unorderedSlowPath() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -232,7 +232,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void orderedSlowPath() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -245,7 +245,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void orderedSlowPathNonEmptyQueue() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -261,7 +261,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
     public void unorderedOnNextRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+            TestSubscriber<Integer> ts = new TestSubscriber<>(1);
             Disposable d = Disposable.empty();
             final QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnordered(ts, d);
             ts.onSubscribe(new BooleanSubscription());
@@ -284,7 +284,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
     public void orderedOnNextRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+            TestSubscriber<Integer> ts = new TestSubscriber<>(1);
             Disposable d = Disposable.empty();
             final QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrdered(ts, d);
             ts.onSubscribe(new BooleanSubscription());
@@ -305,7 +305,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void unorderedFastPathReject() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createUnorderedReject(ts, d);
         ts.onSubscribe(new BooleanSubscription());
@@ -321,7 +321,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
 
     @Test
     public void orderedFastPathReject() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(1);
         Disposable d = Disposable.empty();
         QueueDrainSubscriber<Integer, Integer, Integer> qd = createOrderedReject(ts, d);
         ts.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/SinglePostCompleteSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/SinglePostCompleteSubscriberTest.java
@@ -25,7 +25,7 @@ public class SinglePostCompleteSubscriberTest extends RxJavaTest {
     @Test
     public void requestCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             final SinglePostCompleteSubscriber<Integer, Integer> spc = new SinglePostCompleteSubscriber<Integer, Integer>(ts) {
                 private static final long serialVersionUID = -2848918821531562637L;

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/StrictSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/StrictSubscriberTest.java
@@ -29,7 +29,7 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void strictMode() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
         Subscriber<Object> sub = new Subscriber<Object>() {
 
             @Override
@@ -94,8 +94,8 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void normalOnNext() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
-        SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<Integer>(ts);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<>(ts);
 
         Flowable.range(1, 5).subscribe(wrapper);
 
@@ -104,8 +104,8 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void normalOnNextBackpressured() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(0);
-        SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<Integer>(ts);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0);
+        SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<>(ts);
 
         Flowable.range(1, 5).subscribe(wrapper);
 
@@ -120,8 +120,8 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void normalOnError() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
-        SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<Integer>(ts);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<>(ts);
 
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(new TestException()))
         .subscribe(wrapper);
@@ -131,7 +131,7 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void deferredRequest() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
         Subscriber<Object> sub = new Subscriber<Object>() {
 
             @Override
@@ -163,7 +163,7 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void requestZero() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
         Subscriber<Object> sub = new Subscriber<Object>() {
 
             @Override
@@ -195,7 +195,7 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void requestNegative() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
         Subscriber<Object> sub = new Subscriber<Object>() {
 
             @Override
@@ -227,7 +227,7 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void cancelAfterOnComplete() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
         Subscriber<Object> sub = new Subscriber<Object>() {
 
             Subscription upstream;
@@ -269,7 +269,7 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void cancelAfterOnError() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
         Subscriber<Object> sub = new Subscriber<Object>() {
 
             Subscription upstream;
@@ -311,8 +311,8 @@ public class StrictSubscriberTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
-        SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<Integer>(ts);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<>(ts);
 
         new Flowable<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/SubscriberResourceWrapperTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/SubscriberResourceWrapperTest.java
@@ -28,9 +28,9 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class SubscriberResourceWrapperTest extends RxJavaTest {
 
-    TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+    TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-    SubscriberResourceWrapper<Integer> s = new SubscriberResourceWrapper<Integer>(ts);
+    SubscriberResourceWrapper<Integer> s = new SubscriberResourceWrapper<>(ts);
 
     @Test
     public void cancel() {
@@ -94,7 +94,7 @@ public class SubscriberResourceWrapperTest extends RxJavaTest {
                     @Override
                     public Subscriber<? super Object> apply(
                             Subscriber<? super Object> s) throws Exception {
-                        return new SubscriberResourceWrapper<Object>(s);
+                        return new SubscriberResourceWrapper<>(s);
                     }
                 });
             }
@@ -107,7 +107,7 @@ public class SubscriberResourceWrapperTest extends RxJavaTest {
             @Override
             public Subscriber<? super Object> apply(
                     Subscriber<? super Object> s) throws Exception {
-                return new SubscriberResourceWrapper<Object>(s);
+                return new SubscriberResourceWrapper<>(s);
             }
         }));
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/subscriptions/DeferredScalarSubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscriptions/DeferredScalarSubscriptionTest.java
@@ -26,14 +26,14 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
 
     @Test
     public void queueSubscriptionSyncRejected() {
-        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
+        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<>(new TestSubscriber<>());
 
         assertEquals(QueueFuseable.NONE, ds.requestFusion(QueueFuseable.SYNC));
     }
 
     @Test
     public void clear() {
-        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
+        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<>(new TestSubscriber<>());
 
         ds.value = 1;
 
@@ -45,7 +45,7 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
 
     @Test
     public void cancel() {
-        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
+        DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<>(new TestSubscriber<>());
 
         assertTrue(ds.tryCancel());
 
@@ -55,7 +55,7 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
     @Test
     public void completeCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(new TestSubscriber<Integer>());
+            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<>(new TestSubscriber<>());
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -78,9 +78,9 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
     @Test
     public void requestClearRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(ts);
+            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<>(ts);
             ts.onSubscribe(ds);
             ds.complete(1);
 
@@ -109,9 +109,9 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
     @Test
     public void requestCancelRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+            TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<Integer>(ts);
+            final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<>(ts);
             ts.onSubscribe(ds);
             ds.complete(1);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/subscriptions/ScalarSubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscriptions/ScalarSubscriptionTest.java
@@ -26,9 +26,9 @@ public class ScalarSubscriptionTest extends RxJavaTest {
 
     @Test
     public void badRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-        ScalarSubscription<Integer> sc = new ScalarSubscription<Integer>(ts, 1);
+        ScalarSubscription<Integer> sc = new ScalarSubscription<>(ts, 1);
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -42,9 +42,9 @@ public class ScalarSubscriptionTest extends RxJavaTest {
 
     @Test
     public void noOffer() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-        ScalarSubscription<Integer> sc = new ScalarSubscription<Integer>(ts, 1);
+        ScalarSubscription<Integer> sc = new ScalarSubscription<>(ts, 1);
 
         TestHelper.assertNoOffer(sc);
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/subscriptions/SubscriptionHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscriptions/SubscriptionHelperTest.java
@@ -54,7 +54,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
 
     @Test
     public void set() {
-        AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
 
         BooleanSubscription bs1 = new BooleanSubscription();
 
@@ -71,7 +71,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
 
     @Test
     public void replace() {
-        AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
 
         BooleanSubscription bs1 = new BooleanSubscription();
 
@@ -89,7 +89,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
     @Test
     public void cancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
+            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
 
             Runnable r = new Runnable() {
                 @Override
@@ -105,7 +105,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
     @Test
     public void setRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
+            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
 
             final BooleanSubscription bs1 = new BooleanSubscription();
             final BooleanSubscription bs2 = new BooleanSubscription();
@@ -133,7 +133,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
     @Test
     public void replaceRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
+            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
 
             final BooleanSubscription bs1 = new BooleanSubscription();
             final BooleanSubscription bs2 = new BooleanSubscription();
@@ -161,7 +161,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
 
     @Test
     public void cancelAndChange() {
-        AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
 
         SubscriptionHelper.cancel(atomicSubscription);
 
@@ -180,7 +180,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
 
     @Test
     public void invalidDeferredRequest() {
-        AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
         AtomicLong r = new AtomicLong();
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -196,7 +196,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
     @Test
     public void deferredRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<Subscription>();
+            final AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
             final AtomicLong r = new AtomicLong();
 
             final AtomicLong q = new AtomicLong();
@@ -237,7 +237,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
 
     @Test
     public void setOnceAndRequest() {
-        AtomicReference<Subscription> ref = new AtomicReference<Subscription>();
+        AtomicReference<Subscription> ref = new AtomicReference<>();
 
         Subscription sub = mock(Subscription.class);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/util/AtomicThrowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/AtomicThrowableTest.java
@@ -91,7 +91,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerSubscriberNoError() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -101,7 +101,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerSubscriberError() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -112,7 +112,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerSubscriberTerminated() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -123,7 +123,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerObserverNoError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -133,7 +133,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerObserverError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -144,7 +144,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerObserverTerminated() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -155,7 +155,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerMaybeObserverNoError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -165,7 +165,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerMaybeObserverError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -176,7 +176,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerMaybeObserverTerminated() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -187,7 +187,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerSingleNoError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -197,7 +197,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerSingleError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -208,7 +208,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerSingleTerminated() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -219,7 +219,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerCompletableObserverNoError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -229,7 +229,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerCompletableObserverError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -240,7 +240,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerCompletableObserverTerminated() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -270,7 +270,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerEmitterNoError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -280,7 +280,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerEmitterError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();
@@ -291,7 +291,7 @@ public class AtomicThrowableTest extends RxJavaTest {
 
     @Test
     public void tryTerminateConsumerEmitterTerminated() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         AtomicThrowable ex = new AtomicThrowable();

--- a/src/test/java/io/reactivex/rxjava3/internal/util/CrashingMappedIterable.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/CrashingMappedIterable.java
@@ -45,7 +45,7 @@ public final class CrashingMappedIterable<T> implements Iterable<T> {
         if (--crashOnIterator <= 0) {
             throw new TestException("iterator()");
         }
-        return new CrashingMapperIterator<T>(crashOnHasNext, crashOnNext, mapper);
+        return new CrashingMapperIterator<>(crashOnHasNext, crashOnNext, mapper);
     }
 
     static final class CrashingMapperIterator<T> implements Iterator<T> {

--- a/src/test/java/io/reactivex/rxjava3/internal/util/ExceptionHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/ExceptionHelperTest.java
@@ -33,7 +33,7 @@ public class ExceptionHelperTest extends RxJavaTest {
     public void addRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+            final AtomicReference<Throwable> error = new AtomicReference<>();
 
             final TestException ex = new TestException();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerObserverTest.java
@@ -208,7 +208,7 @@ public class HalfSerializerObserverTest extends RxJavaTest {
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
 
-            final TestObserver<Integer> to = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<>();
             to.onSubscribe(Disposable.empty());
 
             Runnable r1 = new Runnable() {
@@ -240,7 +240,7 @@ public class HalfSerializerObserverTest extends RxJavaTest {
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
 
-            final TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            final TestObserverEx<Integer> to = new TestObserverEx<>();
 
             to.onSubscribe(Disposable.empty());
 

--- a/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerSubscriberTest.java
@@ -214,7 +214,7 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
 
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
             ts.onSubscribe(new BooleanSubscription());
 
             Runnable r1 = new Runnable() {
@@ -246,7 +246,7 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
             final AtomicInteger wip = new AtomicInteger();
             final AtomicThrowable error = new AtomicThrowable();
 
-            final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            final TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
             ts.onSubscribe(new BooleanSubscription());
 

--- a/src/test/java/io/reactivex/rxjava3/internal/util/MergerBiFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/MergerBiFunctionTest.java
@@ -25,7 +25,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void firstEmpty() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<Integer>(new Comparator<Integer>() {
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
             @Override
             public int compare(Integer o1, Integer o2) {
                 return o1.compareTo(o2);
@@ -38,7 +38,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void bothEmpty() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<Integer>(new Comparator<Integer>() {
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
             @Override
             public int compare(Integer o1, Integer o2) {
                 return o1.compareTo(o2);
@@ -51,7 +51,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void secondEmpty() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<Integer>(new Comparator<Integer>() {
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
             @Override
             public int compare(Integer o1, Integer o2) {
                 return o1.compareTo(o2);
@@ -64,7 +64,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void sameSize() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<Integer>(new Comparator<Integer>() {
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
             @Override
             public int compare(Integer o1, Integer o2) {
                 return o1.compareTo(o2);
@@ -77,7 +77,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void sameSizeReverse() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<Integer>(new Comparator<Integer>() {
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
             @Override
             public int compare(Integer o1, Integer o2) {
                 return o1.compareTo(o2);

--- a/src/test/java/io/reactivex/rxjava3/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/MiscUtilTest.java
@@ -68,13 +68,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhile() throws Exception {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(2);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(2);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
@@ -89,13 +89,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhileBi() throws Throwable {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(2);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(2);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
             @Override
@@ -110,13 +110,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhilePreGrow() throws Exception {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(12);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(12);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
@@ -131,13 +131,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhileExact() throws Exception {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(3);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(3);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
@@ -152,13 +152,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhileAll() throws Exception {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(2);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(2);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
@@ -173,13 +173,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhileBigger() throws Exception {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(4);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(4);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(new NonThrowingPredicate<Integer>() {
             @Override
@@ -194,13 +194,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhileBiPreGrow() throws Throwable {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(12);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(12);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
             @Override
@@ -215,13 +215,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhileBiExact() throws Throwable {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(3);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(3);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
             @Override
@@ -236,13 +236,13 @@ public class MiscUtilTest extends RxJavaTest {
 
     @Test
     public void appendOnlyLinkedArrayListForEachWhileBiAll() throws Throwable {
-        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<Integer>(2);
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(2);
 
         list.add(1);
         list.add(2);
         list.add(3);
 
-        final List<Integer> out = new ArrayList<Integer>();
+        final List<Integer> out = new ArrayList<>();
 
         list.forEachWhile(3, new BiPredicate<Integer, Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/util/NotificationLiteTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/NotificationLiteTest.java
@@ -26,7 +26,7 @@ public class NotificationLiteTest extends RxJavaTest {
 
     @Test
     public void acceptFullObserver() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Disposable d = Disposable.empty();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/util/ObservableToFlowabeTestSync.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/ObservableToFlowabeTestSync.java
@@ -26,7 +26,7 @@ public final class ObservableToFlowabeTestSync {
     }
 
     static List<String> readAllLines(File f) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         try {
             BufferedReader in = new BufferedReader(new FileReader(f));
             try {
@@ -65,7 +65,7 @@ public final class ObservableToFlowabeTestSync {
 
             Class<?> clazz2 = Class.forName(basepackage + "flowable." + cn);
 
-            Set<String> methods2 = new HashSet<String>();
+            Set<String> methods2 = new HashSet<>();
 
             for (Method m : clazz2.getMethods()) {
                 methods2.add(m.getName());

--- a/src/test/java/io/reactivex/rxjava3/internal/util/OpenHashSetTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/OpenHashSetTest.java
@@ -39,7 +39,7 @@ public class OpenHashSetTest extends RxJavaTest {
         Value v1 = new Value();
         Value v2 = new Value();
 
-        OpenHashSet<Value> set = new OpenHashSet<Value>();
+        OpenHashSet<Value> set = new OpenHashSet<>();
 
         assertTrue(set.add(v1));
 

--- a/src/test/java/io/reactivex/rxjava3/internal/util/QueueDrainHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/QueueDrainHelperTest.java
@@ -89,8 +89,8 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void postCompleteEmpty() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ArrayDeque<Integer> queue = new ArrayDeque<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
         AtomicLong state = new AtomicLong();
         BooleanSupplier isCancelled = new BooleanSupplier() {
             @Override
@@ -108,8 +108,8 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void postCompleteWithRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ArrayDeque<Integer> queue = new ArrayDeque<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
         AtomicLong state = new AtomicLong();
         BooleanSupplier isCancelled = new BooleanSupplier() {
             @Override
@@ -130,8 +130,8 @@ public class QueueDrainHelperTest extends RxJavaTest {
     @Test
     public void completeRequestRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-            final ArrayDeque<Integer> queue = new ArrayDeque<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
+            final ArrayDeque<Integer> queue = new ArrayDeque<>();
             final AtomicLong state = new AtomicLong();
             final BooleanSupplier isCancelled = new BooleanSupplier() {
                 @Override
@@ -165,8 +165,8 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void postCompleteCancelled() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        ArrayDeque<Integer> queue = new ArrayDeque<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
         AtomicLong state = new AtomicLong();
         BooleanSupplier isCancelled = new BooleanSupplier() {
             @Override
@@ -194,7 +194,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
                 cancel();
             }
         };
-        ArrayDeque<Integer> queue = new ArrayDeque<Integer>();
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
         AtomicLong state = new AtomicLong();
         BooleanSupplier isCancelled = new BooleanSupplier() {
             @Override
@@ -214,7 +214,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void drainMaxLoopMissingBackpressure() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
@@ -259,7 +259,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
         q.offer(1);
 
         QueueDrainHelper.drainMaxLoop(q, ts, false, null, qd);
@@ -269,7 +269,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void drainMaxLoopMissingBackpressureWithResource() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
@@ -314,7 +314,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
         q.offer(1);
 
         Disposable d = Disposable.empty();
@@ -328,7 +328,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void drainMaxLoopDontAccept() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
@@ -373,7 +373,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
         q.offer(1);
 
         QueueDrainHelper.drainMaxLoop(q, ts, false, null, qd);
@@ -383,7 +383,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void checkTerminatedDelayErrorEmpty() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
@@ -428,7 +428,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         QueueDrainHelper.checkTerminated(true, true, ts, true, q, qd);
 
@@ -437,7 +437,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void checkTerminatedDelayErrorNonEmpty() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
@@ -482,7 +482,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         QueueDrainHelper.checkTerminated(true, false, ts, true, q, qd);
 
@@ -491,7 +491,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void checkTerminatedDelayErrorEmptyError() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
@@ -536,7 +536,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         QueueDrainHelper.checkTerminated(true, true, ts, true, q, qd);
 
@@ -545,7 +545,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void checkTerminatedNonDelayErrorError() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
         QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
@@ -590,7 +590,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         QueueDrainHelper.checkTerminated(true, false, ts, false, q, qd);
 
@@ -599,7 +599,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void observerCheckTerminatedDelayErrorEmpty() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
@@ -633,7 +633,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         QueueDrainHelper.checkTerminated(true, true, to, true, q, null, qd);
 
@@ -642,7 +642,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void observerCheckTerminatedDelayErrorEmptyResource() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
@@ -676,7 +676,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         Disposable d = Disposable.empty();
 
@@ -689,7 +689,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void observerCheckTerminatedDelayErrorNonEmpty() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
@@ -723,7 +723,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         QueueDrainHelper.checkTerminated(true, false, to, true, q, null, qd);
 
@@ -732,7 +732,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void observerCheckTerminatedDelayErrorEmptyError() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
@@ -766,7 +766,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         QueueDrainHelper.checkTerminated(true, true, to, true, q, null, qd);
 
@@ -775,7 +775,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void observerCheckTerminatedNonDelayErrorError() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
@@ -809,7 +809,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         QueueDrainHelper.checkTerminated(true, false, to, false, q, null, qd);
 
@@ -818,7 +818,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void observerCheckTerminatedNonDelayErrorErrorResource() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
         ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
@@ -852,7 +852,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
             }
         };
 
-        SpscArrayQueue<Integer> q = new SpscArrayQueue<Integer>(32);
+        SpscArrayQueue<Integer> q = new SpscArrayQueue<>(32);
 
         Disposable d = Disposable.empty();
 
@@ -866,9 +866,9 @@ public class QueueDrainHelperTest extends RxJavaTest {
     @Test
     public void postCompleteAlreadyComplete() {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Queue<Integer> q = new ArrayDeque<Integer>();
+        Queue<Integer> q = new ArrayDeque<>();
         q.offer(1);
 
         AtomicLong state = new AtomicLong(QueueDrainHelper.COMPLETED_MASK);

--- a/src/test/java/io/reactivex/rxjava3/internal/util/TestingHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/TestingHelper.java
@@ -40,7 +40,7 @@ public final class TestingHelper {
 
             @Override
             public List<T> get() {
-                return new ArrayList<T>();
+                return new ArrayList<>();
             }
         };
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/util/VolatileSizeArrayListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/VolatileSizeArrayListTest.java
@@ -25,14 +25,14 @@ public class VolatileSizeArrayListTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        List<Integer> list = new VolatileSizeArrayList<Integer>();
+        List<Integer> list = new VolatileSizeArrayList<>();
 
         assertTrue(list.isEmpty());
         assertEquals(0, list.size());
         assertFalse(list.contains(1));
         assertFalse(list.remove((Integer)1));
 
-        list = new VolatileSizeArrayList<Integer>(16);
+        list = new VolatileSizeArrayList<>(16);
         assertTrue(list.add(1));
         assertTrue(list.addAll(Arrays.asList(3, 4, 7)));
         list.add(1, 2);
@@ -81,7 +81,7 @@ public class VolatileSizeArrayListTest extends RxJavaTest {
 
         assertEquals(Arrays.asList(3, 4, 5), list.subList(2, 5));
 
-        VolatileSizeArrayList<Integer> list2 = new VolatileSizeArrayList<Integer>();
+        VolatileSizeArrayList<Integer> list2 = new VolatileSizeArrayList<>();
         list2.addAll(Arrays.asList(1, 2, 3, 4, 5, 6));
 
         assertNotEquals(list2, list);
@@ -91,7 +91,7 @@ public class VolatileSizeArrayListTest extends RxJavaTest {
         assertEquals(list2, list);
         assertEquals(list, list2);
 
-        List<Integer> list3 = new ArrayList<Integer>();
+        List<Integer> list3 = new ArrayList<>();
         list3.addAll(Arrays.asList(1, 2, 3, 4, 5, 6));
 
         assertNotEquals(list3, list);


### PR DESCRIPTION
Hello, in this pull request i've changed all IDE marked explicit types with diamond operator. Affected packages is internal/ , internal/operators/.
There is one test fail in CompletableTest.repeatNormal , but diamond is not the cause, there is last stack entry: 
java.lang.AssertionError: expected:<6> but was:<5>
	at org.junit.Assert.fail(Assert.java:88)

This PR is part of  #6767 issue resolving.