### PR TITLE
3.x: Remove now unnecessary unchecked warning suppressions

### DIFF
--- a/src/jmh/java/io/reactivex/rxjava3/core/MemoryPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/MemoryPerf.java
@@ -184,7 +184,7 @@ public final class MemoryPerf {
         checkMemory(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
-                return new io.reactivex.rxjava3.observers.TestObserver<Object>();
+                return new io.reactivex.rxjava3.observers.TestObserver<>();
             }
         }, "test-consumer", "Rx2Observable");
 
@@ -374,7 +374,7 @@ public final class MemoryPerf {
         checkMemory(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
-                return new io.reactivex.rxjava3.observers.TestObserver<Object>();
+                return new io.reactivex.rxjava3.observers.TestObserver<>();
             }
         }, "test-consumer", "Rx2Flowable");
 

--- a/src/jmh/java/io/reactivex/rxjava3/core/OperatorMergePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/OperatorMergePerf.java
@@ -134,7 +134,7 @@ public class OperatorMergePerf {
         @Setup
         public void setup(final Blackhole bh) {
             this.bh = bh;
-            observables = new ArrayList<Flowable<Integer>>();
+            observables = new ArrayList<>();
             for (int i = 0; i < size; i++) {
                 observables.add(Flowable.just(i));
             }

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableCollectTest.java
@@ -167,7 +167,6 @@ public final class FlowableCollectTest extends RxJavaTest {
         assertFalse(added.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void collectIntoFlowable() {
         Flowable.just(1, 1, 1, 1, 2)
@@ -316,7 +315,6 @@ public final class FlowableCollectTest extends RxJavaTest {
         assertFalse(added.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void collectInto() {
         Flowable.just(1, 1, 1, 1, 2)

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableConcatTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableConcatTests.java
@@ -61,7 +61,6 @@ public class FlowableConcatTests extends RxJavaTest {
         Flowable<String> f2 = Flowable.just("three", "four");
         Flowable<String> f3 = Flowable.just("five", "six");
 
-        @SuppressWarnings("unchecked")
         Iterable<Flowable<String>> is = Arrays.asList(f1, f2, f3);
 
         List<String> values = Flowable.concat(Flowable.fromIterable(is)).toList().blockingGet();

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
@@ -47,7 +47,6 @@ public class FlowableNullTests extends RxJavaTest {
         Flowable.ambArray((Publisher<Object>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void ambVarargsOneIsNull() {
         Flowable.ambArray(Flowable.never(), null).blockingLast();
@@ -68,7 +67,6 @@ public class FlowableNullTests extends RxJavaTest {
         }).test().assertError(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableOneIsNull() {
         Flowable.amb(Arrays.asList(Flowable.never(), null))
@@ -101,7 +99,6 @@ public class FlowableNullTests extends RxJavaTest {
         }).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableOneIsNull() {
         Flowable.combineLatestDelayError(Arrays.asList(Flowable.never(), null), new Function<Object[], Object>() {
@@ -112,13 +109,11 @@ public class FlowableNullTests extends RxJavaTest {
         }).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionNull() {
         Flowable.combineLatestDelayError(Arrays.asList(just1), null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionReturnsNull() {
         Flowable.combineLatestDelayError(Arrays.asList(just1), new Function<Object[], Object>() {
@@ -144,7 +139,6 @@ public class FlowableNullTests extends RxJavaTest {
         }).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void concatIterableOneIsNull() {
         Flowable.concat(Arrays.asList(just1, null)).blockingLast();
@@ -161,7 +155,6 @@ public class FlowableNullTests extends RxJavaTest {
         Flowable.concatArray((Publisher<Object>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void concatArrayOneIsNull() {
         Flowable.concatArray(just1, null).blockingLast();
@@ -480,7 +473,6 @@ public class FlowableNullTests extends RxJavaTest {
         }, 128, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeIterableOneIsNull() {
         Flowable.merge(Arrays.asList(just1, null), 128, 128).blockingLast();
@@ -512,7 +504,6 @@ public class FlowableNullTests extends RxJavaTest {
         }, 128, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableOneIsNull() {
         Flowable.mergeDelayError(Arrays.asList(just1, null), 128, 128).blockingLast();
@@ -634,13 +625,11 @@ public class FlowableNullTests extends RxJavaTest {
         }).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableFunctionNull() {
         Flowable.zip(Arrays.asList(just1, just1), null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableFunctionReturnsNull() {
         Flowable.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
@@ -676,13 +665,11 @@ public class FlowableNullTests extends RxJavaTest {
         }, true, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionNull() {
         Flowable.zip(Arrays.asList(just1, just1), null, true, 128);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionReturnsNull() {
         Flowable.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
@@ -2679,7 +2666,6 @@ public class FlowableNullTests extends RxJavaTest {
         just1.subscribe((FlowableSubscriber<Object>)null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableFunctionReturnsNull() {
         Flowable.combineLatestDelayError(Arrays.asList(just1), new Function<Object[], Object>() {
@@ -2690,7 +2676,6 @@ public class FlowableNullTests extends RxJavaTest {
         }, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableFunctionNull() {
         Flowable.combineLatestDelayError(Arrays.asList(just1), null, 128);
@@ -2731,7 +2716,6 @@ public class FlowableNullTests extends RxJavaTest {
         just1.doOnCancel(null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableOneIsNull() {
         Flowable.combineLatestDelayError(Arrays.asList(Flowable.never(), null), new Function<Object[], Object>() {

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableTests.java
@@ -1074,7 +1074,6 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void zipIterableObject() {
-        @SuppressWarnings("unchecked")
         final List<Flowable<Integer>> flowables = Arrays.asList(Flowable.just(1, 2, 3), Flowable.just(1, 2, 3));
         Flowable.zip(flowables, new Function<Object[], Object>() {
             @Override
@@ -1090,7 +1089,6 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void combineLatestObject() {
-        @SuppressWarnings("unchecked")
         final List<Flowable<Integer>> flowables = Arrays.asList(Flowable.just(1, 2, 3), Flowable.just(1, 2, 3));
         Flowable.combineLatest(flowables, new Function<Object[], Object>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableMaterializeTest.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 public class CompletableMaterializeTest extends RxJavaTest {
 
     @Test
-    @SuppressWarnings("unchecked")
     public void error() {
         TestException ex = new TestException();
         Completable.error(ex)
@@ -34,7 +33,6 @@ public class CompletableMaterializeTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void empty() {
         Completable.complete()
         .materialize()

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmbTest.java
@@ -102,7 +102,6 @@ public class FlowableAmbTest extends RxJavaTest {
         Flowable<String> flowable3 = createFlowable(new String[] {
                 "3", "33", "333", "3333" }, 3000, null);
 
-        @SuppressWarnings("unchecked")
         Flowable<String> f = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
@@ -131,7 +130,6 @@ public class FlowableAmbTest extends RxJavaTest {
         Flowable<String> flowable3 = createFlowable(new String[] {},
                 3000, new IOException("fake exception"));
 
-        @SuppressWarnings("unchecked")
         Flowable<String> f = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
@@ -158,7 +156,6 @@ public class FlowableAmbTest extends RxJavaTest {
         Flowable<String> flowable3 = createFlowable(new String[] {
                 "3" }, 3000, null);
 
-        @SuppressWarnings("unchecked")
         Flowable<String> f = Flowable.ambArray(flowable1,
                 flowable2, flowable3);
 
@@ -171,7 +168,6 @@ public class FlowableAmbTest extends RxJavaTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void producerRequestThroughAmb() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
@@ -237,7 +233,6 @@ public class FlowableAmbTest extends RxJavaTest {
         assertEquals(Flowable.bufferSize() * 2, ts.values().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void subscriptionOnlyHappensOnce() throws InterruptedException {
         final AtomicLong count = new AtomicLong();
@@ -262,7 +257,6 @@ public class FlowableAmbTest extends RxJavaTest {
         assertEquals(2, count.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void secondaryRequestsPropagatedToChildren() throws InterruptedException {
         //this aync stream should emit first
@@ -302,7 +296,6 @@ public class FlowableAmbTest extends RxJavaTest {
         assertEquals(1, result);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambCancelsOthers() {
         PublishProcessor<Integer> source1 = PublishProcessor.create();
@@ -347,7 +340,6 @@ public class FlowableAmbTest extends RxJavaTest {
         ts2.assertNoErrors();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -370,7 +362,6 @@ public class FlowableAmbTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable2() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -393,19 +384,16 @@ public class FlowableAmbTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayEmpty() {
         assertSame(Flowable.empty(), Flowable.ambArray());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArraySingleElement() {
         assertSame(Flowable.never(), Flowable.ambArray(Flowable.never()));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void disposed() {
         TestHelper.checkDisposed(Flowable.ambArray(Flowable.never(), Flowable.never()));
@@ -442,7 +430,6 @@ public class FlowableAmbTest extends RxJavaTest {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-            @SuppressWarnings("unchecked")
             TestSubscriberEx<Integer> ts = Flowable.ambArray(pp1, pp2).to(TestHelper.<Integer>testConsumer());
 
             Runnable r1 = new Runnable() {
@@ -471,7 +458,6 @@ public class FlowableAmbTest extends RxJavaTest {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-            @SuppressWarnings("unchecked")
             TestSubscriber<Integer> ts = Flowable.ambArray(pp1, pp2).test();
 
             Runnable r1 = new Runnable() {
@@ -499,7 +485,6 @@ public class FlowableAmbTest extends RxJavaTest {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-            @SuppressWarnings("unchecked")
             TestSubscriber<Integer> ts = Flowable.ambArray(pp1, pp2).test();
 
             final Throwable ex = new TestException();
@@ -531,7 +516,6 @@ public class FlowableAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void nullIterableElement() {
         Flowable.amb(Arrays.asList(Flowable.never(), null, Flowable.never()))
@@ -575,21 +559,18 @@ public class FlowableAmbTest extends RxJavaTest {
         Flowable.just(1).ambWith(error).test().assertValue(1).assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableOrder() {
         Flowable<Integer> error = Flowable.error(new RuntimeException());
         Flowable.amb(Arrays.asList(Flowable.just(1), error)).test().assertValue(1).assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayOrder() {
         Flowable<Integer> error = Flowable.error(new RuntimeException());
         Flowable.ambArray(Flowable.just(1), error).test().assertValue(1).assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerSuccessDispose() throws Exception {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
@@ -615,7 +596,6 @@ public class FlowableAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerErrorDispose() throws Exception {
         final TestException ex = new TestException();
@@ -642,7 +622,6 @@ public class FlowableAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerCompleteDispose() throws Exception {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
@@ -668,7 +647,6 @@ public class FlowableAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void publishersInIterable() {
         Publisher<Integer> source = new Publisher<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferTest.java
@@ -988,7 +988,6 @@ public class FlowableBufferTest extends RxJavaTest {
         assertFalse(s.isDisposed());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void postCompleteBackpressure() {
         Flowable<List<Integer>> source = Flowable.range(1, 10).buffer(3, 1);
@@ -1064,7 +1063,6 @@ public class FlowableBufferTest extends RxJavaTest {
         ts.assertNoErrors();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void timeAndSkipOverlap() {
 
@@ -1104,7 +1102,6 @@ public class FlowableBufferTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void timeAndSkipSkip() {
 
@@ -1141,7 +1138,6 @@ public class FlowableBufferTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void timeAndSkipOverlapScheduler() {
 
@@ -1192,7 +1188,6 @@ public class FlowableBufferTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void timeAndSkipSkipDefaultScheduler() {
         RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
@@ -1240,7 +1235,6 @@ public class FlowableBufferTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferBoundaryHint() {
         Flowable.range(1, 5).buffer(Flowable.timer(1, TimeUnit.MINUTES), 2)
@@ -1252,7 +1246,6 @@ public class FlowableBufferTest extends RxJavaTest {
         return new HashSet<>(Arrays.asList(values));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferIntoCustomCollection() {
         Flowable.just(1, 1, 2, 2, 3, 3, 4, 4)
@@ -1266,7 +1259,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertResult(set(1, 2), set(2, 3), set(4));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSkipIntoCustomCollection() {
         Flowable.just(1, 1, 2, 2, 3, 3, 4, 4)
@@ -1280,7 +1272,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertResult(set(1, 2), set(2, 3), set(4));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimeSkipDefault() {
         Flowable.range(1, 5).buffer(1, 1, TimeUnit.MINUTES)
@@ -1307,7 +1298,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierReturnsNull() {
         Flowable.<Integer>never()
         .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
@@ -1327,7 +1317,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierReturnsNull2() {
         Flowable.<Integer>never()
         .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
@@ -1347,7 +1336,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierReturnsNull3() {
         Flowable.<Integer>never()
         .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
@@ -1367,7 +1355,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows() {
         Flowable.just(1)
         .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
@@ -1381,7 +1368,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows2() {
         Flowable.just(1)
         .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
@@ -1395,7 +1381,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows3() {
         Flowable.just(1)
         .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
@@ -1409,7 +1394,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows4() {
         Flowable.<Integer>never()
         .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
@@ -1429,7 +1413,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows5() {
         Flowable.<Integer>never()
         .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
@@ -1449,7 +1432,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows6() {
         Flowable.<Integer>never()
         .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
@@ -1468,7 +1450,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void restartTimer() {
         Flowable.range(1, 5)
@@ -1477,7 +1458,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertResult(Arrays.asList(1, 2), Arrays.asList(3, 4), Arrays.asList(5));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSkipError() {
         Flowable.<Integer>error(new TestException())
@@ -1486,7 +1466,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSupplierCrash2() {
         Flowable.range(1, 2)
@@ -1504,7 +1483,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class, Arrays.asList(1));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSkipSupplierCrash2() {
         Flowable.range(1, 2)
@@ -1522,7 +1500,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferOverlapSupplierCrash2() {
         Flowable.range(1, 2)
@@ -1540,7 +1517,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSkipOverlap() {
         Flowable.range(1, 5)
@@ -1555,7 +1531,6 @@ public class FlowableBufferTest extends RxJavaTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedExactError() {
         Flowable.error(new TestException())
@@ -1564,7 +1539,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedSkipError() {
         Flowable.error(new TestException())
@@ -1573,7 +1547,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedOverlapError() {
         Flowable.error(new TestException())
@@ -1582,7 +1555,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedExactEmpty() {
         Flowable.empty()
@@ -1591,7 +1563,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertResult(Collections.emptyList());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedSkipEmpty() {
         Flowable.empty()
@@ -1600,7 +1571,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertResult(Collections.emptyList());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedOverlapEmpty() {
         Flowable.empty()
@@ -1609,7 +1579,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertResult(Collections.emptyList());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedExactSupplierCrash() {
         TestScheduler scheduler = new TestScheduler();
@@ -1639,7 +1608,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class, Arrays.asList(1));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedExactBoundedError() {
         TestScheduler scheduler = new TestScheduler();
@@ -1713,7 +1681,6 @@ public class FlowableBufferTest extends RxJavaTest {
         TestHelper.assertBadRequestReported(PublishProcessor.create().buffer(2, 1));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void skipError() {
         Flowable.error(new TestException())
@@ -1722,7 +1689,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void skipSingleResult() {
         Flowable.just(1)
@@ -1731,7 +1697,6 @@ public class FlowableBufferTest extends RxJavaTest {
         .assertResult(Arrays.asList(1));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void skipBackpressure() {
         Flowable.range(1, 10)
@@ -1782,7 +1747,6 @@ public class FlowableBufferTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCompletionCancelExact() {
         final AtomicInteger counter = new AtomicInteger();
@@ -1802,7 +1766,6 @@ public class FlowableBufferTest extends RxJavaTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCompletionCancelSkip() {
         final AtomicInteger counter = new AtomicInteger();
@@ -1822,7 +1785,6 @@ public class FlowableBufferTest extends RxJavaTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCompletionCancelOverlap() {
         final AtomicInteger counter = new AtomicInteger();
@@ -1843,7 +1805,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void boundaryOpenCloseDisposedOnComplete() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -1919,7 +1880,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openClosemainError() {
         Flowable.error(new TestException())
         .buffer(Flowable.never(), Functions.justFunction(Flowable.never()))
@@ -1928,7 +1888,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openClosebadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -1966,7 +1925,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseOpenCompletes() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -1995,7 +1953,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseOpenCompletesNoBuffers() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -2024,7 +1981,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseTake() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -2048,7 +2004,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseEmptyBackpressure() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -2069,7 +2024,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseErrorBackpressure() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -2090,7 +2044,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseBadOpen() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -2134,7 +2087,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseBadClose() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -2191,7 +2143,6 @@ public class FlowableBufferTest extends RxJavaTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferExactBoundarySecondBufferCrash() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -2213,7 +2164,6 @@ public class FlowableBufferTest extends RxJavaTest {
         ts.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferExactBoundaryBadSource() {
         Flowable<Integer> pp = new Flowable<Integer>() {
@@ -2425,7 +2375,6 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void bufferExactFailingSupplier() {
         Flowable.empty()
                 .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Supplier<List<Object>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -802,7 +802,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void combineLatestRequestOverflow() throws InterruptedException {
-        @SuppressWarnings("unchecked")
         List<Flowable<Integer>> sources = Arrays.asList(Flowable.fromArray(1, 2, 3, 4),
                 Flowable.fromArray(5, 6, 7, 8));
         Flowable<Integer> f = Flowable.combineLatest(sources, new Function<Object[], Integer>() {
@@ -864,7 +863,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         assertFalse(errorOccurred.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void combineLatestIterable() {
         Flowable<Integer> source = Flowable.just(1);
@@ -916,7 +914,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void firstJustError() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -936,7 +933,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         ts.assertNotComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void secondJustError() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -956,7 +952,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         ts.assertNotComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void oneErrors() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -976,7 +971,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         ts.assertNotComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void twoErrors() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -996,7 +990,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         ts.assertNotComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bothError() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -1140,7 +1133,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void combineLatestDelayErrorIterableOfSources() {
 
         Flowable.combineLatestDelayError(Arrays.asList(
@@ -1156,7 +1148,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void combineLatestDelayErrorIterableOfSourcesWithError() {
 
         Flowable.combineLatestDelayError(Arrays.asList(
@@ -1366,7 +1357,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void dontSubscribeIfDone2() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -1400,7 +1390,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void combine2Flowable2Errors() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -1534,7 +1523,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void syncFirstErrorsAfterItemDelayError() {
         Flowable.combineLatestDelayError(Arrays.asList(
                     Flowable.just(21).concatWith(Flowable.<Integer>error(new TestException())),
@@ -1552,7 +1540,6 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         .assertFailure(TestException.class, 42);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void publishersInIterable() {
         Publisher<Integer> source = new Publisher<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -252,7 +252,6 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
         assertTrue(cex.get(2).toString(), cex.get(2) instanceof TestException);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayErrorIterable() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -266,7 +265,6 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatDelayErrorIterableError() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -298,7 +298,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness2() {
         final AtomicInteger count = new AtomicInteger();
@@ -323,7 +322,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         tsBp.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness3() {
         final AtomicInteger count = new AtomicInteger();
@@ -348,7 +346,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         tsBp.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness4() {
         final AtomicInteger count = new AtomicInteger();
@@ -373,7 +370,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         tsBp.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness5() {
         final AtomicInteger count = new AtomicInteger();
@@ -398,7 +394,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         tsBp.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness6() {
         final AtomicInteger count = new AtomicInteger();
@@ -423,7 +418,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         tsBp.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness7() {
         final AtomicInteger count = new AtomicInteger();
@@ -448,7 +442,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         tsBp.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness8() {
         final AtomicInteger count = new AtomicInteger();
@@ -473,7 +466,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         tsBp.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness9() {
         final AtomicInteger count = new AtomicInteger();
@@ -507,7 +499,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         ts.assertNotComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void innerError() {
         Flowable.concatArrayEager(Flowable.just(1), Flowable.error(new TestException())).subscribe(ts);
@@ -517,7 +508,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         ts.assertNotComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void innerEmpty() {
         Flowable.concatArrayEager(Flowable.empty(), Flowable.empty()).subscribe(ts);
@@ -552,7 +542,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void backpressure() {
         Flowable.concatArrayEager(Flowable.just(1), Flowable.just(1)).subscribe(tsBp);
 
@@ -662,7 +651,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         Assert.assertEquals(1, (long) requests.get(5));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void capacityHint() {
         Flowable<Integer> source = Flowable.just(1);
@@ -699,7 +687,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void badCapacityHint() throws Exception {
         Flowable<Integer> source = Flowable.just(1);
@@ -730,7 +717,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         .assertResult();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatEagerOne() {
         Flowable.concatEager(Arrays.asList(Flowable.just(1)))
@@ -738,7 +724,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatEagerTwo() {
         Flowable.concatEager(Arrays.asList(Flowable.just(1), Flowable.just(2)))
@@ -770,7 +755,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatEagerIterable() {
         Flowable.concatEager(Arrays.asList(Flowable.just(1), Flowable.just(2)))
@@ -1193,7 +1177,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
         PublishProcessor<Integer> pp3 = PublishProcessor.create();
 
-        @SuppressWarnings("unchecked")
         TestSubscriber<Integer> ts = Flowable.concatArrayEagerDelayError(pp1, pp2, pp3)
         .test();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
@@ -283,7 +283,7 @@ public class FlowableConcatTest {
         final Flowable<String> even = Flowable.fromArray(e);
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
-        @SuppressWarnings("unchecked")
+
         TestObservable<Flowable<String>> observableOfObservables = new TestObservable<>(callOnce, okToContinue, odds, even);
         Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
         concatF.subscribe(subscriber);
@@ -322,7 +322,6 @@ public class FlowableConcatTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        @SuppressWarnings("unchecked")
         TestObservable<Flowable<String>> observableOfObservables = new TestObservable<>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
         Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
 
@@ -450,7 +449,6 @@ public class FlowableConcatTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         TestSubscriber<String> ts = new TestSubscriber<>(subscriber, 0L);
 
-        @SuppressWarnings("unchecked")
         TestObservable<Flowable<String>> observableOfObservables = new TestObservable<>(Flowable.unsafeCreate(w1), Flowable.unsafeCreate(w2));
         Flowable<String> concatF = Flowable.concat(Flowable.unsafeCreate(observableOfObservables));
 
@@ -506,10 +504,12 @@ public class FlowableConcatTest {
         private final T seed;
         private final int size;
 
+        @SafeVarargs
         TestObservable(T... values) {
             this(null, null, values);
         }
 
+        @SafeVarargs
         TestObservable(CountDownLatch once, CountDownLatch okToContinue, T... values) {
             this.values = Arrays.asList(values);
             this.size = this.values.size();
@@ -1055,7 +1055,6 @@ public class FlowableConcatTest {
         .assertResult(1, 1, 1, 1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayDelayError() {
         Flowable.concatArrayDelayError(Flowable.just(1), Flowable.just(2),
@@ -1064,7 +1063,6 @@ public class FlowableConcatTest {
         .assertResult(1, 2, 3, 4);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayDelayErrorWithError() {
         Flowable.concatArrayDelayError(Flowable.just(1), Flowable.just(2),
@@ -1074,7 +1072,6 @@ public class FlowableConcatTest {
         .assertFailure(TestException.class, 1, 2, 3, 4);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterableDelayError() {
         Flowable.concatDelayError(
@@ -1084,7 +1081,6 @@ public class FlowableConcatTest {
         .assertResult(1, 2, 3, 4);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterableDelayErrorWithError() {
         Flowable.concatDelayError(
@@ -1163,13 +1159,11 @@ public class FlowableConcatTest {
         .assertResult(1, 2, 3, 4, 5, 1, 2, 3, 4, 5);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void emptyArray() {
         assertSame(Flowable.empty(), Flowable.concatArrayDelayError());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleElementArray() {
         assertSame(Flowable.never(), Flowable.concatArrayDelayError(Flowable.never()));
@@ -1200,13 +1194,11 @@ public class FlowableConcatTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayEmpty() {
         assertSame(Flowable.empty(), Flowable.concatArray());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArraySingleElement() {
         assertSame(Flowable.never(), Flowable.concatArray(Flowable.never()));
@@ -1537,7 +1529,6 @@ public class FlowableConcatTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
@@ -1558,7 +1549,6 @@ public class FlowableConcatTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionDelayError() {
         final int[] calls = { 0 };
@@ -1579,7 +1569,6 @@ public class FlowableConcatTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionIterable() {
         final int[] calls = { 0 };
@@ -1600,7 +1589,6 @@ public class FlowableConcatTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionDelayErrorIterable() {
         final int[] calls = { 0 };
@@ -1621,7 +1609,6 @@ public class FlowableConcatTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCancelPreviousArray() {
         final AtomicInteger counter = new AtomicInteger();
@@ -1640,7 +1627,6 @@ public class FlowableConcatTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCancelPreviousIterable() {
         final AtomicInteger counter = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -2390,7 +2390,6 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void valueSelectorCrashAndMissingBackpressure() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -544,7 +544,6 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         verify(stringSubscriber, times(2)).onNext("hello");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void iterableMaxConcurrent() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -571,7 +570,6 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void iterableMaxConcurrentError() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
@@ -632,7 +630,6 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         .assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayErrorWithError() {
         Flowable.mergeDelayError(
@@ -678,7 +675,6 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         .assertFailure(TestException.class, 1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayErrorMaxConcurrency() {
         Flowable.mergeDelayError(
@@ -688,7 +684,6 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         .assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayErrorWithErrorMaxConcurrency() {
         Flowable.mergeDelayError(
@@ -720,7 +715,6 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         .assertFailure(TestException.class, 1, 2, 3);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayError() {
         Flowable.mergeDelayError(Arrays.asList(Flowable.just(1), Flowable.just(2)))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeTest.java
@@ -1343,7 +1343,6 @@ public class FlowableMergeTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void negativeMaxConcurrent() {
         try {
@@ -1354,7 +1353,6 @@ public class FlowableMergeTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void zeroMaxConcurrent() {
         try {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishTest.java
@@ -1368,7 +1368,6 @@ public class FlowablePublishTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void splitCombineSubscriberChangeAfterOnNext() {
         Flowable<Integer> source = Flowable.range(0, 20)
         .doOnSubscribe(new Consumer<Subscription>() {
@@ -1436,7 +1435,6 @@ public class FlowablePublishTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void splitCombineSubscriberChangeAfterOnNextFused() {
         Flowable<Integer> source = Flowable.range(0, 20)
         .publish(10)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeIntervalTest.java
@@ -129,7 +129,6 @@ public class FlowableTimeIntervalTest extends RxJavaTest {
         TestHelper.checkDisposed(Flowable.just(1).timeInterval());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error() {
         Flowable.error(new TestException())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListTest.java
@@ -113,7 +113,6 @@ public class FlowableToListTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void capacityHintFlowable() {
         Flowable.range(1, 10)
@@ -182,7 +181,6 @@ public class FlowableToListTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void capacityHint() {
         Flowable.range(1, 10)
@@ -198,7 +196,6 @@ public class FlowableToListTest extends RxJavaTest {
         TestHelper.checkDisposed(Flowable.just(1).toList());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error() {
         Flowable.error(new TestException())
@@ -208,7 +205,6 @@ public class FlowableToListTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorSingle() {
         Flowable.error(new TestException())
@@ -217,7 +213,6 @@ public class FlowableToListTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void collectionSupplierThrows() {
         Flowable.just(1)
@@ -232,7 +227,6 @@ public class FlowableToListTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void collectionSupplierReturnsNull() {
         Flowable.just(1)
@@ -248,7 +242,6 @@ public class FlowableToListTest extends RxJavaTest {
         .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleCollectionSupplierThrows() {
         Flowable.just(1)
@@ -262,7 +255,6 @@ public class FlowableToListTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleCollectionSupplierReturnsNull() {
         Flowable.just(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToSortedListTest.java
@@ -112,7 +112,6 @@ public class FlowableToSortedListTest extends RxJavaTest {
         .assertResult(5, 4, 3, 2, 1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedListCapacityFlowable() {
         Flowable.just(5, 1, 2, 4, 3).toSortedList(4).toFlowable()
@@ -120,7 +119,6 @@ public class FlowableToSortedListTest extends RxJavaTest {
         .assertResult(Arrays.asList(1, 2, 3, 4, 5));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedListComparatorCapacityFlowable() {
         Flowable.just(5, 1, 2, 4, 3).toSortedList(new Comparator<Integer>() {
@@ -178,7 +176,6 @@ public class FlowableToSortedListTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedListCapacity() {
         Flowable.just(5, 1, 2, 4, 3).toSortedList(4)
@@ -186,7 +183,6 @@ public class FlowableToSortedListTest extends RxJavaTest {
         .assertResult(Arrays.asList(1, 2, 3, 4, 5));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedListComparatorCapacity() {
         Flowable.just(5, 1, 2, 4, 3).toSortedList(new Comparator<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -328,7 +328,6 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         }, false, 1, 1, 1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void boundaryDirectMissingBackpressure() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -344,7 +343,6 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void boundaryDirectMissingBackpressureNoNullPointerException() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -290,7 +290,6 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         ts.assertValueCount(22);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void backpressureOuterInexact() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>(0L);
@@ -364,7 +363,6 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         });
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorExact() {
         Flowable.error(new TestException())
@@ -373,7 +371,6 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorSkip() {
         Flowable.error(new TestException())
@@ -382,7 +379,6 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorOverlap() {
         Flowable.error(new TestException())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -434,7 +434,6 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void mainWindowMissingBackpressure() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
@@ -515,7 +514,6 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         inner.get().test().assertResult();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void closingIndicatorFunctionCrash() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -434,7 +434,6 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void exactBackpressure() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -449,7 +448,6 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void skipBackpressure() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -464,7 +462,6 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void overlapBackpressure() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -866,7 +863,6 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         });
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void firstWindowMissingBackpressure() {
         Flowable.never()

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -704,7 +704,6 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         .assertFailure(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void combineToNull2() {
         Flowable.just(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
@@ -1422,7 +1422,6 @@ public class FlowableZipTest extends RxJavaTest {
         .assertResult("929");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void zipArrayEmpty() {
         assertSame(Flowable.empty(), Flowable.zipArray(Functions.<Object[]>identity(), false, 16));
@@ -1897,7 +1896,6 @@ public class FlowableZipTest extends RxJavaTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void publishersInIterable() {
         Publisher<Integer> source = new Publisher<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeAmbTest.java
@@ -50,7 +50,6 @@ public class MaybeAmbTest extends RxJavaTest {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambFirstDone() {
         Maybe.amb(Arrays.asList(Maybe.just(1), Maybe.just(2)))
@@ -58,7 +57,6 @@ public class MaybeAmbTest extends RxJavaTest {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void dispose() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -76,7 +74,6 @@ public class MaybeAmbTest extends RxJavaTest {
         assertFalse(pp2.hasSubscribers());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void innerErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -255,7 +252,6 @@ public class MaybeAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void maybeSourcesInIterable() {
         MaybeSource<Integer> source = new MaybeSource<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -29,7 +29,6 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class MaybeConcatIterableTest extends RxJavaTest {
 
-    @SuppressWarnings("unchecked")
     @Test
     public void take() {
         Maybe.concat(Arrays.asList(Maybe.just(1), Maybe.just(2), Maybe.just(3)))
@@ -50,7 +49,6 @@ public class MaybeConcatIterableTest extends RxJavaTest {
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error() {
         Maybe.concat(Arrays.asList(Maybe.just(1), Maybe.<Integer>error(new TestException()), Maybe.just(3)))
@@ -58,7 +56,6 @@ public class MaybeConcatIterableTest extends RxJavaTest {
         .assertFailure(TestException.class, 1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void successCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -124,7 +121,6 @@ public class MaybeConcatIterableTest extends RxJavaTest {
         .assertFailure(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
@@ -144,7 +140,6 @@ public class MaybeConcatIterableTest extends RxJavaTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionDelayError() {
         final int[] calls = { 0 };

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMaterializeTest.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 public class MaybeMaterializeTest extends RxJavaTest {
 
     @Test
-    @SuppressWarnings("unchecked")
     public void success() {
         Maybe.just(1)
         .materialize()
@@ -33,7 +32,6 @@ public class MaybeMaterializeTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void error() {
         TestException ex = new TestException();
         Maybe.error(ex)
@@ -43,7 +41,6 @@ public class MaybeMaterializeTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void empty() {
         Maybe.empty()
         .materialize()

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorXTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorXTest.java
@@ -66,7 +66,6 @@ public class MaybeOnErrorXTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void onErrorReturnFunctionThrows() {
         TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
@@ -79,7 +78,6 @@ public class MaybeOnErrorXTest extends RxJavaTest {
         .to(TestHelper.testConsumer()), TestException.class, IOException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void onErrorCompletePredicateThrows() {
         TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
@@ -116,7 +114,6 @@ public class MaybeOnErrorXTest extends RxJavaTest {
         .assertFailure(AssertionError.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void onErrorResumeNextFunctionThrows() {
         TestHelper.assertCompositeExceptions(Maybe.error(new TestException())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterableTest.java
@@ -38,7 +38,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         }
     };
 
-    @SuppressWarnings("unchecked")
     @Test
     public void firstError() {
         Maybe.zip(Arrays.asList(Maybe.error(new TestException()), Maybe.just(1)), addString)
@@ -46,7 +45,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void secondError() {
         Maybe.zip(Arrays.asList(Maybe.just(1), Maybe.<Integer>error(new TestException())), addString)
@@ -54,7 +52,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -69,7 +66,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         assertFalse(pp.hasSubscribers());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void zipperThrows() {
         Maybe.zip(Arrays.asList(Maybe.just(1), Maybe.just(2)), new Function<Object[], Object>() {
@@ -82,7 +78,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void zipperReturnsNull() {
         Maybe.zip(Arrays.asList(Maybe.just(1), Maybe.just(2)), new Function<Object[], Object>() {
@@ -95,7 +90,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .assertFailure(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void middleError() {
         PublishProcessor<Integer> pp0 = PublishProcessor.create();
@@ -112,7 +106,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         to.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void innerErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -190,7 +183,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .assertFailureAndMessage(TestException.class, "next()");
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableOneIsNull() {
         Maybe.zip(Arrays.asList(null, Maybe.just(1)), new Function<Object[], Object>() {
@@ -202,7 +194,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableTwoIsNull() {
         Maybe.zip(Arrays.asList(Maybe.just(1), null), new Function<Object[], Object>() {
@@ -222,7 +213,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .assertFailureAndMessage(NullPointerException.class, "The zipper returned a null value");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void maybeSourcesInIterable() {
         MaybeSource<Integer> source = new MaybeSource<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
@@ -374,7 +374,6 @@ public class ObservableAmbTest extends RxJavaTest {
         Observable.just(1).ambWith(error).test().assertValue(1).assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableOrder() {
         Observable<Integer> error = Observable.error(new RuntimeException());
@@ -467,7 +466,6 @@ public class ObservableAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void observableSourcesInIterable() {
         ObservableSource<Integer> source = new ObservableSource<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferTest.java
@@ -764,7 +764,6 @@ public class ObservableBufferTest extends RxJavaTest {
         assertFalse(observer.isDisposed());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimeSkipDefault() {
         Observable.range(1, 5).buffer(1, 1, TimeUnit.MINUTES)
@@ -772,7 +771,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertResult(Arrays.asList(1, 2, 3, 4, 5));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferBoundaryHint() {
         Observable.range(1, 5).buffer(Observable.timer(1, TimeUnit.MINUTES), 2)
@@ -784,7 +782,6 @@ public class ObservableBufferTest extends RxJavaTest {
         return new HashSet<>(Arrays.asList(values));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferIntoCustomCollection() {
         Observable.just(1, 1, 2, 2, 3, 3, 4, 4)
@@ -798,7 +795,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertResult(set(1, 2), set(2, 3), set(4));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSkipIntoCustomCollection() {
         Observable.just(1, 1, 2, 2, 3, 3, 4, 4)
@@ -813,7 +809,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows() {
         Observable.just(1)
         .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
@@ -827,7 +822,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows2() {
         Observable.just(1)
         .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
@@ -841,7 +835,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows3() {
         Observable.just(1)
         .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
@@ -855,7 +848,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows4() {
         Observable.<Integer>never()
         .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
@@ -875,7 +867,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows5() {
         Observable.<Integer>never()
         .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
@@ -895,7 +886,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierThrows6() {
         Observable.<Integer>never()
         .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
@@ -915,7 +905,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierReturnsNull() {
         Observable.<Integer>never()
         .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
@@ -935,7 +924,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierReturnsNull2() {
         Observable.<Integer>never()
         .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
@@ -955,7 +943,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void supplierReturnsNull3() {
         Observable.<Integer>never()
         .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
@@ -996,7 +983,6 @@ public class ObservableBufferTest extends RxJavaTest {
         TestHelper.checkDisposed(PublishSubject.create().buffer(Observable.never(), Functions.justFunction(Observable.never())));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void restartTimer() {
         Observable.range(1, 5)
@@ -1005,7 +991,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertResult(Arrays.asList(1, 2), Arrays.asList(3, 4), Arrays.asList(5));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSupplierCrash2() {
         Observable.range(1, 2)
@@ -1023,7 +1008,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class, Arrays.asList(1));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSkipSupplierCrash2() {
         Observable.range(1, 2)
@@ -1041,7 +1025,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSkipError() {
         Observable.<Integer>error(new TestException())
@@ -1050,7 +1033,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferSkipOverlap() {
         Observable.range(1, 5)
@@ -1065,7 +1047,6 @@ public class ObservableBufferTest extends RxJavaTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedExactError() {
         Observable.error(new TestException())
@@ -1074,7 +1055,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedSkipError() {
         Observable.error(new TestException())
@@ -1083,7 +1063,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedOverlapError() {
         Observable.error(new TestException())
@@ -1092,7 +1071,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedExactEmpty() {
         Observable.empty()
@@ -1101,7 +1079,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertResult(Collections.emptyList());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedSkipEmpty() {
         Observable.empty()
@@ -1110,7 +1087,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertResult(Collections.emptyList());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedOverlapEmpty() {
         Observable.empty()
@@ -1119,7 +1095,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertResult(Collections.emptyList());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedExactSupplierCrash() {
         TestScheduler scheduler = new TestScheduler();
@@ -1149,7 +1124,6 @@ public class ObservableBufferTest extends RxJavaTest {
         .assertFailure(TestException.class, Arrays.asList(1));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferTimedExactBoundedError() {
         TestScheduler scheduler = new TestScheduler();
@@ -1207,7 +1181,6 @@ public class ObservableBufferTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCompletionCancelExact() {
         final AtomicInteger counter = new AtomicInteger();
@@ -1227,7 +1200,6 @@ public class ObservableBufferTest extends RxJavaTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCompletionCancelSkip() {
         final AtomicInteger counter = new AtomicInteger();
@@ -1247,7 +1219,6 @@ public class ObservableBufferTest extends RxJavaTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCompletionCancelOverlap() {
         final AtomicInteger counter = new AtomicInteger();
@@ -1268,7 +1239,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void boundaryOpenCloseDisposedOnComplete() {
         PublishSubject<Integer> source = PublishSubject.create();
 
@@ -1344,7 +1314,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openClosemainError() {
         Observable.error(new TestException())
         .buffer(Observable.never(), Functions.justFunction(Observable.never()))
@@ -1353,7 +1322,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openClosebadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -1391,7 +1359,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseOpenCompletes() {
         PublishSubject<Integer> source = PublishSubject.create();
 
@@ -1420,7 +1387,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseOpenCompletesNoBuffers() {
         PublishSubject<Integer> source = PublishSubject.create();
 
@@ -1449,7 +1415,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseTake() {
         PublishSubject<Integer> source = PublishSubject.create();
 
@@ -1473,7 +1438,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseBadOpen() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -1517,7 +1481,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void openCloseBadClose() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -1574,7 +1537,6 @@ public class ObservableBufferTest extends RxJavaTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferExactBoundarySecondBufferCrash() {
         PublishSubject<Integer> ps = PublishSubject.create();
@@ -1596,7 +1558,6 @@ public class ObservableBufferTest extends RxJavaTest {
         to.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void bufferExactBoundaryBadSource() {
         Observable<Integer> ps = new Observable<Integer>() {
@@ -1814,7 +1775,6 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void bufferExactFailingSupplier() {
         Observable.empty()
                 .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Supplier<List<Object>>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollectTest.java
@@ -142,7 +142,6 @@ public final class ObservableCollectTest extends RxJavaTest {
         assertFalse(added.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void collectIntoObservable() {
         Observable.just(1, 1, 1, 1, 2)
@@ -266,7 +265,6 @@ public final class ObservableCollectTest extends RxJavaTest {
         assertFalse(added.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void collectInto() {
         Observable.just(1, 1, 1, 1, 2)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
@@ -818,7 +818,6 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void combineLatestDelayErrorIterableOfSources() {
 
         Observable.combineLatestDelayError(Arrays.asList(
@@ -834,7 +833,6 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void combineLatestDelayErrorIterableOfSourcesWithError() {
 
         Observable.combineLatestDelayError(Arrays.asList(
@@ -1044,7 +1042,6 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void dontSubscribeIfDone2() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -1078,7 +1075,6 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void combine2Observable2Errors() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -1195,7 +1191,6 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void syncFirstErrorsAfterItemDelayError() {
         Observable.combineLatestDelayError(Arrays.asList(
                     Observable.just(21).concatWith(Observable.<Integer>error(new TestException())),
@@ -1213,7 +1208,6 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         .assertFailure(TestException.class, 42);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void observableSourcesInIterable() {
         ObservableSource<Integer> source = new ObservableSource<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -503,7 +503,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void capacityHint() {
         Observable<Integer> source = Observable.just(1);
@@ -540,7 +539,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void badCapacityHint() throws Exception {
         Observable<Integer> source = Observable.just(1);
@@ -564,7 +562,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatEagerIterable() {
         Observable.concatEager(Arrays.asList(Observable.just(1), Observable.just(2)))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
@@ -271,7 +271,7 @@ public class ObservableConcatTest extends RxJavaTest {
         final Observable<String> even = Observable.fromArray(e);
         final CountDownLatch callOnce = new CountDownLatch(1);
         final CountDownLatch okToContinue = new CountDownLatch(1);
-        @SuppressWarnings("unchecked")
+
         TestObservable<Observable<String>> observableOfObservables = new TestObservable<>(callOnce, okToContinue, odds, even);
         Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
         concatF.subscribe(observer);
@@ -310,7 +310,6 @@ public class ObservableConcatTest extends RxJavaTest {
 
         Observer<String> observer = TestHelper.mockObserver();
 
-        @SuppressWarnings("unchecked")
         TestObservable<Observable<String>> observableOfObservables = new TestObservable<>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
         Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
@@ -438,7 +437,6 @@ public class ObservableConcatTest extends RxJavaTest {
         Observer<String> observer = TestHelper.mockObserver();
         TestObserver<String> to = new TestObserver<>(observer);
 
-        @SuppressWarnings("unchecked")
         TestObservable<Observable<String>> observableOfObservables = new TestObservable<>(Observable.unsafeCreate(w1), Observable.unsafeCreate(w2));
         Observable<String> concatF = Observable.concat(Observable.unsafeCreate(observableOfObservables));
 
@@ -493,10 +491,12 @@ public class ObservableConcatTest extends RxJavaTest {
         private final T seed;
         private final int size;
 
+        @SafeVarargs
         TestObservable(T... values) {
             this(null, null, values);
         }
 
+        @SafeVarargs
         TestObservable(CountDownLatch once, CountDownLatch okToContinue, T... values) {
             this.values = Arrays.asList(values);
             this.size = this.values.size();
@@ -799,7 +799,6 @@ public class ObservableConcatTest extends RxJavaTest {
         .assertFailure(TestException.class, 1, 2, 3, 4);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterableDelayError() {
         Observable.concatDelayError(
@@ -809,7 +808,6 @@ public class ObservableConcatTest extends RxJavaTest {
         .assertResult(1, 2, 3, 4);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterableDelayErrorWithError() {
         Observable.concatDelayError(
@@ -1004,7 +1002,6 @@ public class ObservableConcatTest extends RxJavaTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionIterable() {
         final int[] calls = { 0 };
@@ -1025,7 +1022,6 @@ public class ObservableConcatTest extends RxJavaTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionDelayErrorIterable() {
         final int[] calls = { 0 };
@@ -1179,7 +1175,6 @@ public class ObservableConcatTest extends RxJavaTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCancelPreviousIterable() {
         final AtomicInteger counter = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -499,7 +499,6 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayError() {
         Observable.mergeDelayError(Arrays.asList(Observable.just(1), Observable.just(2)))
@@ -515,7 +514,6 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         .assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayErrorWithError() {
         Observable.mergeDelayError(
@@ -561,7 +559,6 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         .assertFailure(TestException.class, 1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayErrorMaxConcurrency() {
         Observable.mergeDelayError(
@@ -571,7 +568,6 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         .assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayErrorWithErrorMaxConcurrency() {
         Observable.mergeDelayError(

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeIntervalTest.java
@@ -128,7 +128,6 @@ public class ObservableTimeIntervalTest extends RxJavaTest {
         TestHelper.checkDisposed(Observable.just(1).timeInterval());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error() {
         Observable.error(new TestException())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToListTest.java
@@ -85,7 +85,6 @@ public class ObservableToListTest extends RxJavaTest {
         Assert.assertEquals(Arrays.asList("one", "two", "three"), actual);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void capacityHintObservable() {
         Observable.range(1, 10)
@@ -154,7 +153,6 @@ public class ObservableToListTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void capacityHint() {
         Observable.range(1, 10)
@@ -170,7 +168,6 @@ public class ObservableToListTest extends RxJavaTest {
         TestHelper.checkDisposed(Observable.just(1).toList());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error() {
         Observable.error(new TestException())
@@ -180,7 +177,6 @@ public class ObservableToListTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorSingle() {
         Observable.error(new TestException())
@@ -189,7 +185,6 @@ public class ObservableToListTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void collectionSupplierThrows() {
         Observable.just(1)
@@ -204,7 +199,6 @@ public class ObservableToListTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void collectionSupplierReturnsNull() {
         Observable.just(1)
@@ -220,7 +214,6 @@ public class ObservableToListTest extends RxJavaTest {
         .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleCollectionSupplierThrows() {
         Observable.just(1)
@@ -234,7 +227,6 @@ public class ObservableToListTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleCollectionSupplierReturnsNull() {
         Observable.just(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToSortedListTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToSortedListTest.java
@@ -96,7 +96,6 @@ public class ObservableToSortedListTest extends RxJavaTest {
         .assertResult(5, 4, 3, 2, 1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedListCapacityObservable() {
         Observable.just(5, 1, 2, 4, 3).toSortedList(4).toObservable()
@@ -104,7 +103,6 @@ public class ObservableToSortedListTest extends RxJavaTest {
         .assertResult(Arrays.asList(1, 2, 3, 4, 5));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedListComparatorCapacityObservable() {
         Observable.just(5, 1, 2, 4, 3).toSortedList(new Comparator<Integer>() {
@@ -152,7 +150,6 @@ public class ObservableToSortedListTest extends RxJavaTest {
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), o.toSortedList().blockingGet());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedListCapacity() {
         Observable.just(5, 1, 2, 4, 3).toSortedList(4)
@@ -160,7 +157,6 @@ public class ObservableToSortedListTest extends RxJavaTest {
         .assertResult(Arrays.asList(1, 2, 3, 4, 5));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedListComparatorCapacity() {
         Observable.just(5, 1, 2, 4, 3).toSortedList(new Comparator<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -293,7 +293,6 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         });
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorExact() {
         Observable.error(new TestException())
@@ -302,7 +301,6 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorSkip() {
         Observable.error(new TestException())
@@ -311,7 +309,6 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorOverlap() {
         Observable.error(new TestException())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -498,7 +498,6 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
         inner.get().test().assertResult();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void closingIndicatorFunctionCrash() {
 
@@ -524,7 +523,6 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
         assertFalse(boundary.hasObservers());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mainError() {
         Observable.error(new TestException())

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWithLatestFromTest.java
@@ -579,7 +579,6 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
         .assertFailure(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void combineToNull2() {
         Observable.just(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
@@ -1430,7 +1430,6 @@ public class ObservableZipTest extends RxJavaTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void observableSourcesInIterable() {
         ObservableSource<Integer> source = new ObservableSource<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleAmbTest.java
@@ -71,7 +71,6 @@ public class SingleAmbTest extends RxJavaTest {
         to.assertResult(2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableWithFirstFires() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -93,7 +92,6 @@ public class SingleAmbTest extends RxJavaTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableWithSecondFires() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -272,7 +270,6 @@ public class SingleAmbTest extends RxJavaTest {
         Single.just(1).ambWith(error).test().assertValue(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableOrder() {
         Single<Integer> error = Single.error(new RuntimeException());
@@ -343,7 +340,6 @@ public class SingleAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleSourcesInIterable() {
         SingleSource<Integer> source = new SingleSource<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleConcatTest.java
@@ -89,7 +89,6 @@ public class SingleConcatTest extends RxJavaTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatEagerIterableTest() {
         PublishProcessor<String> pp1 = PublishProcessor.create();
@@ -163,7 +162,6 @@ public class SingleConcatTest extends RxJavaTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionIterable() {
         final int[] calls = { 0 };

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleMaterializeTest.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 public class SingleMaterializeTest extends RxJavaTest {
 
     @Test
-    @SuppressWarnings("unchecked")
     public void success() {
         Single.just(1)
         .materialize()
@@ -33,7 +32,6 @@ public class SingleMaterializeTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void error() {
         TestException ex = new TestException();
         Maybe.error(ex)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleMergeTest.java
@@ -72,7 +72,6 @@ public class SingleMergeTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeDelayErrorIterable() {
         Single.mergeDelayError(Arrays.asList(

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipIterableTest.java
@@ -38,7 +38,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         }
     };
 
-    @SuppressWarnings("unchecked")
     @Test
     public void firstError() {
         Single.zip(Arrays.asList(Single.error(new TestException()), Single.just(1)), addString)
@@ -46,7 +45,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void secondError() {
         Single.zip(Arrays.asList(Single.just(1), Single.<Integer>error(new TestException())), addString)
@@ -54,7 +52,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void dispose() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -69,7 +66,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         assertFalse(pp.hasSubscribers());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void zipperThrows() {
         Single.zip(Arrays.asList(Single.just(1), Single.just(2)), new Function<Object[], Object>() {
@@ -82,7 +78,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void zipperReturnsNull() {
         Single.zip(Arrays.asList(Single.just(1), Single.just(2)), new Function<Object[], Object>() {
@@ -95,7 +90,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         .assertFailure(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void middleError() {
         PublishProcessor<Integer> pp0 = PublishProcessor.create();
@@ -112,7 +106,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         to.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void innerErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -190,7 +183,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         .assertFailureAndMessage(TestException.class, "next()");
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableOneIsNull() {
         Single.zip(Arrays.asList(null, Single.just(1)), new Function<Object[], Object>() {
@@ -202,7 +194,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         .blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableTwoIsNull() {
         Single.zip(Arrays.asList(Single.just(1), null), new Function<Object[], Object>() {
@@ -238,7 +229,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         .assertResult(2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleSourceZipperReturnsNull() {
         Single.zip(Arrays.asList(Single.just(1)), Functions.justFunction(null))
@@ -246,7 +236,6 @@ public class SingleZipIterableTest extends RxJavaTest {
         .assertFailureAndMessage(NullPointerException.class, "The zipper returned a null value");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleSourcesInIterable() {
         SingleSource<Integer> source = new SingleSource<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipTest.java
@@ -163,7 +163,6 @@ public class SingleZipTest extends RxJavaTest {
         assertEquals(0, counter.get());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noDisposeOnAllSuccess2() {
         final AtomicInteger counter = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava3/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/maybe/MaybeTest.java
@@ -1401,7 +1401,6 @@ public class MaybeTest extends RxJavaTest {
         .assertResult(1, 2, 3, 4);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterable() {
         Maybe.concat(Arrays.asList(Maybe.just(1), Maybe.just(2)))
@@ -1409,7 +1408,6 @@ public class MaybeTest extends RxJavaTest {
         .assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterableEmpty() {
         Maybe.concat(Arrays.asList(Maybe.empty(), Maybe.empty()))
@@ -1417,7 +1415,6 @@ public class MaybeTest extends RxJavaTest {
         .assertResult();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterableBackpressured() {
         TestSubscriber<Integer> ts = Maybe.concat(Arrays.asList(Maybe.just(1), Maybe.just(2)))
@@ -1434,7 +1431,6 @@ public class MaybeTest extends RxJavaTest {
         ts.assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterableBackpressuredNonEager() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1624,7 +1620,6 @@ public class MaybeTest extends RxJavaTest {
         Maybe.just(1).ambWith(error).test().assertValue(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableOrder() {
         Maybe<Integer> error = Maybe.error(new RuntimeException());
@@ -1772,7 +1767,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertResult();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable1SignalsSuccess() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1795,7 +1789,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable2SignalsSuccess() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1818,7 +1811,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertResult(2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable2SignalsSuccessWithOverlap() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1842,7 +1834,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertResult(2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable1SignalsError() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1864,7 +1855,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable2SignalsError() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1886,7 +1876,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable2SignalsErrorWithOverlap() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1909,7 +1898,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertFailureAndMessage(TestException.class, "2");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable1SignalsComplete() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1931,7 +1919,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertResult();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterable2SignalsComplete() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1968,7 +1955,6 @@ public class MaybeTest extends RxJavaTest {
         }).test().assertError(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableOneIsNull() {
         Maybe.amb(Arrays.asList(null, Maybe.just(1)))
@@ -2188,7 +2174,6 @@ public class MaybeTest extends RxJavaTest {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterable() {
         Maybe.merge(Arrays.asList(Maybe.just(1), Maybe.just(2), Maybe.just(3)))
@@ -2493,7 +2478,6 @@ public class MaybeTest extends RxJavaTest {
         assertFalse(Maybe.concatArrayDelayError(Maybe.never()) instanceof MaybeConcatArrayDelayError);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatIterableDelayError() {
         Maybe.concatDelayError(Arrays.asList(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())))
@@ -2539,7 +2523,6 @@ public class MaybeTest extends RxJavaTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatEagerIterable() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -2638,7 +2621,6 @@ public class MaybeTest extends RxJavaTest {
         assertSame(Flowable.empty(), Maybe.mergeArrayDelayError());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeIterableDelayError() {
         Maybe.mergeDelayError(Arrays.asList(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())))
@@ -2900,7 +2882,6 @@ public class MaybeTest extends RxJavaTest {
         .assertResult("[1]");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void zipIterable() {
         Maybe.zip(
@@ -3048,7 +3029,6 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void zipIterableObject() {
-        @SuppressWarnings("unchecked")
         final List<Maybe<Integer>> maybes = Arrays.asList(Maybe.just(1), Maybe.just(4));
         Maybe.zip(maybes, new Function<Object[], Object>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableConcatTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableConcatTests.java
@@ -62,7 +62,6 @@ public class ObservableConcatTests extends RxJavaTest {
         Observable<String> o2 = Observable.just("three", "four");
         Observable<String> o3 = Observable.just("five", "six");
 
-        @SuppressWarnings("unchecked")
         Iterable<Observable<String>> is = Arrays.asList(o1, o2, o3);
 
         List<String> values = Observable.concat(Observable.fromIterable(is)).toList().blockingGet();

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
@@ -66,7 +66,6 @@ public class ObservableNullTests extends RxJavaTest {
         }).test().assertError(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableOneIsNull() {
         Observable.amb(Arrays.asList(Observable.never(), null))
@@ -99,7 +98,6 @@ public class ObservableNullTests extends RxJavaTest {
         }, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableOneIsNull() {
         Observable.combineLatest(Arrays.asList(Observable.never(), null), new Function<Object[], Object>() {
@@ -110,13 +108,11 @@ public class ObservableNullTests extends RxJavaTest {
         }, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionNull() {
         Observable.combineLatest(Arrays.asList(just1), null, 128);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionReturnsNull() {
         Observable.combineLatest(Arrays.asList(just1), new Function<Object[], Object>() {
@@ -152,7 +148,6 @@ public class ObservableNullTests extends RxJavaTest {
         }, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableOneIsNull() {
         Observable.combineLatestDelayError(Arrays.asList(Observable.never(), null), new Function<Object[], Object>() {
@@ -163,13 +158,11 @@ public class ObservableNullTests extends RxJavaTest {
         }, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableFunctionNull() {
         Observable.combineLatestDelayError(Arrays.asList(just1), null, 128);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableFunctionReturnsNull() {
         Observable.combineLatestDelayError(Arrays.asList(just1), new Function<Object[], Object>() {
@@ -195,7 +188,6 @@ public class ObservableNullTests extends RxJavaTest {
         }).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void concatIterableOneIsNull() {
         Observable.concat(Arrays.asList(just1, null)).blockingLast();
@@ -520,7 +512,6 @@ public class ObservableNullTests extends RxJavaTest {
         }, 128, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeIterableOneIsNull() {
         Observable.merge(Arrays.asList(just1, null), 128, 128).blockingLast();
@@ -552,7 +543,6 @@ public class ObservableNullTests extends RxJavaTest {
         }, 128, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableOneIsNull() {
         Observable.mergeDelayError(Arrays.asList(just1, null), 128, 128).blockingLast();
@@ -683,13 +673,11 @@ public class ObservableNullTests extends RxJavaTest {
         }).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableFunctionNull() {
         Observable.zip(Arrays.asList(just1, just1), null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableFunctionReturnsNull() {
         Observable.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
@@ -725,13 +713,11 @@ public class ObservableNullTests extends RxJavaTest {
         }, true, 128).blockingLast();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionNull() {
         Observable.zip(Arrays.asList(just1, just1), null, true, 128);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionReturnsNull() {
         Observable.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableTest.java
@@ -1120,7 +1120,6 @@ public class ObservableTest extends RxJavaTest {
 
     @Test
     public void zipIterableObject() {
-        @SuppressWarnings("unchecked")
         final List<Observable<Integer>> observables = Arrays.asList(Observable.just(1, 2, 3), Observable.just(1, 2, 3));
         Observable.zip(observables, new Function<Object[], Object>() {
             @Override
@@ -1136,7 +1135,6 @@ public class ObservableTest extends RxJavaTest {
 
     @Test
     public void combineLatestObject() {
-        @SuppressWarnings("unchecked")
         final List<Observable<Integer>> observables = Arrays.asList(Observable.just(1, 2, 3), Observable.just(1, 2, 3));
         Observable.combineLatest(observables, new Function<Object[], Object>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelCollectTest.java
@@ -45,7 +45,6 @@ public class ParallelCollectTest extends RxJavaTest {
         }));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void initialCrash() {
         Flowable.range(1, 5)
@@ -66,7 +65,6 @@ public class ParallelCollectTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void reducerCrash() {
         Flowable.range(1, 5)
@@ -117,7 +115,6 @@ public class ParallelCollectTest extends RxJavaTest {
         assertFalse(pp.hasSubscribers());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error() {
         Flowable.<Integer>error(new TestException())
@@ -138,7 +135,6 @@ public class ParallelCollectTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void doubleError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelDoOnNextTryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelDoOnNextTryTest.java
@@ -189,7 +189,6 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void doOnNextFailHandlerThrows() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
@@ -336,7 +335,6 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void doOnNextFailHandlerThrowsConditional() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelFilterTryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelFilterTryTest.java
@@ -192,7 +192,6 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void filterFailHandlerThrows() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
@@ -327,7 +326,6 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void filterFailHandlerThrowsConditional() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelFlowableTest.java
@@ -236,7 +236,6 @@ public class ParallelFlowableTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void toSortedList() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelMapTryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelMapTryTest.java
@@ -167,7 +167,6 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mapFailHandlerThrows() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
@@ -302,7 +301,6 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mapFailHandlerThrowsConditional() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelReduceTest.java
@@ -46,7 +46,6 @@ public class ParallelReduceTest extends RxJavaTest {
         }));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void initialCrash() {
         Flowable.range(1, 5)
@@ -68,7 +67,6 @@ public class ParallelReduceTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void reducerCrash() {
         Flowable.range(1, 5)
@@ -121,7 +119,6 @@ public class ParallelReduceTest extends RxJavaTest {
         assertFalse(pp.hasSubscribers());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error() {
         Flowable.<Integer>error(new TestException())
@@ -143,7 +140,6 @@ public class ParallelReduceTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void doubleError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/rxjava3/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/single/SingleNullTests.java
@@ -49,7 +49,6 @@ public class SingleNullTests extends RxJavaTest {
         }).test().assertError(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambIterableOneIsNull() {
         Single.amb(Arrays.asList(null, just1))
@@ -85,7 +84,6 @@ public class SingleNullTests extends RxJavaTest {
         }).blockingSubscribe();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void concatIterableOneIsNull() {
         Single.concat(Arrays.asList(just1, null)).blockingSubscribe();
@@ -249,7 +247,6 @@ public class SingleNullTests extends RxJavaTest {
         }).blockingSubscribe();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeIterableOneIsNull() {
         Single.merge(Arrays.asList(null, just1)).blockingSubscribe();
@@ -384,7 +381,6 @@ public class SingleNullTests extends RxJavaTest {
         }).blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableOneIsNull() {
         Single.zip(Arrays.asList(null, just1), new Function<Object[], Object>() {
@@ -395,13 +391,11 @@ public class SingleNullTests extends RxJavaTest {
         }).blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableOneFunctionNull() {
         Single.zip(Arrays.asList(just1, just1), null).blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableOneFunctionReturnsNull() {
         Single.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
@@ -529,7 +523,6 @@ public class SingleNullTests extends RxJavaTest {
         }, (Single<Integer>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipIterableTwoIsNull() {
         Single.zip(Arrays.asList(just1, null), new Function<Object[], Object>() {

--- a/src/test/java/io/reactivex/rxjava3/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/single/SingleTest.java
@@ -510,7 +510,6 @@ public class SingleTest extends RxJavaTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void toFlowableIterableRemove() {
-        @SuppressWarnings("unchecked")
         Iterable<? extends Flowable<Integer>> f = SingleInternalHelper.iterableToFlowable(Arrays.asList(Single.just(1)));
 
         Iterator<? extends Flowable<Integer>> iterator = f.iterator();
@@ -520,7 +519,6 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void zipIterableObject() {
-        @SuppressWarnings("unchecked")
         final List<Single<Integer>> singles = Arrays.asList(Single.just(1), Single.just(4));
         Single.zip(singles, new Function<Object[], Object>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/tck/AmbArrayTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/AmbArrayTckTest.java
@@ -21,7 +21,6 @@ import io.reactivex.rxjava3.core.Flowable;
 @Test
 public class AmbArrayTckTest extends BaseTck<Long> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return

--- a/src/test/java/io/reactivex/rxjava3/tck/AmbTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/AmbTckTest.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava3.core.Flowable;
 @Test
 public class AmbTckTest extends BaseTck<Long> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return

--- a/src/test/java/io/reactivex/rxjava3/tck/CombineLatestIterableDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/CombineLatestIterableDelayErrorTckTest.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.functions.Function;
 @Test
 public class CombineLatestIterableDelayErrorTckTest extends BaseTck<Long> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return

--- a/src/test/java/io/reactivex/rxjava3/tck/CombineLatestIterableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/CombineLatestIterableTckTest.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.functions.Function;
 @Test
 public class CombineLatestIterableTckTest extends BaseTck<Long> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return

--- a/src/test/java/io/reactivex/rxjava3/tck/ConcatArrayEagerTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/ConcatArrayEagerTckTest.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava3.core.Flowable;
 @Test
 public class ConcatArrayEagerTckTest extends BaseTck<Long> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return

--- a/src/test/java/io/reactivex/rxjava3/tck/ConcatIterableEagerTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/ConcatIterableEagerTckTest.java
@@ -21,7 +21,6 @@ import io.reactivex.rxjava3.core.Flowable;
 @Test
 public class ConcatIterableEagerTckTest extends BaseTck<Long> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return

--- a/src/test/java/io/reactivex/rxjava3/tck/MergeIterableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/MergeIterableTckTest.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava3.core.Flowable;
 @Test
 public class MergeIterableTckTest extends BaseTck<Long> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return

--- a/src/test/java/io/reactivex/rxjava3/tck/RefCountProcessor.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/RefCountProcessor.java
@@ -46,7 +46,7 @@ import io.reactivex.rxjava3.processors.FlowableProcessor;
     RefCountProcessor(FlowableProcessor<T> actual) {
         this.actual = actual;
         this.upstream = new AtomicReference<>();
-        this.subscribers = new AtomicReference<RefCountSubscriber<T>[]>(EMPTY);
+        this.subscribers = new AtomicReference<>(EMPTY);
     }
 
     @Override

--- a/src/test/java/io/reactivex/rxjava3/tck/ZipIterableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/ZipIterableTckTest.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.functions.Function;
 @Test
 public class ZipIterableTckTest extends BaseTck<Long> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return

--- a/src/test/java/io/reactivex/rxjava3/testsupport/BaseTestConsumerEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/BaseTestConsumerEx.java
@@ -176,6 +176,7 @@ extends BaseTestConsumer<T, U> {
      * @param values the expected values, asserted in order
      * @return this
      */
+    @SafeVarargs
     public final U assertFailure(Predicate<Throwable> errorPredicate, T... values) {
         return assertSubscribed()
                 .assertValues(values)
@@ -192,6 +193,7 @@ extends BaseTestConsumer<T, U> {
      * @param values the expected values, asserted in order
      * @return this
      */
+    @SafeVarargs
     public final U assertFailureAndMessage(Class<? extends Throwable> error,
             String message, T... values) {
         return assertSubscribed()


### PR DESCRIPTION
Most varargs places now have `@SafeVarargs` so there is no need for `@SuppressWarnings("unchecked")`. Some non-test classes need still updating though.