### PR TITLE
Diamond operators in tests, small packages

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/completable/CompletableTest.java
@@ -349,7 +349,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void concatObservablePrefetch() {
-        final List<Long> requested = new ArrayList<Long>();
+        final List<Long> requested = new ArrayList<>();
         Flowable<Completable> cs = Flowable
                 .just(normal.completable)
                 .repeat(10)
@@ -859,7 +859,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void mergeObservableMaxConcurrent() {
-        final List<Long> requested = new ArrayList<Long>();
+        final List<Long> requested = new ArrayList<>();
         Flowable<Completable> cs = Flowable
                 .just(normal.completable)
                 .repeat(10)
@@ -1079,7 +1079,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void mergeDelayErrorObservableMaxConcurrent() {
-        final List<Long> requested = new ArrayList<Long>();
+        final List<Long> requested = new ArrayList<>();
         Flowable<Completable> cs = Flowable
                 .just(normal.completable)
                 .repeat(10)
@@ -1236,7 +1236,7 @@ public class CompletableTest extends RxJavaTest {
         });
 
         final AtomicBoolean disposedFirst = new AtomicBoolean();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         c.subscribe(new CompletableObserver() {
             @Override
@@ -1282,7 +1282,7 @@ public class CompletableTest extends RxJavaTest {
         }, false);
 
         final AtomicBoolean disposedFirst = new AtomicBoolean();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         c.subscribe(new CompletableObserver() {
             @Override
@@ -1571,7 +1571,7 @@ public class CompletableTest extends RxJavaTest {
         Completable c = normal.completable.delay(250, TimeUnit.MILLISECONDS);
 
         final AtomicBoolean done = new AtomicBoolean();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         c.subscribe(new CompletableObserver() {
             @Override
@@ -1611,7 +1611,7 @@ public class CompletableTest extends RxJavaTest {
         final Completable c = error.completable.delay(250, TimeUnit.MILLISECONDS, scheduler);
 
         final AtomicBoolean done = new AtomicBoolean();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         c.subscribe(new CompletableObserver() {
             @Override
@@ -1645,7 +1645,7 @@ public class CompletableTest extends RxJavaTest {
         Completable c = error.completable.delay(250, TimeUnit.MILLISECONDS, Schedulers.computation(), true);
 
         final AtomicBoolean done = new AtomicBoolean();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         c.subscribe(new CompletableObserver() {
             @Override
@@ -1833,7 +1833,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void doOnErrorNoError() {
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         Completable c = normal.completable.doOnError(new Consumer<Throwable>() {
             @Override
@@ -1849,7 +1849,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void doOnErrorHasError() {
-        final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
 
         Completable c = error.completable.doOnError(new Consumer<Throwable>() {
             @Override
@@ -2036,8 +2036,8 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void observeOnNormal() throws InterruptedException {
-        final AtomicReference<String> name = new AtomicReference<String>();
-        final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+        final AtomicReference<String> name = new AtomicReference<>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
         final CountDownLatch cdl = new CountDownLatch(1);
 
         Completable c = normal.completable.observeOn(Schedulers.computation());
@@ -2069,8 +2069,8 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void observeOnError() throws InterruptedException {
-        final AtomicReference<String> name = new AtomicReference<String>();
-        final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+        final AtomicReference<String> name = new AtomicReference<>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
         final CountDownLatch cdl = new CountDownLatch(1);
 
         Completable c = error.completable.observeOn(Schedulers.computation());
@@ -2195,7 +2195,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void repeatNormal() {
-        final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
         final AtomicInteger calls = new AtomicInteger();
 
         Completable c = Completable.fromCallable(new Callable<Object>() {
@@ -2500,7 +2500,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void subscribeTwoCallbacksNormal() {
-        final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
         final AtomicBoolean complete = new AtomicBoolean();
         normal.completable.subscribe(new Action() {
             @Override
@@ -2520,7 +2520,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void subscribeTwoCallbacksError() {
-        final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
         final AtomicBoolean complete = new AtomicBoolean();
         error.completable.subscribe(new Action() {
             @Override
@@ -2558,7 +2558,7 @@ public class CompletableTest extends RxJavaTest {
     public void subscribeTwoCallbacksCompleteThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+            final AtomicReference<Throwable> err = new AtomicReference<>();
             normal.completable.subscribe(new Action() {
                 @Override
                 public void run() { throw new TestException(); }
@@ -2596,7 +2596,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void subscribeObserverNormal() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         normal.completable.toObservable().subscribe(to);
 
@@ -2607,7 +2607,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void subscribeObserverError() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         error.completable.toObservable().subscribe(to);
 
@@ -2673,7 +2673,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void subscribeSubscriberNormal() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         normal.completable.toFlowable().subscribe(ts);
 
@@ -2684,7 +2684,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void subscribeSubscriberError() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         error.completable.toFlowable().subscribe(ts);
 
@@ -2700,7 +2700,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void subscribeOnNormal() {
-        final AtomicReference<String> name = new  AtomicReference<String>();
+        final AtomicReference<String> name = new AtomicReference<>();
 
         Completable c = Completable.unsafeCreate(new CompletableSource() {
             @Override
@@ -2717,7 +2717,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void subscribeOnError() {
-        final AtomicReference<String> name = new  AtomicReference<String>();
+        final AtomicReference<String> name = new AtomicReference<>();
 
         Completable c = Completable.unsafeCreate(new CompletableSource() {
             @Override
@@ -2903,7 +2903,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void unsubscribeOnNormal() throws InterruptedException {
-        final AtomicReference<String> name = new AtomicReference<String>();
+        final AtomicReference<String> name = new AtomicReference<>();
         final CountDownLatch cdl = new CountDownLatch(1);
 
         normal.completable.delay(1, TimeUnit.SECONDS)
@@ -3010,7 +3010,7 @@ public class CompletableTest extends RxJavaTest {
 
         Completable c = Completable.ambArray(c1, c2);
 
-        final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> complete = new AtomicReference<>();
 
         c.subscribe(Functions.EMPTY_ACTION, new Consumer<Throwable>() {
             @Override
@@ -3072,7 +3072,7 @@ public class CompletableTest extends RxJavaTest {
 
         Completable c = Completable.ambArray(c1, c2);
 
-        final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> complete = new AtomicReference<>();
 
         c.subscribe(Functions.EMPTY_ACTION, new Consumer<Throwable>() {
             @Override
@@ -3231,7 +3231,7 @@ public class CompletableTest extends RxJavaTest {
 
         Completable c = c1.ambWith(c2);
 
-        final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> complete = new AtomicReference<>();
 
         c.subscribe(Functions.EMPTY_ACTION, new Consumer<Throwable>() {
             @Override
@@ -3293,7 +3293,7 @@ public class CompletableTest extends RxJavaTest {
 
         Completable c = c1.ambWith(c2);
 
-        final AtomicReference<Throwable> complete = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> complete = new AtomicReference<>();
 
         c.subscribe(Functions.EMPTY_ACTION, new Consumer<Throwable>() {
             @Override
@@ -3356,7 +3356,7 @@ public class CompletableTest extends RxJavaTest {
                     }
                 }));
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         c.subscribe(ts);
 
@@ -3373,7 +3373,7 @@ public class CompletableTest extends RxJavaTest {
         Flowable<Object> c = normal.completable
                 .startWith(Flowable.error(new TestException()));
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         c.subscribe(ts);
 
@@ -3396,7 +3396,7 @@ public class CompletableTest extends RxJavaTest {
                     }
                 }));
 
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         o.subscribe(to);
 
@@ -3413,7 +3413,7 @@ public class CompletableTest extends RxJavaTest {
         Observable<Object> o = normal.completable
                 .startWith(Observable.error(new TestException()));
 
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         o.subscribe(to);
 
@@ -3441,14 +3441,14 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void andThen() {
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
         Completable.complete().andThen(Flowable.just("foo")).subscribe(ts);
         ts.request(1);
         ts.assertValue("foo");
         ts.assertComplete();
         ts.assertNoErrors();
 
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
         Completable.complete().andThen(Observable.just("foo")).subscribe(to);
         to.assertValue("foo");
         to.assertComplete();
@@ -3543,7 +3543,7 @@ public class CompletableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Completable.using(new Supplier<Integer>() {
             @Override
@@ -3613,7 +3613,7 @@ public class CompletableTest extends RxJavaTest {
         PublishSubject<String> stringSubject = PublishSubject.create();
         Completable completable = stringSubject.ignoreElements();
 
-        final AtomicReference<Disposable> disposableRef = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> disposableRef = new AtomicReference<>();
         Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
             public void run() {
@@ -3695,7 +3695,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void andThenSubscribeOn() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>(0);
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>(0);
         TestScheduler scheduler = new TestScheduler();
         Completable.complete().andThen(Flowable.just("foo").delay(1, TimeUnit.SECONDS, scheduler)).subscribe(ts);
 
@@ -3712,7 +3712,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void andThenSingleNever() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>(0);
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>(0);
         Completable.never().andThen(Single.just("foo")).toFlowable().subscribe(ts);
         ts.request(1);
         ts.assertNoValues();
@@ -3721,7 +3721,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void andThenSingleError() {
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
         final AtomicBoolean hasRun = new AtomicBoolean(false);
         final Exception e = new Exception();
         Completable.error(e)
@@ -3740,7 +3740,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void andThenSingleSubscribeOn() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>(0);
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>(0);
         TestScheduler scheduler = new TestScheduler();
         Completable.complete().andThen(Single.just("foo").delay(1, TimeUnit.SECONDS, scheduler)).toFlowable().subscribe(ts);
 
@@ -3992,7 +3992,7 @@ public class CompletableTest extends RxJavaTest {
                     }
                 }));
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         c.subscribe(ts);
 
@@ -4009,7 +4009,7 @@ public class CompletableTest extends RxJavaTest {
         Flowable<Object> c = normal.completable
                 .andThen(Flowable.error(new TestException()));
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         c.subscribe(ts);
 
@@ -4025,7 +4025,7 @@ public class CompletableTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         Consumer<Integer> onDispose = mock(Consumer.class);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Completable.using(new Supplier<Integer>() {
             @Override
@@ -4056,7 +4056,7 @@ public class CompletableTest extends RxJavaTest {
             }
         };
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Completable.using(new Supplier<Integer>() {
             @Override
@@ -4126,7 +4126,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void hookSubscribeStart() throws Throwable {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
 
         Completable completable = Completable.unsafeCreate(new CompletableSource() {
             @Override public void subscribe(CompletableObserver observer) {
@@ -4156,7 +4156,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void onErrorCompleteFunctionThrows() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
 
         error.completable.onErrorComplete(new Predicate<Throwable>() {
             @Override
@@ -4185,7 +4185,7 @@ public class CompletableTest extends RxJavaTest {
         PublishSubject<String> stringSubject = PublishSubject.create();
         Completable completable = stringSubject.ignoreElements();
 
-        final AtomicReference<Disposable> disposableRef = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> disposableRef = new AtomicReference<>();
         Disposable completableSubscription = completable.subscribe(new Action() {
             @Override
             public void run() {
@@ -4207,7 +4207,7 @@ public class CompletableTest extends RxJavaTest {
         PublishSubject<String> stringSubject = PublishSubject.create();
         Completable completable = stringSubject.ignoreElements();
 
-        final AtomicReference<Disposable> disposableRef = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> disposableRef = new AtomicReference<>();
         Disposable completableSubscription = completable.subscribe(Functions.EMPTY_ACTION,
         new Consumer<Throwable>() {
             @Override
@@ -4242,7 +4242,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void andThenNever() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>(0);
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>(0);
         Completable.never().andThen(Flowable.just("foo")).subscribe(ts);
         ts.request(1);
         ts.assertNoValues();
@@ -4251,7 +4251,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void andThenError() {
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
         final AtomicBoolean hasRun = new AtomicBoolean(false);
         final Exception e = new Exception();
         Completable.unsafeCreate(new CompletableSource() {
@@ -4278,7 +4278,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void andThenSingle() {
-        TestSubscriber<String> ts = new TestSubscriber<String>(0);
+        TestSubscriber<String> ts = new TestSubscriber<>(0);
         Completable.complete().andThen(Single.just("foo")).toFlowable().subscribe(ts);
         ts.request(1);
         ts.assertValue("foo");

--- a/src/test/java/io/reactivex/rxjava3/disposables/CompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/CompositeDisposableTest.java
@@ -72,7 +72,7 @@ public class CompositeDisposableTest extends RxJavaTest {
             }));
         }
 
-        final List<Thread> threads = new ArrayList<Thread>();
+        final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             final Thread t = new Thread() {
                 @Override
@@ -253,7 +253,7 @@ public class CompositeDisposableTest extends RxJavaTest {
 
         }));
 
-        final List<Thread> threads = new ArrayList<Thread>();
+        final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             final Thread t = new Thread() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/disposables/DisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/DisposableTest.java
@@ -160,7 +160,7 @@ public class DisposableTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            AtomicReference<Disposable> target = new AtomicReference<Disposable>();
+            AtomicReference<Disposable> target = new AtomicReference<>();
             Disposable d = Disposable.empty();
 
             DisposableHelper.setOnce(target, d);

--- a/src/test/java/io/reactivex/rxjava3/disposables/FutureDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/FutureDisposableTest.java
@@ -26,7 +26,7 @@ public class FutureDisposableTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        FutureTask<Object> ft = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         Disposable d = Disposable.fromFuture(ft);
         assertFalse(d.isDisposed());
 
@@ -43,7 +43,7 @@ public class FutureDisposableTest extends RxJavaTest {
 
     @Test
     public void interruptible() {
-        FutureTask<Object> ft = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         Disposable d = Disposable.fromFuture(ft, true);
         assertFalse(d.isDisposed());
 
@@ -60,7 +60,7 @@ public class FutureDisposableTest extends RxJavaTest {
 
     @Test
     public void normalDone() {
-        FutureTask<Object> ft = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         FutureDisposable d = new FutureDisposable(ft, false);
         assertFalse(d.isDisposed());
 

--- a/src/test/java/io/reactivex/rxjava3/disposables/SequentialDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/SequentialDisposableTest.java
@@ -129,7 +129,7 @@ public class SequentialDisposableTest extends RxJavaTest {
         final int count = 10;
         final CountDownLatch end = new CountDownLatch(count);
 
-        final List<Thread> threads = new ArrayList<Thread>();
+        final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             final Thread t = new Thread() {
                 @Override
@@ -164,12 +164,12 @@ public class SequentialDisposableTest extends RxJavaTest {
     public void concurrentSetDisposableShouldNotInterleave()
             throws InterruptedException {
         final int count = 10;
-        final List<Disposable> subscriptions = new ArrayList<Disposable>();
+        final List<Disposable> subscriptions = new ArrayList<>();
 
         final CountDownLatch start = new CountDownLatch(1);
         final CountDownLatch end = new CountDownLatch(count);
 
-        final List<Thread> threads = new ArrayList<Thread>();
+        final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             final Disposable subscription = mock(Disposable.class);
             subscriptions.add(subscription);

--- a/src/test/java/io/reactivex/rxjava3/disposables/SerialDisposableTests.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/SerialDisposableTests.java
@@ -129,7 +129,7 @@ public class SerialDisposableTests extends RxJavaTest {
         final int count = 10;
         final CountDownLatch end = new CountDownLatch(count);
 
-        final List<Thread> threads = new ArrayList<Thread>();
+        final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             final Thread t = new Thread() {
                 @Override
@@ -164,12 +164,12 @@ public class SerialDisposableTests extends RxJavaTest {
     public void concurrentSetDisposableShouldNotInterleave()
             throws InterruptedException {
         final int count = 10;
-        final List<Disposable> subscriptions = new ArrayList<Disposable>();
+        final List<Disposable> subscriptions = new ArrayList<>();
 
         final CountDownLatch start = new CountDownLatch(1);
         final CountDownLatch end = new CountDownLatch(count);
 
-        final List<Thread> threads = new ArrayList<Thread>();
+        final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             final Disposable subscription = mock(Disposable.class);
             subscriptions.add(subscription);

--- a/src/test/java/io/reactivex/rxjava3/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/exceptions/CompositeExceptionTest.java
@@ -31,7 +31,7 @@ public class CompositeExceptionTest extends RxJavaTest {
     private final Throwable ex3 = new Throwable("Ex3", ex2);
 
     private CompositeException getNewCompositeExceptionWithEx123() {
-        List<Throwable> throwables = new ArrayList<Throwable>();
+        List<Throwable> throwables = new ArrayList<>();
         throwables.add(ex1);
         throwables.add(ex2);
         throwables.add(ex3);
@@ -65,7 +65,7 @@ public class CompositeExceptionTest extends RxJavaTest {
             assertEquals("errors is empty", e.getMessage());
         }
         try {
-            new CompositeException(new ArrayList<Throwable>());
+            new CompositeException(new ArrayList<>());
             fail("CompositeException should fail if errors is empty");
         } catch (IllegalArgumentException e) {
             assertEquals("errors is empty", e.getMessage());
@@ -134,7 +134,7 @@ public class CompositeExceptionTest extends RxJavaTest {
 
     @Test
     public void compositeExceptionFromTwoDuplicateComposites() {
-        List<Throwable> exs = new ArrayList<Throwable>();
+        List<Throwable> exs = new ArrayList<>();
         exs.add(getNewCompositeExceptionWithEx123());
         exs.add(getNewCompositeExceptionWithEx123());
         CompositeException cex = new CompositeException(exs);

--- a/src/test/java/io/reactivex/rxjava3/flowable/Burst.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/Burst.java
@@ -58,12 +58,12 @@ public final class Burst<T> extends Flowable<T> {
 
     @SafeVarargs
     public static <T> Builder<T> items(T... items) {
-        return new Builder<T>(Arrays.asList(items));
+        return new Builder<>(Arrays.asList(items));
     }
 
     final class BurstSubscription implements Subscription {
         private final Subscriber<? super T> subscriber;
-        final Queue<T> q = new ConcurrentLinkedQueue<T>(items);
+        final Queue<T> q = new ConcurrentLinkedQueue<>(items);
         final AtomicLong requested = new AtomicLong();
         volatile boolean cancelled;
 
@@ -121,7 +121,7 @@ public final class Burst<T> extends Flowable<T> {
         }
 
         public Flowable<T> create() {
-            return new Burst<T>(error, items);
+            return new Burst<>(error, items);
         }
 
     }

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableBackpressureTests.java
@@ -82,7 +82,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
     public void observeOn() {
         int num = (int) (Flowable.bufferSize() * 2.1);
         AtomicInteger c = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         incrementingIntegers(c).observeOn(Schedulers.computation()).take(num).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -95,7 +95,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
     public void observeOnWithSlowConsumer() {
         int num = (int) (Flowable.bufferSize() * 0.2);
         AtomicInteger c = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         incrementingIntegers(c).observeOn(Schedulers.computation()).map(
             new Function<Integer, Integer>() {
                 @Override
@@ -121,7 +121,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         int num = (int) (Flowable.bufferSize() * 4.1);
         AtomicInteger c1 = new AtomicInteger();
         AtomicInteger c2 = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable<Integer> merged = Flowable.merge(incrementingIntegers(c1), incrementingIntegers(c2));
 
         merged.take(num).subscribe(ts);
@@ -142,7 +142,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         int num = (int) (Flowable.bufferSize() * 4.1);
         AtomicInteger c1 = new AtomicInteger();
         AtomicInteger c2 = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable<Integer> merged = Flowable.merge(
                 incrementingIntegers(c1).subscribeOn(Schedulers.computation()),
                 incrementingIntegers(c2).subscribeOn(Schedulers.computation()));
@@ -171,7 +171,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
             AtomicInteger c1 = new AtomicInteger();
             AtomicInteger c2 = new AtomicInteger();
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
             Flowable<Integer> merged = Flowable.merge(
                     incrementingIntegers(c1).subscribeOn(Schedulers.computation()),
                     incrementingIntegers(c2).subscribeOn(Schedulers.computation()));
@@ -194,7 +194,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         int num = (int) (Flowable.bufferSize() * 4.1);
         AtomicInteger c1 = new AtomicInteger();
         AtomicInteger c2 = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable<Integer> merged = Flowable.merge(
                 incrementingIntegers(c1).subscribeOn(Schedulers.computation()),
                 incrementingIntegers(c2).subscribeOn(Schedulers.computation()));
@@ -216,7 +216,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
     public void flatMapSync() {
         int num = (int) (Flowable.bufferSize() * 2.1);
         AtomicInteger c = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         incrementingIntegers(c)
         .flatMap(new Function<Integer, Publisher<Integer>>() {
@@ -240,7 +240,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         int num = (int) (Flowable.bufferSize() * 4.1);
         AtomicInteger c1 = new AtomicInteger();
         AtomicInteger c2 = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable<Integer> zipped = Flowable.zip(
                 incrementingIntegers(c1),
@@ -268,7 +268,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         int num = (int) (Flowable.bufferSize() * 2.1);
         AtomicInteger c1 = new AtomicInteger();
         AtomicInteger c2 = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable<Integer> zipped = Flowable.zip(
                 incrementingIntegers(c1).subscribeOn(Schedulers.computation()),
                 incrementingIntegers(c2).subscribeOn(Schedulers.computation()),
@@ -295,8 +295,8 @@ public class FlowableBackpressureTests extends RxJavaTest {
         for (int i = 0; i < 100; i++) {
             int num = (int) (Flowable.bufferSize() * 2.1);
             AtomicInteger c = new AtomicInteger();
-            ConcurrentLinkedQueue<Thread> threads = new ConcurrentLinkedQueue<Thread>();
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            ConcurrentLinkedQueue<Thread> threads = new ConcurrentLinkedQueue<>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
             // observeOn is there to make it async and need backpressure
             incrementingIntegers(c, threads).subscribeOn(Schedulers.computation()).observeOn(Schedulers.computation()).take(num).subscribe(ts);
             ts.awaitDone(5, TimeUnit.SECONDS);
@@ -325,7 +325,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
     public void takeFilterSkipChainAsync() {
         int num = (int) (Flowable.bufferSize() * 2.1);
         AtomicInteger c = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         incrementingIntegers(c).observeOn(Schedulers.computation())
                 .skip(10000)
                 .filter(new Predicate<Integer>() {
@@ -452,7 +452,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
     @Test
     public void firehoseFailsAsExpected() {
         AtomicInteger c = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         firehose(c).observeOn(Schedulers.computation())
         .map(new Function<Integer, Integer>() {
@@ -496,7 +496,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
             }
             int num = (int) (Flowable.bufferSize() * 1.1); // > 1 so that take doesn't prevent buffer overflow
             AtomicInteger c = new AtomicInteger();
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
             firehose(c).onBackpressureDrop()
             .observeOn(Schedulers.computation())
             .map(SLOW_PASS_THRU).take(num).subscribe(ts);
@@ -521,7 +521,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
             final AtomicInteger dropCount = new AtomicInteger();
             final AtomicInteger passCount = new AtomicInteger();
             final int num = Flowable.bufferSize() * 3; // > 1 so that take doesn't prevent buffer overflow
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             firehose(emitCount)
             .onBackpressureDrop(new Consumer<Integer>() {
@@ -561,7 +561,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         for (int i = 0; i < 100; i++) {
             int num = (int) (Flowable.bufferSize() * 1.1); // > 1 so that take doesn't prevent buffer overflow
             AtomicInteger c = new AtomicInteger();
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
             firehose(c).onBackpressureDrop()
             .map(SLOW_PASS_THRU).take(num).subscribe(ts);
             ts.awaitDone(5, TimeUnit.SECONDS);
@@ -584,7 +584,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
             final AtomicInteger dropCount = new AtomicInteger();
             int num = (int) (Flowable.bufferSize() * 1.1); // > 1 so that take doesn't prevent buffer overflow
             AtomicInteger c = new AtomicInteger();
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
             firehose(c).onBackpressureDrop(new Consumer<Integer>() {
                 @Override
                 public void accept(Integer j) {
@@ -613,7 +613,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
     public void onBackpressureBuffer() {
         int num = (int) (Flowable.bufferSize() * 1.1); // > 1 so that take doesn't prevent buffer overflow
         AtomicInteger c = new AtomicInteger();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         firehose(c).takeWhile(new Predicate<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableCollectTest.java
@@ -36,7 +36,7 @@ public final class FlowableCollectTest extends RxJavaTest {
         .collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -109,7 +109,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectorFailureDoesNotResultInTwoErrorEmissionsFlowable() {
         try {
-            final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+            final List<Throwable> list = new CopyOnWriteArrayList<>();
             RxJavaPlugins.setErrorHandler(addToList(list));
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
@@ -171,7 +171,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectIntoFlowable() {
         Flowable.just(1, 1, 1, 1, 2)
-        .collectInto(new HashSet<Integer>(), new BiConsumer<HashSet<Integer>, Integer>() {
+        .collectInto(new HashSet<>(), new BiConsumer<HashSet<Integer>, Integer>() {
             @Override
             public void accept(HashSet<Integer> s, Integer v) throws Exception {
                 s.add(v);
@@ -179,7 +179,7 @@ public final class FlowableCollectTest extends RxJavaTest {
         })
         .toFlowable()
         .test()
-        .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
+        .assertResult(new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
@@ -188,7 +188,7 @@ public final class FlowableCollectTest extends RxJavaTest {
         .collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -261,7 +261,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectorFailureDoesNotResultInTwoErrorEmissions() {
         try {
-            final List<Throwable> list = new CopyOnWriteArrayList<Throwable>();
+            final List<Throwable> list = new CopyOnWriteArrayList<>();
             RxJavaPlugins.setErrorHandler(addToList(list));
             final RuntimeException e1 = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
@@ -320,20 +320,20 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectInto() {
         Flowable.just(1, 1, 1, 1, 2)
-        .collectInto(new HashSet<Integer>(), new BiConsumer<HashSet<Integer>, Integer>() {
+        .collectInto(new HashSet<>(), new BiConsumer<HashSet<Integer>, Integer>() {
             @Override
             public void accept(HashSet<Integer> s, Integer v) throws Exception {
                 s.add(v);
             }
         })
         .test()
-        .assertResult(new HashSet<Integer>(Arrays.asList(1, 2)));
+        .assertResult(new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1, 2)
-            .collect(Functions.justSupplier(new ArrayList<Integer>()), new BiConsumer<ArrayList<Integer>, Integer>() {
+            .collect(Functions.justSupplier(new ArrayList<>()), new BiConsumer<ArrayList<Integer>, Integer>() {
                 @Override
                 public void accept(ArrayList<Integer> a, Integer b) throws Exception {
                     a.add(b);
@@ -341,7 +341,7 @@ public final class FlowableCollectTest extends RxJavaTest {
             }));
 
         TestHelper.checkDisposed(Flowable.just(1, 2)
-                .collect(Functions.justSupplier(new ArrayList<Integer>()), new BiConsumer<ArrayList<Integer>, Integer>() {
+                .collect(Functions.justSupplier(new ArrayList<>()), new BiConsumer<ArrayList<Integer>, Integer>() {
                     @Override
                     public void accept(ArrayList<Integer> a, Integer b) throws Exception {
                         a.add(b);
@@ -354,7 +354,7 @@ public final class FlowableCollectTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Integer>, Flowable<ArrayList<Integer>>>() {
             @Override
             public Flowable<ArrayList<Integer>> apply(Flowable<Integer> f) throws Exception {
-                return f.collect(Functions.justSupplier(new ArrayList<Integer>()),
+                return f.collect(Functions.justSupplier(new ArrayList<>()),
                         new BiConsumer<ArrayList<Integer>, Integer>() {
                             @Override
                             public void accept(ArrayList<Integer> a, Integer b) throws Exception {
@@ -366,7 +366,7 @@ public final class FlowableCollectTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Integer>, Single<ArrayList<Integer>>>() {
             @Override
             public Single<ArrayList<Integer>> apply(Flowable<Integer> f) throws Exception {
-                return f.collect(Functions.justSupplier(new ArrayList<Integer>()),
+                return f.collect(Functions.justSupplier(new ArrayList<>()),
                         new BiConsumer<ArrayList<Integer>, Integer>() {
                             @Override
                             public void accept(ArrayList<Integer> a, Integer b) throws Exception {

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableConversionTest.java
@@ -44,7 +44,7 @@ public class FlowableConversionTest extends RxJavaTest {
         protected Publisher<T> onSubscribe;
 
         public static <T> CylonDetectorObservable<T> create(Publisher<T> onSubscribe) {
-            return new CylonDetectorObservable<T>(onSubscribe);
+            return new CylonDetectorObservable<>(onSubscribe);
         }
 
         protected CylonDetectorObservable(Publisher<T> onSubscribe) {
@@ -56,7 +56,7 @@ public class FlowableConversionTest extends RxJavaTest {
         }
 
         public <R> CylonDetectorObservable<R> lift(FlowableOperator<? extends R, ? super T> operator) {
-            return x(new RobotConversionFunc<T, R>(operator));
+            return x(new RobotConversionFunc<>(operator));
         }
 
         public <R, O> O x(Function<Publisher<T>, O> operator) {
@@ -76,11 +76,11 @@ public class FlowableConversionTest extends RxJavaTest {
         }
 
         public final CylonDetectorObservable<T> beep(Predicate<? super T> predicate) {
-            return new CylonDetectorObservable<T>(new FlowableFilter<T>(Flowable.fromPublisher(onSubscribe), predicate));
+            return new CylonDetectorObservable<>(new FlowableFilter<>(Flowable.fromPublisher(onSubscribe), predicate));
         }
 
         public final <R> CylonDetectorObservable<R> boop(Function<? super T, ? extends R> func) {
-            return new CylonDetectorObservable<R>(new FlowableMap<T, R>(Flowable.fromPublisher(onSubscribe), func));
+            return new CylonDetectorObservable<>(new FlowableMap<>(Flowable.fromPublisher(onSubscribe), func));
         }
 
         public CylonDetectorObservable<String> DESTROY() {
@@ -147,7 +147,7 @@ public class FlowableConversionTest extends RxJavaTest {
 
     @Test
     public void conversionBetweenObservableClasses() {
-        final TestObserver<String> to = new TestObserver<String>(new DefaultObserver<String>() {
+        final TestObserver<String> to = new TestObserver<>(new DefaultObserver<String>() {
 
             @Override
             public void onComplete() {
@@ -175,7 +175,7 @@ public class FlowableConversionTest extends RxJavaTest {
                     System.out.println(pv);
                 }
             })
-            .to(new ConvertToCylonDetector<Object>())
+            .to(new ConvertToCylonDetector<>())
             .beep(new Predicate<Object>() {
                 @Override
                 public boolean test(Object t) {
@@ -189,7 +189,7 @@ public class FlowableConversionTest extends RxJavaTest {
                 }
             })
             .DESTROY()
-            .x(new ConvertToObservable<String>())
+            .x(new ConvertToObservable<>())
             .reduce("Cylon Detector finished. Report:\n", new BiFunction<String, String, String>() {
                 @Override
                 public String apply(String a, String n) {
@@ -204,7 +204,7 @@ public class FlowableConversionTest extends RxJavaTest {
 
     @Test
     public void convertToConcurrentQueue() {
-        final AtomicReference<Throwable> thrown = new AtomicReference<Throwable>(null);
+        final AtomicReference<Throwable> thrown = new AtomicReference<>(null);
         final AtomicBoolean isFinished = new AtomicBoolean(false);
         ConcurrentLinkedQueue<? extends Integer> queue = Flowable.range(0, 5)
                 .flatMap(new Function<Integer, Publisher<Integer>>() {
@@ -228,7 +228,7 @@ public class FlowableConversionTest extends RxJavaTest {
                     .to(new FlowableConverter<Integer, ConcurrentLinkedQueue<Integer>>() {
                         @Override
                         public ConcurrentLinkedQueue<Integer> apply(Flowable<Integer> onSubscribe) {
-                            final ConcurrentLinkedQueue<Integer> q = new ConcurrentLinkedQueue<Integer>();
+                            final ConcurrentLinkedQueue<Integer> q = new ConcurrentLinkedQueue<>();
                             onSubscribe.subscribe(new DefaultSubscriber<Integer>() {
                                 @Override
                                 public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableCovarianceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableCovarianceTest.java
@@ -66,7 +66,7 @@ public class FlowableCovarianceTest extends RxJavaTest {
     @Test
     public void groupByCompose() {
         Flowable<Movie> movies = Flowable.just(new HorrorMovie(), new ActionMovie(), new Movie());
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
 
         movies
         .groupBy(new Function<Movie, Object>() {
@@ -188,9 +188,9 @@ public class FlowableCovarianceTest extends RxJavaTest {
             } else {
                 // diff the two
                 List<Movie> newList = listOfLists.get(1);
-                List<Movie> oldList = new ArrayList<Movie>(listOfLists.get(0));
+                List<Movie> oldList = new ArrayList<>(listOfLists.get(0));
 
-                Set<Movie> delta = new LinkedHashSet<Movie>();
+                Set<Movie> delta = new LinkedHashSet<>();
                 delta.addAll(newList);
                 // remove all that match in old
                 delta.removeAll(oldList);
@@ -212,7 +212,7 @@ public class FlowableCovarianceTest extends RxJavaTest {
         @Override
         public Publisher<Movie> apply(Flowable<List<Movie>> movieList) {
             return movieList
-                .startWithItem(new ArrayList<Movie>())
+                .startWithItem(new ArrayList<>())
                 .buffer(2, 1)
                 .skip(1)
                 .flatMap(calculateDelta);

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableDoOnTest.java
@@ -27,7 +27,7 @@ public class FlowableDoOnTest extends RxJavaTest {
 
     @Test
     public void doOnEach() {
-        final AtomicReference<String> r = new AtomicReference<String>();
+        final AtomicReference<String> r = new AtomicReference<>();
         String output = Flowable.just("one").doOnNext(new Consumer<String>() {
             @Override
             public void accept(String v) {
@@ -41,7 +41,7 @@ public class FlowableDoOnTest extends RxJavaTest {
 
     @Test
     public void doOnError() {
-        final AtomicReference<Throwable> r = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> r = new AtomicReference<>();
         Throwable t = null;
         try {
             Flowable.<String> error(new RuntimeException("an error"))

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableErrorHandlingTests.java
@@ -35,7 +35,7 @@ public class FlowableErrorHandlingTests extends RxJavaTest {
     @Test
     public void onNextError() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> caughtError = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Flowable<Long> f = Flowable.interval(50, TimeUnit.MILLISECONDS);
         Subscriber<Long> subscriber = new DefaultSubscriber<Long>() {
 
@@ -72,7 +72,7 @@ public class FlowableErrorHandlingTests extends RxJavaTest {
     @Test
     public void onNextErrorAcrossThread() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> caughtError = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Flowable<Long> f = Flowable.interval(50, TimeUnit.MILLISECONDS);
         Subscriber<Long> subscriber = new DefaultSubscriber<Long>() {
 

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableEventStream.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableEventStream.java
@@ -33,7 +33,7 @@ public final class FlowableEventStream {
     }
 
     public static Event randomEvent(String type, int numInstances) {
-        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        Map<String, Object> values = new LinkedHashMap<>();
         values.put("count200", randomIntFrom0to(4000));
         values.put("count4xx", randomIntFrom0to(300));
         values.put("count5xx", randomIntFrom0to(500));

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
@@ -239,10 +239,10 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test
     public void fromFutureReturnsNull() {
-        FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         f.run();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         Flowable.fromFuture(f).subscribe(ts);
         ts.assertNoValues();
         ts.assertNotComplete();
@@ -256,24 +256,24 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedUnitNull() {
-        Flowable.fromFuture(new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null), 1, null);
+        Flowable.fromFuture(new FutureTask<>(Functions.EMPTY_RUNNABLE, null), 1, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedSchedulerNull() {
-        Flowable.fromFuture(new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null), 1, TimeUnit.SECONDS, null);
+        Flowable.fromFuture(new FutureTask<>(Functions.EMPTY_RUNNABLE, null), 1, TimeUnit.SECONDS, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedReturnsNull() {
-      FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+      FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         f.run();
         Flowable.fromFuture(f, 1, TimeUnit.SECONDS).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void fromFutureSchedulerNull() {
-        Flowable.fromFuture(new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null), null);
+        Flowable.fromFuture(new FutureTask<>(Functions.EMPTY_RUNNABLE, null), null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -2392,7 +2392,7 @@ public class FlowableNullTests extends RxJavaTest {
         }, new Supplier<Map<Integer, Collection<Integer>>>() {
             @Override
             public Map<Integer, Collection<Integer>> get() {
-                return new HashMap<Integer, Collection<Integer>>();
+                return new HashMap<>();
             }
         }, null);
     }
@@ -2412,7 +2412,7 @@ public class FlowableNullTests extends RxJavaTest {
         }, new Supplier<Map<Integer, Collection<Integer>>>() {
             @Override
             public Map<Integer, Collection<Integer>> get() {
-                return new HashMap<Integer, Collection<Integer>>();
+                return new HashMap<>();
             }
         }, new Function<Integer, Collection<Integer>>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableStartWithTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableStartWithTests.java
@@ -34,7 +34,7 @@ public class FlowableStartWithTests extends RxJavaTest {
 
     @Test
     public void startWithIterable() {
-        List<String> li = new ArrayList<String>();
+        List<String> li = new ArrayList<>();
         li.add("alpha");
         li.add("beta");
         List<String> values = Flowable.just("one", "two").startWithIterable(li).toList().blockingGet();
@@ -47,7 +47,7 @@ public class FlowableStartWithTests extends RxJavaTest {
 
     @Test
     public void startWithObservable() {
-        List<String> li = new ArrayList<String>();
+        List<String> li = new ArrayList<>();
         li.add("alpha");
         li.add("beta");
         List<String> values = Flowable.just("one", "two")

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableSubscriberTest.java
@@ -40,7 +40,7 @@ public class FlowableSubscriberTest {
      */
     @Test
     public void requestFromFinalSubscribeWithRequestValue() {
-        TestSubscriber<String> s = new TestSubscriber<String>(0L);
+        TestSubscriber<String> s = new TestSubscriber<>(0L);
         s.request(10);
         final AtomicLong r = new AtomicLong();
         s.onSubscribe(new Subscription() {
@@ -64,7 +64,7 @@ public class FlowableSubscriberTest {
      */
     @Test
     public void requestFromFinalSubscribeWithoutRequestValue() {
-        TestSubscriber<String> s = new TestSubscriber<String>();
+        TestSubscriber<String> s = new TestSubscriber<>();
         final AtomicLong r = new AtomicLong();
         s.onSubscribe(new Subscription() {
 
@@ -84,7 +84,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void requestFromChainedOperator() throws Throwable {
-        TestSubscriber<String> s = new TestSubscriber<String>(10L);
+        TestSubscriber<String> s = new TestSubscriber<>(10L);
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
             public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
@@ -136,7 +136,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void requestFromDecoupledOperator() throws Throwable {
-        TestSubscriber<String> s = new TestSubscriber<String>(0L);
+        TestSubscriber<String> s = new TestSubscriber<>(0L);
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
             public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
@@ -189,7 +189,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void requestFromDecoupledOperatorThatRequestsN() throws Throwable {
-        TestSubscriber<String> s = new TestSubscriber<String>(10L);
+        TestSubscriber<String> s = new TestSubscriber<>(10L);
         final AtomicLong innerR = new AtomicLong();
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
@@ -260,7 +260,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void requestToFlowable() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(3L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(3L);
         final AtomicLong requested = new AtomicLong();
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
@@ -284,7 +284,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void requestThroughMap() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
@@ -309,7 +309,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void requestThroughTakeThatReducesRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
@@ -336,7 +336,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void requestThroughTakeWhereRequestIsSmallerThanTake() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
@@ -463,7 +463,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void onStartRequestsAreAdditive() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
         Flowable.just(1, 2, 3, 4, 5)
         .subscribe(new DefaultSubscriber<Integer>() {
             @Override
@@ -491,7 +491,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void onStartRequestsAreAdditiveAndOverflowBecomesMaxValue() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
         Flowable.just(1, 2, 3, 4, 5).subscribe(new DefaultSubscriber<Integer>() {
             @Override
             public void onStart() {
@@ -520,7 +520,7 @@ public class FlowableSubscriberTest {
     public void forEachWhile() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Disposable d = pp.forEachWhile(new Predicate<Integer>() {
             @Override
@@ -543,7 +543,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void doubleSubscribe() {
-        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<Integer>(new Predicate<Integer>() {
+        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) throws Exception {
                 return true;
@@ -570,10 +570,10 @@ public class FlowableSubscriberTest {
     public void suppressAfterCompleteEvents() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
             ts.onSubscribe(new BooleanSubscription());
 
-            ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<Integer>(new Predicate<Integer>() {
+            ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
                 @Override
                 public boolean test(Integer v) throws Exception {
                     ts.onNext(v);
@@ -606,10 +606,10 @@ public class FlowableSubscriberTest {
 
     @Test
     public void onNextCrashes() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<Integer>(new Predicate<Integer>() {
+        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) throws Exception {
                 throw new TestException();
@@ -637,7 +637,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void onErrorThrows() {
-        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<Integer>(new Predicate<Integer>() {
+        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) throws Exception {
                 return true;
@@ -672,7 +672,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void onCompleteThrows() {
-        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<Integer>(new Predicate<Integer>() {
+        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) throws Exception {
                 return true;
@@ -703,7 +703,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void subscribeConsumerConsumerWithError() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Flowable.<Integer>error(new TestException()).subscribe(new Consumer<Integer>() {
             @Override
@@ -731,8 +731,8 @@ public class FlowableSubscriberTest {
 
     @Test
     public void safeSubscriberAlreadySafe() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
-        Flowable.just(1).safeSubscribe(new SafeSubscriber<Integer>(ts));
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        Flowable.just(1).safeSubscribe(new SafeSubscriber<>(ts));
 
         ts.assertResult(1);
     }
@@ -748,7 +748,7 @@ public class FlowableSubscriberTest {
 
     @Test
     public void subscribeConsumerConsumer() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Flowable.just(1).subscribe(new Consumer<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableTests.java
@@ -71,7 +71,7 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void fromIterable() {
-        ArrayList<String> items = new ArrayList<String>();
+        ArrayList<String> items = new ArrayList<>();
         items.add("one");
         items.add("two");
         items.add("three");
@@ -350,7 +350,7 @@ public class FlowableTests extends RxJavaTest {
     public void customObservableWithErrorInObserverAsynchronous() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger count = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         // FIXME custom built???
         Flowable.just("1", "2", "three", "4")
@@ -398,7 +398,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void customObservableWithErrorInObserverSynchronous() {
         final AtomicInteger count = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         // FIXME custom built???
         Flowable.just("1", "2", "three", "4")
@@ -440,7 +440,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void customObservableWithErrorInObservableSynchronous() {
         final AtomicInteger count = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
         // FIXME custom built???
         Flowable.just("1", "2").concatWith(Flowable.<String>error(new Supplier<Throwable>() {
             @Override
@@ -660,7 +660,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void takeWithErrorInObserver() {
         final AtomicInteger count = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
         Flowable.just("1", "2", "three", "4").take(3)
         .safeSubscribe(new DefaultSubscriber<String>() {
 
@@ -710,9 +710,9 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void ofTypeWithPolymorphism() {
-        ArrayList<Integer> l1 = new ArrayList<Integer>();
+        ArrayList<Integer> l1 = new ArrayList<>();
         l1.add(1);
-        LinkedList<Integer> l2 = new LinkedList<Integer>();
+        LinkedList<Integer> l2 = new LinkedList<>();
         l2.add(2);
 
         @SuppressWarnings("rawtypes")
@@ -898,21 +898,21 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void mergeWith() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.just(1).mergeWith(Flowable.just(2)).subscribe(ts);
         ts.assertValues(1, 2);
     }
 
     @Test
     public void concatWith() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.just(1).concatWith(Flowable.just(2)).subscribe(ts);
         ts.assertValues(1, 2);
     }
 
     @Test
     public void ambWith() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.just(1).ambWith(Flowable.just(2)).subscribe(ts);
         ts.assertValue(1);
     }
@@ -944,7 +944,7 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void compose() {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
         Flowable.just(1, 2, 3).compose(new FlowableTransformer<Integer, String>() {
             @Override
             public Publisher<String> apply(Flowable<Integer> t1) {
@@ -1008,7 +1008,7 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void extend() {
-        final TestSubscriber<Object> subscriber = new TestSubscriber<Object>();
+        final TestSubscriber<Object> subscriber = new TestSubscriber<>();
         final Object value = new Object();
         Object returned = Flowable.just(value).to(new FlowableConverter<Object, Object>() {
             @Override
@@ -1025,7 +1025,7 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void asExtend() {
-        final TestSubscriber<Object> subscriber = new TestSubscriber<Object>();
+        final TestSubscriber<Object> subscriber = new TestSubscriber<>();
         final Object value = new Object();
         Object returned = Flowable.just(value).to(new FlowableConverter<Object, Object>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableWindowTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableWindowTests.java
@@ -30,7 +30,7 @@ public class FlowableWindowTests extends RxJavaTest {
 
     @Test
     public void window() {
-        final ArrayList<List<Integer>> lists = new ArrayList<List<Integer>>();
+        final ArrayList<List<Integer>> lists = new ArrayList<>();
 
         Flowable.concat(
             Flowable.just(1, 2, 3, 4, 5, 6)

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableZipTests.java
@@ -41,7 +41,7 @@ public class FlowableZipTests extends RxJavaTest {
                 .flatMap(new Function<GroupedFlowable<String, Event>, Publisher<HashMap<String, String>>>() {
                     @Override
                     public Publisher<HashMap<String, String>> apply(final GroupedFlowable<String, Event> ge) {
-                            return ge.scan(new HashMap<String, String>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
+                            return ge.scan(new HashMap<>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
                                 @Override
                                 public HashMap<String, String> apply(HashMap<String, String> accum,
                                         Event perInstanceEvent) {

--- a/src/test/java/io/reactivex/rxjava3/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/maybe/MaybeTest.java
@@ -896,7 +896,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void observeOnDispose() throws Exception {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final CountDownLatch cdl = new CountDownLatch(1);
 
@@ -2282,7 +2282,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void subscribeToOnSuccess() {
-        final List<Integer> values = new ArrayList<Integer>();
+        final List<Integer> values = new ArrayList<>();
 
         Consumer<Integer> onSuccess = new Consumer<Integer>() {
             @Override
@@ -2302,7 +2302,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void subscribeToOnError() {
-        final List<Throwable> values = new ArrayList<Throwable>();
+        final List<Throwable> values = new ArrayList<>();
 
         Consumer<Throwable> onError = new Consumer<Throwable>() {
             @Override
@@ -2323,7 +2323,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void subscribeToOnComplete() {
-        final List<Integer> values = new ArrayList<Integer>();
+        final List<Integer> values = new ArrayList<>();
 
         Action onComplete = new Action() {
             @Override
@@ -2370,7 +2370,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void doOnEventSuccess() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         assertTrue(Maybe.just(1)
         .doOnEvent(new BiConsumer<Integer, Throwable>() {
@@ -2389,7 +2389,7 @@ public class MaybeTest extends RxJavaTest {
     public void doOnEventError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final List<Object> list = new ArrayList<Object>();
+            final List<Object> list = new ArrayList<>();
 
             TestException ex = new TestException();
 
@@ -2413,7 +2413,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void doOnEventComplete() {
-        final List<Object> list = new ArrayList<Object>();
+        final List<Object> list = new ArrayList<>();
 
         assertTrue(Maybe.<Integer>empty()
         .doOnEvent(new BiConsumer<Integer, Throwable>() {

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableCovarianceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableCovarianceTest.java
@@ -66,7 +66,7 @@ public class ObservableCovarianceTest extends RxJavaTest {
     @Test
     public void groupByCompose() {
         Observable<Movie> movies = Observable.just(new HorrorMovie(), new ActionMovie(), new Movie());
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
         movies
         .groupBy(new Function<Movie, Object>() {
             @Override
@@ -187,9 +187,9 @@ public class ObservableCovarianceTest extends RxJavaTest {
             } else {
                 // diff the two
                 List<Movie> newList = listOfLists.get(1);
-                List<Movie> oldList = new ArrayList<Movie>(listOfLists.get(0));
+                List<Movie> oldList = new ArrayList<>(listOfLists.get(0));
 
-                Set<Movie> delta = new LinkedHashSet<Movie>();
+                Set<Movie> delta = new LinkedHashSet<>();
                 delta.addAll(newList);
                 // remove all that match in old
                 delta.removeAll(oldList);
@@ -211,7 +211,7 @@ public class ObservableCovarianceTest extends RxJavaTest {
         @Override
         public Observable<Movie> apply(Observable<List<Movie>> movieList) {
             return movieList
-                .startWithItem(new ArrayList<Movie>())
+                .startWithItem(new ArrayList<>())
                 .buffer(2, 1)
                 .skip(1)
                 .flatMap(calculateDelta);

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableDoOnTest.java
@@ -27,7 +27,7 @@ public class ObservableDoOnTest extends RxJavaTest {
 
     @Test
     public void doOnEach() {
-        final AtomicReference<String> r = new AtomicReference<String>();
+        final AtomicReference<String> r = new AtomicReference<>();
         String output = Observable.just("one").doOnNext(new Consumer<String>() {
             @Override
             public void accept(String v) {
@@ -41,7 +41,7 @@ public class ObservableDoOnTest extends RxJavaTest {
 
     @Test
     public void doOnError() {
-        final AtomicReference<Throwable> r = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> r = new AtomicReference<>();
         Throwable t = null;
         try {
             Observable.<String> error(new RuntimeException("an error"))

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableErrorHandlingTests.java
@@ -33,7 +33,7 @@ public class ObservableErrorHandlingTests extends RxJavaTest {
     @Test
     public void onNextError() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> caughtError = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Observable<Long> o = Observable.interval(50, TimeUnit.MILLISECONDS);
         Observer<Long> observer = new DefaultObserver<Long>() {
 
@@ -69,7 +69,7 @@ public class ObservableErrorHandlingTests extends RxJavaTest {
     @Test
     public void onNextErrorAcrossThread() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> caughtError = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Observable<Long> o = Observable.interval(50, TimeUnit.MILLISECONDS);
         Observer<Long> observer = new DefaultObserver<Long>() {
 

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableEventStream.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableEventStream.java
@@ -33,7 +33,7 @@ public final class ObservableEventStream {
     }
 
     public static Event randomEvent(String type, int numInstances) {
-        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        Map<String, Object> values = new LinkedHashMap<>();
         values.put("count200", randomIntFrom0to(4000));
         values.put("count4xx", randomIntFrom0to(300));
         values.put("count5xx", randomIntFrom0to(500));

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
@@ -289,10 +289,10 @@ public class ObservableNullTests extends RxJavaTest {
 
     @Test
     public void fromFutureReturnsNull() {
-        FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         f.run();
 
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         Observable.fromFuture(f).subscribe(to);
         to.assertNoValues();
         to.assertNotComplete();
@@ -306,24 +306,24 @@ public class ObservableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedUnitNull() {
-        Observable.fromFuture(new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null), 1, null);
+        Observable.fromFuture(new FutureTask<>(Functions.EMPTY_RUNNABLE, null), 1, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedSchedulerNull() {
-        Observable.fromFuture(new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null), 1, TimeUnit.SECONDS, null);
+        Observable.fromFuture(new FutureTask<>(Functions.EMPTY_RUNNABLE, null), 1, TimeUnit.SECONDS, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedReturnsNull() {
-        FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         f.run();
         Observable.fromFuture(f, 1, TimeUnit.SECONDS).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void fromFutureSchedulerNull() {
-        FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         Observable.fromFuture(f, null);
     }
 
@@ -2385,7 +2385,7 @@ public class ObservableNullTests extends RxJavaTest {
         }, new Supplier<Map<Integer, Collection<Integer>>>() {
             @Override
             public Map<Integer, Collection<Integer>> get() {
-                return new HashMap<Integer, Collection<Integer>>();
+                return new HashMap<>();
             }
         }, null);
     }
@@ -2405,7 +2405,7 @@ public class ObservableNullTests extends RxJavaTest {
         }, new Supplier<Map<Integer, Collection<Integer>>>() {
             @Override
             public Map<Integer, Collection<Integer>> get() {
-                return new HashMap<Integer, Collection<Integer>>();
+                return new HashMap<>();
             }
         }, new Function<Integer, Collection<Integer>>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableScanTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableScanTests.java
@@ -27,7 +27,7 @@ public class ObservableScanTests extends RxJavaTest {
     public void unsubscribeScan() throws Exception {
 
         ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
-        .scan(new HashMap<String, String>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
+        .scan(new HashMap<>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
             @Override
             public HashMap<String, String> apply(HashMap<String, String> accum, Event perInstanceEvent) {
                 accum.put("instance", perInstanceEvent.instanceId);

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableStartWithTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableStartWithTests.java
@@ -35,7 +35,7 @@ public class ObservableStartWithTests extends RxJavaTest {
 
     @Test
     public void startWithIterable() {
-        List<String> li = new ArrayList<String>();
+        List<String> li = new ArrayList<>();
         li.add("alpha");
         li.add("beta");
         List<String> values = Observable.just("one", "two").startWithIterable(li).toList().blockingGet();
@@ -48,7 +48,7 @@ public class ObservableStartWithTests extends RxJavaTest {
 
     @Test
     public void startWithObservable() {
-        List<String> li = new ArrayList<String>();
+        List<String> li = new ArrayList<>();
         li.add("alpha");
         li.add("beta");
         List<String> values = Observable.just("one", "two")

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableSubscriberTest.java
@@ -128,7 +128,7 @@ public class ObservableSubscriberTest extends RxJavaTest {
 
     @Test
     public void subscribeConsumerConsumer() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Observable.just(1).subscribe(new Consumer<Integer>() {
             @Override
@@ -147,7 +147,7 @@ public class ObservableSubscriberTest extends RxJavaTest {
 
     @Test
     public void subscribeConsumerConsumerWithError() {
-        final List<Integer> list = new ArrayList<Integer>();
+        final List<Integer> list = new ArrayList<>();
 
         Observable.<Integer>error(new TestException()).subscribe(new Consumer<Integer>() {
             @Override
@@ -175,8 +175,8 @@ public class ObservableSubscriberTest extends RxJavaTest {
 
     @Test
     public void safeSubscriberAlreadySafe() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
-        Observable.just(1).safeSubscribe(new SafeObserver<Integer>(to));
+        TestObserver<Integer> to = new TestObserver<>();
+        Observable.just(1).safeSubscribe(new SafeObserver<>(to));
 
         to.assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableTest.java
@@ -66,7 +66,7 @@ public class ObservableTest extends RxJavaTest {
 
     @Test
     public void fromIterable() {
-        ArrayList<String> items = new ArrayList<String>();
+        ArrayList<String> items = new ArrayList<>();
         items.add("one");
         items.add("two");
         items.add("three");
@@ -367,7 +367,7 @@ public class ObservableTest extends RxJavaTest {
     public void customObservableWithErrorInObserverAsynchronous() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger count = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         // FIXME custom built???
         Observable.just("1", "2", "three", "4")
@@ -415,7 +415,7 @@ public class ObservableTest extends RxJavaTest {
     @Test
     public void customObservableWithErrorInObserverSynchronous() {
         final AtomicInteger count = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
         // FIXME custom built???
         Observable.just("1", "2", "three", "4")
@@ -458,7 +458,7 @@ public class ObservableTest extends RxJavaTest {
     @Test
     public void customObservableWithErrorInObservableSynchronous() {
         final AtomicInteger count = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
         // FIXME custom built???
         Observable.just("1", "2").concatWith(Observable.<String>error(new Supplier<Throwable>() {
             @Override
@@ -678,7 +678,7 @@ public class ObservableTest extends RxJavaTest {
     @Test
     public void takeWithErrorInObserver() {
         final AtomicInteger count = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
         Observable.just("1", "2", "three", "4").take(3)
         .safeSubscribe(new DefaultObserver<String>() {
 
@@ -729,9 +729,9 @@ public class ObservableTest extends RxJavaTest {
 
     @Test
     public void ofTypeWithPolymorphism() {
-        ArrayList<Integer> l1 = new ArrayList<Integer>();
+        ArrayList<Integer> l1 = new ArrayList<>();
         l1.add(1);
-        LinkedList<Integer> l2 = new LinkedList<Integer>();
+        LinkedList<Integer> l2 = new LinkedList<>();
         l2.add(2);
 
         @SuppressWarnings("rawtypes")
@@ -921,21 +921,21 @@ public class ObservableTest extends RxJavaTest {
 
     @Test
     public void mergeWith() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.just(1).mergeWith(Observable.just(2)).subscribe(to);
         to.assertValues(1, 2);
     }
 
     @Test
     public void concatWith() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.just(1).concatWith(Observable.just(2)).subscribe(to);
         to.assertValues(1, 2);
     }
 
     @Test
     public void ambWith() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
         Observable.just(1).ambWith(Observable.just(2)).subscribe(to);
         to.assertValue(1);
     }
@@ -967,7 +967,7 @@ public class ObservableTest extends RxJavaTest {
 
     @Test
     public void compose() {
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
 
         Observable.just(1, 2, 3).compose(new ObservableTransformer<Integer, String>() {
             @Override
@@ -1048,7 +1048,7 @@ public class ObservableTest extends RxJavaTest {
 
     @Test
     public void extend() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
         final Object value = new Object();
         Object returned = Observable.just(value).to(new ObservableConverter<Object, Object>() {
             @Override
@@ -1065,7 +1065,7 @@ public class ObservableTest extends RxJavaTest {
 
     @Test
     public void asExtend() {
-        final TestObserver<Object> to = new TestObserver<Object>();
+        final TestObserver<Object> to = new TestObserver<>();
         final Object value = new Object();
         Object returned = Observable.just(value).to(new ObservableConverter<Object, Object>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableWindowTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableWindowTests.java
@@ -31,7 +31,7 @@ public class ObservableWindowTests extends RxJavaTest {
 
     @Test
     public void window() {
-        final ArrayList<List<Integer>> lists = new ArrayList<List<Integer>>();
+        final ArrayList<List<Integer>> lists = new ArrayList<>();
 
         Observable.concat(
             Observable.just(1, 2, 3, 4, 5, 6)

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableZipTests.java
@@ -41,7 +41,7 @@ public class ObservableZipTests extends RxJavaTest {
                 .flatMap(new Function<GroupedObservable<String, Event>, Observable<HashMap<String, String>>>() {
                     @Override
                     public Observable<HashMap<String, String>> apply(final GroupedObservable<String, Event> ge) {
-                            return ge.scan(new HashMap<String, String>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
+                            return ge.scan(new HashMap<>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
                                 @Override
                                 public HashMap<String, String> apply(HashMap<String, String> accum,
                                         Event perInstanceEvent) {

--- a/src/test/java/io/reactivex/rxjava3/observers/DisposableCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/DisposableCompletableObserverTest.java
@@ -33,7 +33,7 @@ public class DisposableCompletableObserverTest extends RxJavaTest {
 
         int complete;
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         @Override
         protected void onStart() {

--- a/src/test/java/io/reactivex/rxjava3/observers/DisposableMaybeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/DisposableMaybeObserverTest.java
@@ -31,9 +31,9 @@ public class DisposableMaybeObserverTest extends RxJavaTest {
 
         int start;
 
-        final List<T> values = new ArrayList<T>();
+        final List<T> values = new ArrayList<>();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         int complete;
 
@@ -62,7 +62,7 @@ public class DisposableMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestMaybe<Integer> tc = new TestMaybe<Integer>();
+        TestMaybe<Integer> tc = new TestMaybe<>();
 
         assertFalse(tc.isDisposed());
         assertEquals(0, tc.start);
@@ -85,7 +85,7 @@ public class DisposableMaybeObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestMaybe<Integer> tc = new TestMaybe<Integer>();
+            TestMaybe<Integer> tc = new TestMaybe<>();
 
             tc.onSubscribe(Disposable.empty());
 
@@ -105,7 +105,7 @@ public class DisposableMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestMaybe<Integer> tc = new TestMaybe<Integer>();
+        TestMaybe<Integer> tc = new TestMaybe<>();
         tc.dispose();
 
         assertTrue(tc.isDisposed());

--- a/src/test/java/io/reactivex/rxjava3/observers/DisposableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/DisposableObserverTest.java
@@ -32,9 +32,9 @@ public class DisposableObserverTest extends RxJavaTest {
 
         int start;
 
-        final List<T> values = new ArrayList<T>();
+        final List<T> values = new ArrayList<>();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         int completions;
 
@@ -63,7 +63,7 @@ public class DisposableObserverTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestDisposableObserver<Integer> tc = new TestDisposableObserver<Integer>();
+        TestDisposableObserver<Integer> tc = new TestDisposableObserver<>();
 
         assertFalse(tc.isDisposed());
         assertEquals(0, tc.start);
@@ -84,7 +84,7 @@ public class DisposableObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestDisposableObserver<Integer> tc = new TestDisposableObserver<Integer>();
+            TestDisposableObserver<Integer> tc = new TestDisposableObserver<>();
 
             tc.onSubscribe(Disposable.empty());
 
@@ -104,7 +104,7 @@ public class DisposableObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestDisposableObserver<Integer> tc = new TestDisposableObserver<Integer>();
+        TestDisposableObserver<Integer> tc = new TestDisposableObserver<>();
 
         assertFalse(tc.isDisposed());
 

--- a/src/test/java/io/reactivex/rxjava3/observers/DisposableSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/DisposableSingleObserverTest.java
@@ -31,9 +31,9 @@ public class DisposableSingleObserverTest extends RxJavaTest {
 
         int start;
 
-        final List<T> values = new ArrayList<T>();
+        final List<T> values = new ArrayList<>();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         @Override
         protected void onStart() {
@@ -56,7 +56,7 @@ public class DisposableSingleObserverTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestSingle<Integer> tc = new TestSingle<Integer>();
+        TestSingle<Integer> tc = new TestSingle<>();
 
         assertFalse(tc.isDisposed());
         assertEquals(0, tc.start);
@@ -77,7 +77,7 @@ public class DisposableSingleObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestSingle<Integer> tc = new TestSingle<Integer>();
+            TestSingle<Integer> tc = new TestSingle<>();
 
             tc.onSubscribe(Disposable.empty());
 
@@ -97,7 +97,7 @@ public class DisposableSingleObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestSingle<Integer> tc = new TestSingle<Integer>();
+        TestSingle<Integer> tc = new TestSingle<>();
         tc.dispose();
 
         assertTrue(tc.isDisposed());

--- a/src/test/java/io/reactivex/rxjava3/observers/ResourceCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/ResourceCompletableObserverTest.java
@@ -28,7 +28,7 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class ResourceCompletableObserverTest extends RxJavaTest {
     static final class TestResourceCompletableObserver extends ResourceCompletableObserver {
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         int complete;
 

--- a/src/test/java/io/reactivex/rxjava3/observers/ResourceMaybeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/ResourceMaybeObserverTest.java
@@ -30,7 +30,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
     static final class TestResourceMaybeObserver<T> extends ResourceMaybeObserver<T> {
         T value;
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         int complete;
 
@@ -67,13 +67,13 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
         rmo.add(null);
     }
 
     @Test
     public void addResources() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
 
@@ -98,7 +98,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void onCompleteCleansUp() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
 
@@ -117,7 +117,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void onSuccessCleansUp() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
 
@@ -136,7 +136,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
 
@@ -155,7 +155,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
         assertEquals(0, rmo.start);
@@ -173,7 +173,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void empty() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
         assertEquals(0, rmo.start);
@@ -191,7 +191,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void error() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
         assertEquals(0, rmo.start);
@@ -215,7 +215,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+            TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
             rmo.onSubscribe(Disposable.empty());
 
@@ -235,7 +235,7 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<Integer>();
+        TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
         rmo.dispose();
 
         Disposable d = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava3/observers/ResourceObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/ResourceObserverTest.java
@@ -30,9 +30,9 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 public class ResourceObserverTest extends RxJavaTest {
 
     static final class TestResourceObserver<T> extends ResourceObserver<T> {
-        final List<T> values = new ArrayList<T>();
+        final List<T> values = new ArrayList<>();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         int complete;
 
@@ -67,13 +67,13 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        TestResourceObserver<Integer> ro = new TestResourceObserver<Integer>();
+        TestResourceObserver<Integer> ro = new TestResourceObserver<>();
         ro.add(null);
     }
 
     @Test
     public void addResources() {
-        TestResourceObserver<Integer> ro = new TestResourceObserver<Integer>();
+        TestResourceObserver<Integer> ro = new TestResourceObserver<>();
 
         assertFalse(ro.isDisposed());
 
@@ -98,7 +98,7 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test
     public void onCompleteCleansUp() {
-        TestResourceObserver<Integer> ro = new TestResourceObserver<Integer>();
+        TestResourceObserver<Integer> ro = new TestResourceObserver<>();
 
         assertFalse(ro.isDisposed());
 
@@ -117,7 +117,7 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        TestResourceObserver<Integer> ro = new TestResourceObserver<Integer>();
+        TestResourceObserver<Integer> ro = new TestResourceObserver<>();
 
         assertFalse(ro.isDisposed());
 
@@ -136,7 +136,7 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestResourceObserver<Integer> tc = new TestResourceObserver<Integer>();
+        TestResourceObserver<Integer> tc = new TestResourceObserver<>();
 
         assertFalse(tc.isDisposed());
         assertEquals(0, tc.start);
@@ -153,7 +153,7 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test
     public void error() {
-        TestResourceObserver<Integer> tc = new TestResourceObserver<Integer>();
+        TestResourceObserver<Integer> tc = new TestResourceObserver<>();
 
         assertFalse(tc.isDisposed());
         assertEquals(0, tc.start);
@@ -176,7 +176,7 @@ public class ResourceObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestResourceObserver<Integer> tc = new TestResourceObserver<Integer>();
+            TestResourceObserver<Integer> tc = new TestResourceObserver<>();
 
             tc.onSubscribe(Disposable.empty());
 
@@ -196,7 +196,7 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestResourceObserver<Integer> tc = new TestResourceObserver<Integer>();
+        TestResourceObserver<Integer> tc = new TestResourceObserver<>();
         tc.dispose();
 
         Disposable d = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava3/observers/ResourceSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/ResourceSingleObserverTest.java
@@ -30,7 +30,7 @@ public class ResourceSingleObserverTest extends RxJavaTest {
     static final class TestResourceSingleObserver<T> extends ResourceSingleObserver<T> {
         T value;
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         int start;
 
@@ -58,13 +58,13 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<Integer>();
+        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
         rso.add(null);
     }
 
     @Test
     public void addResources() {
-        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<Integer>();
+        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
         assertFalse(rso.isDisposed());
 
@@ -89,7 +89,7 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test
     public void onSuccessCleansUp() {
-        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<Integer>();
+        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
         assertFalse(rso.isDisposed());
 
@@ -108,7 +108,7 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<Integer>();
+        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
         assertFalse(rso.isDisposed());
 
@@ -127,7 +127,7 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<Integer>();
+        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
         assertFalse(rso.isDisposed());
         assertEquals(0, rso.start);
@@ -144,7 +144,7 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test
     public void error() {
-        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<Integer>();
+        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
         assertFalse(rso.isDisposed());
         assertEquals(0, rso.start);
@@ -167,7 +167,7 @@ public class ResourceSingleObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<Integer>();
+            TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
             rso.onSubscribe(Disposable.empty());
 
@@ -187,7 +187,7 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<Integer>();
+        TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
         rso.dispose();
 
         Disposable d = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava3/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SafeObserverTest.java
@@ -30,7 +30,7 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onNextFailure() {
-        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        AtomicReference<Throwable> onError = new AtomicReference<>();
         try {
             OBSERVER_ONNEXT_FAIL(onError).onNext("one");
             fail("expects exception to be thrown");
@@ -43,9 +43,9 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onNextFailureSafe() {
-        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        AtomicReference<Throwable> onError = new AtomicReference<>();
         try {
-            SafeObserver<String> safeObserver = new SafeObserver<String>(OBSERVER_ONNEXT_FAIL(onError));
+            SafeObserver<String> safeObserver = new SafeObserver<>(OBSERVER_ONNEXT_FAIL(onError));
             safeObserver.onSubscribe(Disposable.empty());
             safeObserver.onNext("one");
             assertNotNull(onError.get());
@@ -58,7 +58,7 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onCompleteFailure() {
-        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        AtomicReference<Throwable> onError = new AtomicReference<>();
         try {
             OBSERVER_ONCOMPLETED_FAIL(onError).onComplete();
             fail("expects exception to be thrown");
@@ -198,16 +198,16 @@ public class SafeObserverTest extends RxJavaTest {
             public void onComplete() {
             }
         };
-        SafeObserver<Integer> observer = new SafeObserver<Integer>(actual);
+        SafeObserver<Integer> observer = new SafeObserver<>(actual);
 
         assertSame(actual, observer.downstream);
     }
 
     @Test
     public void dispose() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
+        SafeObserver<Integer> so = new SafeObserver<>(to);
 
         Disposable d = Disposable.empty();
 
@@ -222,9 +222,9 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onNextAfterComplete() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
+        SafeObserver<Integer> so = new SafeObserver<>(to);
 
         Disposable d = Disposable.empty();
 
@@ -243,9 +243,9 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onNextNull() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
+        SafeObserver<Integer> so = new SafeObserver<>(to);
 
         Disposable d = Disposable.empty();
 
@@ -258,9 +258,9 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onNextWithoutOnSubscribe() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
+        SafeObserver<Integer> so = new SafeObserver<>(to);
 
         so.onNext(1);
 
@@ -269,9 +269,9 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorWithoutOnSubscribe() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
+        SafeObserver<Integer> so = new SafeObserver<>(to);
 
         so.onError(new TestException());
 
@@ -283,9 +283,9 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onCompleteWithoutOnSubscribe() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
+        SafeObserver<Integer> so = new SafeObserver<>(to);
 
         so.onComplete();
 
@@ -294,9 +294,9 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void onNextNormal() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
-        SafeObserver<Integer> so = new SafeObserver<Integer>(to);
+        SafeObserver<Integer> so = new SafeObserver<>(to);
 
         Disposable d = Disposable.empty();
 
@@ -369,7 +369,7 @@ public class SafeObserverTest extends RxJavaTest {
         }
 
         public SafeObserver<Object> toSafe() {
-            return new SafeObserver<Object>(this);
+            return new SafeObserver<>(this);
         }
 
         public CrashDummy assertError(Class<? extends Throwable> clazz) {

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -41,7 +41,7 @@ public class SerializedObserverTest extends RxJavaTest {
     }
 
     private Observer<String> serializedObserver(Observer<String> o) {
-        return new SerializedObserver<String>(o);
+        return new SerializedObserver<>(o);
     }
 
     @Test
@@ -163,7 +163,7 @@ public class SerializedObserverTest extends RxJavaTest {
         try {
             TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
             // we need Synchronized + SafeObserver to handle synchronization plus life-cycle
-            Observer<String> w = serializedObserver(new SafeObserver<String>(tw));
+            Observer<String> w = serializedObserver(new SafeObserver<>(tw));
 
             Future<?> f1 = tp.submit(new OnNextThread(w, 12000));
             Future<?> f2 = tp.submit(new OnNextThread(w, 5000));
@@ -219,7 +219,7 @@ public class SerializedObserverTest extends RxJavaTest {
         try {
             TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
             // we need Synchronized + SafeObserver to handle synchronization plus life-cycle
-            Observer<String> w = serializedObserver(new SafeObserver<String>(tw));
+            Observer<String> w = serializedObserver(new SafeObserver<>(tw));
             w.onSubscribe(Disposable.empty());
 
             Future<?> f1 = tp.submit(new OnNextThread(w, 12000));
@@ -275,7 +275,7 @@ public class SerializedObserverTest extends RxJavaTest {
                 final CountDownLatch latch = new CountDownLatch(1);
                 final CountDownLatch running = new CountDownLatch(2);
 
-                TestObserverEx<String> to = new TestObserverEx<String>(new DefaultObserver<String>() {
+                TestObserverEx<String> to = new TestObserverEx<>(new DefaultObserver<String>() {
 
                     @Override
                     public void onComplete() {
@@ -356,7 +356,7 @@ public class SerializedObserverTest extends RxJavaTest {
     @Test
     public void threadStarvation() throws InterruptedException {
 
-        TestObserver<String> to = new TestObserver<String>(new DefaultObserver<String>() {
+        TestObserver<String> to = new TestObserver<>(new DefaultObserver<String>() {
 
             @Override
             public void onComplete() {
@@ -552,7 +552,7 @@ public class SerializedObserverTest extends RxJavaTest {
         /**
          * used to store the order and number of events received.
          */
-        private final LinkedBlockingQueue<TestConcurrencySubscriberEvent> events = new LinkedBlockingQueue<TestConcurrencySubscriberEvent>();
+        private final LinkedBlockingQueue<TestConcurrencySubscriberEvent> events = new LinkedBlockingQueue<>();
         private final int waitTime;
 
         @SuppressWarnings("unused")
@@ -848,7 +848,7 @@ public class SerializedObserverTest extends RxJavaTest {
     public void errorReentry() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
+            final AtomicReference<Observer<Integer>> serial = new AtomicReference<>();
 
             TestObserver<Integer> to = new TestObserver<Integer>() {
                 @Override
@@ -858,7 +858,7 @@ public class SerializedObserverTest extends RxJavaTest {
                     super.onNext(v);
                 }
             };
-            SerializedObserver<Integer> sobs = new SerializedObserver<Integer>(to);
+            SerializedObserver<Integer> sobs = new SerializedObserver<>(to);
             sobs.onSubscribe(Disposable.empty());
             serial.set(sobs);
 
@@ -875,7 +875,7 @@ public class SerializedObserverTest extends RxJavaTest {
 
     @Test
     public void completeReentry() {
-        final AtomicReference<Observer<Integer>> serial = new AtomicReference<Observer<Integer>>();
+        final AtomicReference<Observer<Integer>> serial = new AtomicReference<>();
 
         TestObserver<Integer> to = new TestObserver<Integer>() {
             @Override
@@ -885,7 +885,7 @@ public class SerializedObserverTest extends RxJavaTest {
                 super.onNext(v);
             }
         };
-        SerializedObserver<Integer> sobs = new SerializedObserver<Integer>(to);
+        SerializedObserver<Integer> sobs = new SerializedObserver<>(to);
         sobs.onSubscribe(Disposable.empty());
         serial.set(sobs);
 
@@ -898,9 +898,9 @@ public class SerializedObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
-        SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
+        SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
         Disposable d = Disposable.empty();
 
@@ -918,9 +918,9 @@ public class SerializedObserverTest extends RxJavaTest {
     @Test
     public void onCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
+            final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
             Disposable d = Disposable.empty();
 
@@ -944,9 +944,9 @@ public class SerializedObserverTest extends RxJavaTest {
     @Test
     public void onNextOnCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
+            final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
             Disposable d = Disposable.empty();
 
@@ -980,9 +980,9 @@ public class SerializedObserverTest extends RxJavaTest {
     @Test
     public void onNextOnErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
+            final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
             Disposable d = Disposable.empty();
 
@@ -1018,9 +1018,9 @@ public class SerializedObserverTest extends RxJavaTest {
     @Test
     public void onNextOnErrorRaceDelayError() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to, true);
+            final SerializedObserver<Integer> so = new SerializedObserver<>(to, true);
 
             Disposable d = Disposable.empty();
 
@@ -1059,9 +1059,9 @@ public class SerializedObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
-            final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
+            final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
             so.onSubscribe(Disposable.empty());
 
@@ -1083,9 +1083,9 @@ public class SerializedObserverTest extends RxJavaTest {
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+                TestObserverEx<Integer> to = new TestObserverEx<>();
 
-                final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
+                final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
                 Disposable d = Disposable.empty();
 
@@ -1130,9 +1130,9 @@ public class SerializedObserverTest extends RxJavaTest {
     @Test
     public void nullOnNext() {
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        final SerializedObserver<Integer> so = new SerializedObserver<Integer>(to);
+        final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
         Disposable d = Disposable.empty();
 

--- a/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
@@ -46,7 +46,7 @@ public class TestObserverTest extends RxJavaTest {
     @Test
     public void assertTestObserver() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
         oi.subscribe(subscriber);
 
         subscriber.assertValues(1, 2);
@@ -57,7 +57,7 @@ public class TestObserverTest extends RxJavaTest {
     @Test
     public void assertNotMatchCount() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
         oi.subscribe(subscriber);
 
         thrown.expect(AssertionError.class);
@@ -72,7 +72,7 @@ public class TestObserverTest extends RxJavaTest {
     @Test
     public void assertNotMatchValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
         oi.subscribe(subscriber);
 
         thrown.expect(AssertionError.class);
@@ -87,7 +87,7 @@ public class TestObserverTest extends RxJavaTest {
     @Test
     public void assertTerminalEventNotReceived() {
         PublishProcessor<Integer> p = PublishProcessor.create();
-        TestSubscriber<Integer> subscriber = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
         p.subscribe(subscriber);
 
         p.onNext(1);
@@ -108,7 +108,7 @@ public class TestObserverTest extends RxJavaTest {
 
         Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
 
-        oi.subscribe(new TestSubscriber<Integer>(mockSubscriber));
+        oi.subscribe(new TestSubscriber<>(mockSubscriber));
 
         InOrder inOrder = inOrder(mockSubscriber);
         inOrder.verify(mockSubscriber, times(1)).onNext(1);
@@ -121,7 +121,7 @@ public class TestObserverTest extends RxJavaTest {
     public void wrappingMockWhenUnsubscribeInvolved() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).take(2);
         Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
-        oi.subscribe(new TestSubscriber<Integer>(mockSubscriber));
+        oi.subscribe(new TestSubscriber<>(mockSubscriber));
 
         InOrder inOrder = inOrder(mockSubscriber);
         inOrder.verify(mockSubscriber, times(1)).onNext(1);
@@ -132,12 +132,12 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void errorSwallowed() {
-        Flowable.error(new RuntimeException()).subscribe(new TestSubscriber<Object>());
+        Flowable.error(new RuntimeException()).subscribe(new TestSubscriber<>());
     }
 
     @Test
     public void nullExpected() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onNext(1);
 
         try {
@@ -151,7 +151,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void nullActual() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onNext(null);
 
         try {
@@ -334,7 +334,7 @@ public class TestObserverTest extends RxJavaTest {
 
         to = TestObserver.create();
 
-        to.onSubscribe(new ScalarDisposable<Integer>(to, 1));
+        to.onSubscribe(new ScalarDisposable<>(to, 1));
     }
 
     @Test
@@ -645,7 +645,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertEmpty() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         try {
             to.assertEmpty();
@@ -670,7 +670,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void awaitDoneTimed() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Thread.currentThread().interrupt();
 
@@ -683,7 +683,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertErrorMultiple() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         TestException e = new TestException();
         to.onError(e);
@@ -711,7 +711,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void errorInPredicate() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
         to.onError(new RuntimeException());
         try {
             to.assertError(new Predicate<Throwable>() {
@@ -729,7 +729,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertComplete() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -756,7 +756,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void completeWithoutOnSubscribe() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         to.onComplete();
 
@@ -765,7 +765,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestObserver<Integer> to = new TestObserver<Integer>(new Observer<Integer>() {
+        TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -801,7 +801,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestObserver<Integer> to = new TestObserver<Integer>(new Observer<Integer>() {
+        TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -853,7 +853,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         Observable.empty().subscribe(to);
 
@@ -868,7 +868,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatch() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1).subscribe(to);
 
@@ -881,7 +881,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1).subscribe(to);
 
@@ -896,7 +896,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1, 2).subscribe(to);
 
@@ -911,7 +911,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         Observable.empty().subscribe(to);
 
@@ -926,7 +926,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateMatch() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1, 2).subscribe(to);
 
@@ -939,7 +939,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1, 2, 3).subscribe(to);
 
@@ -954,7 +954,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1, 2).subscribe(to);
 
@@ -969,7 +969,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexEmpty() {
-        TestObserver<Object> to = new TestObserver<Object>();
+        TestObserver<Object> to = new TestObserver<>();
 
         Observable.empty().subscribe(to);
 
@@ -980,7 +980,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexMatch() {
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.just("a", "b").subscribe(to);
 
@@ -989,7 +989,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.just("a", "b", "c").subscribe(to);
 
@@ -1000,7 +1000,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexInvalidIndex() {
-        TestObserver<String> to = new TestObserver<String>();
+        TestObserver<String> to = new TestObserver<>();
 
         Observable.just("a", "b").subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelCollectTest.java
@@ -35,7 +35,7 @@ public class ParallelCollectTest extends RxJavaTest {
         .collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -74,7 +74,7 @@ public class ParallelCollectTest extends RxJavaTest {
         .collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -99,7 +99,7 @@ public class ParallelCollectTest extends RxJavaTest {
         .collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -125,7 +125,7 @@ public class ParallelCollectTest extends RxJavaTest {
         .collect(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiConsumer<List<Integer>, Integer>() {
             @Override
@@ -147,7 +147,7 @@ public class ParallelCollectTest extends RxJavaTest {
             .collect(new Supplier<List<Object>>() {
                 @Override
                 public List<Object> get() throws Exception {
-                    return new ArrayList<Object>();
+                    return new ArrayList<>();
                 }
             }, new BiConsumer<List<Object>, Object>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelFlowableTest.java
@@ -49,7 +49,7 @@ public class ParallelFlowableTest extends RxJavaTest {
             .sequential()
             ;
 
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
             result.subscribe(ts);
 
@@ -77,7 +77,7 @@ public class ParallelFlowableTest extends RxJavaTest {
             .sequential()
             ;
 
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
             result.subscribe(ts);
 
@@ -113,7 +113,7 @@ public class ParallelFlowableTest extends RxJavaTest {
                 .sequential()
                 ;
 
-                TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+                TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
                 result.subscribe(ts);
 
@@ -154,7 +154,7 @@ public class ParallelFlowableTest extends RxJavaTest {
                 .sequential()
                 ;
 
-                TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+                TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
                 result.subscribe(ts);
 
@@ -176,7 +176,7 @@ public class ParallelFlowableTest extends RxJavaTest {
     @Test
     public void reduceFull() {
         for (int i = 1; i <= Runtime.getRuntime().availableProcessors() * 2; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.range(1, 10)
             .parallel(i)
@@ -205,7 +205,7 @@ public class ParallelFlowableTest extends RxJavaTest {
                 Scheduler scheduler = Schedulers.from(exec);
 
                 try {
-                    TestSubscriber<Long> ts = new TestSubscriber<Long>();
+                    TestSubscriber<Long> ts = new TestSubscriber<>();
 
                     Flowable.range(1, n)
                     .map(new Function<Integer, Long>() {
@@ -239,7 +239,7 @@ public class ParallelFlowableTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void toSortedList() {
-        TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+        TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         Flowable.fromArray(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
         .parallel()
@@ -251,7 +251,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
     @Test
     public void sorted() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0);
 
         Flowable.fromArray(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
         .parallel()
@@ -278,11 +278,11 @@ public class ParallelFlowableTest extends RxJavaTest {
         Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         };
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         Flowable.range(1, 10)
         .parallel()
         .collect(as, new BiConsumer<List<Integer>, Integer>() {
@@ -310,7 +310,7 @@ public class ParallelFlowableTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void from() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ParallelFlowable.fromArray(Flowable.range(1, 5), Flowable.range(6, 5))
         .sequential()
@@ -325,7 +325,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
     @Test
     public void concatMapUnordered() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.range(1, 5)
         .parallel()
@@ -347,7 +347,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
     @Test
     public void flatMapUnordered() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.range(1, 5)
         .parallel()
@@ -377,10 +377,10 @@ public class ParallelFlowableTest extends RxJavaTest {
             Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
                 public List<Integer> get() throws Exception {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             };
-            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000)
             .parallel(3)
@@ -424,10 +424,10 @@ public class ParallelFlowableTest extends RxJavaTest {
             Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
                 public List<Integer> get() throws Exception {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             };
-            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000).hide()
             .parallel(3)
@@ -471,10 +471,10 @@ public class ParallelFlowableTest extends RxJavaTest {
             Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
                 public List<Integer> get() throws Exception {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             };
-            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000).hide()
             .observeOn(s)
@@ -519,10 +519,10 @@ public class ParallelFlowableTest extends RxJavaTest {
             Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
                 public List<Integer> get() throws Exception {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             };
-            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000).hide()
             .observeOn(s)
@@ -567,10 +567,10 @@ public class ParallelFlowableTest extends RxJavaTest {
             Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
                 public List<Integer> get() throws Exception {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             };
-            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000)
             .observeOn(s)
@@ -615,10 +615,10 @@ public class ParallelFlowableTest extends RxJavaTest {
             Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
                 public List<Integer> get() throws Exception {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             };
-            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000)
             .take(1000)
@@ -664,10 +664,10 @@ public class ParallelFlowableTest extends RxJavaTest {
             Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
                 @Override
                 public List<Integer> get() throws Exception {
-                    return new ArrayList<Integer>();
+                    return new ArrayList<>();
                 }
             };
-            TestSubscriber<List<Integer>> ts = new TestSubscriber<List<Integer>>();
+            TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             UnicastProcessor<Integer> up = UnicastProcessor.create();
 
@@ -711,7 +711,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
     @Test
     public void emptySourceZeroRequest() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(0);
+        TestSubscriber<Object> ts = new TestSubscriber<>(0);
 
         Flowable.range(1, 3).parallel(3).sequential().subscribe(ts);
 
@@ -762,7 +762,7 @@ public class ParallelFlowableTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void badParallelismStage() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 10)
         .parallel(2)
@@ -774,9 +774,9 @@ public class ParallelFlowableTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void badParallelismStage2() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
-        TestSubscriber<Integer> ts3 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>();
+        TestSubscriber<Integer> ts3 = new TestSubscriber<>();
 
         Flowable.range(1, 10)
         .parallel(2)
@@ -1305,7 +1305,7 @@ public class ParallelFlowableTest extends RxJavaTest {
         TestSubscriber<Object>[] consumers = new TestSubscriber[n + 1];
 
         for (int i = 0; i <= n; i++) {
-            consumers[i] = new TestSubscriber<Object>();
+            consumers[i] = new TestSubscriber<>();
         }
 
         source.subscribe(consumers);
@@ -1323,7 +1323,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
     @Test
     public void mergeBiFunction() throws Exception {
-        MergerBiFunction<Integer> f = new MergerBiFunction<Integer>(Functions.<Integer>naturalComparator());
+        MergerBiFunction<Integer> f = new MergerBiFunction<>(Functions.<Integer>naturalComparator());
 
         assertEquals(0, f.apply(Collections.<Integer>emptyList(), Collections.<Integer>emptyList()).size());
 
@@ -1331,12 +1331,12 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         for (int i = 0; i < 4; i++) {
             int k = 0;
-            List<Integer> list1 = new ArrayList<Integer>();
+            List<Integer> list1 = new ArrayList<>();
             for (int j = 0; j < i; j++) {
                 list1.add(k++);
             }
 
-            List<Integer> list2 = new ArrayList<Integer>();
+            List<Integer> list2 = new ArrayList<>();
             for (int j = i; j < 4; j++) {
                 list2.add(k++);
             }

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelFromPublisherTest.java
@@ -71,12 +71,12 @@ public class ParallelFromPublisherTest extends RxJavaTest {
 
         @Override
         public Publisher<T> apply(Flowable<T> upstream) {
-            return new StripBoundary<T>(upstream);
+            return new StripBoundary<>(upstream);
         }
 
         @Override
         protected void subscribeActual(Subscriber<? super T> s) {
-            source.subscribe(new StripBoundarySubscriber<T>(s));
+            source.subscribe(new StripBoundarySubscriber<>(s));
         }
 
         static final class StripBoundarySubscriber<T> extends BasicFuseableSubscriber<T, T> {
@@ -117,7 +117,7 @@ public class ParallelFromPublisherTest extends RxJavaTest {
                 throw new TestException();
             }
         })
-        .compose(new StripBoundary<Object>(null))
+        .compose(new StripBoundary<>(null))
         .parallel()
         .sequential()
         .test()
@@ -137,7 +137,7 @@ public class ParallelFromPublisherTest extends RxJavaTest {
                 throw new TestException();
             }
         })
-        .compose(new StripBoundary<Object>(null))
+        .compose(new StripBoundary<>(null))
         .parallel()
         .sequential()
         .test()
@@ -148,8 +148,8 @@ public class ParallelFromPublisherTest extends RxJavaTest {
 
     @Test
     public void boundaryConfinement() {
-        final Set<String> between = new HashSet<String>();
-        final ConcurrentHashMap<String, String> processing = new ConcurrentHashMap<String, String>();
+        final Set<String> between = new HashSet<>();
+        final ConcurrentHashMap<String, String> processing = new ConcurrentHashMap<>();
 
         TestSubscriberEx<Object> ts = Flowable.range(1, 10)
         .observeOn(Schedulers.single(), false, 1)

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelReduceTest.java
@@ -35,7 +35,7 @@ public class ParallelReduceTest extends RxJavaTest {
         .reduce(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
             @Override
@@ -76,7 +76,7 @@ public class ParallelReduceTest extends RxJavaTest {
         .reduce(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
             @Override
@@ -102,7 +102,7 @@ public class ParallelReduceTest extends RxJavaTest {
         .reduce(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
             @Override
@@ -129,7 +129,7 @@ public class ParallelReduceTest extends RxJavaTest {
         .reduce(new Supplier<List<Integer>>() {
             @Override
             public List<Integer> get() throws Exception {
-                return new ArrayList<Integer>();
+                return new ArrayList<>();
             }
         }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
             @Override
@@ -152,7 +152,7 @@ public class ParallelReduceTest extends RxJavaTest {
             .reduce(new Supplier<List<Object>>() {
                 @Override
                 public List<Object> get() throws Exception {
-                    return new ArrayList<Object>();
+                    return new ArrayList<>();
                 }
             }, new BiFunction<List<Object>, Object, List<Object>>() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelRunOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelRunOnTest.java
@@ -135,7 +135,7 @@ public class ParallelRunOnTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void errorConditionalBackpressured() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
+        TestSubscriber<Object> ts = new TestSubscriber<>(0L);
 
         Flowable.error(new TestException())
         .parallel(1)
@@ -150,7 +150,7 @@ public class ParallelRunOnTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void emptyConditionalBackpressured() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(0L);
+        TestSubscriber<Object> ts = new TestSubscriber<>(0L);
 
         Flowable.empty()
         .parallel(1)

--- a/src/test/java/io/reactivex/rxjava3/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava3/plugins/RxJavaPluginsTest.java
@@ -599,7 +599,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
             RxJavaPlugins.setOnSingleAssembly(new Function<Single, Single>() {
                 @Override
                 public Single apply(Single t) {
-                    return new SingleJust<Integer>(10);
+                    return new SingleJust<>(10);
                 }
             });
 
@@ -806,7 +806,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void onError() {
         try {
-            final List<Throwable> list = new ArrayList<Throwable>();
+            final List<Throwable> list = new ArrayList<>();
 
             RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
                 @Override
@@ -827,7 +827,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void onErrorNoHandler() {
         try {
-            final List<Throwable> list = new ArrayList<Throwable>();
+            final List<Throwable> list = new ArrayList<>();
 
             RxJavaPlugins.setErrorHandler(null);
 
@@ -858,7 +858,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void onErrorCrashes() {
         try {
-            final List<Throwable> list = new ArrayList<Throwable>();
+            final List<Throwable> list = new ArrayList<>();
 
             RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
                 @Override
@@ -893,7 +893,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void onErrorWithNull() {
         try {
-            final List<Throwable> list = new ArrayList<Throwable>();
+            final List<Throwable> list = new ArrayList<>();
 
             RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
                 @Override
@@ -1523,7 +1523,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void onErrorNull() {
         try {
-            final AtomicReference<Throwable> t = new AtomicReference<Throwable>();
+            final AtomicReference<Throwable> t = new AtomicReference<>();
 
             RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
                 @Override
@@ -1547,7 +1547,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
         assertNotNull(scheduler);
         Worker w = scheduler.createWorker();
         try {
-            final AtomicReference<Thread> value = new AtomicReference<Thread>();
+            final AtomicReference<Thread> value = new AtomicReference<>();
             final CountDownLatch cdl = new CountDownLatch(1);
 
             w.schedule(new Runnable() {
@@ -1703,7 +1703,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
             RxJavaPlugins.setOnParallelAssembly(new Function<ParallelFlowable, ParallelFlowable>() {
                 @Override
                 public ParallelFlowable apply(ParallelFlowable pf) throws Exception {
-                    return new ParallelFromPublisher<Integer>(Flowable.just(2), 2, 2);
+                    return new ParallelFromPublisher<>(Flowable.just(2), 2, 2);
                 }
             });
 

--- a/src/test/java/io/reactivex/rxjava3/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/AsyncProcessorTest.java
@@ -136,7 +136,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         processor.subscribe(ts);
 
         processor.onNext("one");
@@ -185,7 +185,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
          */
         for (int i = 0; i < 50; i++) {
             final AsyncProcessor<String> processor = AsyncProcessor.create();
-            final AtomicReference<String> value1 = new AtomicReference<String>();
+            final AtomicReference<String> value1 = new AtomicReference<>();
 
             processor.subscribe(new Consumer<String>() {
 
@@ -243,7 +243,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     private static class SubjectSubscriberThread extends Thread {
 
         private final AsyncProcessor<String> processor;
-        private final AtomicReference<String> value = new AtomicReference<String>();
+        private final AtomicReference<String> value = new AtomicReference<>();
 
         SubjectSubscriberThread(AsyncProcessor<String> processor) {
             this.processor = processor;
@@ -327,7 +327,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void fusionLive() {
-        AsyncProcessor<Integer> ap = new AsyncProcessor<Integer>();
+        AsyncProcessor<Integer> ap = new AsyncProcessor<>();
 
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
@@ -350,7 +350,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void fusionOfflie() {
-        AsyncProcessor<Integer> ap = new AsyncProcessor<Integer>();
+        AsyncProcessor<Integer> ap = new AsyncProcessor<>();
         ap.onNext(1);
         ap.onComplete();
 
@@ -461,7 +461,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void onNextCrossCancel() {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
-        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts2 = new TestSubscriber<>();
         TestSubscriber<Object> ts1 = new TestSubscriber<Object>() {
             @Override
             public void onNext(Object t) {
@@ -484,7 +484,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void onErrorCrossCancel() {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
-        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts2 = new TestSubscriber<>();
         TestSubscriber<Object> ts1 = new TestSubscriber<Object>() {
             @Override
             public void onError(Throwable t) {
@@ -506,7 +506,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void onCompleteCrossCancel() {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
-        final TestSubscriber<Object> ts2 = new TestSubscriber<Object>();
+        final TestSubscriber<Object> ts2 = new TestSubscriber<>();
         TestSubscriber<Object> ts1 = new TestSubscriber<Object>() {
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava3/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/BehaviorProcessorTest.java
@@ -137,7 +137,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         Subscriber<Object> observerB = TestHelper.mockSubscriber();
         Subscriber<Object> observerC = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(observerA);
+        TestSubscriber<Object> ts = new TestSubscriber<>(observerA);
 
         channel.subscribe(ts);
         channel.subscribe(observerB);
@@ -389,7 +389,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                     }
                 });
 
-                final AtomicReference<Object> o = new AtomicReference<Object>();
+                final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.io())
                 .subscribe(new DefaultSubscriber<Object>() {
@@ -715,7 +715,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorProcessor<Object> p = BehaviorProcessor.create();
 
-            final TestSubscriber<Object> ts = new TestSubscriber<Object>();
+            final TestSubscriber<Object> ts = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -742,7 +742,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorProcessor<Object> p = BehaviorProcessor.create();
 
-            final TestSubscriber<Object> ts = new TestSubscriber<Object>();
+            final TestSubscriber<Object> ts = new TestSubscriber<>();
 
             final TestException ex = new TestException();
 
@@ -804,9 +804,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         BehaviorProcessor<Integer> bp = BehaviorProcessor.create();
         bp.onNext(1);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        BehaviorSubscription<Integer> bs = new BehaviorSubscription<Integer>(ts, bp);
+        BehaviorSubscription<Integer> bs = new BehaviorSubscription<>(ts, bp);
         ts.onSubscribe(bs);
 
         assertFalse(bs.cancelled);
@@ -835,9 +835,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             BehaviorProcessor<Integer> bp = BehaviorProcessor.create();
             bp.onNext(1);
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            final BehaviorSubscription<Integer> bs = new BehaviorSubscription<Integer>(ts, bp);
+            final BehaviorSubscription<Integer> bs = new BehaviorSubscription<>(ts, bp);
             ts.onSubscribe(bs);
 
             Runnable r1 = new Runnable() {
@@ -864,9 +864,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             BehaviorProcessor<Integer> bp = BehaviorProcessor.create();
             bp.onNext(1);
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            final BehaviorSubscription<Integer> bs = new BehaviorSubscription<Integer>(ts, bp);
+            final BehaviorSubscription<Integer> bs = new BehaviorSubscription<>(ts, bp);
             ts.onSubscribe(bs);
 
             Runnable r1 = new Runnable() {
@@ -891,9 +891,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
         BehaviorProcessor<Integer> bp = BehaviorProcessor.create();
         bp.onNext(1);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final BehaviorSubscription<Integer> bs = new BehaviorSubscription<Integer>(ts, bp);
+        final BehaviorSubscription<Integer> bs = new BehaviorSubscription<>(ts, bp);
         ts.onSubscribe(bs);
 
         bs.emitting = true;
@@ -910,9 +910,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             BehaviorProcessor<Integer> bp = BehaviorProcessor.create();
             bp.onNext(1);
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            final BehaviorSubscription<Integer> bs = new BehaviorSubscription<Integer>(ts, bp);
+            final BehaviorSubscription<Integer> bs = new BehaviorSubscription<>(ts, bp);
             ts.onSubscribe(bs);
 
             bs.request(-1);

--- a/src/test/java/io/reactivex/rxjava3/processors/MulticastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/MulticastProcessorTest.java
@@ -229,7 +229,7 @@ public class MulticastProcessorTest extends RxJavaTest {
     @Test
     public void crossCancel() {
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
             @Override
@@ -257,7 +257,7 @@ public class MulticastProcessorTest extends RxJavaTest {
     @Test
     public void crossCancelError() {
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
             @Override
@@ -285,7 +285,7 @@ public class MulticastProcessorTest extends RxJavaTest {
     @Test
     public void crossCancelComplete() {
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
             @Override
@@ -314,7 +314,7 @@ public class MulticastProcessorTest extends RxJavaTest {
     @Test
     public void crossCancel1() {
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1);
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>(1);
 
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(1) {
             @Override
@@ -536,7 +536,7 @@ public class MulticastProcessorTest extends RxJavaTest {
             final MulticastProcessor<Integer> mp = MulticastProcessor.create();
 
             final TestSubscriber<Integer> ts = mp.test();
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -565,7 +565,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
             mp.test();
             final TestSubscriber<Integer> ts = mp.test();
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -593,7 +593,7 @@ public class MulticastProcessorTest extends RxJavaTest {
             final MulticastProcessor<Integer> mp = MulticastProcessor.create(true);
 
             final TestSubscriber<Integer> ts = mp.test();
-            final TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/PublishProcessorTest.java
@@ -69,7 +69,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         Subscriber<Object> observerB = TestHelper.mockSubscriber();
         Subscriber<Object> observerC = TestHelper.mockSubscriber();
 
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(observerA);
+        TestSubscriber<Object> ts = new TestSubscriber<>(observerA);
 
         channel.subscribe(ts);
         channel.subscribe(observerB);
@@ -178,7 +178,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         PublishProcessor<String> processor = PublishProcessor.create();
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         processor.subscribe(ts);
 
         processor.onNext("one");
@@ -213,7 +213,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         final AtomicInteger countChildren = new AtomicInteger();
         final AtomicInteger countTotal = new AtomicInteger();
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
 
         s.flatMap(new Function<Integer, Flowable<String>>() {
 
@@ -264,7 +264,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         Subscriber<Integer> subscriber1 = TestHelper.mockSubscriber();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(subscriber1);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(subscriber1);
         pp.subscribe(ts);
 
         // emit
@@ -282,7 +282,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
         pp.onNext(2);
 
         Subscriber<Integer> subscriber2 = TestHelper.mockSubscriber();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(subscriber2);
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(subscriber2);
         pp.subscribe(ts2);
 
         // emit
@@ -412,7 +412,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void crossCancel() {
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
@@ -435,7 +435,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void crossCancelOnError() {
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
             @Override
             public void onError(Throwable t) {
@@ -458,7 +458,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void crossCancelOnComplete() {
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -162,8 +162,8 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         });
 
         // used to collect results of each thread
-        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<List<Long>>());
-        final List<Thread> threads = Collections.synchronizedList(new ArrayList<Thread>());
+        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<>());
+        final List<Thread> threads = Collections.synchronizedList(new ArrayList<>());
 
         for (int i = 1; i <= 200; i++) {
             final int count = i;
@@ -196,7 +196,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         }
 
         // assert all threads got the same results
-        List<Long> sums = new ArrayList<Long>();
+        List<Long> sums = new ArrayList<>();
         for (List<Long> values : listOfListsOfValues) {
             long v = 0;
             for (long l : values) {
@@ -229,7 +229,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
     public void subscribeCompletionRaceCondition() {
         for (int i = 0; i < 50; i++) {
             final ReplayProcessor<String> processor = ReplayProcessor.createUnbounded();
-            final AtomicReference<String> value1 = new AtomicReference<String>();
+            final AtomicReference<String> value1 = new AtomicReference<>();
 
             processor.subscribe(new Consumer<String>() {
 
@@ -292,7 +292,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
     public void raceForTerminalState() {
         final List<Integer> expected = Arrays.asList(1);
         for (int i = 0; i < 100000; i++) {
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(ts);
             ts.awaitDone(5, TimeUnit.SECONDS);
             ts.assertValueSequence(expected);
@@ -303,7 +303,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
     private static class SubjectObserverThread extends Thread {
 
         private final ReplayProcessor<String> processor;
-        private final AtomicReference<String> value = new AtomicReference<String>();
+        private final AtomicReference<String> value = new AtomicReference<>();
 
         SubjectObserverThread(ReplayProcessor<String> processor) {
             this.processor = processor;
@@ -350,7 +350,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
                     }
                 });
 
-                final AtomicReference<Object> o = new AtomicReference<Object>();
+                final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs
 //                .doOnSubscribe(v -> System.out.println("!! " + j))

--- a/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorConcurrencyTest.java
@@ -162,8 +162,8 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
         });
 
         // used to collect results of each thread
-        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<List<Long>>());
-        final List<Thread> threads = Collections.synchronizedList(new ArrayList<Thread>());
+        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<>());
+        final List<Thread> threads = Collections.synchronizedList(new ArrayList<>());
 
         for (int i = 1; i <= 200; i++) {
             final int count = i;
@@ -196,7 +196,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
         }
 
         // assert all threads got the same results
-        List<Long> sums = new ArrayList<Long>();
+        List<Long> sums = new ArrayList<>();
         for (List<Long> values : listOfListsOfValues) {
             long v = 0;
             for (long l : values) {
@@ -229,7 +229,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
     public void subscribeCompletionRaceCondition() {
         for (int i = 0; i < 50; i++) {
             final ReplayProcessor<String> processor = ReplayProcessor.create();
-            final AtomicReference<String> value1 = new AtomicReference<String>();
+            final AtomicReference<String> value1 = new AtomicReference<>();
 
             processor.subscribe(new Consumer<String>() {
 
@@ -292,7 +292,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
     public void raceForTerminalState() {
         final List<Integer> expected = Arrays.asList(1);
         for (int i = 0; i < 100000; i++) {
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(ts);
             ts.awaitDone(5, TimeUnit.SECONDS);
             ts.assertValueSequence(expected);
@@ -303,7 +303,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
     static class SubjectObserverThread extends Thread {
 
         private final ReplayProcessor<String> processor;
-        private final AtomicReference<String> value = new AtomicReference<String>();
+        private final AtomicReference<String> value = new AtomicReference<>();
 
         SubjectObserverThread(ReplayProcessor<String> processor) {
             this.processor = processor;
@@ -347,7 +347,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
                     }
                 });
 
-                final AtomicReference<Object> o = new AtomicReference<Object>();
+                final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.io())
                 .subscribe(new DefaultSubscriber<Object>() {

--- a/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorTest.java
@@ -76,7 +76,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         Subscriber<Object> observerB = TestHelper.mockSubscriber();
         Subscriber<Object> observerC = TestHelper.mockSubscriber();
         Subscriber<Object> observerD = TestHelper.mockSubscriber();
-        TestSubscriber<Object> ts = new TestSubscriber<Object>(observerA);
+        TestSubscriber<Object> ts = new TestSubscriber<>(observerA);
 
         channel.subscribe(ts);
         channel.subscribe(observerB);
@@ -227,7 +227,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
-        TestSubscriber<String> ts = new TestSubscriber<String>(subscriber);
+        TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
         processor.subscribe(ts);
 
         processor.onNext("one");
@@ -258,7 +258,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void newSubscriberDoesntBlockExisting() throws InterruptedException {
 
-        final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<String>();
+        final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<>();
         Subscriber<String> subscriber1 = new DefaultSubscriber<String>() {
 
             @Override
@@ -279,7 +279,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         };
 
-        final AtomicReference<String> lastValueForSubscriber2 = new AtomicReference<String>();
+        final AtomicReference<String> lastValueForSubscriber2 = new AtomicReference<>();
         final CountDownLatch oneReceived = new CountDownLatch(1);
         final CountDownLatch makeSlow = new CountDownLatch(1);
         final CountDownLatch completed = new CountDownLatch(1);
@@ -806,7 +806,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         rs.onNext(3);
         rs.onComplete();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         rs.subscribe(ts);
 
@@ -834,7 +834,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         rs.onNext(3);
         rs.onComplete();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         rs.subscribe(ts);
 
@@ -862,7 +862,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         rs.onNext(3);
         rs.onComplete();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         rs.subscribe(ts);
 
@@ -1026,7 +1026,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void subscribeCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             final ReplayProcessor<Integer> rp = ReplayProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava3/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/SerializedProcessorTest.java
@@ -31,8 +31,8 @@ public class SerializedProcessorTest extends RxJavaTest {
 
     @Test
     public void basic() {
-        SerializedProcessor<String> processor = new SerializedProcessor<String>(PublishProcessor.<String> create());
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        SerializedProcessor<String> processor = new SerializedProcessor<>(PublishProcessor.<String>create());
+        TestSubscriber<String> ts = new TestSubscriber<>();
         processor.subscribe(ts);
         processor.onNext("hello");
         processor.onComplete();
@@ -416,7 +416,7 @@ public class SerializedProcessorTest extends RxJavaTest {
 
     @Test
     public void onNextOnNextRace() {
-        Set<Integer> expectedSet = new HashSet<Integer>(Arrays.asList(1, 2));
+        Set<Integer> expectedSet = new HashSet<>(Arrays.asList(1, 2));
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FlowableProcessor<Integer> s = PublishProcessor.<Integer>create().toSerialized();
@@ -445,7 +445,7 @@ public class SerializedProcessorTest extends RxJavaTest {
             .assertValueCount(2)
             ;
 
-            Set<Integer> actualSet = new HashSet<Integer>(ts.values());
+            Set<Integer> actualSet = new HashSet<>(ts.values());
             assertEquals("" + actualSet, expectedSet, actualSet);
         }
     }

--- a/src/test/java/io/reactivex/rxjava3/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/UnicastProcessorTest.java
@@ -268,7 +268,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void rejectSyncFusion() {
         UnicastProcessor<Object> p = UnicastProcessor.create();
 
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>().setInitialFusionMode(QueueFuseable.SYNC);
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>().setInitialFusionMode(QueueFuseable.SYNC);
 
         p.subscribe(ts);
 
@@ -302,7 +302,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastProcessor<Object> p = UnicastProcessor.create();
 
-            final TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>().setInitialFusionMode(QueueFuseable.ANY);
+            final TestSubscriberEx<Object> ts = new TestSubscriberEx<>().setInitialFusionMode(QueueFuseable.ANY);
 
             p.subscribe(ts);
 
@@ -329,8 +329,8 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastProcessor<Integer> us = UnicastProcessor.create();
 
-            final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
-            final TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>();
+            final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
+            final TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/AbstractSchedulerTests.java
@@ -395,7 +395,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             }
         });
 
-        ConcurrentObserverValidator<String> observer = new ConcurrentObserverValidator<String>();
+        ConcurrentObserverValidator<String> observer = new ConcurrentObserverValidator<>();
         // this should call onNext concurrently
         f.subscribe(observer);
 
@@ -414,7 +414,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
         Flowable<String> f = Flowable.fromArray("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten");
 
-        ConcurrentObserverValidator<String> observer = new ConcurrentObserverValidator<String>();
+        ConcurrentObserverValidator<String> observer = new ConcurrentObserverValidator<>();
 
         f.observeOn(scheduler).subscribe(observer);
 
@@ -449,7 +449,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
                     }
                 });
 
-        ConcurrentObserverValidator<String> observer = new ConcurrentObserverValidator<String>();
+        ConcurrentObserverValidator<String> observer = new ConcurrentObserverValidator<>();
 
         f.subscribe(observer);
 
@@ -471,7 +471,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
     private static class ConcurrentObserverValidator<T> extends DefaultSubscriber<T> {
 
         final AtomicInteger concurrentCounter = new AtomicInteger();
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
         final CountDownLatch completed = new CountDownLatch(1);
 
         @Override
@@ -685,7 +685,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             return;
         }
 
-        final AtomicReference<Disposable> disposable = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> disposable = new AtomicReference<>();
 
         try {
             assertRunnableDecorated(new Runnable() {

--- a/src/test/java/io/reactivex/rxjava3/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/ComputationSchedulerTests.java
@@ -39,7 +39,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
 
         final int NUM = 1000000;
         final CountDownLatch latch = new CountDownLatch(1);
-        final HashMap<String, Integer> map = new HashMap<String, Integer>();
+        final HashMap<String, Integer> map = new HashMap<>();
 
         final Scheduler.Worker inner = Schedulers.computation().createWorker();
 

--- a/src/test/java/io/reactivex/rxjava3/schedulers/ExecutorSchedulerFairTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/ExecutorSchedulerFairTest.java
@@ -72,7 +72,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
     /** A simple executor which queues tasks and executes them one-by-one if executeOne() is called. */
     static final class TestExecutor implements Executor {
-        final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<Runnable>();
+        final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
         @Override
         public void execute(Runnable command) {
             queue.offer(command);

--- a/src/test/java/io/reactivex/rxjava3/schedulers/ExecutorSchedulerInterruptibleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/ExecutorSchedulerInterruptibleTest.java
@@ -69,7 +69,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
     /** A simple executor which queues tasks and executes them one-by-one if executeOne() is called. */
     static final class TestExecutor implements Executor {
-        final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<Runnable>();
+        final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
         @Override
         public void execute(Runnable command) {
             queue.offer(command);

--- a/src/test/java/io/reactivex/rxjava3/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/ExecutorSchedulerTest.java
@@ -155,7 +155,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
     /** A simple executor which queues tasks and executes them one-by-one if executeOne() is called. */
     static final class TestExecutor implements Executor {
-        final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<Runnable>();
+        final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
         @Override
         public void execute(Runnable command) {
             queue.offer(command);

--- a/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerLifecycleTest.java
@@ -32,7 +32,7 @@ public class SchedulerLifecycleTest extends RxJavaTest {
         System.out.println("testShutdown >> Giving time threads to spin-up");
         Thread.sleep(500);
 
-        Set<Thread> rxThreads = new HashSet<Thread>();
+        Set<Thread> rxThreads = new HashSet<>();
         for (Thread t : Thread.getAllStackTraces().keySet()) {
             if (t.getName().startsWith("Rx")) {
                 rxThreads.add(t);
@@ -108,7 +108,7 @@ public class SchedulerLifecycleTest extends RxJavaTest {
         System.out.println("testStartIdempotence >> giving some time");
         Thread.sleep(500);
 
-        Set<Thread> rxThreadsBefore = new HashSet<Thread>();
+        Set<Thread> rxThreadsBefore = new HashSet<>();
         for (Thread t : Thread.getAllStackTraces().keySet()) {
             if (t.getName().startsWith("Rx")) {
                 rxThreadsBefore.add(t);
@@ -120,7 +120,7 @@ public class SchedulerLifecycleTest extends RxJavaTest {
         System.out.println("testStartIdempotence >> giving some time again");
         Thread.sleep(500);
 
-        Set<Thread> rxThreadsAfter = new HashSet<Thread>();
+        Set<Thread> rxThreadsAfter = new HashSet<>();
         for (Thread t : Thread.getAllStackTraces().keySet()) {
             if (t.getName().startsWith("Rx")) {
                 rxThreadsAfter.add(t);

--- a/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerTestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerTestHelper.java
@@ -33,7 +33,7 @@ final class SchedulerTestHelper {
         Thread.UncaughtExceptionHandler originalHandler = Thread.getDefaultUncaughtExceptionHandler();
         try {
             CapturingUncaughtExceptionHandler handler = new CapturingUncaughtExceptionHandler();
-            CapturingObserver<Object> observer = new CapturingObserver<Object>();
+            CapturingObserver<Object> observer = new CapturingObserver<>();
             Thread.setDefaultUncaughtExceptionHandler(handler);
             IllegalStateException error = new IllegalStateException("Should be delivered to handler");
             Flowable.error(error)

--- a/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerWorkerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerWorkerTest.java
@@ -76,7 +76,7 @@ public class SchedulerWorkerTest extends RxJavaTest {
         Scheduler.Worker w = s.createWorker();
 
         try {
-            final List<Long> times = new ArrayList<Long>();
+            final List<Long> times = new ArrayList<>();
 
             Disposable d = w.schedulePeriodically(new Runnable() {
                 @Override
@@ -118,7 +118,7 @@ public class SchedulerWorkerTest extends RxJavaTest {
         Scheduler.Worker w = s.createWorker();
 
         try {
-            final List<Long> times = new ArrayList<Long>();
+            final List<Long> times = new ArrayList<>();
 
             Disposable d = w.schedulePeriodically(new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/schedulers/TimedTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/TimedTest.java
@@ -25,7 +25,7 @@ public class TimedTest extends RxJavaTest {
 
     @Test
     public void properties() {
-        Timed<Integer> timed = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
+        Timed<Integer> timed = new Timed<>(1, 5, TimeUnit.SECONDS);
 
         assertEquals(1, timed.value().intValue());
         assertEquals(5, timed.time());
@@ -35,22 +35,22 @@ public class TimedTest extends RxJavaTest {
 
     @Test
     public void hashCodeOf() {
-        Timed<Integer> t1 = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
+        Timed<Integer> t1 = new Timed<>(1, 5, TimeUnit.SECONDS);
 
         assertEquals(TimeUnit.SECONDS.hashCode() + 31 * (5 + 31 * 1), t1.hashCode());
 
-        Timed<Integer> t2 = new Timed<Integer>(null, 5, TimeUnit.SECONDS);
+        Timed<Integer> t2 = new Timed<>(null, 5, TimeUnit.SECONDS);
 
         assertEquals(TimeUnit.SECONDS.hashCode() + 31 * (5 + 31 * 0), t2.hashCode());
     }
 
     @Test
     public void equalsWith() {
-        Timed<Integer> t1 = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
-        Timed<Integer> t2 = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
-        Timed<Integer> t3 = new Timed<Integer>(2, 5, TimeUnit.SECONDS);
-        Timed<Integer> t4 = new Timed<Integer>(1, 4, TimeUnit.SECONDS);
-        Timed<Integer> t5 = new Timed<Integer>(1, 5, TimeUnit.MINUTES);
+        Timed<Integer> t1 = new Timed<>(1, 5, TimeUnit.SECONDS);
+        Timed<Integer> t2 = new Timed<>(1, 5, TimeUnit.SECONDS);
+        Timed<Integer> t3 = new Timed<>(2, 5, TimeUnit.SECONDS);
+        Timed<Integer> t4 = new Timed<>(1, 4, TimeUnit.SECONDS);
+        Timed<Integer> t5 = new Timed<>(1, 5, TimeUnit.MINUTES);
 
         assertEquals(t1, t1);
         assertEquals(t1, t2);
@@ -83,13 +83,13 @@ public class TimedTest extends RxJavaTest {
 
     @Test
     public void toStringOf() {
-        Timed<Integer> t1 = new Timed<Integer>(1, 5, TimeUnit.SECONDS);
+        Timed<Integer> t1 = new Timed<>(1, 5, TimeUnit.SECONDS);
 
         assertEquals("Timed[time=5, unit=SECONDS, value=1]", t1.toString());
     }
 
     @Test(expected = NullPointerException.class)
     public void timeUnitNullFail() throws Exception {
-        new Timed<Integer>(1, 5, null);
+        new Timed<>(1, 5, null);
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/schedulers/TrampolineSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/TrampolineSchedulerTest.java
@@ -63,7 +63,7 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
 
     @Test
     public void nestedTrampolineWithUnsubscribe() {
-        final ArrayList<String> workDone = new ArrayList<String>();
+        final ArrayList<String> workDone = new ArrayList<>();
         final CompositeDisposable workers = new CompositeDisposable();
         Worker worker = Schedulers.trampoline().createWorker();
         try {
@@ -107,7 +107,7 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
     public void trampolineWorkerHandlesConcurrentScheduling() {
         final Worker trampolineWorker = Schedulers.trampoline().createWorker();
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
-        final TestSubscriber<Disposable> ts = new TestSubscriber<Disposable>(subscriber);
+        final TestSubscriber<Disposable> ts = new TestSubscriber<>(subscriber);
 
         // Spam the trampoline with actions.
         Flowable.range(0, 50)

--- a/src/test/java/io/reactivex/rxjava3/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava3/single/SingleCacheTest.java
@@ -89,7 +89,7 @@ public class SingleCacheTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         Single<Integer> cache = ps.single(-99).cache();
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
             @Override
@@ -114,7 +114,7 @@ public class SingleCacheTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         Single<Integer> cache = ps.single(-99).cache();
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/single/SingleNullTests.java
@@ -177,7 +177,7 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromFutureReturnsNull() {
-        FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         f.run();
         Single.fromFuture(f).blockingGet();
     }
@@ -189,7 +189,7 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedUnitNull() {
-        Single.fromFuture(new FutureTask<Object>(new Callable<Object>() {
+        Single.fromFuture(new FutureTask<>(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
                 return null;
@@ -199,7 +199,7 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedSchedulerNull() {
-        Single.fromFuture(new FutureTask<Object>(new Callable<Object>() {
+        Single.fromFuture(new FutureTask<>(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
                 return null;
@@ -209,14 +209,14 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedReturnsNull() {
-        FutureTask<Object> f = new FutureTask<Object>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         f.run();
         Single.fromFuture(f, 1, TimeUnit.SECONDS).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void fromFutureSchedulerNull() {
-        Single.fromFuture(new FutureTask<Object>(new Callable<Object>() {
+        Single.fromFuture(new FutureTask<>(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
                 return null;

--- a/src/test/java/io/reactivex/rxjava3/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/single/SingleTest.java
@@ -35,14 +35,14 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void helloWorld() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Single.just("Hello World!").toFlowable().subscribe(ts);
         ts.assertValueSequence(Arrays.asList("Hello World!"));
     }
 
     @Test
     public void helloWorld2() {
-        final AtomicReference<String> v = new AtomicReference<String>();
+        final AtomicReference<String> v = new AtomicReference<>();
         Single.just("Hello World!").subscribe(new SingleObserver<String>() {
 
             @Override
@@ -66,7 +66,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void map() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Single.just("A")
                 .map(new Function<String, String>() {
                     @Override
@@ -80,7 +80,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void zip() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Single<String> a = Single.just("A");
         Single<String> b = Single.just("B");
 
@@ -96,7 +96,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void zipWith() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
 
         Single.just("A").zipWith(Single.just("B"), new BiFunction<String, String, String>() {
             @Override
@@ -110,7 +110,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void merge() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Single<String> a = Single.just("A");
         Single<String> b = Single.just("B");
 
@@ -120,7 +120,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void mergeWith() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
 
         Single.just("A").mergeWith(Single.just("B")).subscribe(ts);
         ts.assertValueSequence(Arrays.asList("A", "B"));
@@ -128,7 +128,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void createSuccess() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Single.unsafeCreate(new SingleSource<Object>() {
             @Override
@@ -143,7 +143,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void createError() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
         Single.unsafeCreate(new SingleSource<Object>() {
             @Override
             public void subscribe(SingleObserver<? super Object> observer) {
@@ -158,7 +158,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void async() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Single.just("Hello")
                 .subscribeOn(Schedulers.io())
                 .map(new Function<String, String>() {
@@ -183,7 +183,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void flatMap() throws InterruptedException {
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>();
+        TestSubscriberEx<String> ts = new TestSubscriberEx<>();
         Single.just("Hello").flatMap(new Function<String, Single<String>>() {
             @Override
             public Single<String> apply(String s) {
@@ -200,7 +200,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void timeout() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(SingleObserver<? super String> observer) {
@@ -222,7 +222,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void timeoutWithFallback() {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
             @Override
             public void subscribe(SingleObserver<? super String> observer) {
@@ -245,7 +245,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void unsubscribe() throws InterruptedException {
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         final AtomicBoolean unsubscribed = new AtomicBoolean();
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(2);
@@ -436,7 +436,7 @@ public class SingleTest extends RxJavaTest {
             }
         });
 
-        TestSubscriber<String> ts = new TestSubscriber<String>(0L);
+        TestSubscriber<String> ts = new TestSubscriber<>(0L);
 
         s.toFlowable().subscribe(ts);
 
@@ -450,7 +450,7 @@ public class SingleTest extends RxJavaTest {
     @Test
     public void toObservable() {
         Flowable<String> a = Single.just("a").toFlowable();
-        TestSubscriber<String> ts = new TestSubscriber<String>();
+        TestSubscriber<String> ts = new TestSubscriber<>();
         a.subscribe(ts);
         ts.assertValue("a");
         ts.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava3/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/AsyncSubjectTest.java
@@ -136,7 +136,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
         AsyncSubject<String> subject = AsyncSubject.create();
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         subject.subscribe(to);
 
         subject.onNext("one");
@@ -185,7 +185,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
          */
         for (int i = 0; i < 50; i++) {
             final AsyncSubject<String> subject = AsyncSubject.create();
-            final AtomicReference<String> value1 = new AtomicReference<String>();
+            final AtomicReference<String> value1 = new AtomicReference<>();
 
             subject.subscribe(new Consumer<String>() {
 
@@ -243,7 +243,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     private static class SubjectSubscriberThread extends Thread {
 
         private final AsyncSubject<String> subject;
-        private final AtomicReference<String> value = new AtomicReference<String>();
+        private final AtomicReference<String> value = new AtomicReference<>();
 
         SubjectSubscriberThread(AsyncSubject<String> subject) {
             this.subject = subject;
@@ -327,7 +327,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void fusionLive() {
-        AsyncSubject<Integer> ap = new AsyncSubject<Integer>();
+        AsyncSubject<Integer> ap = new AsyncSubject<>();
 
         TestObserverEx<Integer> to = ap.to(TestHelper.<Integer>testConsumer(false, QueueFuseable.ANY));
 
@@ -347,7 +347,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void fusionOfflie() {
-        AsyncSubject<Integer> ap = new AsyncSubject<Integer>();
+        AsyncSubject<Integer> ap = new AsyncSubject<>();
         ap.onNext(1);
         ap.onComplete();
 
@@ -455,7 +455,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     public void onNextCrossCancel() {
         AsyncSubject<Object> p = AsyncSubject.create();
 
-        final TestObserver<Object> to2 = new TestObserver<Object>();
+        final TestObserver<Object> to2 = new TestObserver<>();
         TestObserver<Object> to1 = new TestObserver<Object>() {
             @Override
             public void onNext(Object t) {
@@ -478,7 +478,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     public void onErrorCrossCancel() {
         AsyncSubject<Object> p = AsyncSubject.create();
 
-        final TestObserver<Object> to2 = new TestObserver<Object>();
+        final TestObserver<Object> to2 = new TestObserver<>();
         TestObserver<Object> to1 = new TestObserver<Object>() {
             @Override
             public void onError(Throwable t) {
@@ -500,7 +500,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     public void onCompleteCrossCancel() {
         AsyncSubject<Object> p = AsyncSubject.create();
 
-        final TestObserver<Object> to2 = new TestObserver<Object>();
+        final TestObserver<Object> to2 = new TestObserver<>();
         TestObserver<Object> to1 = new TestObserver<Object>() {
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava3/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/BehaviorSubjectTest.java
@@ -136,7 +136,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         Observer<Object> observerB = TestHelper.mockObserver();
         Observer<Object> observerC = TestHelper.mockObserver();
 
-        TestObserver<Object> to = new TestObserver<Object>(observerA);
+        TestObserver<Object> to = new TestObserver<>(observerA);
 
         channel.subscribe(to);
         channel.subscribe(observerB);
@@ -389,7 +389,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
                     }
                 });
 
-                final AtomicReference<Object> o = new AtomicReference<Object>();
+                final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.io())
                 .subscribe(new DefaultObserver<Object>() {
@@ -679,7 +679,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.create();
 
-            final TestObserver<Object> to = new TestObserver<Object>();
+            final TestObserver<Object> to = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -706,7 +706,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final BehaviorSubject<Object> p = BehaviorSubject.create();
 
-            final TestObserver<Object> to = new TestObserver<Object>();
+            final TestObserver<Object> to = new TestObserver<>();
 
             final TestException ex = new TestException();
 
@@ -735,9 +735,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         BehaviorSubject<Integer> bs = BehaviorSubject.create();
         bs.onNext(1);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
-        BehaviorDisposable<Integer> bd = new BehaviorDisposable<Integer>(to, bs);
+        BehaviorDisposable<Integer> bd = new BehaviorDisposable<>(to, bs);
         to.onSubscribe(bd);
 
         assertFalse(bd.isDisposed());
@@ -766,9 +766,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             BehaviorSubject<Integer> bs = BehaviorSubject.create();
             bs.onNext(1);
 
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
-            final BehaviorDisposable<Integer> bd = new BehaviorDisposable<Integer>(to, bs);
+            final BehaviorDisposable<Integer> bd = new BehaviorDisposable<>(to, bs);
             to.onSubscribe(bd);
 
             Runnable r1 = new Runnable() {
@@ -795,9 +795,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             BehaviorSubject<Integer> bs = BehaviorSubject.create();
             bs.onNext(1);
 
-            TestObserver<Integer> to = new TestObserver<Integer>();
+            TestObserver<Integer> to = new TestObserver<>();
 
-            final BehaviorDisposable<Integer> bd = new BehaviorDisposable<Integer>(to, bs);
+            final BehaviorDisposable<Integer> bd = new BehaviorDisposable<>(to, bs);
             to.onSubscribe(bd);
 
             Runnable r1 = new Runnable() {
@@ -822,9 +822,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
         BehaviorSubject<Integer> bs = BehaviorSubject.create();
         bs.onNext(1);
 
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        TestObserver<Integer> to = new TestObserver<>();
 
-        final BehaviorDisposable<Integer> bd = new BehaviorDisposable<Integer>(to, bs);
+        final BehaviorDisposable<Integer> bd = new BehaviorDisposable<>(to, bs);
         to.onSubscribe(bd);
 
         bd.emitting = true;

--- a/src/test/java/io/reactivex/rxjava3/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/PublishSubjectTest.java
@@ -68,7 +68,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         Observer<Object> observerB = TestHelper.mockObserver();
         Observer<Object> observerC = TestHelper.mockObserver();
 
-        TestObserver<Object> to = new TestObserver<Object>(observerA);
+        TestObserver<Object> to = new TestObserver<>(observerA);
 
         channel.subscribe(to);
         channel.subscribe(observerB);
@@ -177,7 +177,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         PublishSubject<String> subject = PublishSubject.create();
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         subject.subscribe(to);
 
         subject.onNext("one");
@@ -212,7 +212,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         final AtomicInteger countChildren = new AtomicInteger();
         final AtomicInteger countTotal = new AtomicInteger();
 
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
 
         s.flatMap(new Function<Integer, Observable<String>>() {
 
@@ -263,7 +263,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         Observer<Integer> o1 = TestHelper.mockObserver();
-        TestObserver<Integer> to = new TestObserver<Integer>(o1);
+        TestObserver<Integer> to = new TestObserver<>(o1);
         ps.subscribe(to);
 
         // emit
@@ -281,7 +281,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         ps.onNext(2);
 
         Observer<Integer> o2 = TestHelper.mockObserver();
-        TestObserver<Integer> to2 = new TestObserver<Integer>(o2);
+        TestObserver<Integer> to2 = new TestObserver<>(o2);
         ps.subscribe(to2);
 
         // emit
@@ -392,7 +392,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void crossCancel() {
-        final TestObserver<Integer> to1 = new TestObserver<Integer>();
+        final TestObserver<Integer> to1 = new TestObserver<>();
         TestObserver<Integer> to2 = new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
@@ -415,7 +415,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void crossCancelOnError() {
-        final TestObserver<Integer> to1 = new TestObserver<Integer>();
+        final TestObserver<Integer> to1 = new TestObserver<>();
         TestObserver<Integer> to2 = new TestObserver<Integer>() {
             @Override
             public void onError(Throwable t) {
@@ -438,7 +438,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void crossCancelOnComplete() {
-        final TestObserver<Integer> to1 = new TestObserver<Integer>();
+        final TestObserver<Integer> to1 = new TestObserver<>();
         TestObserver<Integer> to2 = new TestObserver<Integer>() {
             @Override
             public void onComplete() {
@@ -572,7 +572,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> to = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<>();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -166,8 +166,8 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         });
 
         // used to collect results of each thread
-        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<List<Long>>());
-        final List<Thread> threads = Collections.synchronizedList(new ArrayList<Thread>());
+        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<>());
+        final List<Thread> threads = Collections.synchronizedList(new ArrayList<>());
 
         for (int i = 1; i <= 200; i++) {
             final int count = i;
@@ -200,7 +200,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         }
 
         // assert all threads got the same results
-        List<Long> sums = new ArrayList<Long>();
+        List<Long> sums = new ArrayList<>();
         for (List<Long> values : listOfListsOfValues) {
             long v = 0;
             for (long l : values) {
@@ -233,7 +233,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
     public void subscribeCompletionRaceCondition() {
         for (int i = 0; i < 50; i++) {
             final ReplaySubject<String> subject = ReplaySubject.createUnbounded();
-            final AtomicReference<String> value1 = new AtomicReference<String>();
+            final AtomicReference<String> value1 = new AtomicReference<>();
 
             subject.subscribe(new Consumer<String>() {
 
@@ -296,7 +296,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
     public void raceForTerminalState() {
         final List<Integer> expected = Arrays.asList(1);
         for (int i = 0; i < 100000; i++) {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(to);
             to.awaitDone(5, TimeUnit.SECONDS);
             to.assertValueSequence(expected);
@@ -307,7 +307,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
     static class SubjectObserverThread extends Thread {
 
         private final ReplaySubject<String> subject;
-        private final AtomicReference<String> value = new AtomicReference<String>();
+        private final AtomicReference<String> value = new AtomicReference<>();
 
         SubjectObserverThread(ReplaySubject<String> subject) {
             this.subject = subject;
@@ -354,7 +354,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
                     }
                 });
 
-                final AtomicReference<Object> o = new AtomicReference<Object>();
+                final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs
 //                .doOnSubscribe(v -> System.out.println("!! " + j))

--- a/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectConcurrencyTest.java
@@ -166,8 +166,8 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
         });
 
         // used to collect results of each thread
-        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<List<Long>>());
-        final List<Thread> threads = Collections.synchronizedList(new ArrayList<Thread>());
+        final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<>());
+        final List<Thread> threads = Collections.synchronizedList(new ArrayList<>());
 
         for (int i = 1; i <= 200; i++) {
             final int count = i;
@@ -200,7 +200,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
         }
 
         // assert all threads got the same results
-        List<Long> sums = new ArrayList<Long>();
+        List<Long> sums = new ArrayList<>();
         for (List<Long> values : listOfListsOfValues) {
             long v = 0;
             for (long l : values) {
@@ -233,7 +233,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
     public void subscribeCompletionRaceCondition() {
         for (int i = 0; i < 50; i++) {
             final ReplaySubject<String> subject = ReplaySubject.create();
-            final AtomicReference<String> value1 = new AtomicReference<String>();
+            final AtomicReference<String> value1 = new AtomicReference<>();
 
             subject.subscribe(new Consumer<String>() {
 
@@ -296,7 +296,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
     public void raceForTerminalState() {
         final List<Integer> expected = Arrays.asList(1);
         for (int i = 0; i < 100000; i++) {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+            TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(to);
             to.awaitDone(5, TimeUnit.SECONDS);
             to.assertValueSequence(expected);
@@ -307,7 +307,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
     static class SubjectObserverThread extends Thread {
 
         private final ReplaySubject<String> subject;
-        private final AtomicReference<String> value = new AtomicReference<String>();
+        private final AtomicReference<String> value = new AtomicReference<>();
 
         SubjectObserverThread(ReplaySubject<String> subject) {
             this.subject = subject;
@@ -351,7 +351,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
                     }
                 });
 
-                final AtomicReference<Object> o = new AtomicReference<Object>();
+                final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.io())
                 .subscribe(new DefaultObserver<Object>() {

--- a/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectTest.java
@@ -74,7 +74,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         Observer<Object> observerB = TestHelper.mockObserver();
         Observer<Object> observerC = TestHelper.mockObserver();
         Observer<Object> observerD = TestHelper.mockObserver();
-        TestObserver<Object> to = new TestObserver<Object>(observerA);
+        TestObserver<Object> to = new TestObserver<>(observerA);
 
         channel.subscribe(to);
         channel.subscribe(observerB);
@@ -225,7 +225,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         ReplaySubject<String> subject = ReplaySubject.create();
 
         Observer<String> observer = TestHelper.mockObserver();
-        TestObserver<String> to = new TestObserver<String>(observer);
+        TestObserver<String> to = new TestObserver<>(observer);
         subject.subscribe(to);
 
         subject.onNext("one");
@@ -256,7 +256,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     @Test
     public void newSubscriberDoesntBlockExisting() throws InterruptedException {
 
-        final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<String>();
+        final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<>();
         Observer<String> observer1 = new DefaultObserver<String>() {
 
             @Override
@@ -277,7 +277,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         };
 
-        final AtomicReference<String> lastValueForSubscriber2 = new AtomicReference<String>();
+        final AtomicReference<String> lastValueForSubscriber2 = new AtomicReference<>();
         final CountDownLatch oneReceived = new CountDownLatch(1);
         final CountDownLatch makeSlow = new CountDownLatch(1);
         final CountDownLatch completed = new CountDownLatch(1);
@@ -940,7 +940,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     @Test
     public void subscribeCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestObserver<Integer> to = new TestObserver<Integer>();
+            final TestObserver<Integer> to = new TestObserver<>();
 
             final ReplaySubject<Integer> rp = ReplaySubject.create();
 

--- a/src/test/java/io/reactivex/rxjava3/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/SerializedSubjectTest.java
@@ -32,8 +32,8 @@ public class SerializedSubjectTest extends RxJavaTest {
 
     @Test
     public void basic() {
-        SerializedSubject<String> subject = new SerializedSubject<String>(PublishSubject.<String> create());
-        TestObserver<String> to = new TestObserver<String>();
+        SerializedSubject<String> subject = new SerializedSubject<>(PublishSubject.<String>create());
+        TestObserver<String> to = new TestObserver<>();
         subject.subscribe(to);
         subject.onNext("hello");
         subject.onComplete();
@@ -417,7 +417,7 @@ public class SerializedSubjectTest extends RxJavaTest {
 
     @Test
     public void onNextOnNextRace() {
-        Set<Integer> expectedSet = new HashSet<Integer>(Arrays.asList(1, 2));
+        Set<Integer> expectedSet = new HashSet<>(Arrays.asList(1, 2));
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Subject<Integer> s = PublishSubject.<Integer>create().toSerialized();
@@ -446,7 +446,7 @@ public class SerializedSubjectTest extends RxJavaTest {
             .assertValueCount(2)
             ;
 
-            Set<Integer> actualSet = new HashSet<Integer>(to.values());
+            Set<Integer> actualSet = new HashSet<>(to.values());
             assertEquals("" + actualSet, expectedSet, actualSet);
         }
     }

--- a/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
@@ -43,7 +43,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void fusionLive() {
         UnicastSubject<Integer> ap = UnicastSubject.create();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         ap.subscribe(to);
 
@@ -68,7 +68,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         ap.onNext(1);
         ap.onComplete();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         ap.subscribe(to);
 
@@ -124,7 +124,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         UnicastSubject<Integer> ap = UnicastSubject.create(false);
         ap.onNext(1);
         ap.onError(new RuntimeException());
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
         ap.subscribe(to);
 
         to
@@ -139,7 +139,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         ap.onNext(2);
         ap.onNext(3);
         ap.onComplete();
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
         ap.subscribe(to);
 
         to
@@ -303,7 +303,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void rejectSyncFusion() {
         UnicastSubject<Object> p = UnicastSubject.create();
 
-        TestObserverEx<Object> to = new TestObserverEx<Object>(QueueFuseable.SYNC);
+        TestObserverEx<Object> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
         p.subscribe(to);
 
@@ -337,7 +337,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastSubject<Object> p = UnicastSubject.create();
 
-            final TestObserverEx<Object> to = new TestObserverEx<Object>(QueueFuseable.ANY);
+            final TestObserverEx<Object> to = new TestObserverEx<>(QueueFuseable.ANY);
 
             p.subscribe(to);
 
@@ -363,9 +363,11 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void dispose() {
         final int[] calls = { 0 };
 
-        UnicastSubject<Integer> us = new UnicastSubject<Integer>(128, new Runnable() {
+        UnicastSubject<Integer> us = new UnicastSubject<>(128, new Runnable() {
             @Override
-            public void run() { calls[0]++; }
+            public void run() {
+                calls[0]++;
+            }
         });
 
         TestHelper.checkDisposed(us);
@@ -393,8 +395,8 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final UnicastSubject<Integer> us = UnicastSubject.create();
 
-            final TestObserverEx<Integer> to1 = new TestObserverEx<Integer>();
-            final TestObserverEx<Integer> to2 = new TestObserverEx<Integer>();
+            final TestObserverEx<Integer> to1 = new TestObserverEx<>();
+            final TestObserverEx<Integer> to2 = new TestObserverEx<>();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava3/subscribers/DefaultSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/DefaultSubscriberTest.java
@@ -25,7 +25,7 @@ public class DefaultSubscriberTest extends RxJavaTest {
 
     static final class RequestEarly extends DefaultSubscriber<Integer> {
 
-        final List<Object> events = new ArrayList<Object>();
+        final List<Object> events = new ArrayList<>();
 
         RequestEarly() {
             request(5);

--- a/src/test/java/io/reactivex/rxjava3/subscribers/DisposableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/DisposableSubscriberTest.java
@@ -31,9 +31,9 @@ public class DisposableSubscriberTest extends RxJavaTest {
 
         int start;
 
-        final List<T> values = new ArrayList<T>();
+        final List<T> values = new ArrayList<>();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         int completions;
 
@@ -62,7 +62,7 @@ public class DisposableSubscriberTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestDisposableSubscriber<Integer> tc = new TestDisposableSubscriber<Integer>();
+        TestDisposableSubscriber<Integer> tc = new TestDisposableSubscriber<>();
 
         assertFalse(tc.isDisposed());
         assertEquals(0, tc.start);
@@ -83,7 +83,7 @@ public class DisposableSubscriberTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestDisposableSubscriber<Integer> tc = new TestDisposableSubscriber<Integer>();
+            TestDisposableSubscriber<Integer> tc = new TestDisposableSubscriber<>();
 
             tc.onSubscribe(new BooleanSubscription());
 
@@ -103,7 +103,7 @@ public class DisposableSubscriberTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestDisposableSubscriber<Integer> tc = new TestDisposableSubscriber<Integer>();
+        TestDisposableSubscriber<Integer> tc = new TestDisposableSubscriber<>();
 
         assertFalse(tc.isDisposed());
 

--- a/src/test/java/io/reactivex/rxjava3/subscribers/ResourceSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/ResourceSubscriberTest.java
@@ -30,9 +30,9 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 public class ResourceSubscriberTest extends RxJavaTest {
 
     static class TestResourceSubscriber<T> extends ResourceSubscriber<T> {
-        final List<T> values = new ArrayList<T>();
+        final List<T> values = new ArrayList<>();
 
-        final List<Throwable> errors = new ArrayList<Throwable>();
+        final List<Throwable> errors = new ArrayList<>();
 
         int complete;
 
@@ -71,13 +71,13 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<Integer>();
+        TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<>();
         ro.add(null);
     }
 
     @Test
     public void addResources() {
-        TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<Integer>();
+        TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<>();
 
         assertFalse(ro.isDisposed());
 
@@ -102,7 +102,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test
     public void onCompleteCleansUp() {
-        TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<Integer>();
+        TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<>();
 
         assertFalse(ro.isDisposed());
 
@@ -121,7 +121,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<Integer>();
+        TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<>();
 
         assertFalse(ro.isDisposed());
 
@@ -140,7 +140,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test
     public void normal() {
-        TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<Integer>();
+        TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<>();
 
         assertFalse(tc.isDisposed());
         assertEquals(0, tc.start);
@@ -161,7 +161,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<Integer>();
+            TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<>();
 
             tc.onSubscribe(new BooleanSubscription());
 
@@ -181,7 +181,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<Integer>();
+        TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<>();
         tc.dispose();
 
         BooleanSubscription bs = new BooleanSubscription();
@@ -219,7 +219,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     static final class RequestEarly extends ResourceSubscriber<Integer> {
 
-        final List<Object> events = new ArrayList<Object>();
+        final List<Object> events = new ArrayList<>();
 
         RequestEarly() {
             request(5);

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SafeSubscriberTest.java
@@ -41,7 +41,7 @@ public class SafeSubscriberTest extends RxJavaTest {
         Flowable<String> st = Flowable.unsafeCreate(t);
 
         Subscriber<String> w = TestHelper.mockSubscriber();
-        st.subscribe(new SafeSubscriber<String>(new TestSubscriber<String>(w)));
+        st.subscribe(new SafeSubscriber<>(new TestSubscriber<>(w)));
 
         t.sendOnNext("one");
         t.sendOnError(new RuntimeException("bad"));
@@ -62,7 +62,7 @@ public class SafeSubscriberTest extends RxJavaTest {
 
         Subscriber<String> w = TestHelper.mockSubscriber();
 
-        st.subscribe(new SafeSubscriber<String>(new TestSubscriber<String>(w)));
+        st.subscribe(new SafeSubscriber<>(new TestSubscriber<>(w)));
 
         t.sendOnNext("one");
         t.sendOnError(new RuntimeException("bad"));
@@ -82,7 +82,7 @@ public class SafeSubscriberTest extends RxJavaTest {
         Flowable<String> st = Flowable.unsafeCreate(t);
 
         Subscriber<String> w = TestHelper.mockSubscriber();
-        st.subscribe(new SafeSubscriber<String>(new TestSubscriber<String>(w)));
+        st.subscribe(new SafeSubscriber<>(new TestSubscriber<>(w)));
 
         t.sendOnNext("one");
         t.sendOnCompleted();
@@ -103,7 +103,7 @@ public class SafeSubscriberTest extends RxJavaTest {
         Flowable<String> st = Flowable.unsafeCreate(t);
 
         Subscriber<String> w = TestHelper.mockSubscriber();
-        st.subscribe(new SafeSubscriber<String>(new TestSubscriber<String>(w)));
+        st.subscribe(new SafeSubscriber<>(new TestSubscriber<>(w)));
 
         t.sendOnNext("one");
         t.sendOnCompleted();
@@ -159,7 +159,7 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onNextFailure() {
-        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        AtomicReference<Throwable> onError = new AtomicReference<>();
         try {
             OBSERVER_ONNEXT_FAIL(onError).onNext("one");
             fail("expects exception to be thrown");
@@ -172,9 +172,9 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onNextFailureSafe() {
-        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        AtomicReference<Throwable> onError = new AtomicReference<>();
         try {
-            SafeSubscriber<String> safeObserver = new SafeSubscriber<String>(OBSERVER_ONNEXT_FAIL(onError));
+            SafeSubscriber<String> safeObserver = new SafeSubscriber<>(OBSERVER_ONNEXT_FAIL(onError));
             safeObserver.onSubscribe(new BooleanSubscription());
             safeObserver.onNext("one");
             assertNotNull(onError.get());
@@ -187,7 +187,7 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onCompleteFailure() {
-        AtomicReference<Throwable> onError = new AtomicReference<Throwable>();
+        AtomicReference<Throwable> onError = new AtomicReference<>();
         try {
             OBSERVER_ONCOMPLETED_FAIL(onError).onComplete();
             fail("expects exception to be thrown");
@@ -341,16 +341,16 @@ public class SafeSubscriberTest extends RxJavaTest {
             public void onComplete() {
             }
         };
-        SafeSubscriber<Integer> s = new SafeSubscriber<Integer>(actual);
+        SafeSubscriber<Integer> s = new SafeSubscriber<>(actual);
 
         assertSame(actual, s.downstream);
     }
 
     @Test
     public void dispose() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        SafeSubscriber<Integer> so = new SafeSubscriber<>(ts);
 
         BooleanSubscription bs = new BooleanSubscription();
 
@@ -365,9 +365,9 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onNextAfterComplete() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        SafeSubscriber<Integer> so = new SafeSubscriber<>(ts);
 
         BooleanSubscription bs = new BooleanSubscription();
 
@@ -386,9 +386,9 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onNextNull() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        SafeSubscriber<Integer> so = new SafeSubscriber<>(ts);
 
         BooleanSubscription bs = new BooleanSubscription();
 
@@ -401,9 +401,9 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onNextWithoutOnSubscribe() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        SafeSubscriber<Integer> so = new SafeSubscriber<>(ts);
 
         so.onNext(1);
 
@@ -412,9 +412,9 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorWithoutOnSubscribe() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        SafeSubscriber<Integer> so = new SafeSubscriber<>(ts);
 
         so.onError(new TestException());
 
@@ -426,9 +426,9 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onCompleteWithoutOnSubscribe() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        SafeSubscriber<Integer> so = new SafeSubscriber<>(ts);
 
         so.onComplete();
 
@@ -437,9 +437,9 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void onNextNormal() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        SafeSubscriber<Integer> so = new SafeSubscriber<Integer>(ts);
+        SafeSubscriber<Integer> so = new SafeSubscriber<>(ts);
 
         BooleanSubscription bs = new BooleanSubscription();
 
@@ -520,7 +520,7 @@ public class SafeSubscriberTest extends RxJavaTest {
         }
 
         public SafeSubscriber<Object> toSafe() {
-            return new SafeSubscriber<Object>(this);
+            return new SafeSubscriber<>(this);
         }
 
         public CrashDummy assertError(Class<? extends Throwable> clazz) {

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
@@ -42,7 +42,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     }
 
     private Subscriber<String> serializedSubscriber(Subscriber<String> subscriber) {
-        return new SerializedSubscriber<String>(subscriber);
+        return new SerializedSubscriber<>(subscriber);
     }
 
     @Test
@@ -164,7 +164,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
         try {
             TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
             // we need Synchronized + SafeSubscriber to handle synchronization plus life-cycle
-            Subscriber<String> w = serializedSubscriber(new SafeSubscriber<String>(tw));
+            Subscriber<String> w = serializedSubscriber(new SafeSubscriber<>(tw));
 
             Future<?> f1 = tp.submit(new OnNextThread(w, 12000));
             Future<?> f2 = tp.submit(new OnNextThread(w, 5000));
@@ -220,7 +220,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
         try {
             TestConcurrencySubscriber tw = new TestConcurrencySubscriber();
             // we need Synchronized + SafeSubscriber to handle synchronization plus life-cycle
-            Subscriber<String> w = serializedSubscriber(new SafeSubscriber<String>(tw));
+            Subscriber<String> w = serializedSubscriber(new SafeSubscriber<>(tw));
             w.onSubscribe(new BooleanSubscription());
 
             Future<?> f1 = tp.submit(new OnNextThread(w, 12000));
@@ -276,7 +276,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
                 final CountDownLatch latch = new CountDownLatch(1);
                 final CountDownLatch running = new CountDownLatch(2);
 
-                TestSubscriberEx<String> ts = new TestSubscriberEx<String>(new DefaultSubscriber<String>() {
+                TestSubscriberEx<String> ts = new TestSubscriberEx<>(new DefaultSubscriber<String>() {
 
                     @Override
                     public void onComplete() {
@@ -357,7 +357,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @Test
     public void threadStarvation() throws InterruptedException {
 
-        TestSubscriber<String> ts = new TestSubscriber<String>(new DefaultSubscriber<String>() {
+        TestSubscriber<String> ts = new TestSubscriber<>(new DefaultSubscriber<String>() {
 
             @Override
             public void onComplete() {
@@ -553,7 +553,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
         /**
          * Used to store the order and number of events received.
          */
-        private final LinkedBlockingQueue<TestConcurrencySubscriberEvent> events = new LinkedBlockingQueue<TestConcurrencySubscriberEvent>();
+        private final LinkedBlockingQueue<TestConcurrencySubscriberEvent> events = new LinkedBlockingQueue<>();
         private final int waitTime;
 
         @SuppressWarnings("unused")
@@ -849,7 +849,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     public void errorReentry() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<Subscriber<Integer>>();
+            final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
 
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
                 @Override
@@ -859,7 +859,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
                     super.onNext(v);
                 }
             };
-            SerializedSubscriber<Integer> sobs = new SerializedSubscriber<Integer>(ts);
+            SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(ts);
             sobs.onSubscribe(new BooleanSubscription());
             serial.set(sobs);
 
@@ -876,7 +876,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeReentry() {
-        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<Subscriber<Integer>>();
+        final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
@@ -886,7 +886,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
                 super.onNext(v);
             }
         };
-        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<Integer>(ts);
+        SerializedSubscriber<Integer> sobs = new SerializedSubscriber<>(ts);
         sobs.onSubscribe(new BooleanSubscription());
         serial.set(sobs);
 
@@ -899,9 +899,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
+        SerializedSubscriber<Integer> so = new SerializedSubscriber<>(ts);
 
         BooleanSubscription bs = new BooleanSubscription();
 
@@ -915,9 +915,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @Test
     public void onCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
+            final SerializedSubscriber<Integer> so = new SerializedSubscriber<>(ts);
 
             BooleanSubscription bs = new BooleanSubscription();
 
@@ -941,9 +941,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @Test
     public void onNextOnCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
+            final SerializedSubscriber<Integer> so = new SerializedSubscriber<>(ts);
 
             BooleanSubscription bs = new BooleanSubscription();
 
@@ -977,9 +977,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @Test
     public void onNextOnErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
+            final SerializedSubscriber<Integer> so = new SerializedSubscriber<>(ts);
 
             BooleanSubscription bs = new BooleanSubscription();
 
@@ -1015,9 +1015,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @Test
     public void onNextOnErrorRaceDelayError() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts, true);
+            final SerializedSubscriber<Integer> so = new SerializedSubscriber<>(ts, true);
 
             BooleanSubscription bs = new BooleanSubscription();
 
@@ -1056,9 +1056,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
+            final SerializedSubscriber<Integer> so = new SerializedSubscriber<>(ts);
 
             so.onSubscribe(new BooleanSubscription());
 
@@ -1079,9 +1079,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+                TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-                final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
+                final SerializedSubscriber<Integer> so = new SerializedSubscriber<>(ts);
 
                 BooleanSubscription bs = new BooleanSubscription();
 
@@ -1124,9 +1124,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @Test
     public void nullOnNext() {
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        final SerializedSubscriber<Integer> so = new SerializedSubscriber<Integer>(ts);
+        final SerializedSubscriber<Integer> so = new SerializedSubscriber<>(ts);
 
         so.onSubscribe(new BooleanSubscription());
 

--- a/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
@@ -44,7 +44,7 @@ public class TestSubscriberTest extends RxJavaTest {
     @Test
     public void assertTestSubscriber() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         oi.subscribe(ts);
 
         ts.assertValues(1, 2);
@@ -56,7 +56,7 @@ public class TestSubscriberTest extends RxJavaTest {
     @Test
     public void assertNotMatchCount() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         oi.subscribe(ts);
 
         thrown.expect(AssertionError.class);
@@ -72,7 +72,7 @@ public class TestSubscriberTest extends RxJavaTest {
     @Test
     public void assertNotMatchValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         oi.subscribe(ts);
 
         thrown.expect(AssertionError.class);
@@ -88,7 +88,7 @@ public class TestSubscriberTest extends RxJavaTest {
     @Test
     public void assertTerminalEventNotReceived() {
         PublishProcessor<Integer> p = PublishProcessor.create();
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         p.subscribe(ts);
 
         p.onNext(1);
@@ -109,7 +109,7 @@ public class TestSubscriberTest extends RxJavaTest {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
         Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
 
-        oi.subscribe(new TestSubscriber<Integer>(mockSubscriber));
+        oi.subscribe(new TestSubscriber<>(mockSubscriber));
 
         InOrder inOrder = inOrder(mockSubscriber);
         inOrder.verify(mockSubscriber, times(1)).onNext(1);
@@ -122,7 +122,7 @@ public class TestSubscriberTest extends RxJavaTest {
     public void wrappingMockWhenUnsubscribeInvolved() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).take(2);
         Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
-        oi.subscribe(new TestSubscriber<Integer>(mockSubscriber));
+        oi.subscribe(new TestSubscriber<>(mockSubscriber));
 
         InOrder inOrder = inOrder(mockSubscriber);
         inOrder.verify(mockSubscriber, times(1)).onNext(1);
@@ -134,14 +134,14 @@ public class TestSubscriberTest extends RxJavaTest {
     @Test
     public void assertError() {
         RuntimeException e = new RuntimeException("Oops");
-        TestSubscriber<Object> subscriber = new TestSubscriber<Object>();
+        TestSubscriber<Object> subscriber = new TestSubscriber<>();
         Flowable.error(e).subscribe(subscriber);
         subscriber.assertError(e);
     }
 
     @Test
     public void awaitTerminalEventWithDuration() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         Flowable.just(1).subscribe(ts);
         ts.awaitDone(1, TimeUnit.SECONDS);
         ts.assertComplete();
@@ -150,7 +150,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void awaitTerminalEventWithDurationAndUnsubscribeOnTimeout() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         final AtomicBoolean unsub = new AtomicBoolean(false);
         Flowable.just(1)
         //
@@ -169,28 +169,28 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullDelegate1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(null);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(null);
         ts.onComplete();
     }
 
     @Test(expected = NullPointerException.class)
     public void nullDelegate2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(null);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(null);
         ts.onComplete();
     }
 
     @Test(expected = NullPointerException.class)
     public void nullDelegate3() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(null, 0L);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(null, 0L);
         ts.onComplete();
     }
 
     @Test
     public void delegate1() {
-        TestSubscriber<Integer> ts0 = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts0 = new TestSubscriber<>();
         ts0.onSubscribe(EmptySubscription.INSTANCE);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(ts0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(ts0);
         ts.onComplete();
 
         ts0.assertComplete();
@@ -199,8 +199,8 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void delegate2() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(ts1);
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(ts1);
         ts2.onComplete();
 
         ts1.assertComplete();
@@ -208,21 +208,21 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void delegate3() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(ts1, 0L);
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+        TestSubscriber<Integer> ts2 = new TestSubscriber<>(ts1, 0L);
         ts2.onComplete();
         ts1.assertComplete();
     }
 
     @Test
     public void unsubscribed() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         assertFalse(ts.isCancelled());
     }
 
     @Test
     public void noErrors() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onError(new TestException());
         try {
             ts.assertNoErrors();
@@ -235,7 +235,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void notCompleted() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         try {
             ts.assertComplete();
         } catch (AssertionError ex) {
@@ -247,7 +247,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void multipleCompletions() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onComplete();
         ts.onComplete();
         try {
@@ -261,7 +261,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void completed() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onComplete();
         try {
             ts.assertNotComplete();
@@ -274,7 +274,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void multipleCompletions2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onComplete();
         ts.onComplete();
         try {
@@ -288,7 +288,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void multipleErrors() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
         ts.onError(new TestException());
         ts.onError(new TestException());
@@ -312,7 +312,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void multipleErrors2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
         ts.onError(new TestException());
         ts.onError(new TestException());
@@ -333,7 +333,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void multipleErrors3() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
         ts.onError(new TestException());
         ts.onError(new TestException());
@@ -354,7 +354,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void multipleErrors4() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
         ts.onError(new TestException());
         ts.onError(new TestException());
@@ -375,7 +375,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void differentError() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onError(new TestException());
         try {
             ts.assertError(new TestException());
@@ -388,7 +388,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void differentError2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onError(new RuntimeException());
         try {
             ts.assertError(new TestException());
@@ -401,7 +401,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void differentError3() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onError(new RuntimeException());
         try {
             ts.assertError(TestException.class);
@@ -415,7 +415,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void differentError4() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onError(new RuntimeException());
         try {
             ts.assertError(Functions.<Throwable>alwaysFalse());
@@ -428,7 +428,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void errorInPredicate() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onError(new RuntimeException());
         try {
             ts.assertError(new Predicate<Throwable>() {
@@ -446,7 +446,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void noError() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         try {
             ts.assertError(TestException.class);
         } catch (AssertionError ex) {
@@ -458,7 +458,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void noError2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         try {
             ts.assertError(new TestException());
         } catch (AssertionError ex) {
@@ -470,7 +470,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void noError3() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         try {
             ts.assertError(Functions.<Throwable>alwaysTrue());
         } catch (AssertionError ex) {
@@ -482,7 +482,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void interruptTerminalEventAwait() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
@@ -508,7 +508,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void interruptTerminalEventAwaitTimed() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
@@ -535,7 +535,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void interruptTerminalEventAwaitAndUnsubscribe() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
@@ -563,7 +563,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void noTerminalEventBut1Completed() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         ts.onComplete();
 
@@ -577,7 +577,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void noTerminalEventBut1Error() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         ts.onError(new TestException());
 
@@ -591,7 +591,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void noTerminalEventBut1Error1Complete() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         ts.onComplete();
         ts.onError(new TestException());
@@ -613,7 +613,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void noTerminalEventBut2Errors() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
 
         ts.onError(new TestException());
@@ -635,7 +635,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void noValues() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onNext(1);
 
         try {
@@ -648,7 +648,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void valueCount() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onNext(1);
         ts.onNext(2);
 
@@ -668,7 +668,7 @@ public class TestSubscriberTest extends RxJavaTest {
                 throw new TestException();
             }
         };
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(ts0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(ts0);
 
         try {
             ts.onComplete();
@@ -687,7 +687,7 @@ public class TestSubscriberTest extends RxJavaTest {
                 throw new TestException();
             }
         };
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(ts0);
+        TestSubscriber<Integer> ts = new TestSubscriber<>(ts0);
 
         try {
             ts.onError(new RuntimeException());
@@ -1207,7 +1207,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertEmpty() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         try {
             ts.assertEmpty();
@@ -1232,7 +1232,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void awaitDoneTimed() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Thread.currentThread().interrupt();
 
@@ -1245,7 +1245,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertErrorMultiple() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         TestException e = new TestException();
         ts.onError(e);
@@ -1267,7 +1267,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertComplete() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1294,7 +1294,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeWithoutOnSubscribe() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         ts.onComplete();
 
@@ -1303,7 +1303,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(new FlowableSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1339,7 +1339,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(new FlowableSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1375,7 +1375,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.empty().subscribe(ts);
 
@@ -1390,7 +1390,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatch() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1).subscribe(ts);
 
@@ -1403,7 +1403,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1).subscribe(ts);
 
@@ -1418,7 +1418,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1, 2).subscribe(ts);
 
@@ -1433,7 +1433,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
 
         Flowable.empty().subscribe(ts);
 
@@ -1448,7 +1448,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateMatch() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1, 2).subscribe(ts);
 
@@ -1461,7 +1461,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1, 2, 3).subscribe(ts);
 
@@ -1476,7 +1476,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1, 2).subscribe(ts);
 
@@ -1563,7 +1563,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void disposeIndicated() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>();
+        TestSubscriber<Object> ts = new TestSubscriber<>();
         ts.cancel();
 
         try {

--- a/src/test/java/io/reactivex/rxjava3/tck/FromFutureTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/FromFutureTckTest.java
@@ -25,7 +25,7 @@ public class FromFutureTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(final long elements) {
-        FutureTask<Long> ft = new FutureTask<Long>(new Callable<Long>() {
+        FutureTask<Long> ft = new FutureTask<>(new Callable<Long>() {
             @Override
             public Long call() throws Exception {
                 return 1L;

--- a/src/test/java/io/reactivex/rxjava3/tck/MulticastProcessorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/MulticastProcessorTckTest.java
@@ -32,7 +32,7 @@ public class MulticastProcessorTckTest extends IdentityProcessorVerification<Int
     @Override
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
         MulticastProcessor<Integer> mp = MulticastProcessor.create();
-        return new RefCountProcessor<Integer>(mp);
+        return new RefCountProcessor<>(mp);
     }
 
     @Override

--- a/src/test/java/io/reactivex/rxjava3/tck/RefCountProcessor.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/RefCountProcessor.java
@@ -45,7 +45,7 @@ import io.reactivex.rxjava3.processors.FlowableProcessor;
     @SuppressWarnings("unchecked")
     RefCountProcessor(FlowableProcessor<T> actual) {
         this.actual = actual;
-        this.upstream = new AtomicReference<Subscription>();
+        this.upstream = new AtomicReference<>();
         this.subscribers = new AtomicReference<RefCountSubscriber<T>[]>(EMPTY);
     }
 
@@ -75,7 +75,7 @@ import io.reactivex.rxjava3.processors.FlowableProcessor;
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        RefCountSubscriber<T> rcs = new RefCountSubscriber<T>(s, this);
+        RefCountSubscriber<T> rcs = new RefCountSubscriber<>(s, this);
         if (!add(rcs)) {
             EmptySubscription.error(new IllegalStateException("RefCountProcessor terminated"), s);
             return;

--- a/src/test/java/io/reactivex/rxjava3/tck/UnicastProcessorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/UnicastProcessorTckTest.java
@@ -32,7 +32,7 @@ public class UnicastProcessorTckTest extends IdentityProcessorVerification<Integ
     @Override
     public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
-        return new RefCountProcessor<Integer>(up);
+        return new RefCountProcessor<>(up);
     }
 
     @Override

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -152,7 +152,7 @@ public enum TestHelper {
     }
 
     public static List<Throwable> trackPluginErrors() {
-        final List<Throwable> list = Collections.synchronizedList(new ArrayList<Throwable>());
+        final List<Throwable> list = Collections.synchronizedList(new ArrayList<>());
 
         RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
             @Override
@@ -2901,7 +2901,7 @@ public enum TestHelper {
 
         @Override
         protected void subscribeActual(Subscriber<? super T> s) {
-            source.subscribe(new StripBoundarySubscriber<T>(s));
+            source.subscribe(new StripBoundarySubscriber<>(s));
         }
 
         static final class StripBoundarySubscriber<T> implements FlowableSubscriber<T>, QueueSubscription<T> {
@@ -3017,7 +3017,7 @@ public enum TestHelper {
 
         @Override
         protected void subscribeActual(Observer<? super T> observer) {
-            source.subscribe(new StripBoundaryObserver<T>(observer));
+            source.subscribe(new StripBoundaryObserver<>(observer));
         }
 
         static final class StripBoundaryObserver<T> implements Observer<T>, QueueDisposable<T> {

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverEx.java
@@ -36,7 +36,7 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
     private final Observer<? super T> downstream;
 
     /** Holds the current subscription if any. */
-    private final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    private final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     private QueueDisposable<T> qd;
 

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverExTest.java
@@ -45,7 +45,7 @@ public class TestObserverExTest extends RxJavaTest {
     @Test
     public void assertTestObserverEx() {
         Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
-        TestObserverEx<Integer> subscriber = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
         oi.subscribe(subscriber);
 
         subscriber.assertValues(1, 2);
@@ -56,7 +56,7 @@ public class TestObserverExTest extends RxJavaTest {
     @Test
     public void assertNotMatchCount() {
         Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
-        TestObserverEx<Integer> subscriber = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
         oi.subscribe(subscriber);
 
         thrown.expect(AssertionError.class);
@@ -71,7 +71,7 @@ public class TestObserverExTest extends RxJavaTest {
     @Test
     public void assertNotMatchValue() {
         Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
-        TestObserverEx<Integer> subscriber = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
         oi.subscribe(subscriber);
 
         thrown.expect(AssertionError.class);
@@ -86,7 +86,7 @@ public class TestObserverExTest extends RxJavaTest {
     @Test
     public void assertNeverAtNotMatchingValue() {
         Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
-        TestObserverEx<Integer> subscriber = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
         oi.subscribe(subscriber);
 
         subscriber.assertNever(3);
@@ -97,7 +97,7 @@ public class TestObserverExTest extends RxJavaTest {
     @Test
     public void assertNeverAtMatchingValue() {
         Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
-        TestObserverEx<Integer> subscriber = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
         oi.subscribe(subscriber);
 
         subscriber.assertValues(1, 2);
@@ -111,7 +111,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertNeverAtMatchingPredicate() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(1, 2).subscribe(to);
 
@@ -129,7 +129,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertNeverAtNotMatchingPredicate() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(2, 3).subscribe(to);
 
@@ -144,7 +144,7 @@ public class TestObserverExTest extends RxJavaTest {
     @Test
     public void assertTerminalEventNotReceived() {
         PublishSubject<Integer> p = PublishSubject.create();
-        TestObserverEx<Integer> subscriber = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
         p.subscribe(subscriber);
 
         p.onNext(1);
@@ -165,7 +165,7 @@ public class TestObserverExTest extends RxJavaTest {
 
         Observer<Integer> mockSubscriber = TestHelper.mockObserver();
 
-        oi.subscribe(new TestObserverEx<Integer>(mockSubscriber));
+        oi.subscribe(new TestObserverEx<>(mockSubscriber));
 
         InOrder inOrder = inOrder(mockSubscriber);
         inOrder.verify(mockSubscriber, times(1)).onNext(1);
@@ -178,7 +178,7 @@ public class TestObserverExTest extends RxJavaTest {
     public void wrappingMockWhenUnsubscribeInvolved() {
         Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).take(2);
         Observer<Integer> mockSubscriber = TestHelper.mockObserver();
-        oi.subscribe(new TestObserverEx<Integer>(mockSubscriber));
+        oi.subscribe(new TestObserverEx<>(mockSubscriber));
 
         InOrder inOrder = inOrder(mockSubscriber);
         inOrder.verify(mockSubscriber, times(1)).onNext(1);
@@ -189,12 +189,12 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errorSwallowed() {
-        Observable.error(new RuntimeException()).subscribe(new TestObserverEx<Object>());
+        Observable.error(new RuntimeException()).subscribe(new TestObserverEx<>());
     }
 
     @Test
     public void nullExpected() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onNext(1);
 
         try {
@@ -208,7 +208,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void nullActual() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onNext(null);
 
         try {
@@ -222,7 +222,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void terminalErrorOnce() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onError(new TestException());
         to.onError(new TestException());
 
@@ -237,7 +237,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void terminalCompletedOnce() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onComplete();
         to.onComplete();
 
@@ -252,7 +252,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void terminalOneKind() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onError(new TestException());
         to.onComplete();
 
@@ -267,9 +267,9 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void createDelegate() {
-        TestObserverEx<Integer> to1 = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to1 = new TestObserverEx<>();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(to1);
+        TestObserverEx<Integer> to = new TestObserverEx<>(to1);
 
         to.assertNotSubscribed();
 
@@ -326,7 +326,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertError() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         try {
             to.assertError(TestException.class);
@@ -451,7 +451,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertFailure() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -474,7 +474,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertFuseable() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -494,10 +494,10 @@ public class TestObserverExTest extends RxJavaTest {
             // expected
         }
 
-        to = new TestObserverEx<Integer>();
+        to = new TestObserverEx<>();
         to.setInitialFusionMode(QueueFuseable.ANY);
 
-        to.onSubscribe(new ScalarDisposable<Integer>(to, 1));
+        to.onSubscribe(new ScalarDisposable<>(to, 1));
 
         to.assertFuseable();
 
@@ -521,7 +521,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertTerminated() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.assertNotTerminated();
 
@@ -537,7 +537,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertResult() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -574,7 +574,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void await() throws Exception {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -596,7 +596,7 @@ public class TestObserverExTest extends RxJavaTest {
 
         to.assertNoErrors().assertComplete();
 
-        final TestObserverEx<Integer> to1 = new TestObserverEx<Integer>();
+        final TestObserverEx<Integer> to1 = new TestObserverEx<>();
 
         to1.onSubscribe(Disposable.empty());
 
@@ -612,7 +612,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errors() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -627,7 +627,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void onNext() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -658,7 +658,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void multipleTerminals() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -701,7 +701,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValue() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -735,13 +735,13 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void onNextMisbehave() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onNext(1);
 
         to.assertError(IllegalStateException.class);
 
-        to = new TestObserverEx<Integer>();
+        to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -752,7 +752,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertTerminated2() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -778,7 +778,7 @@ public class TestObserverExTest extends RxJavaTest {
             // expected
         }
 
-        to = new TestObserverEx<Integer>();
+        to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -795,13 +795,13 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void onSubscribe() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(null);
 
         to.assertError(NullPointerException.class);
 
-        to = new TestObserverEx<Integer>();
+        to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -813,7 +813,7 @@ public class TestObserverExTest extends RxJavaTest {
 
         to.assertError(IllegalStateException.class);
 
-        to = new TestObserverEx<Integer>();
+        to = new TestObserverEx<>();
         to.dispose();
 
         d1 = Disposable.empty();
@@ -826,7 +826,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueSequence() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -859,7 +859,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertEmpty() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         try {
             to.assertEmpty();
@@ -884,7 +884,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void awaitDoneTimed() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Thread.currentThread().interrupt();
 
@@ -897,7 +897,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertNotSubscribed() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.assertNotSubscribed();
 
@@ -913,7 +913,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertErrorMultiple() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         TestException e = new TestException();
         to.errors().add(e);
@@ -947,7 +947,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errorInPredicate() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         to.onError(new RuntimeException());
         try {
             to.assertError(new Predicate<Throwable>() {
@@ -965,7 +965,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertComplete() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
 
@@ -992,7 +992,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void completeWithoutOnSubscribe() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onComplete();
 
@@ -1001,7 +1001,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(new Observer<Integer>() {
+        TestObserverEx<Integer> to = new TestObserverEx<>(new Observer<Integer>() {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1037,7 +1037,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>(new Observer<Integer>() {
+        TestObserverEx<Integer> to = new TestObserverEx<>(new Observer<Integer>() {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1073,7 +1073,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void syncQueueThrows() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         to.setInitialFusionMode(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
@@ -1091,7 +1091,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void asyncQueueThrows() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         to.setInitialFusionMode(QueueFuseable.ANY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
@@ -1129,7 +1129,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void asyncFusion() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
         to.setInitialFusionMode(QueueFuseable.ANY);
 
         UnicastSubject<Integer> up = UnicastSubject.create();
@@ -1148,7 +1148,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
 
         Observable.empty().subscribe(to);
 
@@ -1163,7 +1163,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatch() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(1).subscribe(to);
 
@@ -1176,7 +1176,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(1).subscribe(to);
 
@@ -1191,7 +1191,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(1, 2).subscribe(to);
 
@@ -1206,7 +1206,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
 
         Observable.empty().subscribe(to);
 
@@ -1221,7 +1221,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateMatch() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(1, 2).subscribe(to);
 
@@ -1234,7 +1234,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(1, 2, 3).subscribe(to);
 
@@ -1249,7 +1249,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Observable.just(1, 2).subscribe(to);
 
@@ -1264,7 +1264,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexEmpty() {
-        TestObserverEx<Object> to = new TestObserverEx<Object>();
+        TestObserverEx<Object> to = new TestObserverEx<>();
 
         Observable.empty().subscribe(to);
 
@@ -1275,7 +1275,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexMatch() {
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
 
         Observable.just("a", "b").subscribe(to);
 
@@ -1284,7 +1284,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
 
         Observable.just("a", "b", "c").subscribe(to);
 
@@ -1295,7 +1295,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexInvalidIndex() {
-        TestObserverEx<String> to = new TestObserverEx<String>();
+        TestObserverEx<String> to = new TestObserverEx<>();
 
         Observable.just("a", "b").subscribe(to);
 
@@ -1322,7 +1322,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnly() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onSubscribe(Disposable.empty());
         to.assertValuesOnly();
 
@@ -1335,7 +1335,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsOnUnexpectedValue() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onSubscribe(Disposable.empty());
         to.assertValuesOnly();
 
@@ -1354,7 +1354,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsWhenCompleted() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onSubscribe(Disposable.empty());
 
         to.onComplete();
@@ -1369,7 +1369,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsWhenErrored() {
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>();
+        TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onSubscribe(Disposable.empty());
 
         to.onError(new TestException());

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberEx.java
@@ -88,7 +88,7 @@ implements FlowableSubscriber<T>, Subscription {
             throw new IllegalArgumentException("Negative initial request not allowed");
         }
         this.downstream = actual;
-        this.upstream = new AtomicReference<Subscription>();
+        this.upstream = new AtomicReference<>();
         this.missedRequested = new AtomicLong(initialRequest);
     }
 

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberExTest.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberExTest.java
@@ -44,7 +44,7 @@ public class TestSubscriberExTest extends RxJavaTest {
     @Test
     public void assertTestSubscriberEx() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         oi.subscribe(ts);
 
         ts.assertValues(1, 2);
@@ -55,7 +55,7 @@ public class TestSubscriberExTest extends RxJavaTest {
     @Test
     public void assertNotMatchCount() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         oi.subscribe(ts);
 
         thrown.expect(AssertionError.class);
@@ -68,7 +68,7 @@ public class TestSubscriberExTest extends RxJavaTest {
     @Test
     public void assertNotMatchValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         oi.subscribe(ts);
 
         thrown.expect(AssertionError.class);
@@ -81,7 +81,7 @@ public class TestSubscriberExTest extends RxJavaTest {
     @Test
     public void assertNeverAtNotMatchingValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         oi.subscribe(ts);
 
         ts.assertNever(3);
@@ -92,7 +92,7 @@ public class TestSubscriberExTest extends RxJavaTest {
     @Test
     public void assertNeverAtMatchingValue() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         oi.subscribe(ts);
 
         ts.assertValues(1, 2);
@@ -106,7 +106,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertNeverAtMatchingPredicate() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.just(1, 2).subscribe(ts);
 
@@ -124,7 +124,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertNeverAtNotMatchingPredicate() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.just(2, 3).subscribe(ts);
 
@@ -139,7 +139,7 @@ public class TestSubscriberExTest extends RxJavaTest {
     @Test
     public void assertTerminalEventNotReceived() {
         PublishProcessor<Integer> p = PublishProcessor.create();
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         p.subscribe(ts);
 
         p.onNext(1);
@@ -157,7 +157,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
         Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
 
-        oi.subscribe(new TestSubscriberEx<Integer>(mockSubscriber));
+        oi.subscribe(new TestSubscriberEx<>(mockSubscriber));
 
         InOrder inOrder = inOrder(mockSubscriber);
         inOrder.verify(mockSubscriber, times(1)).onNext(1);
@@ -170,7 +170,7 @@ public class TestSubscriberExTest extends RxJavaTest {
     public void wrappingMockWhenUnsubscribeInvolved() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)).take(2);
         Subscriber<Integer> mockSubscriber = TestHelper.mockSubscriber();
-        oi.subscribe(new TestSubscriberEx<Integer>(mockSubscriber));
+        oi.subscribe(new TestSubscriberEx<>(mockSubscriber));
 
         InOrder inOrder = inOrder(mockSubscriber);
         inOrder.verify(mockSubscriber, times(1)).onNext(1);
@@ -182,14 +182,14 @@ public class TestSubscriberExTest extends RxJavaTest {
     @Test
     public void assertError() {
         RuntimeException e = new RuntimeException("Oops");
-        TestSubscriberEx<Object> subscriber = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> subscriber = new TestSubscriberEx<>();
         Flowable.error(e).subscribe(subscriber);
         subscriber.assertError(e);
     }
 
     @Test
     public void awaitTerminalEventWithDurationAndUnsubscribeOnTimeout() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
         final AtomicBoolean unsub = new AtomicBoolean(false);
         Flowable.just(1)
         //
@@ -208,28 +208,28 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullDelegate1() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(null);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(null);
         ts.onComplete();
     }
 
     @Test(expected = NullPointerException.class)
     public void nullDelegate2() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(null);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(null);
         ts.onComplete();
     }
 
     @Test(expected = NullPointerException.class)
     public void nullDelegate3() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(null, 0L);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(null, 0L);
         ts.onComplete();
     }
 
     @Test
     public void delegate1() {
-        TestSubscriberEx<Integer> ts0 = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts0 = new TestSubscriberEx<>();
         ts0.onSubscribe(EmptySubscription.INSTANCE);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(ts0);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(ts0);
         ts.onComplete();
 
         ts0.assertTerminated();
@@ -237,8 +237,8 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void delegate2() {
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>(ts1);
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>(ts1);
         ts2.onComplete();
 
         ts1.assertComplete();
@@ -246,21 +246,21 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void delegate3() {
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
-        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<Integer>(ts1, 0L);
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
+        TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>(ts1, 0L);
         ts2.onComplete();
         ts1.assertComplete();
     }
 
     @Test
     public void unsubscribed() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         assertFalse(ts.isCancelled());
     }
 
     @Test
     public void noErrors() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onError(new TestException());
         try {
             ts.assertNoErrors();
@@ -273,7 +273,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void notCompleted() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         try {
             ts.assertComplete();
         } catch (AssertionError ex) {
@@ -285,7 +285,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void multipleCompletions() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onComplete();
         ts.onComplete();
         try {
@@ -299,7 +299,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void completed() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onComplete();
         try {
             ts.assertNotComplete();
@@ -312,7 +312,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void multipleCompletions2() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onComplete();
         ts.onComplete();
         try {
@@ -326,7 +326,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void multipleErrors() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
         ts.onError(new TestException());
         ts.onError(new TestException());
@@ -350,7 +350,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void multipleErrors2() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
         ts.onError(new TestException());
         ts.onError(new TestException());
@@ -371,7 +371,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void multipleErrors3() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
         ts.onError(new TestException());
         ts.onError(new TestException());
@@ -392,7 +392,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void multipleErrors4() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
         ts.onError(new TestException());
         ts.onError(new TestException());
@@ -413,7 +413,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void differentError() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onError(new TestException());
         try {
             ts.assertError(new TestException());
@@ -426,7 +426,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void differentError2() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onError(new RuntimeException());
         try {
             ts.assertError(new TestException());
@@ -439,7 +439,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void differentError3() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onError(new RuntimeException());
         try {
             ts.assertError(TestException.class);
@@ -453,7 +453,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void differentError4() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onError(new RuntimeException());
         try {
             ts.assertError(Functions.<Throwable>alwaysFalse());
@@ -466,7 +466,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void errorInPredicate() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onError(new RuntimeException());
         try {
             ts.assertError(new Predicate<Throwable>() {
@@ -484,7 +484,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void noError() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         try {
             ts.assertError(TestException.class);
         } catch (AssertionError ex) {
@@ -496,7 +496,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void noError2() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         try {
             ts.assertError(new TestException());
         } catch (AssertionError ex) {
@@ -508,7 +508,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void noError3() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         try {
             ts.assertError(Functions.<Throwable>alwaysTrue());
         } catch (AssertionError ex) {
@@ -520,7 +520,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void interruptTerminalEventAwait() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
@@ -546,7 +546,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void interruptTerminalEventAwaitTimed() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
@@ -573,7 +573,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void interruptTerminalEventAwaitAndUnsubscribe() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
@@ -602,7 +602,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void noTerminalEventBut1Completed() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onComplete();
 
@@ -616,7 +616,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void noTerminalEventBut1Error() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onError(new TestException());
 
@@ -630,7 +630,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void noTerminalEventBut1Error1Completed() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onComplete();
         ts.onError(new TestException());
@@ -645,7 +645,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void noTerminalEventBut2Errors() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(EmptySubscription.INSTANCE);
 
         ts.onError(new TestException());
@@ -667,7 +667,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void noValues() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onNext(1);
 
         try {
@@ -680,7 +680,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void valueCount() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onNext(1);
         ts.onNext(2);
 
@@ -700,7 +700,7 @@ public class TestSubscriberExTest extends RxJavaTest {
                 throw new TestException();
             }
         };
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(ts0);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(ts0);
 
         try {
             ts.onComplete();
@@ -719,7 +719,7 @@ public class TestSubscriberExTest extends RxJavaTest {
                 throw new TestException();
             }
         };
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(ts0);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(ts0);
 
         try {
             ts.onError(new RuntimeException());
@@ -732,9 +732,9 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void createDelegate() {
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(ts1);
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(ts1);
 
         ts.assertNotSubscribed();
 
@@ -791,7 +791,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertError2() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         try {
             ts.assertError(TestException.class);
@@ -916,7 +916,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertFailure() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -939,7 +939,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertFuseable() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -958,10 +958,10 @@ public class TestSubscriberExTest extends RxJavaTest {
         } catch (AssertionError ex) {
             // expected
         }
-        ts = new TestSubscriberEx<Integer>();
+        ts = new TestSubscriberEx<>();
         ts.setInitialFusionMode(QueueFuseable.ANY);
 
-        ts.onSubscribe(new ScalarSubscription<Integer>(ts, 1));
+        ts.onSubscribe(new ScalarSubscription<>(ts, 1));
 
         ts.assertFuseable();
 
@@ -985,7 +985,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertTerminated() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.assertNotTerminated();
 
@@ -1001,7 +1001,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertResult() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1038,7 +1038,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void await() throws Exception {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1064,7 +1064,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
         assertTrue(ts.await(5, TimeUnit.SECONDS));
 
-        final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<Integer>();
+        final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
 
         ts1.onSubscribe(new BooleanSubscription());
 
@@ -1080,7 +1080,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void errors() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1095,7 +1095,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void onNext() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1127,7 +1127,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void multipleTerminals() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1170,7 +1170,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValue() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1204,13 +1204,13 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void onNextMisbehave() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onNext(1);
 
         ts.assertError(IllegalStateException.class);
 
-        ts = new TestSubscriberEx<Integer>();
+        ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1221,7 +1221,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void awaitTerminalEventInterrupt() {
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1250,7 +1250,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertTerminated2() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1276,7 +1276,7 @@ public class TestSubscriberExTest extends RxJavaTest {
             // expected
         }
 
-        ts = new TestSubscriberEx<Integer>();
+        ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1293,13 +1293,13 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void onSubscribe() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(null);
 
         ts.assertError(NullPointerException.class);
 
-        ts = new TestSubscriberEx<Integer>();
+        ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1311,7 +1311,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
         ts.assertError(IllegalStateException.class);
 
-        ts = new TestSubscriberEx<Integer>();
+        ts = new TestSubscriberEx<>();
         ts.dispose();
 
         bs1 = new BooleanSubscription();
@@ -1324,7 +1324,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValueSequence() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1357,7 +1357,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertEmpty() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         try {
             ts.assertEmpty();
@@ -1382,7 +1382,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void awaitDoneTimed() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Thread.currentThread().interrupt();
 
@@ -1395,7 +1395,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertNotSubscribed() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.assertNotSubscribed();
 
@@ -1411,7 +1411,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertErrorMultiple() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         TestException e = new TestException();
         ts.errors().add(e);
@@ -1439,7 +1439,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertComplete() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -1466,7 +1466,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void completeWithoutOnSubscribe() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         ts.onComplete();
 
@@ -1475,7 +1475,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(new FlowableSubscriber<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1511,7 +1511,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(new FlowableSubscriber<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1547,7 +1547,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void syncQueueThrows() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
         ts.setInitialFusionMode(QueueFuseable.SYNC);
 
         Flowable.range(1, 5)
@@ -1565,7 +1565,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void asyncQueueThrows() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
         ts.setInitialFusionMode(QueueFuseable.ANY);
 
         UnicastProcessor<Integer> up = UnicastProcessor.create();
@@ -1587,7 +1587,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
         Flowable.empty().subscribe(ts);
 
@@ -1602,7 +1602,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatch() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.just(1).subscribe(ts);
 
@@ -1615,7 +1615,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.just(1).subscribe(ts);
 
@@ -1630,7 +1630,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.just(1, 2).subscribe(ts);
 
@@ -1645,7 +1645,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
         Flowable.empty().subscribe(ts);
 
@@ -1660,7 +1660,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateMatch() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.just(1, 2).subscribe(ts);
 
@@ -1673,7 +1673,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.just(1, 2, 3).subscribe(ts);
 
@@ -1688,7 +1688,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         Flowable.just(1, 2).subscribe(ts);
 
@@ -1775,7 +1775,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void disposeIndicated() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<Object>();
+        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
         ts.cancel();
 
         try {
@@ -1824,7 +1824,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnly() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(new BooleanSubscription());
         ts.assertValuesOnly();
 
@@ -1837,7 +1837,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsOnUnexpectedValue() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(new BooleanSubscription());
         ts.assertValuesOnly();
 
@@ -1856,7 +1856,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsWhenCompleted() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(new BooleanSubscription());
 
         ts.onComplete();
@@ -1871,7 +1871,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsWhenErrored() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onSubscribe(new BooleanSubscription());
 
         ts.onError(new TestException());

--- a/src/test/java/io/reactivex/rxjava3/validators/BaseTypeParser.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/BaseTypeParser.java
@@ -48,7 +48,7 @@ public final class BaseTypeParser {
     }
 
     public static List<RxMethod> parse(File f, String baseClassName) throws Exception {
-        List<RxMethod> list = new ArrayList<RxMethod>();
+        List<RxMethod> list = new ArrayList<>();
 
         StringBuilder b = JavadocForAnnotations.readFile(f);
 

--- a/src/test/java/io/reactivex/rxjava3/validators/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/CheckLocalVariablesInTests.java
@@ -49,7 +49,7 @@ public class CheckLocalVariablesInTests {
             return;
         }
 
-        Queue<File> dirs = new ArrayDeque<File>();
+        Queue<File> dirs = new ArrayDeque<>();
 
         StringBuilder fail = new StringBuilder();
         fail.append("The following code pattern was found: ").append(pattern).append("\n");

--- a/src/test/java/io/reactivex/rxjava3/validators/FixLicenseHeaders.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/FixLicenseHeaders.java
@@ -52,7 +52,7 @@ public class FixLicenseHeaders {
             return;
         }
 
-        Queue<File> dirs = new ArrayDeque<File>();
+        Queue<File> dirs = new ArrayDeque<>();
 
         File parent = f.getParentFile().getParentFile();
         dirs.offer(parent);
@@ -73,7 +73,7 @@ public class FixLicenseHeaders {
                     } else {
                         if (u.getName().endsWith(".java")) {
 
-                            List<String> lines = new ArrayList<String>();
+                            List<String> lines = new ArrayList<>();
                             BufferedReader in = new BufferedReader(new FileReader(u));
                             try {
                                 for (;;) {

--- a/src/test/java/io/reactivex/rxjava3/validators/InternalWrongNaming.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/InternalWrongNaming.java
@@ -81,7 +81,7 @@ public class InternalWrongNaming {
     }
 
     static List<String> readFile(File u) throws Exception {
-        List<String> lines = new ArrayList<String>();
+        List<String> lines = new ArrayList<>();
 
         BufferedReader in = new BufferedReader(new FileReader(u));
         try {

--- a/src/test/java/io/reactivex/rxjava3/validators/JavadocFindUnescapedAngleBrackets.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/JavadocFindUnescapedAngleBrackets.java
@@ -31,7 +31,7 @@ public class JavadocFindUnescapedAngleBrackets {
 
         base = base.getParentFile().getParentFile();
 
-        Queue<File[]> files = new ArrayDeque<File[]>();
+        Queue<File[]> files = new ArrayDeque<>();
 
         files.offer(base.listFiles());
 

--- a/src/test/java/io/reactivex/rxjava3/validators/NewLinesBeforeAnnotation.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/NewLinesBeforeAnnotation.java
@@ -72,7 +72,7 @@ public class NewLinesBeforeAnnotation {
             return;
         }
 
-        Queue<File> dirs = new ArrayDeque<File>();
+        Queue<File> dirs = new ArrayDeque<>();
 
         StringBuilder fail = new StringBuilder();
         fail.append("The following code pattern was found: ");
@@ -102,7 +102,7 @@ public class NewLinesBeforeAnnotation {
                         String fname = u.getName();
                         if (fname.endsWith(".java")) {
 
-                            List<String> lines = new ArrayList<String>();
+                            List<String> lines = new ArrayList<>();
                             BufferedReader in = new BufferedReader(new FileReader(u));
                             try {
                                 for (;;) {

--- a/src/test/java/io/reactivex/rxjava3/validators/NoAnonymousInnerClassesTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/NoAnonymousInnerClassesTest.java
@@ -39,7 +39,7 @@ public class NoAnonymousInnerClassesTest {
 
         StringBuilder b = new StringBuilder("Anonymous inner classes found:");
 
-        Queue<File> queue = new ArrayDeque<File>();
+        Queue<File> queue = new ArrayDeque<>();
 
         queue.offer(f);
 

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -82,7 +82,7 @@ public class ParamValidationCheckerTest {
     static Map<Class<?>, List<Object>> defaultInstances;
 
     static {
-        overrides = new HashMap<String, List<ParamOverride>>();
+        overrides = new HashMap<>();
 
         // ***********************************************************************************************************************
 
@@ -514,7 +514,7 @@ public class ParamValidationCheckerTest {
 
         // -----------------------------------------------------------------------------------
 
-        ignores = new HashMap<String, List<ParamIgnore>>();
+        ignores = new HashMap<>();
 
         // needs special param validation due to (long)start + end - 1 <= Integer.MAX_VALUE
         addIgnore(new ParamIgnore(Flowable.class, "range", Integer.TYPE, Integer.TYPE));
@@ -544,7 +544,7 @@ public class ParamValidationCheckerTest {
 
         // -----------------------------------------------------------------------------------
 
-        defaultValues = new HashMap<Class<?>, Object>();
+        defaultValues = new HashMap<>();
 
         defaultValues.put(Publisher.class, new NeverPublisher());
         defaultValues.put(Flowable.class, new NeverPublisher());
@@ -645,7 +645,7 @@ public class ParamValidationCheckerTest {
 
         // -----------------------------------------------------------------------------------
 
-        defaultInstances = new HashMap<Class<?>, List<Object>>();
+        defaultInstances = new HashMap<>();
 
 //        addDefaultInstance(Flowable.class, Flowable.empty(), "Empty()");
 //        addDefaultInstance(Flowable.class, Flowable.empty().hide(), "Empty().Hide()");
@@ -677,7 +677,7 @@ public class ParamValidationCheckerTest {
         String key = ignore.toString();
         List<ParamIgnore> list = ignores.get(key);
         if (list == null) {
-            list = new ArrayList<ParamIgnore>();
+            list = new ArrayList<>();
             ignores.put(key, list);
         }
         list.add(ignore);
@@ -687,7 +687,7 @@ public class ParamValidationCheckerTest {
         String key = ignore.toString();
         List<ParamOverride> list = overrides.get(key);
         if (list == null) {
-            list = new ArrayList<ParamOverride>();
+            list = new ArrayList<>();
             overrides.put(key, list);
         }
         list.add(ignore);
@@ -696,7 +696,7 @@ public class ParamValidationCheckerTest {
     static void addDefaultInstance(Class<?> clazz, Object o, String tag) {
         List<Object> list = defaultInstances.get(clazz);
         if (list == null) {
-            list = new ArrayList<Object>();
+            list = new ArrayList<>();
             defaultInstances.put(clazz, list);
         }
         list.add(o);
@@ -786,7 +786,7 @@ public class ParamValidationCheckerTest {
 
                 List<ParamOverride> overrideList = overrides.get(key);
 
-                List<Object> baseObjects = new ArrayList<Object>();
+                List<Object> baseObjects = new ArrayList<>();
 
                 if ((m.getModifiers() & Modifier.STATIC) != 0) {
                     baseObjects.add(null);
@@ -853,7 +853,7 @@ public class ParamValidationCheckerTest {
                             }
                         }
 
-                        List<Object> entryValues = new ArrayList<Object>();
+                        List<Object> entryValues = new ArrayList<>();
 
                         if (entryClass.isPrimitive()) {
                             addCheckPrimitive(params[i], overrideEntry, entryValues);

--- a/src/test/java/io/reactivex/rxjava3/validators/TestPrefixInMethodName.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/TestPrefixInMethodName.java
@@ -37,7 +37,7 @@ public class TestPrefixInMethodName {
             return;
         }
 
-        Queue<File> dirs = new ArrayDeque<File>();
+        Queue<File> dirs = new ArrayDeque<>();
 
         StringBuilder fail = new StringBuilder();
         fail.append("The following code pattern was found: ").append(pattern).append("\n");
@@ -66,7 +66,7 @@ public class TestPrefixInMethodName {
                         if (fname.endsWith(".java")) {
 
                             int lineNum = 0;
-                            List<String> lines = new ArrayList<String>();
+                            List<String> lines = new ArrayList<>();
                             BufferedReader in = new BufferedReader(new FileReader(u));
                             //boolean found = false;
                             try {

--- a/src/test/java/io/reactivex/rxjava3/validators/TextualAorAn.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/TextualAorAn.java
@@ -32,7 +32,7 @@ public class TextualAorAn {
             return;
         }
 
-        Queue<File> dirs = new ArrayDeque<File>();
+        Queue<File> dirs = new ArrayDeque<>();
 
         File parent = f.getParentFile().getParentFile();
         dirs.offer(parent);
@@ -53,7 +53,7 @@ public class TextualAorAn {
                     } else {
                         if (u.getName().endsWith(".java")) {
 
-                            List<String> lines = new ArrayList<String>();
+                            List<String> lines = new ArrayList<>();
                             BufferedReader in = new BufferedReader(new FileReader(u));
                             try {
                                 for (;;) {

--- a/src/test/java/io/reactivex/rxjava3/validators/TooManyEmptyNewLines.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/TooManyEmptyNewLines.java
@@ -52,7 +52,7 @@ public class TooManyEmptyNewLines {
             return;
         }
 
-        Queue<File> dirs = new ArrayDeque<File>();
+        Queue<File> dirs = new ArrayDeque<>();
 
         StringBuilder fail = new StringBuilder();
         fail.append("The following code pattern was found: ");
@@ -82,7 +82,7 @@ public class TooManyEmptyNewLines {
                         String fname = u.getName();
                         if (fname.endsWith(".java")) {
 
-                            List<String> lines = new ArrayList<String>();
+                            List<String> lines = new ArrayList<>();
                             BufferedReader in = new BufferedReader(new FileReader(u));
                             try {
                                 for (;;) {


### PR DESCRIPTION
Hello, in this pull request i've changed all IDE marked explicit types with diamond operator. Affected packages is in tests root.

There is one test fail in CompletableTest.repeatNormal , but diamond is not the cause, there is last stack entry: 
java.lang.AssertionError: expected:<6> but was:<5>
	at org.junit.Assert.fail(Assert.java:88)

This PR is part of  #6767 issue resolving.