### PR TITLE
3.x: Add NonNull & SafeVarargs annotations + validator

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -121,7 +121,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable ambArray(final CompletableSource... sources) {
+    @SafeVarargs
+    public static Completable ambArray(@NonNull CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
@@ -150,7 +151,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable amb(final Iterable<? extends CompletableSource> sources) {
+    public static Completable amb(@NonNull Iterable<? extends CompletableSource> sources) {
         Objects.requireNonNull(sources, "sources is null");
 
         return RxJavaPlugins.onAssembly(new CompletableAmb(null, sources));
@@ -188,7 +189,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable concatArray(CompletableSource... sources) {
+    @SafeVarargs
+    public static Completable concatArray(@NonNull CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
@@ -214,7 +216,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable concat(Iterable<? extends CompletableSource> sources) {
+    public static Completable concat(@NonNull Iterable<? extends CompletableSource> sources) {
         Objects.requireNonNull(sources, "sources is null");
 
         return RxJavaPlugins.onAssembly(new CompletableConcatIterable(sources));
@@ -238,7 +240,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public static Completable concat(Publisher<? extends CompletableSource> sources) {
+    @NonNull
+    public static Completable concat(@NonNull Publisher<? extends CompletableSource> sources) {
         return concat(sources, 2);
     }
 
@@ -262,7 +265,7 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public static Completable concat(Publisher<? extends CompletableSource> sources, int prefetch) {
+    public static Completable concat(@NonNull Publisher<? extends CompletableSource> sources, int prefetch) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new CompletableConcat(sources, prefetch));
@@ -312,7 +315,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable create(CompletableOnSubscribe source) {
+    public static Completable create(@NonNull CompletableOnSubscribe source) {
         Objects.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new CompletableCreate(source));
     }
@@ -335,7 +338,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable unsafeCreate(CompletableSource source) {
+    public static Completable unsafeCreate(@NonNull CompletableSource source) {
         Objects.requireNonNull(source, "source is null");
         if (source instanceof Completable) {
             throw new IllegalArgumentException("Use of unsafeCreate(Completable)!");
@@ -357,7 +360,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable defer(final Supplier<? extends CompletableSource> completableSupplier) {
+    public static Completable defer(@NonNull Supplier<? extends CompletableSource> completableSupplier) {
         Objects.requireNonNull(completableSupplier, "completableSupplier");
         return RxJavaPlugins.onAssembly(new CompletableDefer(completableSupplier));
     }
@@ -381,7 +384,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable error(final Supplier<? extends Throwable> errorSupplier) {
+    public static Completable error(@NonNull Supplier<? extends Throwable> errorSupplier) {
         Objects.requireNonNull(errorSupplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new CompletableErrorSupplier(errorSupplier));
     }
@@ -401,7 +404,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable error(final Throwable error) {
+    public static Completable error(@NonNull Throwable error) {
         Objects.requireNonNull(error, "error is null");
         return RxJavaPlugins.onAssembly(new CompletableError(error));
     }
@@ -429,7 +432,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable fromAction(final Action run) {
+    public static Completable fromAction(@NonNull Action run) {
         Objects.requireNonNull(run, "run is null");
         return RxJavaPlugins.onAssembly(new CompletableFromAction(run));
     }
@@ -458,7 +461,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable fromCallable(final Callable<?> callable) {
+    public static Completable fromCallable(@NonNull Callable<?> callable) {
         Objects.requireNonNull(callable, "callable is null");
         return RxJavaPlugins.onAssembly(new CompletableFromCallable(callable));
     }
@@ -479,7 +482,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable fromFuture(final Future<?> future) {
+    public static Completable fromFuture(@NonNull Future<?> future) {
         Objects.requireNonNull(future, "future is null");
         return fromAction(Functions.futureAction(future));
     }
@@ -504,9 +507,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Completable fromMaybe(final MaybeSource<T> maybe) {
+    public static <T> Completable fromMaybe(@NonNull MaybeSource<T> maybe) {
         Objects.requireNonNull(maybe, "maybe is null");
-        return RxJavaPlugins.onAssembly(new MaybeIgnoreElementCompletable<T>(maybe));
+        return RxJavaPlugins.onAssembly(new MaybeIgnoreElementCompletable<>(maybe));
     }
 
     /**
@@ -532,7 +535,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable fromRunnable(final Runnable run) {
+    public static Completable fromRunnable(@NonNull Runnable run) {
         Objects.requireNonNull(run, "run is null");
         return RxJavaPlugins.onAssembly(new CompletableFromRunnable(run));
     }
@@ -554,9 +557,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Completable fromObservable(final ObservableSource<T> observable) {
+    public static <T> Completable fromObservable(@NonNull ObservableSource<T> observable) {
         Objects.requireNonNull(observable, "observable is null");
-        return RxJavaPlugins.onAssembly(new CompletableFromObservable<T>(observable));
+        return RxJavaPlugins.onAssembly(new CompletableFromObservable<>(observable));
     }
 
     /**
@@ -592,9 +595,9 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Completable fromPublisher(final Publisher<T> publisher) {
+    public static <T> Completable fromPublisher(@NonNull Publisher<T> publisher) {
         Objects.requireNonNull(publisher, "publisher is null");
-        return RxJavaPlugins.onAssembly(new CompletableFromPublisher<T>(publisher));
+        return RxJavaPlugins.onAssembly(new CompletableFromPublisher<>(publisher));
     }
 
     /**
@@ -614,9 +617,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Completable fromSingle(final SingleSource<T> single) {
+    public static <T> Completable fromSingle(@NonNull SingleSource<T> single) {
         Objects.requireNonNull(single, "single is null");
-        return RxJavaPlugins.onAssembly(new CompletableFromSingle<T>(single));
+        return RxJavaPlugins.onAssembly(new CompletableFromSingle<>(single));
     }
 
     /**
@@ -644,7 +647,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable fromSupplier(final Supplier<?> supplier) {
+    public static Completable fromSupplier(@NonNull Supplier<?> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new CompletableFromSupplier(supplier));
     }
@@ -679,7 +682,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable mergeArray(CompletableSource... sources) {
+    @SafeVarargs
+    public static Completable mergeArray(@NonNull CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return complete();
@@ -720,7 +724,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable merge(Iterable<? extends CompletableSource> sources) {
+    public static Completable merge(@NonNull Iterable<? extends CompletableSource> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new CompletableMergeIterable(sources));
     }
@@ -758,7 +762,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
-    public static Completable merge(Publisher<? extends CompletableSource> sources) {
+    @NonNull
+    public static Completable merge(@NonNull Publisher<? extends CompletableSource> sources) {
         return merge0(sources, Integer.MAX_VALUE, false);
     }
 
@@ -797,7 +802,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public static Completable merge(Publisher<? extends CompletableSource> sources, int maxConcurrency) {
+    @NonNull
+    public static Completable merge(@NonNull Publisher<? extends CompletableSource> sources, int maxConcurrency) {
         return merge0(sources, maxConcurrency, false);
     }
 
@@ -823,7 +829,7 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    private static Completable merge0(Publisher<? extends CompletableSource> sources, int maxConcurrency, boolean delayErrors) {
+    private static Completable merge0(@NonNull Publisher<? extends CompletableSource> sources, int maxConcurrency, boolean delayErrors) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         return RxJavaPlugins.onAssembly(new CompletableMerge(sources, maxConcurrency, delayErrors));
@@ -846,7 +852,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable mergeArrayDelayError(CompletableSource... sources) {
+    @SafeVarargs
+    public static Completable mergeArrayDelayError(@NonNull CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new CompletableMergeDelayErrorArray(sources));
     }
@@ -868,7 +875,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable mergeDelayError(Iterable<? extends CompletableSource> sources) {
+    public static Completable mergeDelayError(@NonNull Iterable<? extends CompletableSource> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new CompletableMergeDelayErrorIterable(sources));
     }
@@ -893,7 +900,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
-    public static Completable mergeDelayError(Publisher<? extends CompletableSource> sources) {
+    @NonNull
+    public static Completable mergeDelayError(@NonNull Publisher<? extends CompletableSource> sources) {
         return merge0(sources, Integer.MAX_VALUE, true);
     }
 
@@ -919,7 +927,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public static Completable mergeDelayError(Publisher<? extends CompletableSource> sources, int maxConcurrency) {
+    @NonNull
+    public static Completable mergeDelayError(@NonNull Publisher<? extends CompletableSource> sources, int maxConcurrency) {
         return merge0(sources, maxConcurrency, true);
     }
 
@@ -935,6 +944,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static Completable never() {
         return RxJavaPlugins.onAssembly(CompletableNever.INSTANCE);
     }
@@ -953,7 +963,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Completable timer(long delay, TimeUnit unit) {
+    @NonNull
+    public static Completable timer(long delay, @NonNull TimeUnit unit) {
         return timer(delay, unit, Schedulers.computation());
     }
 
@@ -974,7 +985,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Completable timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
+    public static Completable timer(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new CompletableTimer(delay, unit, scheduler));
@@ -1010,9 +1021,10 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <R> Completable using(Supplier<R> resourceSupplier,
-            Function<? super R, ? extends CompletableSource> completableFunction,
-            Consumer<? super R> disposer) {
+    @NonNull
+    public static <R> Completable using(@NonNull Supplier<R> resourceSupplier,
+            @NonNull Function<? super R, ? extends CompletableSource> completableFunction,
+            @NonNull Consumer<? super R> disposer) {
         return using(resourceSupplier, completableFunction, disposer, true);
     }
 
@@ -1045,15 +1057,15 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <R> Completable using(
-            final Supplier<R> resourceSupplier,
-            final Function<? super R, ? extends CompletableSource> completableFunction,
-            final Consumer<? super R> disposer,
-            final boolean eager) {
+            @NonNull Supplier<R> resourceSupplier,
+            @NonNull Function<? super R, ? extends CompletableSource> completableFunction,
+            @NonNull Consumer<? super R> disposer,
+            boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(completableFunction, "completableFunction is null");
         Objects.requireNonNull(disposer, "disposer is null");
 
-        return RxJavaPlugins.onAssembly(new CompletableUsing<R>(resourceSupplier, completableFunction, disposer, eager));
+        return RxJavaPlugins.onAssembly(new CompletableUsing<>(resourceSupplier, completableFunction, disposer, eager));
     }
 
     /**
@@ -1072,7 +1084,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable wrap(CompletableSource source) {
+    public static Completable wrap(@NonNull CompletableSource source) {
         Objects.requireNonNull(source, "source is null");
         if (source instanceof Completable) {
             return RxJavaPlugins.onAssembly((Completable)source);
@@ -1097,7 +1109,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable ambWith(CompletableSource other) {
+    public final Completable ambWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return ambArray(this, other);
     }
@@ -1121,9 +1133,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Observable<T> andThen(ObservableSource<T> next) {
+    public final <@NonNull T> Observable<T> andThen(@NonNull ObservableSource<T> next) {
         Objects.requireNonNull(next, "next is null");
-        return RxJavaPlugins.onAssembly(new CompletableAndThenObservable<T>(this, next));
+        return RxJavaPlugins.onAssembly(new CompletableAndThenObservable<>(this, next));
     }
 
     /**
@@ -1149,9 +1161,9 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Flowable<T> andThen(Publisher<T> next) {
+    public final <@NonNull T> Flowable<T> andThen(@NonNull Publisher<T> next) {
         Objects.requireNonNull(next, "next is null");
-        return RxJavaPlugins.onAssembly(new CompletableAndThenPublisher<T>(this, next));
+        return RxJavaPlugins.onAssembly(new CompletableAndThenPublisher<>(this, next));
     }
 
     /**
@@ -1173,9 +1185,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Single<T> andThen(SingleSource<T> next) {
+    public final <@NonNull T> Single<T> andThen(@NonNull SingleSource<T> next) {
         Objects.requireNonNull(next, "next is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<T>(next, this));
+        return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<>(next, this));
     }
 
     /**
@@ -1197,9 +1209,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Maybe<T> andThen(MaybeSource<T> next) {
+    public final <@NonNull T> Maybe<T> andThen(@NonNull MaybeSource<T> next) {
         Objects.requireNonNull(next, "next is null");
-        return RxJavaPlugins.onAssembly(new MaybeDelayWithCompletable<T>(next, this));
+        return RxJavaPlugins.onAssembly(new MaybeDelayWithCompletable<>(next, this));
     }
 
     /**
@@ -1219,7 +1231,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable andThen(CompletableSource next) {
+    @NonNull
+    public final Completable andThen(@NonNull CompletableSource next) {
         Objects.requireNonNull(next, "next is null");
         return RxJavaPlugins.onAssembly(new CompletableAndThenCompletable(this, next));
     }
@@ -1241,7 +1254,7 @@ public abstract class Completable implements CompletableSource {
      */
     @SchedulerSupport(SchedulerSupport.NONE)
     public final void blockingAwait() {
-        BlockingMultiObserver<Void> observer = new BlockingMultiObserver<Void>();
+        BlockingMultiObserver<Void> observer = new BlockingMultiObserver<>();
         subscribe(observer);
         observer.blockingGet();
     }
@@ -1266,11 +1279,10 @@ public abstract class Completable implements CompletableSource {
      * @throws RuntimeException wrapping an InterruptedException if the current thread is interrupted
      */
     @CheckReturnValue
-    @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final boolean blockingAwait(long timeout, TimeUnit unit) {
+    public final boolean blockingAwait(long timeout, @NonNull TimeUnit unit) {
         Objects.requireNonNull(unit, "unit is null");
-        BlockingMultiObserver<Void> observer = new BlockingMultiObserver<Void>();
+        BlockingMultiObserver<Void> observer = new BlockingMultiObserver<>();
         subscribe(observer);
         return observer.blockingAwait(timeout, unit);
     }
@@ -1294,6 +1306,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable cache() {
         return RxJavaPlugins.onAssembly(new CompletableCache(this));
     }
@@ -1313,7 +1326,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable compose(CompletableTransformer transformer) {
+    @NonNull
+    public final Completable compose(@NonNull CompletableTransformer transformer) {
         return wrap(Objects.requireNonNull(transformer, "transformer is null").apply(this));
     }
 
@@ -1336,7 +1350,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatWith(CompletableSource other) {
+    public final Completable concatWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new CompletableAndThenCompletable(this, other));
     }
@@ -1356,7 +1370,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Completable delay(long delay, TimeUnit unit) {
+    @NonNull
+    public final Completable delay(long delay, @NonNull TimeUnit unit) {
         return delay(delay, unit, Schedulers.computation(), false);
     }
 
@@ -1377,7 +1392,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable delay(long delay, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Completable delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return delay(delay, unit, scheduler, false);
     }
 
@@ -1400,7 +1416,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable delay(final long delay, final TimeUnit unit, final Scheduler scheduler, final boolean delayError) {
+    public final Completable delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new CompletableDelay(this, delay, unit, scheduler, delayError));
@@ -1424,7 +1440,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Completable delaySubscription(long delay, TimeUnit unit) {
+    @NonNull
+    public final Completable delaySubscription(long delay, @NonNull TimeUnit unit) {
         return delaySubscription(delay, unit, Schedulers.computation());
     }
 
@@ -1448,7 +1465,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable delaySubscription(long delay, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Completable delaySubscription(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return Completable.timer(delay, unit, scheduler).andThen(this);
     }
 
@@ -1467,7 +1485,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doOnComplete(Action onComplete) {
+    @NonNull
+    public final Completable doOnComplete(@NonNull Action onComplete) {
         return doOnLifecycle(Functions.emptyConsumer(), Functions.emptyConsumer(),
                 onComplete, Functions.EMPTY_ACTION,
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION);
@@ -1488,7 +1507,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doOnDispose(Action onDispose) {
+    @NonNull
+    public final Completable doOnDispose(@NonNull Action onDispose) {
         return doOnLifecycle(Functions.emptyConsumer(), Functions.emptyConsumer(),
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION,
                 Functions.EMPTY_ACTION, onDispose);
@@ -1509,7 +1529,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doOnError(Consumer<? super Throwable> onError) {
+    @NonNull
+    public final Completable doOnError(@NonNull Consumer<? super Throwable> onError) {
         return doOnLifecycle(Functions.emptyConsumer(), onError,
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION,
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION);
@@ -1531,7 +1552,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doOnEvent(final Consumer<? super Throwable> onEvent) {
+    public final Completable doOnEvent(@NonNull Consumer<? super Throwable> onEvent) {
         Objects.requireNonNull(onEvent, "onEvent is null");
         return RxJavaPlugins.onAssembly(new CompletableDoOnEvent(this, onEvent));
     }
@@ -1584,7 +1605,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doOnSubscribe(Consumer<? super Disposable> onSubscribe) {
+    @NonNull
+    public final Completable doOnSubscribe(@NonNull Consumer<? super Disposable> onSubscribe) {
         return doOnLifecycle(onSubscribe, Functions.emptyConsumer(),
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION,
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION);
@@ -1605,7 +1627,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doOnTerminate(final Action onTerminate) {
+    @NonNull
+    public final Completable doOnTerminate(@NonNull Action onTerminate) {
         return doOnLifecycle(Functions.emptyConsumer(), Functions.emptyConsumer(),
                 Functions.EMPTY_ACTION, onTerminate,
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION);
@@ -1626,7 +1649,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doAfterTerminate(final Action onAfterTerminate) {
+    @NonNull
+    public final Completable doAfterTerminate(@NonNull Action onAfterTerminate) {
         return doOnLifecycle(
                 Functions.emptyConsumer(),
                 Functions.emptyConsumer(),
@@ -1658,7 +1682,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doFinally(Action onFinally) {
+    public final Completable doFinally(@NonNull Action onFinally) {
         Objects.requireNonNull(onFinally, "onFinally is null");
         return RxJavaPlugins.onAssembly(new CompletableDoFinally(this, onFinally));
     }
@@ -1796,7 +1820,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable lift(final CompletableOperator onLift) {
+    public final Completable lift(@NonNull CompletableOperator onLift) {
         Objects.requireNonNull(onLift, "onLift is null");
         return RxJavaPlugins.onAssembly(new CompletableLift(this, onLift));
     }
@@ -1818,6 +1842,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <T> Single<Notification<T>> materialize() {
         return RxJavaPlugins.onAssembly(new CompletableMaterialize<T>(this));
     }
@@ -1838,7 +1863,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable mergeWith(CompletableSource other) {
+    public final Completable mergeWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return mergeArray(this, other);
     }
@@ -1858,7 +1883,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable observeOn(final Scheduler scheduler) {
+    public final Completable observeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new CompletableObserveOn(this, scheduler));
     }
@@ -1876,6 +1901,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable onErrorComplete() {
         return onErrorComplete(Functions.alwaysTrue());
     }
@@ -1896,7 +1922,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable onErrorComplete(final Predicate<? super Throwable> predicate) {
+    public final Completable onErrorComplete(@NonNull Predicate<? super Throwable> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
 
         return RxJavaPlugins.onAssembly(new CompletableOnErrorComplete(this, predicate));
@@ -1919,7 +1945,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable onErrorResumeNext(final Function<? super Throwable, ? extends CompletableSource> errorMapper) {
+    public final Completable onErrorResumeNext(@NonNull Function<? super Throwable, ? extends CompletableSource> errorMapper) {
         Objects.requireNonNull(errorMapper, "errorMapper is null");
         return RxJavaPlugins.onAssembly(new CompletableResumeNext(this, errorMapper));
     }
@@ -1940,6 +1966,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable onTerminateDetach() {
         return RxJavaPlugins.onAssembly(new CompletableDetach(this));
     }
@@ -1956,6 +1983,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable repeat() {
         return fromPublisher(toFlowable().repeat());
     }
@@ -1974,6 +2002,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable repeat(long times) {
         return fromPublisher(toFlowable().repeat(times));
     }
@@ -1993,7 +2022,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable repeatUntil(BooleanSupplier stop) {
+    @NonNull
+    public final Completable repeatUntil(@NonNull BooleanSupplier stop) {
         return fromPublisher(toFlowable().repeatUntil(stop));
     }
 
@@ -2014,7 +2044,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
+    @NonNull
+    public final Completable repeatWhen(@NonNull Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
         return fromPublisher(toFlowable().repeatWhen(handler));
     }
 
@@ -2030,6 +2061,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable retry() {
         return fromPublisher(toFlowable().retry());
     }
@@ -2049,7 +2081,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
+    @NonNull
+    public final Completable retry(@NonNull BiPredicate<? super Integer, ? super Throwable> predicate) {
         return fromPublisher(toFlowable().retry(predicate));
     }
 
@@ -2068,6 +2101,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable retry(long times) {
         return fromPublisher(toFlowable().retry(times));
     }
@@ -2092,7 +2126,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable retry(long times, Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Completable retry(long times, @NonNull Predicate<? super Throwable> predicate) {
         return fromPublisher(toFlowable().retry(times, predicate));
     }
 
@@ -2112,7 +2147,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable retry(Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Completable retry(@NonNull Predicate<? super Throwable> predicate) {
         return fromPublisher(toFlowable().retry(predicate));
     }
 
@@ -2158,7 +2194,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable retryWhen(Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
+    @NonNull
+    public final Completable retryWhen(@NonNull Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         return fromPublisher(toFlowable().retryWhen(handler));
     }
 
@@ -2178,7 +2215,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable startWith(CompletableSource other) {
+    public final Completable startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return concatArray(other, this);
     }
@@ -2200,9 +2237,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Observable<T> startWith(Observable<T> other) {
+    public final <T> Observable<T> startWith(@NonNull ObservableSource<T> other) {
         Objects.requireNonNull(other, "other is null");
-        return other.concatWith(this.<T>toObservable());
+        return Observable.wrap(other).concatWith(this.<T>toObservable());
     }
     /**
      * Returns a Flowable which first delivers the events
@@ -2225,7 +2262,7 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Flowable<T> startWith(Publisher<T> other) {
+    public final <T> Flowable<T> startWith(@NonNull Publisher<T> other) {
         Objects.requireNonNull(other, "other is null");
         return this.<T>toFlowable().startWith(other);
     }
@@ -2246,6 +2283,7 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable hide() {
         return RxJavaPlugins.onAssembly(new CompletableHide(this));
     }
@@ -2262,6 +2300,7 @@ public abstract class Completable implements CompletableSource {
      * @return the Disposable that allows disposing the subscription
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Disposable subscribe() {
         EmptyCompletableObserver observer = new EmptyCompletableObserver();
         subscribe(observer);
@@ -2270,7 +2309,7 @@ public abstract class Completable implements CompletableSource {
 
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
-    public final void subscribe(CompletableObserver observer) {
+    public final void subscribe(@NonNull CompletableObserver observer) {
         Objects.requireNonNull(observer, "observer is null");
         try {
 
@@ -2326,7 +2365,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <E extends CompletableObserver> E subscribeWith(E observer) {
+    @NonNull
+    public final <@NonNull E extends CompletableObserver> E subscribeWith(E observer) {
         subscribe(observer);
         return observer;
     }
@@ -2347,7 +2387,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(final Action onComplete, final Consumer<? super Throwable> onError) {
+    public final Disposable subscribe(@NonNull Action onComplete, @NonNull Consumer<? super Throwable> onError) {
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
 
@@ -2375,7 +2415,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(final Action onComplete) {
+    public final Disposable subscribe(@NonNull Action onComplete) {
         Objects.requireNonNull(onComplete, "onComplete is null");
 
         CallbackCompletableObserver observer = new CallbackCompletableObserver(onComplete);
@@ -2399,7 +2439,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable subscribeOn(final Scheduler scheduler) {
+    public final Completable subscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
 
         return RxJavaPlugins.onAssembly(new CompletableSubscribeOn(this, scheduler));
@@ -2426,7 +2466,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable takeUntil(CompletableSource other) {
+    public final Completable takeUntil(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
 
         return RxJavaPlugins.onAssembly(new CompletableTakeUntilCompletable(this, other));
@@ -2448,7 +2488,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Completable timeout(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Completable timeout(long timeout, @NonNull TimeUnit unit) {
         return timeout0(timeout, unit, Schedulers.computation(), null);
     }
 
@@ -2471,7 +2512,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Completable timeout(long timeout, TimeUnit unit, CompletableSource other) {
+    public final Completable timeout(long timeout, @NonNull TimeUnit unit, @NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, Schedulers.computation(), other);
     }
@@ -2494,7 +2535,8 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable timeout(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Completable timeout(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return timeout0(timeout, unit, scheduler, null);
     }
 
@@ -2519,7 +2561,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable timeout(long timeout, TimeUnit unit, Scheduler scheduler, CompletableSource other) {
+    public final Completable timeout(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, @NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, scheduler, other);
     }
@@ -2590,6 +2632,7 @@ public abstract class Completable implements CompletableSource {
     @SuppressWarnings("unchecked")
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <T> Flowable<T> toFlowable() {
         if (this instanceof FuseToFlowable) {
             return ((FuseToFlowable<T>)this).fuseToFlowable();
@@ -2613,6 +2656,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <T> Maybe<T> toMaybe() {
         if (this instanceof FuseToMaybe) {
             return ((FuseToMaybe<T>)this).fuseToMaybe();
@@ -2635,6 +2679,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SuppressWarnings("unchecked")
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <T> Observable<T> toObservable() {
         if (this instanceof FuseToObservable) {
             return ((FuseToObservable<T>)this).fuseToObservable();
@@ -2659,7 +2704,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Single<T> toSingle(final Supplier<? extends T> completionValueSupplier) {
+    public final <@NonNull T> Single<T> toSingle(@NonNull Supplier<? extends T> completionValueSupplier) {
         Objects.requireNonNull(completionValueSupplier, "completionValueSupplier is null");
         return RxJavaPlugins.onAssembly(new CompletableToSingle<T>(this, completionValueSupplier, null));
     }
@@ -2681,9 +2726,9 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T> Single<T> toSingleDefault(final T completionValue) {
+    public final <@NonNull T> Single<T> toSingleDefault(T completionValue) {
         Objects.requireNonNull(completionValue, "completionValue is null");
-        return RxJavaPlugins.onAssembly(new CompletableToSingle<T>(this, null, completionValue));
+        return RxJavaPlugins.onAssembly(new CompletableToSingle<>(this, null, completionValue));
     }
 
     /**
@@ -2702,7 +2747,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable unsubscribeOn(final Scheduler scheduler) {
+    public final Completable unsubscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new CompletableDisposeOn(this, scheduler));
     }
@@ -2724,8 +2769,9 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestObserver<Void> test() {
-        TestObserver<Void> to = new TestObserver<Void>();
+        TestObserver<Void> to = new TestObserver<>();
         subscribe(to);
         return to;
     }
@@ -2745,8 +2791,9 @@ public abstract class Completable implements CompletableSource {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestObserver<Void> test(boolean dispose) {
-        TestObserver<Void> to = new TestObserver<Void>();
+        TestObserver<Void> to = new TestObserver<>();
 
         if (dispose) {
             to.dispose();

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -185,7 +185,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> amb(Iterable<? extends Publisher<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new FlowableAmb<T>(null, sources));
+        return RxJavaPlugins.onAssembly(new FlowableAmb<>(null, sources));
     }
 
     /**
@@ -223,7 +223,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (len == 1) {
             return fromPublisher(sources[0]);
         }
-        return RxJavaPlugins.onAssembly(new FlowableAmb<T>(sources, null));
+        return RxJavaPlugins.onAssembly(new FlowableAmb<>(sources, null));
     }
 
     /**
@@ -276,7 +276,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatestArray(Publisher<? extends T>[] sources, Function<? super Object[], ? extends R> combiner) {
+    @NonNull
+    public static <T, @NonNull R> Flowable<R> combineLatestArray(@NonNull Publisher<? extends T>[] sources, @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatestArray(sources, combiner, bufferSize());
     }
 
@@ -323,7 +324,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatestArray(Publisher<? extends T>[] sources, Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    public static <T, R> Flowable<R> combineLatestArray(@NonNull Publisher<? extends T>[] sources, @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return empty();
@@ -373,8 +374,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatest(Iterable<? extends Publisher<? extends T>> sources,
-            Function<? super Object[], ? extends R> combiner) {
+    @NonNull
+    public static <T, @NonNull R> Flowable<R> combineLatest(@NonNull Iterable<? extends Publisher<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatest(sources, combiner, bufferSize());
     }
 
@@ -421,8 +423,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatest(Iterable<? extends Publisher<? extends T>> sources,
-            Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    public static <T, R> Flowable<R> combineLatest(@NonNull Iterable<? extends Publisher<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -469,8 +471,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatestDelayError(Publisher<? extends T>[] sources,
-            Function<? super Object[], ? extends R> combiner) {
+    @NonNull
+    public static <T, @NonNull R> Flowable<R> combineLatestDelayError(@NonNull Publisher<? extends T>[] sources,
+            @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatestDelayError(sources, combiner, bufferSize());
     }
 
@@ -518,8 +521,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatestDelayError(Publisher<? extends T>[] sources,
-            Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    public static <T, @NonNull R> Flowable<R> combineLatestDelayError(@NonNull Publisher<? extends T>[] sources,
+            @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -570,8 +573,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatestDelayError(Iterable<? extends Publisher<? extends T>> sources,
-            Function<? super Object[], ? extends R> combiner) {
+    @NonNull
+    public static <T, @NonNull R> Flowable<R> combineLatestDelayError(@NonNull Iterable<? extends Publisher<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatestDelayError(sources, combiner, bufferSize());
     }
 
@@ -618,8 +622,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, R> Flowable<R> combineLatestDelayError(Iterable<? extends Publisher<? extends T>> sources,
-            Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    @NonNull
+    public static <T, R> Flowable<R> combineLatestDelayError(@NonNull Iterable<? extends Publisher<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -662,9 +667,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, R> Flowable<R> combineLatest(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> combiner) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return combineLatestArray(new Publisher[] { source1, source2 }, Functions.toFunction(combiner), bufferSize());
@@ -711,9 +717,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, R> Flowable<R> combineLatest(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            Publisher<? extends T3> source3,
-            Function3<? super T1, ? super T2, ? super T3, ? extends R> combiner) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull Publisher<? extends T3> source3,
+            @NonNull Function3<? super T1, ? super T2, ? super T3, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -764,9 +770,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, R> Flowable<R> combineLatest(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            Publisher<? extends T3> source3, Publisher<? extends T4> source4,
-            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combiner) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull Publisher<? extends T3> source3, @NonNull Publisher<? extends T4> source4,
+            @NonNull Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -821,10 +827,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, R> Flowable<R> combineLatest(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            Publisher<? extends T3> source3, Publisher<? extends T4> source4,
-            Publisher<? extends T5> source5,
-            Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combiner) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull Publisher<? extends T3> source3, @NonNull Publisher<? extends T4> source4,
+            @NonNull Publisher<? extends T5> source5,
+            @NonNull Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -883,10 +889,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Flowable<R> combineLatest(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            Publisher<? extends T3> source3, Publisher<? extends T4> source4,
-            Publisher<? extends T5> source5, Publisher<? extends T6> source6,
-            Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combiner) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull Publisher<? extends T3> source3, @NonNull Publisher<? extends T4> source4,
+            @NonNull Publisher<? extends T5> source5, @NonNull Publisher<? extends T6> source6,
+            @NonNull Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -949,11 +955,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Flowable<R> combineLatest(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            Publisher<? extends T3> source3, Publisher<? extends T4> source4,
-            Publisher<? extends T5> source5, Publisher<? extends T6> source6,
-            Publisher<? extends T7> source7,
-            Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combiner) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull Publisher<? extends T3> source3, @NonNull Publisher<? extends T4> source4,
+            @NonNull Publisher<? extends T5> source5, @NonNull Publisher<? extends T6> source6,
+            @NonNull Publisher<? extends T7> source7,
+            @NonNull Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1020,11 +1026,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Flowable<R> combineLatest(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            Publisher<? extends T3> source3, Publisher<? extends T4> source4,
-            Publisher<? extends T5> source5, Publisher<? extends T6> source6,
-            Publisher<? extends T7> source7, Publisher<? extends T8> source8,
-            Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combiner) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull Publisher<? extends T3> source3, @NonNull Publisher<? extends T4> source4,
+            @NonNull Publisher<? extends T5> source5, @NonNull Publisher<? extends T6> source6,
+            @NonNull Publisher<? extends T7> source7, @NonNull Publisher<? extends T8> source8,
+            @NonNull Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1095,12 +1101,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Flowable<R> combineLatest(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            Publisher<? extends T3> source3, Publisher<? extends T4> source4,
-            Publisher<? extends T5> source5, Publisher<? extends T6> source6,
-            Publisher<? extends T7> source7, Publisher<? extends T8> source8,
-            Publisher<? extends T9> source9,
-            Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combiner) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull Publisher<? extends T3> source3, @NonNull Publisher<? extends T4> source4,
+            @NonNull Publisher<? extends T5> source5, @NonNull Publisher<? extends T6> source6,
+            @NonNull Publisher<? extends T7> source7, @NonNull Publisher<? extends T8> source8,
+            @NonNull Publisher<? extends T9> source9,
+            @NonNull Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1136,7 +1142,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concat(Iterable<? extends Publisher<? extends T>> sources) {
+    public static <T> Flowable<T> concat(@NonNull Iterable<? extends Publisher<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         // unlike general sources, fromIterable can only throw on a boundary because it is consumed only there
         return fromIterable(sources).concatMapDelayError((Function)Functions.identity(), false, 2);
@@ -1167,7 +1173,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concat(Publisher<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> concat(@NonNull Publisher<? extends Publisher<? extends T>> sources) {
         return concat(sources, bufferSize());
     }
 
@@ -1199,7 +1206,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concat(Publisher<? extends Publisher<? extends T>> sources, int prefetch) {
+    @NonNull
+    public static <T> Flowable<T> concat(@NonNull Publisher<? extends Publisher<? extends T>> sources, int prefetch) {
         return fromPublisher(sources).concatMap((Function)Functions.identity(), prefetch);
     }
 
@@ -1231,7 +1239,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concat(Publisher<? extends T> source1, Publisher<? extends T> source2) {
+    public static <T> Flowable<T> concat(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return concatArray(source1, source2);
@@ -1268,8 +1276,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concat(
-            Publisher<? extends T> source1, Publisher<? extends T> source2,
-            Publisher<? extends T> source3) {
+            @NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2,
+            @NonNull Publisher<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1309,8 +1317,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concat(
-            Publisher<? extends T> source1, Publisher<? extends T> source2,
-            Publisher<? extends T> source3, Publisher<? extends T> source4) {
+            @NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2,
+            @NonNull Publisher<? extends T> source3, @NonNull Publisher<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1342,14 +1350,15 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T> Flowable<T> concatArray(Publisher<? extends T>... sources) {
+    @NonNull
+    public static <T> Flowable<T> concatArray(@NonNull Publisher<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         } else
         if (sources.length == 1) {
             return fromPublisher(sources[0]);
         }
-        return RxJavaPlugins.onAssembly(new FlowableConcatArray<T>(sources, false));
+        return RxJavaPlugins.onAssembly(new FlowableConcatArray<>(sources, false));
     }
 
     /**
@@ -1375,14 +1384,15 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T> Flowable<T> concatArrayDelayError(Publisher<? extends T>... sources) {
+    @NonNull
+    public static <T> Flowable<T> concatArrayDelayError(@NonNull Publisher<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         } else
         if (sources.length == 1) {
             return fromPublisher(sources[0]);
         }
-        return RxJavaPlugins.onAssembly(new FlowableConcatArray<T>(sources, true));
+        return RxJavaPlugins.onAssembly(new FlowableConcatArray<>(sources, true));
     }
 
     /**
@@ -1411,7 +1421,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T> Flowable<T> concatArrayEager(Publisher<? extends T>... sources) {
+    @NonNull
+    public static <T> Flowable<T> concatArrayEager(@NonNull Publisher<? extends T>... sources) {
         return concatArrayEager(bufferSize(), bufferSize(), sources);
     }
 
@@ -1445,7 +1456,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Flowable<T> concatArrayEager(int maxConcurrency, int prefetch, Publisher<? extends T>... sources) {
+    @SafeVarargs
+    public static <T> Flowable<T> concatArrayEager(int maxConcurrency, int prefetch, @NonNull Publisher<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -1479,7 +1491,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
     @SafeVarargs
-    public static <T> Flowable<T> concatArrayEagerDelayError(Publisher<? extends T>... sources) {
+    @NonNull
+    public static <T> Flowable<T> concatArrayEagerDelayError(@NonNull Publisher<? extends T>... sources) {
         return concatArrayEagerDelayError(bufferSize(), bufferSize(), sources);
     }
 
@@ -1513,7 +1526,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T> Flowable<T> concatArrayEagerDelayError(int maxConcurrency, int prefetch, Publisher<? extends T>... sources) {
+    @SafeVarargs
+    @NonNull
+    public static <T> Flowable<T> concatArrayEagerDelayError(int maxConcurrency, int prefetch, @NonNull Publisher<? extends T>... sources) {
         return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(), true, maxConcurrency, prefetch);
     }
 
@@ -1540,7 +1555,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatDelayError(Iterable<? extends Publisher<? extends T>> sources) {
+    public static <T> Flowable<T> concatDelayError(@NonNull Iterable<? extends Publisher<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return fromIterable(sources).concatMapDelayError((Function)Functions.identity());
     }
@@ -1563,7 +1578,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatDelayError(Publisher<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> concatDelayError(@NonNull Publisher<? extends Publisher<? extends T>> sources) {
         return concatDelayError(sources, bufferSize(), true);
     }
 
@@ -1589,7 +1605,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatDelayError(Publisher<? extends Publisher<? extends T>> sources, int prefetch, boolean tillTheEnd) {
+    @NonNull
+    public static <T> Flowable<T> concatDelayError(@NonNull Publisher<? extends Publisher<? extends T>> sources, int prefetch, boolean tillTheEnd) {
         return fromPublisher(sources).concatMapDelayError((Function)Functions.identity(), tillTheEnd, prefetch);
     }
 
@@ -1615,7 +1632,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatEager(Publisher<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> concatEager(@NonNull Publisher<? extends Publisher<? extends T>> sources) {
         return concatEager(sources, bufferSize(), bufferSize());
     }
 
@@ -1646,7 +1664,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Flowable<T> concatEager(Publisher<? extends Publisher<? extends T>> sources, int maxConcurrency, int prefetch) {
+    public static <T> Flowable<T> concatEager(@NonNull Publisher<? extends Publisher<? extends T>> sources, int maxConcurrency, int prefetch) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -1675,7 +1693,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatEager(Iterable<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> concatEager(@NonNull Iterable<? extends Publisher<? extends T>> sources) {
         return concatEager(sources, bufferSize(), bufferSize());
     }
 
@@ -1706,7 +1725,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> Flowable<T> concatEager(Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency, int prefetch) {
+    public static <T> Flowable<T> concatEager(@NonNull Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency, int prefetch) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -1769,10 +1788,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> create(FlowableOnSubscribe<T> source, BackpressureStrategy mode) {
+    public static <T> Flowable<T> create(@NonNull FlowableOnSubscribe<T> source, @NonNull BackpressureStrategy mode) {
         Objects.requireNonNull(source, "source is null");
         Objects.requireNonNull(mode, "mode is null");
-        return RxJavaPlugins.onAssembly(new FlowableCreate<T>(source, mode));
+        return RxJavaPlugins.onAssembly(new FlowableCreate<>(source, mode));
     }
 
     /**
@@ -1806,9 +1825,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> defer(Supplier<? extends Publisher<? extends T>> supplier) {
+    public static <T> Flowable<T> defer(@NonNull Supplier<? extends Publisher<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableDefer<T>(supplier));
+        return RxJavaPlugins.onAssembly(new FlowableDefer<>(supplier));
     }
 
     /**
@@ -1833,6 +1852,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Flowable<T> empty() {
         return RxJavaPlugins.onAssembly((Flowable<T>) FlowableEmpty.INSTANCE);
     }
@@ -1861,7 +1881,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> error(Supplier<? extends Throwable> supplier) {
+    public static <T> Flowable<T> error(@NonNull Supplier<? extends Throwable> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new FlowableError<T>(supplier));
     }
@@ -1890,7 +1910,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> error(final Throwable throwable) {
+    public static <T> Flowable<T> error(@NonNull Throwable throwable) {
         Objects.requireNonNull(throwable, "throwable is null");
         return error(Functions.justSupplier(throwable));
     }
@@ -1919,7 +1939,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T> Flowable<T> fromArray(T... items) {
+    public static <@NonNull T> Flowable<T> fromArray(@NonNull T... items) {
         Objects.requireNonNull(items, "items is null");
         if (items.length == 0) {
             return empty();
@@ -1927,7 +1947,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (items.length == 1) {
             return just(items[0]);
         }
-        return RxJavaPlugins.onAssembly(new FlowableFromArray<T>(items));
+        return RxJavaPlugins.onAssembly(new FlowableFromArray<>(items));
     }
 
     /**
@@ -1966,7 +1986,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> fromCallable(Callable<? extends T> supplier) {
+    public static <@NonNull T> Flowable<T> fromCallable(@NonNull Callable<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new FlowableFromCallable<T>(supplier));
     }
@@ -2008,7 +2028,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> fromFuture(Future<? extends T> future) {
+    public static <@NonNull T> Flowable<T> fromFuture(@NonNull Future<? extends T> future) {
         Objects.requireNonNull(future, "future is null");
         return RxJavaPlugins.onAssembly(new FlowableFromFuture<T>(future, 0L, null));
     }
@@ -2054,7 +2074,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
+    public static <@NonNull T> Flowable<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit) {
         Objects.requireNonNull(future, "future is null");
         Objects.requireNonNull(unit, "unit is null");
         return RxJavaPlugins.onAssembly(new FlowableFromFuture<T>(future, timeout, unit));
@@ -2105,7 +2125,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static <T> Flowable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
+    public static <@NonNull T> Flowable<T> fromFuture(Future<? extends T> future, long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return fromFuture((Future<T>)future, timeout, unit).subscribeOn(scheduler);
     }
@@ -2144,7 +2164,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static <T> Flowable<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
+    public static <@NonNull T> Flowable<T> fromFuture(Future<? extends T> future, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return fromFuture((Future<T>)future).subscribeOn(scheduler);
     }
@@ -2174,7 +2194,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> fromIterable(Iterable<? extends T> source) {
+    public static <@NonNull T> Flowable<T> fromIterable(@NonNull Iterable<? extends T> source) {
         Objects.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new FlowableFromIterable<T>(source));
     }
@@ -2211,7 +2231,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
-    public static <T> Flowable<T> fromPublisher(final Publisher<? extends T> source) {
+    public static <T> Flowable<T> fromPublisher(@NonNull Publisher<? extends T> source) {
         if (source instanceof Flowable) {
             return RxJavaPlugins.onAssembly((Flowable<T>)source);
         }
@@ -2256,7 +2276,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> fromSupplier(Supplier<? extends T> supplier) {
+    public static <@NonNull T> Flowable<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new FlowableFromSupplier<T>(supplier));
     }
@@ -2286,7 +2306,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> generate(final Consumer<Emitter<T>> generator) {
+    public static <T> Flowable<T> generate(@NonNull Consumer<@NonNull Emitter<T>> generator) {
         Objects.requireNonNull(generator, "generator is null");
         return generate(Functions.nullSupplier(),
                 FlowableInternalHelper.<T, Object>simpleGenerator(generator),
@@ -2320,7 +2340,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Supplier<S> initialState, final BiConsumer<S, Emitter<T>> generator) {
+    public static <T, S> Flowable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiConsumer<S, @NonNull Emitter<T>> generator) {
         Objects.requireNonNull(generator, "generator is null");
         return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator),
                 Functions.emptyConsumer());
@@ -2355,8 +2375,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Supplier<S> initialState, final BiConsumer<S, Emitter<T>> generator,
-            Consumer<? super S> disposeState) {
+    public static <T, S> Flowable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiConsumer<S, @NonNull Emitter<T>> generator,
+            @NonNull Consumer<? super S> disposeState) {
         Objects.requireNonNull(generator, "generator is null");
         return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator), disposeState);
     }
@@ -2388,7 +2408,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Supplier<S> initialState, BiFunction<S, Emitter<T>, S> generator) {
+    @NonNull
+    public static <T, S> Flowable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiFunction<S, @NonNull Emitter<T>, S> generator) {
         return generate(initialState, generator, Functions.emptyConsumer());
     }
 
@@ -2422,11 +2443,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Flowable<T> generate(Supplier<S> initialState, BiFunction<S, Emitter<T>, S> generator, Consumer<? super S> disposeState) {
+    public static <T, S> Flowable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiFunction<S, @NonNull Emitter<T>, S> generator, @NonNull Consumer<? super S> disposeState) {
         Objects.requireNonNull(initialState, "initialState is null");
         Objects.requireNonNull(generator, "generator is null");
         Objects.requireNonNull(disposeState, "disposeState is null");
-        return RxJavaPlugins.onAssembly(new FlowableGenerate<T, S>(initialState, generator, disposeState));
+        return RxJavaPlugins.onAssembly(new FlowableGenerate<>(initialState, generator, disposeState));
     }
 
     /**
@@ -2457,7 +2478,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Flowable<Long> interval(long initialDelay, long period, TimeUnit unit) {
+    @NonNull
+    public static Flowable<Long> interval(long initialDelay, long period, @NonNull TimeUnit unit) {
         return interval(initialDelay, period, unit, Schedulers.computation());
     }
 
@@ -2492,7 +2514,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Flowable<Long> interval(long initialDelay, long period, TimeUnit unit, Scheduler scheduler) {
+    public static Flowable<Long> interval(long initialDelay, long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new FlowableInterval(Math.max(0L, initialDelay), Math.max(0L, period), unit, scheduler));
@@ -2520,7 +2542,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Flowable<Long> interval(long period, TimeUnit unit) {
+    @NonNull
+    public static Flowable<Long> interval(long period, @NonNull TimeUnit unit) {
         return interval(period, period, unit, Schedulers.computation());
     }
 
@@ -2550,7 +2573,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Flowable<Long> interval(long period, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public static Flowable<Long> interval(long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return interval(period, period, unit, scheduler);
     }
 
@@ -2574,7 +2598,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Flowable<Long> intervalRange(long start, long count, long initialDelay, long period, TimeUnit unit) {
+    @NonNull
+    public static Flowable<Long> intervalRange(long start, long count, long initialDelay, long period, @NonNull TimeUnit unit) {
         return intervalRange(start, count, initialDelay, period, unit, Schedulers.computation());
     }
 
@@ -2600,7 +2625,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Flowable<Long> intervalRange(long start, long count, long initialDelay, long period, TimeUnit unit, Scheduler scheduler) {
+    public static Flowable<Long> intervalRange(long start, long count, long initialDelay, long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         if (count < 0L) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
         }
@@ -2652,9 +2677,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item) {
+    public static <@NonNull T> Flowable<T> just(T item) {
         Objects.requireNonNull(item, "item is null");
-        return RxJavaPlugins.onAssembly(new FlowableJust<T>(item));
+        return RxJavaPlugins.onAssembly(new FlowableJust<>(item));
     }
 
     /**
@@ -2681,7 +2706,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
 
@@ -2714,7 +2739,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2, T item3) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2, T item3) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2750,7 +2775,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2, T item3, T item4) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2, T item3, T item4) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2789,7 +2814,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2831,7 +2856,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2876,7 +2901,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2924,7 +2949,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2975,7 +3000,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8, T item9) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8, T item9) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -3029,7 +3054,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8, T item9, T item10) {
+    public static <@NonNull T> Flowable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8, T item9, T item10) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -3091,7 +3116,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency, int bufferSize) {
+    @NonNull
+    public static <T> Flowable<T> merge(@NonNull Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency, int bufferSize) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
@@ -3142,7 +3168,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeArray(int maxConcurrency, int bufferSize, Publisher<? extends T>... sources) {
+    @SafeVarargs
+    @NonNull
+    public static <T> Flowable<T> mergeArray(int maxConcurrency, int bufferSize, @NonNull Publisher<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
@@ -3186,7 +3214,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Iterable<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> merge(@NonNull Iterable<? extends Publisher<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity());
     }
 
@@ -3235,7 +3264,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency) {
+    @NonNull
+    public static <T> Flowable<T> merge(@NonNull Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
@@ -3280,7 +3310,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Publisher<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> merge(@NonNull Publisher<? extends Publisher<? extends T>> sources) {
         return merge(sources, bufferSize());
     }
 
@@ -3331,7 +3362,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Publisher<? extends Publisher<? extends T>> sources, int maxConcurrency) {
+    @NonNull
+    public static <T> Flowable<T> merge(@NonNull Publisher<? extends Publisher<? extends T>> sources, int maxConcurrency) {
         return fromPublisher(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
@@ -3374,7 +3406,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeArray(Publisher<? extends T>... sources) {
+    @SafeVarargs
+    @NonNull
+    public static <T> Flowable<T> mergeArray(@NonNull Publisher<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), sources.length);
     }
 
@@ -3420,7 +3454,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Publisher<? extends T> source1, Publisher<? extends T> source2) {
+    public static <T> Flowable<T> merge(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return fromArray(source1, source2).flatMap((Function)Functions.identity(), false, 2);
@@ -3470,7 +3504,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Publisher<? extends T> source1, Publisher<? extends T> source2, Publisher<? extends T> source3) {
+    public static <T> Flowable<T> merge(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2, @NonNull Publisher<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -3524,8 +3558,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> merge(
-            Publisher<? extends T> source1, Publisher<? extends T> source2,
-            Publisher<? extends T> source3, Publisher<? extends T> source4) {
+            @NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2,
+            @NonNull Publisher<? extends T> source3, @NonNull Publisher<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -3565,7 +3599,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Iterable<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> mergeDelayError(@NonNull Iterable<? extends Publisher<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true);
     }
 
@@ -3605,7 +3640,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency, int bufferSize) {
+    @NonNull
+    public static <T> Flowable<T> mergeDelayError(@NonNull Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency, int bufferSize) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
@@ -3645,7 +3681,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeArrayDelayError(int maxConcurrency, int bufferSize, Publisher<? extends T>... sources) {
+    @SafeVarargs
+    @NonNull
+    public static <T> Flowable<T> mergeArrayDelayError(int maxConcurrency, int bufferSize, @NonNull Publisher<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
@@ -3683,7 +3721,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency) {
+    @NonNull
+    public static <T> Flowable<T> mergeDelayError(@NonNull Iterable<? extends Publisher<? extends T>> sources, int maxConcurrency) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
@@ -3719,7 +3758,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Publisher<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends Publisher<? extends T>> sources) {
         return mergeDelayError(sources, bufferSize());
     }
 
@@ -3759,7 +3799,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Publisher<? extends Publisher<? extends T>> sources, int maxConcurrency) {
+    @NonNull
+    public static <T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends Publisher<? extends T>> sources, int maxConcurrency) {
         return fromPublisher(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
@@ -3795,7 +3836,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeArrayDelayError(Publisher<? extends T>... sources) {
+    @SafeVarargs
+    @NonNull
+    public static <T> Flowable<T> mergeArrayDelayError(@NonNull Publisher<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, sources.length);
     }
 
@@ -3833,7 +3876,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Publisher<? extends T> source1, Publisher<? extends T> source2) {
+    public static <T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return fromArray(source1, source2).flatMap((Function)Functions.identity(), true, 2);
@@ -3876,7 +3919,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Publisher<? extends T> source1, Publisher<? extends T> source2, Publisher<? extends T> source3) {
+    public static <T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2, @NonNull Publisher<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -3923,8 +3966,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> mergeDelayError(
-            Publisher<? extends T> source1, Publisher<? extends T> source2,
-            Publisher<? extends T> source3, Publisher<? extends T> source4) {
+            @NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2,
+            @NonNull Publisher<? extends T> source3, @NonNull Publisher<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -3954,6 +3997,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Flowable<T> never() {
         return RxJavaPlugins.onAssembly((Flowable<T>) FlowableNever.INSTANCE);
     }
@@ -3982,6 +4026,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static Flowable<Integer> range(int start, int count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
@@ -4022,6 +4067,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static Flowable<Long> rangeLong(long start, long count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
@@ -4068,7 +4114,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(Publisher<? extends T> source1, Publisher<? extends T> source2) {
+    @NonNull
+    public static <T> Single<Boolean> sequenceEqual(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize());
     }
 
@@ -4101,8 +4148,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(Publisher<? extends T> source1, Publisher<? extends T> source2,
-            BiPredicate<? super T, ? super T> isEqual) {
+    @NonNull
+    public static <T> Single<Boolean> sequenceEqual(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2,
+            @NonNull BiPredicate<? super T, ? super T> isEqual) {
         return sequenceEqual(source1, source2, isEqual, bufferSize());
     }
 
@@ -4138,13 +4186,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(Publisher<? extends T> source1, Publisher<? extends T> source2,
-            BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
+    public static <T> Single<Boolean> sequenceEqual(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2,
+            @NonNull BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(isEqual, "isEqual is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableSequenceEqualSingle<T>(source1, source2, isEqual, bufferSize));
+        return RxJavaPlugins.onAssembly(new FlowableSequenceEqualSingle<>(source1, source2, isEqual, bufferSize));
     }
 
     /**
@@ -4174,7 +4222,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(Publisher<? extends T> source1, Publisher<? extends T> source2, int bufferSize) {
+    @NonNull
+    public static <T> Single<Boolean> sequenceEqual(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2, int bufferSize) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize);
     }
 
@@ -4214,7 +4263,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> switchOnNext(Publisher<? extends Publisher<? extends T>> sources, int bufferSize) {
+    @NonNull
+    public static <T> Flowable<T> switchOnNext(@NonNull Publisher<? extends Publisher<? extends T>> sources, int bufferSize) {
         return fromPublisher(sources).switchMap((Function)Functions.identity(), bufferSize);
     }
 
@@ -4252,7 +4302,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> switchOnNext(Publisher<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> switchOnNext(@NonNull Publisher<? extends Publisher<? extends T>> sources) {
         return fromPublisher(sources).switchMap((Function)Functions.identity());
     }
 
@@ -4291,7 +4342,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> switchOnNextDelayError(Publisher<? extends Publisher<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> switchOnNextDelayError(@NonNull Publisher<? extends Publisher<? extends T>> sources) {
         return switchOnNextDelayError(sources, bufferSize());
     }
 
@@ -4332,7 +4384,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> switchOnNextDelayError(Publisher<? extends Publisher<? extends T>> sources, int prefetch) {
+    @NonNull
+    public static <T> Flowable<T> switchOnNextDelayError(@NonNull Publisher<? extends Publisher<? extends T>> sources, int prefetch) {
         return fromPublisher(sources).switchMapDelayError(Functions.<Publisher<? extends T>>identity(), prefetch);
     }
 
@@ -4358,7 +4411,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Flowable<Long> timer(long delay, TimeUnit unit) {
+    @NonNull
+    public static Flowable<Long> timer(long delay, @NonNull TimeUnit unit) {
         return timer(delay, unit, Schedulers.computation());
     }
 
@@ -4389,7 +4443,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Flowable<Long> timer(long delay, TimeUnit unit, Scheduler scheduler) {
+    public static Flowable<Long> timer(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
 
@@ -4418,12 +4472,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> unsafeCreate(Publisher<T> onSubscribe) {
+    public static <T> Flowable<T> unsafeCreate(@NonNull Publisher<T> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         if (onSubscribe instanceof Flowable) {
             throw new IllegalArgumentException("unsafeCreate(Flowable) should be upgraded");
         }
-        return RxJavaPlugins.onAssembly(new FlowableFromPublisher<T>(onSubscribe));
+        return RxJavaPlugins.onAssembly(new FlowableFromPublisher<>(onSubscribe));
     }
 
     /**
@@ -4452,8 +4506,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Flowable<T> using(Supplier<? extends D> resourceSupplier,
-            Function<? super D, ? extends Publisher<? extends T>> sourceSupplier, Consumer<? super D> resourceDisposer) {
+    @NonNull
+    public static <T, D> Flowable<T> using(
+            @NonNull Supplier<? extends D> resourceSupplier,
+            @NonNull Function<? super D, ? extends Publisher<? extends T>> sourceSupplier,
+            @NonNull Consumer<? super D> resourceDisposer) {
         return using(resourceSupplier, sourceSupplier, resourceDisposer, true);
     }
 
@@ -4494,9 +4551,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Flowable<T> using(Supplier<? extends D> resourceSupplier,
-            Function<? super D, ? extends Publisher<? extends T>> sourceSupplier,
-                    Consumer<? super D> resourceDisposer, boolean eager) {
+    public static <T, D> Flowable<T> using(
+            @NonNull Supplier<? extends D> resourceSupplier,
+            @NonNull Function<? super D, ? extends Publisher<? extends T>> sourceSupplier,
+            @NonNull Consumer<? super D> resourceDisposer,
+            boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
         Objects.requireNonNull(resourceDisposer, "resourceDisposer is null");
@@ -4551,7 +4610,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> zip(Iterable<? extends Publisher<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
+    public static <T, R> Flowable<R> zip(@NonNull Iterable<? extends Publisher<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new FlowableZip<T, R>(null, sources, zipper, bufferSize(), false));
@@ -4610,8 +4669,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Flowable<R> zip(Iterable<? extends Publisher<? extends T>> sources,
-            Function<? super Object[], ? extends R> zipper, boolean delayError,
+    public static <T, R> Flowable<R> zip(@NonNull Iterable<? extends Publisher<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> zipper, boolean delayError,
             int bufferSize) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
@@ -4672,8 +4731,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> zipper) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2);
@@ -4733,8 +4792,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize(), source1, source2);
@@ -4795,8 +4854,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError, int bufferSize) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError, int bufferSize) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize, source1, source2);
@@ -4859,8 +4918,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2, Publisher<? extends T3> source3,
-            Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2, @NonNull Publisher<? extends T3> source3,
+            @NonNull Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -4927,9 +4986,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2, Publisher<? extends T3> source3,
-            Publisher<? extends T4> source4,
-            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2, @NonNull Publisher<? extends T3> source3,
+            @NonNull Publisher<? extends T4> source4,
+            @NonNull Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -5000,9 +5059,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2, Publisher<? extends T3> source3,
-            Publisher<? extends T4> source4, Publisher<? extends T5> source5,
-            Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2, @NonNull Publisher<? extends T3> source3,
+            @NonNull Publisher<? extends T4> source4, @NonNull Publisher<? extends T5> source5,
+            @NonNull Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -5076,9 +5135,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2, Publisher<? extends T3> source3,
-            Publisher<? extends T4> source4, Publisher<? extends T5> source5, Publisher<? extends T6> source6,
-            Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2, @NonNull Publisher<? extends T3> source3,
+            @NonNull Publisher<? extends T4> source4, @NonNull Publisher<? extends T5> source5, @NonNull Publisher<? extends T6> source6,
+            @NonNull Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -5156,10 +5215,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2, Publisher<? extends T3> source3,
-            Publisher<? extends T4> source4, Publisher<? extends T5> source5, Publisher<? extends T6> source6,
-            Publisher<? extends T7> source7,
-            Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2, @NonNull Publisher<? extends T3> source3,
+            @NonNull Publisher<? extends T4> source4, @NonNull Publisher<? extends T5> source5, @NonNull Publisher<? extends T6> source6,
+            @NonNull Publisher<? extends T7> source7,
+            @NonNull Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -5241,10 +5300,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2, Publisher<? extends T3> source3,
-            Publisher<? extends T4> source4, Publisher<? extends T5> source5, Publisher<? extends T6> source6,
-            Publisher<? extends T7> source7, Publisher<? extends T8> source8,
-            Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2, @NonNull Publisher<? extends T3> source3,
+            @NonNull Publisher<? extends T4> source4, @NonNull Publisher<? extends T5> source5, @NonNull Publisher<? extends T6> source6,
+            @NonNull Publisher<? extends T7> source7, @NonNull Publisher<? extends T8> source8,
+            @NonNull Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -5330,10 +5389,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Flowable<R> zip(
-            Publisher<? extends T1> source1, Publisher<? extends T2> source2, Publisher<? extends T3> source3,
-            Publisher<? extends T4> source4, Publisher<? extends T5> source5, Publisher<? extends T6> source6,
-            Publisher<? extends T7> source7, Publisher<? extends T8> source8, Publisher<? extends T9> source9,
-            Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper) {
+            @NonNull Publisher<? extends T1> source1, @NonNull Publisher<? extends T2> source2, @NonNull Publisher<? extends T3> source3,
+            @NonNull Publisher<? extends T4> source4, @NonNull Publisher<? extends T5> source5, @NonNull Publisher<? extends T6> source6,
+            @NonNull Publisher<? extends T7> source7, @NonNull Publisher<? extends T8> source8, @NonNull Publisher<? extends T9> source9,
+            @NonNull Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper) {
 
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -5401,8 +5460,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T, R> Flowable<R> zipArray(Function<? super Object[], ? extends R> zipper,
-            boolean delayError, int bufferSize, Publisher<? extends T>... sources) {
+    public static <T, R> Flowable<R> zipArray(@NonNull Function<? super Object[], ? extends R> zipper,
+            boolean delayError, int bufferSize, @NonNull Publisher<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         }
@@ -5438,9 +5497,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> all(Predicate<? super T> predicate) {
+    public final Single<Boolean> all(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new FlowableAllSingle<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableAllSingle<>(this, predicate));
     }
 
     /**
@@ -5467,7 +5526,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> ambWith(Publisher<? extends T> other) {
+    public final Flowable<T> ambWith(@NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return ambArray(this, other);
     }
@@ -5499,9 +5558,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> any(Predicate<? super T> predicate) {
+    public final Single<Boolean> any(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new FlowableAnySingle<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableAnySingle<>(this, predicate));
     }
 
     /**
@@ -5527,8 +5586,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final T blockingFirst() {
-        BlockingFirstSubscriber<T> s = new BlockingFirstSubscriber<T>();
+        BlockingFirstSubscriber<T> s = new BlockingFirstSubscriber<>();
         subscribe(s);
         T v = s.blockingGet();
         if (v != null) {
@@ -5561,8 +5621,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final T blockingFirst(T defaultItem) {
-        BlockingFirstSubscriber<T> s = new BlockingFirstSubscriber<T>();
+    @NonNull
+    public final T blockingFirst(@NonNull T defaultItem) {
+        BlockingFirstSubscriber<T> s = new BlockingFirstSubscriber<>();
         subscribe(s);
         T v = s.blockingGet();
         return v != null ? v : defaultItem;
@@ -5602,7 +5663,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingForEach(Consumer<? super T> onNext) {
+    public final void blockingForEach(@NonNull Consumer<? super T> onNext) {
         Iterator<T> it = blockingIterable().iterator();
         while (it.hasNext()) {
             try {
@@ -5633,6 +5694,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Iterable<T> blockingIterable() {
         return blockingIterable(bufferSize());
     }
@@ -5657,9 +5719,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Iterable<T> blockingIterable(int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return new BlockingFlowableIterable<T>(this, bufferSize);
+        return new BlockingFlowableIterable<>(this, bufferSize);
     }
 
     /**
@@ -5687,8 +5750,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final T blockingLast() {
-        BlockingLastSubscriber<T> s = new BlockingLastSubscriber<T>();
+        BlockingLastSubscriber<T> s = new BlockingLastSubscriber<>();
         subscribe(s);
         T v = s.blockingGet();
         if (v != null) {
@@ -5723,8 +5787,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final T blockingLast(T defaultItem) {
-        BlockingLastSubscriber<T> s = new BlockingLastSubscriber<T>();
+    @NonNull
+    public final T blockingLast(@NonNull T defaultItem) {
+        BlockingLastSubscriber<T> s = new BlockingLastSubscriber<>();
         subscribe(s);
         T v = s.blockingGet();
         return v != null ? v : defaultItem;
@@ -5753,8 +5818,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Iterable<T> blockingLatest() {
-        return new BlockingFlowableLatest<T>(this);
+        return new BlockingFlowableLatest<>(this);
     }
 
     /**
@@ -5780,8 +5846,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Iterable<T> blockingMostRecent(T initialItem) {
-        return new BlockingFlowableMostRecent<T>(this, initialItem);
+    @NonNull
+    public final Iterable<T> blockingMostRecent(@NonNull T initialItem) {
+        return new BlockingFlowableMostRecent<>(this, initialItem);
     }
 
     /**
@@ -5804,8 +5871,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Iterable<T> blockingNext() {
-        return new BlockingFlowableNext<T>(this);
+        return new BlockingFlowableNext<>(this);
     }
 
     /**
@@ -5831,6 +5899,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final T blockingSingle() {
         return singleOrError().blockingGet();
     }
@@ -5862,7 +5931,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final T blockingSingle(T defaultItem) {
+    @NonNull
+    public final T blockingSingle(@NonNull T defaultItem) {
         return single(defaultItem).blockingGet();
     }
 
@@ -5891,6 +5961,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Future<T> toFuture() {
         return subscribeWith(new FutureSubscriber<T>());
     }
@@ -5945,7 +6016,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext) {
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext) {
         FlowableBlockingSubscribe.subscribe(this, onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
 
@@ -5977,7 +6048,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext, int bufferSize) {
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext, int bufferSize) {
         FlowableBlockingSubscribe.subscribe(this, onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION, bufferSize);
     }
 
@@ -6001,7 +6072,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, Functions.EMPTY_ACTION);
     }
 
@@ -6027,7 +6098,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError,
         int bufferSize) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, Functions.EMPTY_ACTION, bufferSize);
     }
@@ -6052,7 +6123,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete) {
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError, @NonNull Action onComplete) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, onComplete);
     }
 
@@ -6078,7 +6149,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete,
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError, @NonNull Action onComplete,
         int bufferSize) {
         FlowableBlockingSubscribe.subscribe(this, onNext, onError, onComplete, bufferSize);
     }
@@ -6103,7 +6174,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Subscriber<? super T> subscriber) {
+    public final void blockingSubscribe(@NonNull Subscriber<? super T> subscriber) {
         FlowableBlockingSubscribe.subscribe(this, subscriber);
     }
 
@@ -6133,6 +6204,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<List<T>> buffer(int count) {
         return buffer(count, count);
     }
@@ -6167,6 +6239,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<List<T>> buffer(int count, int skip) {
         return buffer(count, skip, ArrayListSupplier.<T>asSupplier());
     }
@@ -6206,11 +6279,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Flowable<U> buffer(int count, int skip, Supplier<U> bufferSupplier) {
+    public final <U extends Collection<? super T>> Flowable<U> buffer(int count, int skip, @NonNull Supplier<U> bufferSupplier) {
         ObjectHelper.verifyPositive(count, "count");
         ObjectHelper.verifyPositive(skip, "skip");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableBuffer<T, U>(this, count, skip, bufferSupplier));
+        return RxJavaPlugins.onAssembly(new FlowableBuffer<>(this, count, skip, bufferSupplier));
     }
 
     /**
@@ -6243,7 +6316,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Flowable<U> buffer(int count, Supplier<U> bufferSupplier) {
+    @NonNull
+    public final <U extends Collection<? super T>> Flowable<U> buffer(int count, @NonNull Supplier<U> bufferSupplier) {
         return buffer(count, count, bufferSupplier);
     }
 
@@ -6277,7 +6351,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<List<T>> buffer(long timespan, long timeskip, TimeUnit unit) {
+    @NonNull
+    public final Flowable<List<T>> buffer(long timespan, long timeskip, @NonNull TimeUnit unit) {
         return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.<T>asSupplier());
     }
 
@@ -6314,7 +6389,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<List<T>> buffer(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<List<T>> buffer(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.<T>asSupplier());
     }
 
@@ -6356,12 +6432,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <U extends Collection<? super T>> Flowable<U> buffer(long timespan, long timeskip, TimeUnit unit,
-            Scheduler scheduler, Supplier<U> bufferSupplier) {
+    public final <U extends Collection<? super T>> Flowable<U> buffer(long timespan, long timeskip, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler, @NonNull Supplier<U> bufferSupplier) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false));
+        return RxJavaPlugins.onAssembly(new FlowableBufferTimed<>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false));
     }
 
     /**
@@ -6393,7 +6469,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<List<T>> buffer(long timespan, TimeUnit unit) {
+    @NonNull
+    public final Flowable<List<T>> buffer(long timespan, @NonNull TimeUnit unit) {
         return buffer(timespan, unit, Schedulers.computation(), Integer.MAX_VALUE);
     }
 
@@ -6429,7 +6506,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, int count) {
+    @NonNull
+    public final Flowable<List<T>> buffer(long timespan, @NonNull TimeUnit unit, int count) {
         return buffer(timespan, unit, Schedulers.computation(), count);
     }
 
@@ -6468,7 +6546,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler, int count) {
+    @NonNull
+    public final Flowable<List<T>> buffer(long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int count) {
         return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asSupplier(), false);
     }
 
@@ -6513,16 +6592,17 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
+    @NonNull
     public final <U extends Collection<? super T>> Flowable<U> buffer(
-            long timespan, TimeUnit unit,
-            Scheduler scheduler, int count,
-            Supplier<U> bufferSupplier,
+            long timespan, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler, int count,
+            @NonNull Supplier<U> bufferSupplier,
             boolean restartTimerOnMaxSize) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         ObjectHelper.verifyPositive(count, "count");
-        return RxJavaPlugins.onAssembly(new FlowableBufferTimed<T, U>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize));
+        return RxJavaPlugins.onAssembly(new FlowableBufferTimed<>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize));
     }
 
     /**
@@ -6556,7 +6636,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<List<T>> buffer(long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asSupplier(), false);
     }
 
@@ -6590,9 +6671,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <TOpening, TClosing> Flowable<List<T>> buffer(
-            Flowable<? extends TOpening> openingIndicator,
-            Function<? super TOpening, ? extends Publisher<? extends TClosing>> closingIndicator) {
+            @NonNull Flowable<? extends TOpening> openingIndicator,
+            @NonNull Function<? super TOpening, ? extends Publisher<? extends TClosing>> closingIndicator) {
         return buffer(openingIndicator, closingIndicator, ArrayListSupplier.<T>asSupplier());
     }
 
@@ -6630,10 +6712,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <TOpening, TClosing, U extends Collection<? super T>> Flowable<U> buffer(
-            Flowable<? extends TOpening> openingIndicator,
-            Function<? super TOpening, ? extends Publisher<? extends TClosing>> closingIndicator,
-            Supplier<U> bufferSupplier) {
+            @NonNull Flowable<? extends TOpening> openingIndicator,
+            @NonNull Function<? super TOpening, ? extends Publisher<? extends TClosing>> closingIndicator,
+            @NonNull Supplier<U> bufferSupplier) {
         Objects.requireNonNull(openingIndicator, "openingIndicator is null");
         Objects.requireNonNull(closingIndicator, "closingIndicator is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -6670,7 +6753,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Flowable<List<T>> buffer(Publisher<B> boundaryIndicator) {
+    @NonNull
+    public final <B> Flowable<List<T>> buffer(@NonNull Publisher<B> boundaryIndicator) {
         return buffer(boundaryIndicator, ArrayListSupplier.<T>asSupplier());
     }
 
@@ -6706,7 +6790,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Flowable<List<T>> buffer(Publisher<B> boundaryIndicator, final int initialCapacity) {
+    @NonNull
+    public final <B> Flowable<List<T>> buffer(@NonNull Publisher<B> boundaryIndicator, final int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
         return buffer(boundaryIndicator, Functions.<T>createArrayList(initialCapacity));
     }
@@ -6745,10 +6830,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B, U extends Collection<? super T>> Flowable<U> buffer(Publisher<B> boundaryIndicator, Supplier<U> bufferSupplier) {
+    @NonNull
+    public final <B, U extends Collection<? super T>> Flowable<U> buffer(@NonNull Publisher<B> boundaryIndicator, @NonNull Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundaryIndicator, "boundaryIndicator is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableBufferExactBoundary<T, U, B>(this, boundaryIndicator, bufferSupplier));
+        return RxJavaPlugins.onAssembly(new FlowableBufferExactBoundary<>(this, boundaryIndicator, bufferSupplier));
     }
 
     /**
@@ -6805,6 +6891,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> cache() {
         return cacheWithInitialCapacity(16);
     }
@@ -6867,9 +6954,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> cacheWithInitialCapacity(int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
-        return RxJavaPlugins.onAssembly(new FlowableCache<T>(this, initialCapacity));
+        return RxJavaPlugins.onAssembly(new FlowableCache<>(this, initialCapacity));
     }
 
     /**
@@ -6897,7 +6985,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> cast(final Class<U> clazz) {
+    public final <U> Flowable<U> cast(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
     }
@@ -6936,7 +7024,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<U> collect(Supplier<? extends U> initialItemSupplier, BiConsumer<? super U, ? super T> collector) {
+    public final <U> Single<U> collect(@NonNull Supplier<? extends U> initialItemSupplier, @NonNull BiConsumer<? super U, ? super T> collector) {
         Objects.requireNonNull(initialItemSupplier, "initialItemSupplier is null");
         Objects.requireNonNull(collector, "collector is null");
         return RxJavaPlugins.onAssembly(new FlowableCollectSingle<T, U>(this, initialItemSupplier, collector));
@@ -6975,7 +7063,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<U> collectInto(final U initialItem, BiConsumer<? super U, ? super T> collector) {
+    public final <@NonNull U> Single<U> collectInto(U initialItem, @NonNull BiConsumer<? super U, ? super T> collector) {
         Objects.requireNonNull(initialItem, "initialItem is null");
         return collect(Functions.justSupplier(initialItem), collector);
     }
@@ -7006,7 +7094,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> compose(FlowableTransformer<? super T, ? extends R> composer) {
+    @NonNull
+    public final <R> Flowable<R> compose(@NonNull FlowableTransformer<? super T, ? extends R> composer) {
         return fromPublisher(((FlowableTransformer<T, R>) Objects.requireNonNull(composer, "composer is null")).apply(this));
     }
 
@@ -7042,7 +7131,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMap(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> concatMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return concatMap(mapper, 2);
     }
 
@@ -7082,7 +7172,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, int prefetch) {
+    public final <R> Flowable<R> concatMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         if (this instanceof ScalarSupplier) {
@@ -7093,7 +7183,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             }
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new FlowableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMap<>(this, mapper, prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -7135,11 +7225,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Flowable<R> concatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, int prefetch, Scheduler scheduler) {
+    public final <R> Flowable<R> concatMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper, int prefetch, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         Objects.requireNonNull(scheduler, "scheduler");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapScheduler<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE, scheduler));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapScheduler<>(this, mapper, prefetch, ErrorMode.IMMEDIATE, scheduler));
     }
 
     /**
@@ -7165,7 +7255,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
+    @NonNull
+    public final Completable concatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         return concatMapCompletable(mapper, 2);
     }
 
@@ -7197,10 +7288,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int prefetch) {
+    public final Completable concatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapCompletable<T>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapCompletable<>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
     }
 
     /**
@@ -7227,7 +7318,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper) {
+    @NonNull
+    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         return concatMapCompletableDelayError(mapper, true, 2);
     }
 
@@ -7261,7 +7353,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd) {
+    @NonNull
+    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd) {
         return concatMapCompletableDelayError(mapper, tillTheEnd, 2);
     }
 
@@ -7300,10 +7393,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd, int prefetch) {
+    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapCompletable<T>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapCompletable<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
     }
 
     /**
@@ -7334,7 +7427,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> concatMapDelayError(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return concatMapDelayError(mapper, true, 2);
     }
 
@@ -7373,7 +7467,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
+    public final <R> Flowable<R> concatMapDelayError(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper,
             boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -7385,7 +7479,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             }
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new FlowableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMap<>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
     }
 
     /**
@@ -7425,12 +7519,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Flowable<R> concatMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
-            boolean tillTheEnd, int prefetch, Scheduler scheduler) {
+    public final <R> Flowable<R> concatMapDelayError(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper,
+            boolean tillTheEnd, int prefetch, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapScheduler<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, scheduler));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapScheduler<>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, scheduler));
     }
 
     /**
@@ -7456,7 +7550,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapEager(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> concatMapEager(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return concatMapEager(mapper, bufferSize(), bufferSize());
     }
 
@@ -7486,12 +7581,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapEager(Function<? super T, ? extends Publisher<? extends R>> mapper,
+    public final <R> Flowable<R> concatMapEager(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper,
             int maxConcurrency, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager<T, R>(this, mapper, maxConcurrency, prefetch, ErrorMode.IMMEDIATE));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager<>(this, mapper, maxConcurrency, prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -7520,7 +7615,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapEagerDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
+    @NonNull
+    public final <R> Flowable<R> concatMapEagerDelayError(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper,
             boolean tillTheEnd) {
         return concatMapEagerDelayError(mapper, tillTheEnd, bufferSize(), bufferSize());
     }
@@ -7556,12 +7652,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapEagerDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper,
+    public final <R> Flowable<R> concatMapEagerDelayError(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper,
             boolean tillTheEnd, int maxConcurrency, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager<T, R>(this, mapper, maxConcurrency, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapEager<>(this, mapper, maxConcurrency, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
     }
 
     /**
@@ -7589,7 +7685,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> concatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    @NonNull
+    public final <U> Flowable<U> concatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
         return concatMapIterable(mapper, 2);
     }
 
@@ -7621,10 +7718,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> concatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper, int prefetch) {
+    public final <U> Flowable<U> concatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableFlattenIterable<T, U>(this, mapper, prefetch));
+        return RxJavaPlugins.onAssembly(new FlowableFlattenIterable<>(this, mapper, prefetch));
     }
 
     /**
@@ -7654,7 +7751,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> concatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return concatMapMaybe(mapper, 2);
     }
 
@@ -7690,10 +7788,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper, int prefetch) {
+    public final <R> Flowable<R> concatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapMaybe<T, R>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapMaybe<>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
     }
 
     /**
@@ -7723,7 +7821,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return concatMapMaybeDelayError(mapper, true, 2);
     }
 
@@ -7760,7 +7859,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd) {
+    @NonNull
+    public final <R> Flowable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd) {
         return concatMapMaybeDelayError(mapper, tillTheEnd, 2);
     }
 
@@ -7801,10 +7901,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
+    public final <R> Flowable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapMaybe<T, R>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapMaybe<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
     }
 
     /**
@@ -7834,7 +7934,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> concatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return concatMapSingle(mapper, 2);
     }
 
@@ -7870,10 +7971,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper, int prefetch) {
+    public final <R> Flowable<R> concatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapSingle<T, R>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapSingle<>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
     }
 
     /**
@@ -7903,7 +8004,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return concatMapSingleDelayError(mapper, true, 2);
     }
 
@@ -7940,7 +8042,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd) {
+    @NonNull
+    public final <R> Flowable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd) {
         return concatMapSingleDelayError(mapper, tillTheEnd, 2);
     }
 
@@ -7981,10 +8084,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
+    public final <R> Flowable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapSingle<T, R>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapSingle<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
     }
 
     /**
@@ -8011,7 +8114,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> concatWith(Publisher<? extends T> other) {
+    public final Flowable<T> concatWith(@NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concat(this, other);
     }
@@ -8036,9 +8139,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> concatWith(@NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableConcatWithSingle<T>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableConcatWithSingle<>(this, other));
     }
 
     /**
@@ -8061,9 +8165,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableConcatWithMaybe<T>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableConcatWithMaybe<>(this, other));
     }
 
     /**
@@ -8088,9 +8193,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> concatWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableConcatWithCompletable<T>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableConcatWithCompletable<>(this, other));
     }
 
     /**
@@ -8116,7 +8222,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> contains(final Object item) {
+    public final Single<Boolean> contains(@NonNull Object item) {
         Objects.requireNonNull(item, "item is null");
         return any(Functions.equalsWith(item));
     }
@@ -8141,8 +8247,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<Long> count() {
-        return RxJavaPlugins.onAssembly(new FlowableCountSingle<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableCountSingle<>(this));
     }
 
     /**
@@ -8179,9 +8286,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<T> debounce(Function<? super T, ? extends Publisher<U>> debounceIndicator) {
+    public final <U> Flowable<T> debounce(@NonNull Function<? super T, ? extends Publisher<U>> debounceIndicator) {
         Objects.requireNonNull(debounceIndicator, "debounceIndicator is null");
-        return RxJavaPlugins.onAssembly(new FlowableDebounce<T, U>(this, debounceIndicator));
+        return RxJavaPlugins.onAssembly(new FlowableDebounce<>(this, debounceIndicator));
     }
 
     /**
@@ -8222,7 +8329,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> debounce(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> debounce(long timeout, @NonNull TimeUnit unit) {
         return debounce(timeout, unit, Schedulers.computation());
     }
 
@@ -8267,10 +8375,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> debounce(long timeout, TimeUnit unit, Scheduler scheduler) {
+    public final Flowable<T> debounce(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableDebounceTimed<T>(this, timeout, unit, scheduler));
+        return RxJavaPlugins.onAssembly(new FlowableDebounceTimed<>(this, timeout, unit, scheduler));
     }
 
     /**
@@ -8298,7 +8406,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> defaultIfEmpty(T defaultItem) {
+    public final Flowable<T> defaultIfEmpty(@NonNull T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem is null");
         return switchIfEmpty(just(defaultItem));
     }
@@ -8334,7 +8442,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<T> delay(final Function<? super T, ? extends Publisher<U>> itemDelayIndicator) {
+    public final <U> Flowable<T> delay(@NonNull Function<? super T, ? extends Publisher<U>> itemDelayIndicator) {
         Objects.requireNonNull(itemDelayIndicator, "itemDelayIndicator is null");
         return flatMap(FlowableInternalHelper.itemDelay(itemDelayIndicator));
     }
@@ -8361,7 +8469,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> delay(long delay, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> delay(long delay, @NonNull TimeUnit unit) {
         return delay(delay, unit, Schedulers.computation(), false);
     }
 
@@ -8390,7 +8499,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> delay(long delay, TimeUnit unit, boolean delayError) {
+    @NonNull
+    public final Flowable<T> delay(long delay, @NonNull TimeUnit unit, boolean delayError) {
         return delay(delay, unit, Schedulers.computation(), delayError);
     }
 
@@ -8418,7 +8528,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> delay(long delay, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return delay(delay, unit, scheduler, false);
     }
 
@@ -8450,11 +8561,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> delay(long delay, TimeUnit unit, Scheduler scheduler, boolean delayError) {
+    public final Flowable<T> delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
 
-        return RxJavaPlugins.onAssembly(new FlowableDelay<T>(this, Math.max(0L, delay), unit, scheduler, delayError));
+        return RxJavaPlugins.onAssembly(new FlowableDelay<>(this, Math.max(0L, delay), unit, scheduler, delayError));
     }
 
     /**
@@ -8492,8 +8603,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Flowable<T> delay(Publisher<U> subscriptionIndicator,
-            Function<? super T, ? extends Publisher<V>> itemDelayIndicator) {
+    @NonNull
+    public final <U, V> Flowable<T> delay(@NonNull Publisher<U> subscriptionIndicator,
+            @NonNull Function<? super T, ? extends Publisher<V>> itemDelayIndicator) {
         return delaySubscription(subscriptionIndicator).delay(itemDelayIndicator);
     }
 
@@ -8519,9 +8631,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<T> delaySubscription(Publisher<U> subscriptionIndicator) {
+    public final <U> Flowable<T> delaySubscription(@NonNull Publisher<U> subscriptionIndicator) {
         Objects.requireNonNull(subscriptionIndicator, "subscriptionIndicator is null");
-        return RxJavaPlugins.onAssembly(new FlowableDelaySubscriptionOther<T, U>(this, subscriptionIndicator));
+        return RxJavaPlugins.onAssembly(new FlowableDelaySubscriptionOther<>(this, subscriptionIndicator));
     }
 
     /**
@@ -8545,7 +8657,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> delaySubscription(long delay, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> delaySubscription(long delay, @NonNull TimeUnit unit) {
         return delaySubscription(delay, unit, Schedulers.computation());
     }
 
@@ -8574,7 +8687,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> delaySubscription(long delay, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> delaySubscription(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return delaySubscription(timer(delay, unit, scheduler));
     }
 
@@ -8632,9 +8746,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final <R> Flowable<R> dematerialize(Function<? super T, Notification<R>> selector) {
+    public final <R> Flowable<R> dematerialize(@NonNull Function<@NonNull ? super T, @NonNull Notification<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
-        return RxJavaPlugins.onAssembly(new FlowableDematerialize<T, R>(this, selector));
+        return RxJavaPlugins.onAssembly(new FlowableDematerialize<>(this, selector));
     }
 
     /**
@@ -8674,6 +8788,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> distinct() {
         return distinct((Function)Functions.identity(), Functions.<T>createHashSet());
     }
@@ -8717,7 +8832,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Flowable<T> distinct(Function<? super T, K> keySelector) {
+    @NonNull
+    public final <K> Flowable<T> distinct(@NonNull Function<? super T, K> keySelector) {
         return distinct(keySelector, Functions.<K>createHashSet());
     }
 
@@ -8751,11 +8867,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Flowable<T> distinct(Function<? super T, K> keySelector,
-            Supplier<? extends Collection<? super K>> collectionSupplier) {
+    @NonNull
+    public final <K> Flowable<T> distinct(@NonNull Function<? super T, K> keySelector,
+            @NonNull Supplier<? extends Collection<? super K>> collectionSupplier) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableDistinct<T, K>(this, keySelector, collectionSupplier));
+        return RxJavaPlugins.onAssembly(new FlowableDistinct<>(this, keySelector, collectionSupplier));
     }
 
     /**
@@ -8795,6 +8912,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> distinctUntilChanged() {
         return distinctUntilChanged(Functions.identity());
     }
@@ -8841,9 +8959,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Flowable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
+    @NonNull
+    public final <K> Flowable<T> distinctUntilChanged(@NonNull Function<? super T, K> keySelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
-        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<T, K>(this, keySelector, ObjectHelper.equalsPredicate()));
+        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<>(this, keySelector, ObjectHelper.equalsPredicate()));
     }
 
     /**
@@ -8879,9 +8998,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
+    @NonNull
+    public final Flowable<T> distinctUntilChanged(@NonNull BiPredicate<? super T, ? super T> comparer) {
         Objects.requireNonNull(comparer, "comparer is null");
-        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<T, T>(this, Functions.<T>identity(), comparer));
+        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<>(this, Functions.<T>identity(), comparer));
     }
 
     /**
@@ -8909,9 +9029,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doFinally(Action onFinally) {
+    @NonNull
+    public final Flowable<T> doFinally(@NonNull Action onFinally) {
         Objects.requireNonNull(onFinally, "onFinally is null");
-        return RxJavaPlugins.onAssembly(new FlowableDoFinally<T>(this, onFinally));
+        return RxJavaPlugins.onAssembly(new FlowableDoFinally<>(this, onFinally));
     }
 
     /**
@@ -8936,9 +9057,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doAfterNext(Consumer<? super T> onAfterNext) {
+    @NonNull
+    public final Flowable<T> doAfterNext(@NonNull Consumer<? super T> onAfterNext) {
         Objects.requireNonNull(onAfterNext, "onAfterNext is null");
-        return RxJavaPlugins.onAssembly(new FlowableDoAfterNext<T>(this, onAfterNext));
+        return RxJavaPlugins.onAssembly(new FlowableDoAfterNext<>(this, onAfterNext));
     }
 
     /**
@@ -8964,7 +9086,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doAfterTerminate(Action onAfterTerminate) {
+    @NonNull
+    public final Flowable<T> doAfterTerminate(@NonNull Action onAfterTerminate) {
         return doOnEach(Functions.emptyConsumer(), Functions.emptyConsumer(),
                 Functions.EMPTY_ACTION, onAfterTerminate);
     }
@@ -8997,7 +9120,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnCancel(Action onCancel) {
+    @NonNull
+    public final Flowable<T> doOnCancel(@NonNull Action onCancel) {
         return doOnLifecycle(Functions.emptyConsumer(), Functions.EMPTY_LONG_CONSUMER, onCancel);
     }
 
@@ -9021,7 +9145,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnComplete(Action onComplete) {
+    @NonNull
+    public final Flowable<T> doOnComplete(@NonNull Action onComplete) {
         return doOnEach(Functions.emptyConsumer(), Functions.emptyConsumer(),
                 onComplete, Functions.EMPTY_ACTION);
     }
@@ -9046,13 +9171,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    private Flowable<T> doOnEach(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
+    private Flowable<T> doOnEach(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError,
             Action onComplete, Action onAfterTerminate) {
         Objects.requireNonNull(onNext, "onNext is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
         Objects.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
-        return RxJavaPlugins.onAssembly(new FlowableDoOnEach<T>(this, onNext, onError, onComplete, onAfterTerminate));
+        return RxJavaPlugins.onAssembly(new FlowableDoOnEach<>(this, onNext, onError, onComplete, onAfterTerminate));
     }
 
     /**
@@ -9076,7 +9201,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnEach(final Consumer<? super Notification<T>> onNotification) {
+    public final Flowable<T> doOnEach(@NonNull Consumer<@NonNull ? super Notification<T>> onNotification) {
         Objects.requireNonNull(onNotification, "onNotification is null");
         return doOnEach(
                 Functions.notificationOnNext(onNotification),
@@ -9113,7 +9238,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnEach(final Subscriber<? super T> subscriber) {
+    public final Flowable<T> doOnEach(@NonNull Subscriber<? super T> subscriber) {
         Objects.requireNonNull(subscriber, "subscriber is null");
         return doOnEach(
                 FlowableInternalHelper.subscriberOnNext(subscriber),
@@ -9145,7 +9270,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnError(Consumer<? super Throwable> onError) {
+    @NonNull
+    public final Flowable<T> doOnError(@NonNull Consumer<? super Throwable> onError) {
         return doOnEach(Functions.emptyConsumer(), onError,
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION);
     }
@@ -9176,12 +9302,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnLifecycle(final Consumer<? super Subscription> onSubscribe,
-            final LongConsumer onRequest, final Action onCancel) {
+    public final Flowable<T> doOnLifecycle(@NonNull Consumer<? super Subscription> onSubscribe,
+            @NonNull LongConsumer onRequest, @NonNull Action onCancel) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         Objects.requireNonNull(onRequest, "onRequest is null");
         Objects.requireNonNull(onCancel, "onCancel is null");
-        return RxJavaPlugins.onAssembly(new FlowableDoOnLifecycle<T>(this, onSubscribe, onRequest, onCancel));
+        return RxJavaPlugins.onAssembly(new FlowableDoOnLifecycle<>(this, onSubscribe, onRequest, onCancel));
     }
 
     /**
@@ -9204,7 +9330,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnNext(Consumer<? super T> onNext) {
+    @NonNull
+    public final Flowable<T> doOnNext(@NonNull Consumer<? super T> onNext) {
         return doOnEach(onNext, Functions.emptyConsumer(),
                 Functions.EMPTY_ACTION, Functions.EMPTY_ACTION);
     }
@@ -9234,7 +9361,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnRequest(LongConsumer onRequest) {
+    @NonNull
+    public final Flowable<T> doOnRequest(@NonNull LongConsumer onRequest) {
         return doOnLifecycle(Functions.emptyConsumer(), onRequest, Functions.EMPTY_ACTION);
     }
 
@@ -9261,7 +9389,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnSubscribe(Consumer<? super Subscription> onSubscribe) {
+    @NonNull
+    public final Flowable<T> doOnSubscribe(@NonNull Consumer<? super Subscription> onSubscribe) {
         return doOnLifecycle(onSubscribe, Functions.EMPTY_LONG_CONSUMER, Functions.EMPTY_ACTION);
     }
 
@@ -9290,7 +9419,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> doOnTerminate(final Action onTerminate) {
+    @NonNull
+    public final Flowable<T> doOnTerminate(@NonNull Action onTerminate) {
         return doOnEach(Functions.emptyConsumer(), Functions.actionConsumer(onTerminate),
                 onTerminate, Functions.EMPTY_ACTION);
     }
@@ -9316,11 +9446,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> elementAt(long index) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
-        return RxJavaPlugins.onAssembly(new FlowableElementAtMaybe<T>(this, index));
+        return RxJavaPlugins.onAssembly(new FlowableElementAtMaybe<>(this, index));
     }
 
     /**
@@ -9349,12 +9480,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> elementAt(long index, T defaultItem) {
+    public final Single<T> elementAt(long index, @NonNull T defaultItem) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
         Objects.requireNonNull(defaultItem, "defaultItem is null");
-        return RxJavaPlugins.onAssembly(new FlowableElementAtSingle<T>(this, index, defaultItem));
+        return RxJavaPlugins.onAssembly(new FlowableElementAtSingle<>(this, index, defaultItem));
     }
 
     /**
@@ -9380,11 +9511,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> elementAtOrError(long index) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
-        return RxJavaPlugins.onAssembly(new FlowableElementAtSingle<T>(this, index, null));
+        return RxJavaPlugins.onAssembly(new FlowableElementAtSingle<>(this, index, null));
     }
 
     /**
@@ -9410,9 +9542,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> filter(Predicate<? super T> predicate) {
+    public final Flowable<T> filter(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new FlowableFilter<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableFilter<>(this, predicate));
     }
 
     /**
@@ -9433,6 +9565,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> firstElement() {
         return elementAt(0);
     }
@@ -9458,7 +9591,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> first(T defaultItem) {
+    @NonNull
+    public final Single<T> first(@NonNull T defaultItem) {
         return elementAt(0, defaultItem);
     }
 
@@ -9480,6 +9614,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL) // take may trigger UNBOUNDED_IN
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> firstOrError() {
         return elementAtOrError(0);
     }
@@ -9512,7 +9647,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return flatMap(mapper, false, bufferSize(), bufferSize());
     }
 
@@ -9547,7 +9683,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, boolean delayErrors) {
+    @NonNull
+    public final <R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper, boolean delayErrors) {
         return flatMap(mapper, delayErrors, bufferSize(), bufferSize());
     }
 
@@ -9583,7 +9720,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, int maxConcurrency) {
+    @NonNull
+    public final <R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper, int maxConcurrency) {
         return flatMap(mapper, false, maxConcurrency, bufferSize());
     }
 
@@ -9622,7 +9760,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
+    @NonNull
+    public final <R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
         return flatMap(mapper, delayErrors, maxConcurrency, bufferSize());
     }
 
@@ -9664,7 +9803,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends R>> mapper,
+    public final <R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper,
             boolean delayErrors, int maxConcurrency, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
@@ -9677,7 +9816,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             }
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new FlowableFlatMap<T, R>(this, mapper, delayErrors, maxConcurrency, bufferSize));
+        return RxJavaPlugins.onAssembly(new FlowableFlatMap<>(this, mapper, delayErrors, maxConcurrency, bufferSize));
     }
 
     /**
@@ -9714,13 +9853,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> flatMap(
-            Function<? super T, ? extends Publisher<? extends R>> onNextMapper,
-            Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper,
-            Supplier<? extends Publisher<? extends R>> onCompleteSupplier) {
+            @NonNull Function<? super T, ? extends Publisher<? extends R>> onNextMapper,
+            @NonNull Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper,
+            @NonNull Supplier<? extends Publisher<? extends R>> onCompleteSupplier) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
-        return merge(new FlowableMapNotification<T, Publisher<? extends R>>(this, onNextMapper, onErrorMapper, onCompleteSupplier));
+        return merge(new FlowableMapNotification<>(this, onNextMapper, onErrorMapper, onCompleteSupplier));
     }
 
     /**
@@ -9761,14 +9900,14 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> flatMap(
-            Function<? super T, ? extends Publisher<? extends R>> onNextMapper,
-            Function<Throwable, ? extends Publisher<? extends R>> onErrorMapper,
-            Supplier<? extends Publisher<? extends R>> onCompleteSupplier,
+            @NonNull Function<? super T, ? extends Publisher<? extends R>> onNextMapper,
+            @NonNull Function<Throwable, ? extends Publisher<? extends R>> onErrorMapper,
+            @NonNull Supplier<? extends Publisher<? extends R>> onCompleteSupplier,
             int maxConcurrency) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
-        return merge(new FlowableMapNotification<T, Publisher<? extends R>>(
+        return merge(new FlowableMapNotification<>(
                 this, onNextMapper, onErrorMapper, onCompleteSupplier), maxConcurrency);
     }
 
@@ -9803,8 +9942,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> combiner) {
+    @NonNull
+    public final <U, R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner) {
         return flatMap(mapper, combiner, false, bufferSize(), bufferSize());
     }
 
@@ -9842,8 +9982,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors) {
+    @NonNull
+    public final <U, R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors) {
         return flatMap(mapper, combiner, delayErrors, bufferSize(), bufferSize());
     }
 
@@ -9885,8 +10026,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency) {
+    @NonNull
+    public final <U, R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency) {
         return flatMap(mapper, combiner, delayErrors, maxConcurrency, bufferSize());
     }
 
@@ -9931,8 +10073,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> flatMap(final Function<? super T, ? extends Publisher<? extends U>> mapper,
-            final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
+    public final <U, R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
@@ -9975,8 +10117,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
+    @NonNull
+    public final <U, R> Flowable<R> flatMap(@NonNull Function<? super T, ? extends Publisher<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
         return flatMap(mapper, combiner, false, maxConcurrency, bufferSize());
     }
 
@@ -9995,7 +10138,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable flatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
+    @NonNull
+    public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         return flatMapCompletable(mapper, false, Integer.MAX_VALUE);
     }
 
@@ -10020,10 +10164,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable flatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors, int maxConcurrency) {
+    public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors, int maxConcurrency) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new FlowableFlatMapCompletableCompletable<T>(this, mapper, delayErrors, maxConcurrency));
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapCompletableCompletable<>(this, mapper, delayErrors, maxConcurrency));
     }
 
     /**
@@ -10052,7 +10196,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    @NonNull
+    public final <U> Flowable<U> flatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
         return flatMapIterable(mapper, bufferSize());
     }
 
@@ -10085,10 +10230,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper, int bufferSize) {
+    public final <U> Flowable<U> flatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableFlattenIterable<T, U>(this, mapper, bufferSize));
+        return RxJavaPlugins.onAssembly(new FlowableFlattenIterable<>(this, mapper, bufferSize));
     }
 
     /**
@@ -10122,8 +10267,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Flowable<V> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper,
-            final BiFunction<? super T, ? super U, ? extends V> resultSelector) {
+    public final <U, V> Flowable<V> flatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends V> resultSelector) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(resultSelector, "resultSelector is null");
         return flatMap(FlowableInternalHelper.flatMapIntoIterable(mapper), resultSelector, false, bufferSize(), bufferSize());
@@ -10165,8 +10310,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Flowable<V> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper,
-            final BiFunction<? super T, ? super U, ? extends V> resultSelector, int prefetch) {
+    public final <U, V> Flowable<V> flatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends V> resultSelector, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(resultSelector, "resultSelector is null");
         return flatMap(FlowableInternalHelper.flatMapIntoIterable(mapper), resultSelector, false, bufferSize(), prefetch);
@@ -10188,7 +10333,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> flatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return flatMapMaybe(mapper, false, Integer.MAX_VALUE);
     }
 
@@ -10215,10 +10361,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
+    public final <R> Flowable<R> flatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new FlowableFlatMapMaybe<T, R>(this, mapper, delayErrors, maxConcurrency));
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapMaybe<>(this, mapper, delayErrors, maxConcurrency));
     }
 
     /**
@@ -10237,7 +10383,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> flatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return flatMapSingle(mapper, false, Integer.MAX_VALUE);
     }
 
@@ -10264,10 +10411,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
+    public final <R> Flowable<R> flatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new FlowableFlatMapSingle<T, R>(this, mapper, delayErrors, maxConcurrency));
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapSingle<>(this, mapper, delayErrors, maxConcurrency));
     }
 
     /**
@@ -10293,7 +10440,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable forEach(Consumer<? super T> onNext) {
+    @NonNull
+    public final Disposable forEach(@NonNull Consumer<? super T> onNext) {
         return subscribe(onNext);
     }
 
@@ -10323,7 +10471,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable forEachWhile(Predicate<? super T> onNext) {
+    @NonNull
+    public final Disposable forEachWhile(@NonNull Predicate<? super T> onNext) {
         return forEachWhile(onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
 
@@ -10352,7 +10501,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable forEachWhile(Predicate<? super T> onNext, Consumer<? super Throwable> onError) {
+    @NonNull
+    public final Disposable forEachWhile(@NonNull Predicate<? super T> onNext, @NonNull Consumer<? super Throwable> onError) {
         return forEachWhile(onNext, onError, Functions.EMPTY_ACTION);
     }
 
@@ -10385,13 +10535,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.NONE)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable forEachWhile(final Predicate<? super T> onNext, final Consumer<? super Throwable> onError,
-            final Action onComplete) {
+    public final Disposable forEachWhile(@NonNull Predicate<? super T> onNext, @NonNull Consumer<? super Throwable> onError,
+            @NonNull Action onComplete) {
         Objects.requireNonNull(onNext, "onNext is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
 
-        ForEachWhileSubscriber<T> s = new ForEachWhileSubscriber<T>(onNext, onError, onComplete);
+        ForEachWhileSubscriber<T> s = new ForEachWhileSubscriber<>(onNext, onError, onComplete);
         subscribe(s);
         return s;
     }
@@ -10450,7 +10600,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Flowable<GroupedFlowable<K, T>> groupBy(Function<? super T, ? extends K> keySelector) {
+    @NonNull
+    public final <K> Flowable<GroupedFlowable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector) {
         return groupBy(keySelector, Functions.<T>identity(), false, bufferSize());
     }
 
@@ -10509,7 +10660,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Flowable<GroupedFlowable<K, T>> groupBy(Function<? super T, ? extends K> keySelector, boolean delayError) {
+    @NonNull
+    public final <K> Flowable<GroupedFlowable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector, boolean delayError) {
         return groupBy(keySelector, Functions.<T>identity(), delayError, bufferSize());
     }
 
@@ -10572,8 +10724,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-            Function<? super T, ? extends V> valueSelector) {
+    @NonNull
+    public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector) {
         return groupBy(keySelector, valueSelector, false, bufferSize());
     }
 
@@ -10637,8 +10790,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-            Function<? super T, ? extends V> valueSelector, boolean delayError) {
+    @NonNull
+    public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector, boolean delayError) {
         return groupBy(keySelector, valueSelector, delayError, bufferSize());
     }
 
@@ -10704,8 +10858,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-            Function<? super T, ? extends V> valueSelector,
+    public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
             boolean delayError, int bufferSize) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
@@ -10825,10 +10979,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-            Function<? super T, ? extends V> valueSelector,
+    public final <K, V> Flowable<GroupedFlowable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
             boolean delayError, int bufferSize,
-            Function<? super Consumer<Object>, ? extends Map<K, Object>> evictingMapFactory) {
+            @NonNull Function<? super Consumer<Object>, ? extends Map<K, Object>> evictingMapFactory) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -10876,10 +11030,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <TRight, TLeftEnd, TRightEnd, R> Flowable<R> groupJoin(
-            Publisher<? extends TRight> other,
-            Function<? super T, ? extends Publisher<TLeftEnd>> leftEnd,
-            Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
-            BiFunction<? super T, ? super Flowable<TRight>, ? extends R> resultSelector) {
+            @NonNull Publisher<? extends TRight> other,
+            @NonNull Function<? super T, ? extends Publisher<TLeftEnd>> leftEnd,
+            @NonNull Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
+            @NonNull BiFunction<? super T, ? super Flowable<TRight>, ? extends R> resultSelector) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(leftEnd, "leftEnd is null");
         Objects.requireNonNull(rightEnd, "rightEnd is null");
@@ -10907,8 +11061,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> hide() {
-        return RxJavaPlugins.onAssembly(new FlowableHide<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableHide<>(this));
     }
 
     /**
@@ -10930,8 +11085,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable ignoreElements() {
-        return RxJavaPlugins.onAssembly(new FlowableIgnoreElementsCompletable<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableIgnoreElementsCompletable<>(this));
     }
 
     /**
@@ -10955,6 +11111,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<Boolean> isEmpty() {
         return all(Functions.alwaysFalse());
     }
@@ -10998,10 +11155,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <TRight, TLeftEnd, TRightEnd, R> Flowable<R> join(
-            Publisher<? extends TRight> other,
-            Function<? super T, ? extends Publisher<TLeftEnd>> leftEnd,
-            Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
-            BiFunction<? super T, ? super TRight, ? extends R> resultSelector) {
+            @NonNull Publisher<? extends TRight> other,
+            @NonNull Function<? super T, ? extends Publisher<TLeftEnd>> leftEnd,
+            @NonNull Function<? super TRight, ? extends Publisher<TRightEnd>> rightEnd,
+            @NonNull BiFunction<? super T, ? super TRight, ? extends R> resultSelector) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(leftEnd, "leftEnd is null");
         Objects.requireNonNull(rightEnd, "rightEnd is null");
@@ -11029,8 +11186,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> lastElement() {
-        return RxJavaPlugins.onAssembly(new FlowableLastMaybe<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableLastMaybe<>(this));
     }
 
     /**
@@ -11055,9 +11213,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> last(T defaultItem) {
+    public final Single<T> last(@NonNull T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem");
-        return RxJavaPlugins.onAssembly(new FlowableLastSingle<T>(this, defaultItem));
+        return RxJavaPlugins.onAssembly(new FlowableLastSingle<>(this, defaultItem));
     }
 
     /**
@@ -11079,8 +11237,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> lastOrError() {
-        return RxJavaPlugins.onAssembly(new FlowableLastSingle<T>(this, null));
+        return RxJavaPlugins.onAssembly(new FlowableLastSingle<>(this, null));
     }
 
     /**
@@ -11233,7 +11392,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> lift(FlowableOperator<? extends R, ? super T> lifter) {
+    public final <R> Flowable<R> lift(@NonNull FlowableOperator<? extends R, ? super T> lifter) {
         Objects.requireNonNull(lifter, "lifter is null");
         return RxJavaPlugins.onAssembly(new FlowableLift<R, T>(this, lifter));
     }
@@ -11289,8 +11448,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<Notification<T>> materialize() {
-        return RxJavaPlugins.onAssembly(new FlowableMaterialize<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableMaterialize<>(this));
     }
 
     /**
@@ -11317,7 +11477,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> mergeWith(Publisher<? extends T> other) {
+    public final Flowable<T> mergeWith(@NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return merge(this, other);
     }
@@ -11347,7 +11507,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> mergeWith(@NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableMergeWithSingle<T>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableMergeWithSingle<>(this, other));
     }
 
     /**
@@ -11376,7 +11536,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableMergeWithMaybe<T>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableMergeWithMaybe<>(this, other));
     }
 
     /**
@@ -11402,7 +11562,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> mergeWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableMergeWithCompletable<T>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableMergeWithCompletable<>(this, other));
     }
 
     /**
@@ -11451,7 +11611,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> observeOn(Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> observeOn(@NonNull Scheduler scheduler) {
         return observeOn(scheduler, false, bufferSize());
     }
 
@@ -11502,7 +11663,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> observeOn(Scheduler scheduler, boolean delayError) {
+    @NonNull
+    public final Flowable<T> observeOn(@NonNull Scheduler scheduler, boolean delayError) {
         return observeOn(scheduler, delayError, bufferSize());
     }
 
@@ -11555,10 +11717,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
+    public final Flowable<T> observeOn(@NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableObserveOn<T>(this, scheduler, delayError, bufferSize));
+        return RxJavaPlugins.onAssembly(new FlowableObserveOn<>(this, scheduler, delayError, bufferSize));
     }
 
     /**
@@ -11583,7 +11745,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> ofType(final Class<U> clazz) {
+    public final <U> Flowable<U> ofType(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
         return filter(Functions.isInstanceOf(clazz)).cast(clazz);
     }
@@ -11607,6 +11769,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> onBackpressureBuffer() {
         return onBackpressureBuffer(bufferSize(), false, true);
     }
@@ -11633,6 +11796,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> onBackpressureBuffer(boolean delayError) {
         return onBackpressureBuffer(bufferSize(), delayError, true);
     }
@@ -11660,6 +11824,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> onBackpressureBuffer(int capacity) {
         return onBackpressureBuffer(capacity, false, false);
     }
@@ -11691,6 +11856,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> onBackpressureBuffer(int capacity, boolean delayError) {
         return onBackpressureBuffer(capacity, delayError, false);
     }
@@ -11724,9 +11890,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> onBackpressureBuffer(int capacity, boolean delayError, boolean unbounded) {
         ObjectHelper.verifyPositive(capacity, "capacity");
-        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBuffer<T>(this, capacity, unbounded, delayError, Functions.EMPTY_ACTION));
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBuffer<>(this, capacity, unbounded, delayError, Functions.EMPTY_ACTION));
     }
 
     /**
@@ -11761,10 +11928,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> onBackpressureBuffer(int capacity, boolean delayError, boolean unbounded,
-            Action onOverflow) {
+            @NonNull Action onOverflow) {
         Objects.requireNonNull(onOverflow, "onOverflow is null");
         ObjectHelper.verifyPositive(capacity, "capacity");
-        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBuffer<T>(this, capacity, unbounded, delayError, onOverflow));
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBuffer<>(this, capacity, unbounded, delayError, onOverflow));
     }
 
     /**
@@ -11791,7 +11958,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> onBackpressureBuffer(int capacity, Action onOverflow) {
+    @NonNull
+    public final Flowable<T> onBackpressureBuffer(int capacity, @NonNull Action onOverflow) {
         return onBackpressureBuffer(capacity, false, false, onOverflow);
     }
 
@@ -11832,10 +12000,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> onBackpressureBuffer(long capacity, Action onOverflow, BackpressureOverflowStrategy overflowStrategy) {
+    public final Flowable<T> onBackpressureBuffer(long capacity, @NonNull Action onOverflow, @NonNull BackpressureOverflowStrategy overflowStrategy) {
         Objects.requireNonNull(overflowStrategy, "overflowStrategy is null");
         ObjectHelper.verifyPositive(capacity, "capacity");
-        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBufferStrategy<T>(this, capacity, onOverflow, overflowStrategy));
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureBufferStrategy<>(this, capacity, onOverflow, overflowStrategy));
     }
 
     /**
@@ -11860,8 +12028,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> onBackpressureDrop() {
-        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureDrop<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureDrop<>(this));
     }
 
     /**
@@ -11889,9 +12058,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> onBackpressureDrop(Consumer<? super T> onDrop) {
+    public final Flowable<T> onBackpressureDrop(@NonNull Consumer<? super T> onDrop) {
         Objects.requireNonNull(onDrop, "onDrop is null");
-        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureDrop<T>(this, onDrop));
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureDrop<>(this, onDrop));
     }
 
     /**
@@ -11922,8 +12091,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> onBackpressureLatest() {
-        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureLatest<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableOnBackpressureLatest<>(this));
     }
 
     /**
@@ -11965,9 +12135,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> onErrorResumeNext(Function<? super Throwable, ? extends Publisher<? extends T>> resumeFunction) {
+    public final Flowable<T> onErrorResumeNext(@NonNull Function<? super Throwable, ? extends Publisher<? extends T>> resumeFunction) {
         Objects.requireNonNull(resumeFunction, "resumeFunction is null");
-        return RxJavaPlugins.onAssembly(new FlowableOnErrorNext<T>(this, resumeFunction));
+        return RxJavaPlugins.onAssembly(new FlowableOnErrorNext<>(this, resumeFunction));
     }
 
     /**
@@ -12009,7 +12179,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> onErrorResumeWith(final Publisher<? extends T> next) {
+    public final Flowable<T> onErrorResumeWith(@NonNull Publisher<? extends T> next) {
         Objects.requireNonNull(next, "next is null");
         return onErrorResumeNext(Functions.justFunction(next));
     }
@@ -12049,9 +12219,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
+    public final Flowable<T> onErrorReturn(@NonNull Function<? super Throwable, ? extends T> valueSupplier) {
         Objects.requireNonNull(valueSupplier, "valueSupplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableOnErrorReturn<T>(this, valueSupplier));
+        return RxJavaPlugins.onAssembly(new FlowableOnErrorReturn<>(this, valueSupplier));
     }
 
     /**
@@ -12089,7 +12259,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> onErrorReturnItem(final T item) {
+    public final Flowable<T> onErrorReturnItem(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return onErrorReturn(Functions.justFunction(item));
     }
@@ -12111,8 +12281,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> onTerminateDetach() {
-        return RxJavaPlugins.onAssembly(new FlowableDetach<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableDetach<>(this));
     }
 
     /**
@@ -12140,6 +12311,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
+    @NonNull
     public final ParallelFlowable<T> parallel() {
         return ParallelFlowable.from(this);
     }
@@ -12170,6 +12342,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
+    @NonNull
     public final ParallelFlowable<T> parallel(int parallelism) {
         ObjectHelper.verifyPositive(parallelism, "parallelism");
         return ParallelFlowable.from(this, parallelism);
@@ -12203,6 +12376,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @CheckReturnValue
+    @NonNull
     public final ParallelFlowable<T> parallel(int parallelism, int prefetch) {
         ObjectHelper.verifyPositive(parallelism, "parallelism");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -12231,6 +12405,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final ConnectableFlowable<T> publish() {
         return publish(bufferSize());
     }
@@ -12263,7 +12438,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> publish(Function<? super Flowable<T>, ? extends Publisher<R>> selector) {
+    @NonNull
+    public final <R> Flowable<R> publish(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector) {
         return publish(selector, bufferSize());
     }
 
@@ -12298,10 +12474,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> publish(Function<? super Flowable<T>, ? extends Publisher<? extends R>> selector, int prefetch) {
+    public final <R> Flowable<R> publish(@NonNull Function<? super Flowable<T>, ? extends Publisher<? extends R>> selector, int prefetch) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowablePublishMulticast<T, R>(this, selector, prefetch, false));
+        return RxJavaPlugins.onAssembly(new FlowablePublishMulticast<>(this, selector, prefetch, false));
     }
 
     /**
@@ -12328,9 +12504,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final ConnectableFlowable<T> publish(int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowablePublish<T>(this, bufferSize));
+        return RxJavaPlugins.onAssembly(new FlowablePublish<>(this, bufferSize));
     }
 
     /**
@@ -12354,6 +12531,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> rebatchRequests(int n) {
         return observeOn(ImmediateThinScheduler.INSTANCE, true, n);
     }
@@ -12393,9 +12571,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> reduce(BiFunction<T, T, T> reducer) {
+    public final Maybe<T> reduce(@NonNull BiFunction<T, T, T> reducer) {
         Objects.requireNonNull(reducer, "reducer is null");
-        return RxJavaPlugins.onAssembly(new FlowableReduceMaybe<T>(this, reducer));
+        return RxJavaPlugins.onAssembly(new FlowableReduceMaybe<>(this, reducer));
     }
 
     /**
@@ -12455,10 +12633,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> reduce(R seed, BiFunction<R, ? super T, R> reducer) {
+    public final <@NonNull R> Single<R> reduce(R seed, @NonNull BiFunction<R, ? super T, R> reducer) {
         Objects.requireNonNull(seed, "seed is null");
         Objects.requireNonNull(reducer, "reducer is null");
-        return RxJavaPlugins.onAssembly(new FlowableReduceSeedSingle<T, R>(this, seed, reducer));
+        return RxJavaPlugins.onAssembly(new FlowableReduceSeedSingle<>(this, seed, reducer));
     }
 
     /**
@@ -12500,10 +12678,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> reduceWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
+    public final <@NonNull R> Single<R> reduceWith(@NonNull Supplier<R> seedSupplier, @NonNull BiFunction<R, ? super T, R> reducer) {
         Objects.requireNonNull(seedSupplier, "seedSupplier is null");
         Objects.requireNonNull(reducer, "reducer is null");
-        return RxJavaPlugins.onAssembly(new FlowableReduceWithSingle<T, R>(this, seedSupplier, reducer));
+        return RxJavaPlugins.onAssembly(new FlowableReduceWithSingle<>(this, seedSupplier, reducer));
     }
 
     /**
@@ -12524,6 +12702,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> repeat() {
         return repeat(Long.MAX_VALUE);
     }
@@ -12553,6 +12732,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> repeat(long times) {
         if (times < 0) {
             throw new IllegalArgumentException("times >= 0 required but it was " + times);
@@ -12560,7 +12740,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (times == 0) {
             return empty();
         }
-        return RxJavaPlugins.onAssembly(new FlowableRepeat<T>(this, times));
+        return RxJavaPlugins.onAssembly(new FlowableRepeat<>(this, times));
     }
 
     /**
@@ -12588,9 +12768,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> repeatUntil(BooleanSupplier stop) {
+    public final Flowable<T> repeatUntil(@NonNull BooleanSupplier stop) {
         Objects.requireNonNull(stop, "stop is null");
-        return RxJavaPlugins.onAssembly(new FlowableRepeatUntil<T>(this, stop));
+        return RxJavaPlugins.onAssembly(new FlowableRepeatUntil<>(this, stop));
     }
 
     /**
@@ -12619,9 +12799,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> repeatWhen(final Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
+    public final Flowable<T> repeatWhen(@NonNull Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
-        return RxJavaPlugins.onAssembly(new FlowableRepeatWhen<T>(this, handler));
+        return RxJavaPlugins.onAssembly(new FlowableRepeatWhen<>(this, handler));
     }
 
     /**
@@ -12647,6 +12827,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final ConnectableFlowable<T> replay() {
         return FlowableReplay.createFrom(this);
     }
@@ -12678,7 +12859,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this), selector);
     }
@@ -12718,7 +12899,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this, bufferSize, false), selector);
@@ -12761,7 +12942,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize, boolean eagerTruncate) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this, bufferSize, eagerTruncate), selector);
@@ -12805,7 +12986,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, int bufferSize, long time, TimeUnit unit) {
+    @NonNull
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit) {
         return replay(selector, bufferSize, time, unit, Schedulers.computation());
     }
 
@@ -12853,7 +13035,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -12908,7 +13090,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -12949,7 +13131,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, long time, TimeUnit unit) {
+    @NonNull
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, long time, @NonNull TimeUnit unit) {
         return replay(selector, time, unit, Schedulers.computation());
     }
 
@@ -12989,7 +13172,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -13034,7 +13217,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Flowable<R> replay(Function<? super Flowable<T>, ? extends Publisher<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -13072,7 +13255,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final ConnectableFlowable<T> replay(final int bufferSize) {
+    @NonNull
+    public final ConnectableFlowable<T> replay(int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return FlowableReplay.create(this, bufferSize, false);
     }
@@ -13109,7 +13293,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final ConnectableFlowable<T> replay(final int bufferSize, boolean eagerTruncate) {
+    @NonNull
+    public final ConnectableFlowable<T> replay(int bufferSize, boolean eagerTruncate) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return FlowableReplay.create(this, bufferSize, eagerTruncate);
     }
@@ -13150,7 +13335,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final ConnectableFlowable<T> replay(int bufferSize, long time, TimeUnit unit) {
+    @NonNull
+    public final ConnectableFlowable<T> replay(int bufferSize, long time, @NonNull TimeUnit unit) {
         return replay(bufferSize, time, unit, Schedulers.computation());
     }
 
@@ -13194,7 +13380,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final ConnectableFlowable<T> replay(final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    @NonNull
+    public final ConnectableFlowable<T> replay(int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -13244,7 +13431,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final ConnectableFlowable<T> replay(final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    @NonNull
+    public final ConnectableFlowable<T> replay(int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -13282,7 +13470,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final ConnectableFlowable<T> replay(long time, TimeUnit unit) {
+    @NonNull
+    public final ConnectableFlowable<T> replay(long time, @NonNull TimeUnit unit) {
         return replay(time, unit, Schedulers.computation());
     }
 
@@ -13319,7 +13508,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final ConnectableFlowable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler) {
+    @NonNull
+    public final ConnectableFlowable<T> replay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.create(this, time, unit, scheduler, false);
@@ -13360,7 +13550,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final ConnectableFlowable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    @NonNull
+    public final ConnectableFlowable<T> replay(final long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.create(this, time, unit, scheduler, eagerTruncate);
@@ -13393,6 +13584,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> retry() {
         return retry(Long.MAX_VALUE, Functions.alwaysTrue());
     }
@@ -13421,10 +13613,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
+    public final Flowable<T> retry(@NonNull BiPredicate<@NonNull ? super Integer, @NonNull ? super Throwable> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
 
-        return RxJavaPlugins.onAssembly(new FlowableRetryBiPredicate<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableRetryBiPredicate<>(this, predicate));
     }
 
     /**
@@ -13457,6 +13649,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> retry(long count) {
         return retry(count, Functions.alwaysTrue());
     }
@@ -13479,13 +13672,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> retry(long times, Predicate<? super Throwable> predicate) {
+    public final Flowable<T> retry(long times, @NonNull Predicate<@NonNull ? super Throwable> predicate) {
         if (times < 0) {
             throw new IllegalArgumentException("times >= 0 required but it was " + times);
         }
         Objects.requireNonNull(predicate, "predicate is null");
 
-        return RxJavaPlugins.onAssembly(new FlowableRetryPredicate<T>(this, times, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableRetryPredicate<>(this, times, predicate));
     }
 
     /**
@@ -13504,7 +13697,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> retry(Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Flowable<T> retry(@NonNull Predicate<@NonNull ? super Throwable> predicate) {
         return retry(Long.MAX_VALUE, predicate);
     }
 
@@ -13524,7 +13718,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> retryUntil(final BooleanSupplier stop) {
+    public final Flowable<T> retryUntil(@NonNull BooleanSupplier stop) {
         Objects.requireNonNull(stop, "stop is null");
         return retry(Long.MAX_VALUE, Functions.predicateReverseFor(stop));
     }
@@ -13611,10 +13805,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> retryWhen(
-            final Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
+            @NonNull Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
 
-        return RxJavaPlugins.onAssembly(new FlowableRetryWhen<T>(this, handler));
+        return RxJavaPlugins.onAssembly(new FlowableRetryWhen<>(this, handler));
     }
 
     /**
@@ -13633,7 +13827,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void safeSubscribe(Subscriber<? super T> s) {
+    public final void safeSubscribe(@NonNull Subscriber<? super T> s) {
         Objects.requireNonNull(s, "s is null");
         if (s instanceof SafeSubscriber) {
             subscribe((SafeSubscriber<? super T>)s);
@@ -13667,7 +13861,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> sample(long period, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> sample(long period, @NonNull TimeUnit unit) {
         return sample(period, unit, Schedulers.computation());
     }
 
@@ -13702,7 +13897,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> sample(long period, TimeUnit unit, boolean emitLast) {
+    @NonNull
+    public final Flowable<T> sample(long period, @NonNull TimeUnit unit, boolean emitLast) {
         return sample(period, unit, Schedulers.computation(), emitLast);
     }
 
@@ -13734,10 +13930,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> sample(long period, TimeUnit unit, Scheduler scheduler) {
+    public final Flowable<T> sample(long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableSampleTimed<T>(this, period, unit, scheduler, false));
+        return RxJavaPlugins.onAssembly(new FlowableSampleTimed<>(this, period, unit, scheduler, false));
     }
 
     /**
@@ -13775,10 +13971,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> sample(long period, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
+    public final Flowable<T> sample(long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean emitLast) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableSampleTimed<T>(this, period, unit, scheduler, emitLast));
+        return RxJavaPlugins.onAssembly(new FlowableSampleTimed<>(this, period, unit, scheduler, emitLast));
     }
 
     /**
@@ -13807,9 +14003,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<T> sample(Publisher<U> sampler) {
+    public final <U> Flowable<T> sample(@NonNull Publisher<U> sampler) {
         Objects.requireNonNull(sampler, "sampler is null");
-        return RxJavaPlugins.onAssembly(new FlowableSamplePublisher<T>(this, sampler, false));
+        return RxJavaPlugins.onAssembly(new FlowableSamplePublisher<>(this, sampler, false));
     }
 
     /**
@@ -13845,9 +14041,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<T> sample(Publisher<U> sampler, boolean emitLast) {
+    public final <U> Flowable<T> sample(@NonNull Publisher<U> sampler, boolean emitLast) {
         Objects.requireNonNull(sampler, "sampler is null");
-        return RxJavaPlugins.onAssembly(new FlowableSamplePublisher<T>(this, sampler, emitLast));
+        return RxJavaPlugins.onAssembly(new FlowableSamplePublisher<>(this, sampler, emitLast));
     }
 
     /**
@@ -13878,9 +14074,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> scan(BiFunction<T, T, T> accumulator) {
+    public final Flowable<T> scan(@NonNull BiFunction<T, T, T> accumulator) {
         Objects.requireNonNull(accumulator, "accumulator is null");
-        return RxJavaPlugins.onAssembly(new FlowableScan<T>(this, accumulator));
+        return RxJavaPlugins.onAssembly(new FlowableScan<>(this, accumulator));
     }
 
     /**
@@ -13932,7 +14128,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> scan(final R initialValue, BiFunction<R, ? super T, R> accumulator) {
+    public final <@NonNull R> Flowable<R> scan(R initialValue, @NonNull BiFunction<R, ? super T, R> accumulator) {
         Objects.requireNonNull(initialValue, "initialValue is null");
         return scanWith(Functions.justSupplier(initialValue), accumulator);
     }
@@ -13972,10 +14168,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> scanWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
+    public final <@NonNull R> Flowable<R> scanWith(@NonNull Supplier<R> seedSupplier, @NonNull BiFunction<R, ? super T, R> accumulator) {
         Objects.requireNonNull(seedSupplier, "seedSupplier is null");
         Objects.requireNonNull(accumulator, "accumulator is null");
-        return RxJavaPlugins.onAssembly(new FlowableScanSeed<T, R>(this, seedSupplier, accumulator));
+        return RxJavaPlugins.onAssembly(new FlowableScanSeed<>(this, seedSupplier, accumulator));
     }
 
     /**
@@ -14004,8 +14200,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> serialize() {
-        return RxJavaPlugins.onAssembly(new FlowableSerialized<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableSerialized<>(this));
     }
 
     /**
@@ -14032,6 +14229,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> share() {
         return publish().refCount();
     }
@@ -14056,8 +14254,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> singleElement() {
-        return RxJavaPlugins.onAssembly(new FlowableSingleMaybe<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableSingleMaybe<>(this));
     }
 
     /**
@@ -14084,9 +14283,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> single(T defaultItem) {
+    public final Single<T> single(@NonNull T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem is null");
-        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<T>(this, defaultItem));
+        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<>(this, defaultItem));
     }
 
     /**
@@ -14110,8 +14309,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> singleOrError() {
-        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<T>(this, null));
+        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<>(this, null));
     }
 
     /**
@@ -14136,11 +14336,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> skip(long count) {
         if (count <= 0L) {
             return RxJavaPlugins.onAssembly(this);
         }
-        return RxJavaPlugins.onAssembly(new FlowableSkip<T>(this, count));
+        return RxJavaPlugins.onAssembly(new FlowableSkip<>(this, count));
     }
 
     /**
@@ -14168,7 +14369,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> skip(long time, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> skip(long time, @NonNull TimeUnit unit) {
         return skipUntil(timer(time, unit));
     }
 
@@ -14198,7 +14400,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> skip(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> skip(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return skipUntil(timer(time, unit, scheduler));
     }
 
@@ -14230,6 +14433,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> skipLast(int count) {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
@@ -14237,7 +14441,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (count == 0) {
             return RxJavaPlugins.onAssembly(this);
         }
-        return RxJavaPlugins.onAssembly(new FlowableSkipLast<T>(this, count));
+        return RxJavaPlugins.onAssembly(new FlowableSkipLast<>(this, count));
     }
 
     /**
@@ -14267,7 +14471,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> skipLast(long time, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> skipLast(long time, @NonNull TimeUnit unit) {
         return skipLast(time, unit, Schedulers.computation(), false, bufferSize());
     }
 
@@ -14301,7 +14506,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> skipLast(long time, TimeUnit unit, boolean delayError) {
+    @NonNull
+    public final Flowable<T> skipLast(long time, @NonNull TimeUnit unit, boolean delayError) {
         return skipLast(time, unit, Schedulers.computation(), delayError, bufferSize());
     }
 
@@ -14333,7 +14539,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> skipLast(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> skipLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return skipLast(time, unit, scheduler, false, bufferSize());
     }
 
@@ -14368,7 +14575,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> skipLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError) {
+    @NonNull
+    public final Flowable<T> skipLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         return skipLast(time, unit, scheduler, delayError, bufferSize());
     }
 
@@ -14406,13 +14614,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> skipLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
+    public final Flowable<T> skipLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         // the internal buffer holds pairs of (timestamp, value) so double the default buffer size
         int s = bufferSize << 1;
-        return RxJavaPlugins.onAssembly(new FlowableSkipLastTimed<T>(this, time, unit, scheduler, s, delayError));
+        return RxJavaPlugins.onAssembly(new FlowableSkipLastTimed<>(this, time, unit, scheduler, s, delayError));
     }
 
     /**
@@ -14440,9 +14648,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<T> skipUntil(Publisher<U> other) {
+    public final <U> Flowable<T> skipUntil(@NonNull Publisher<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableSkipUntil<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableSkipUntil<>(this, other));
     }
 
     /**
@@ -14468,9 +14676,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> skipWhile(Predicate<? super T> predicate) {
+    public final Flowable<T> skipWhile(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new FlowableSkipWhile<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableSkipWhile<>(this, predicate));
     }
     /**
      * Returns a Flowable that emits the events emitted by source Publisher, in a
@@ -14496,6 +14704,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> sorted() {
         return toList().toFlowable().map(Functions.listSorter(Functions.<T>naturalComparator())).flatMapIterable(Functions.<List<T>>identity());
     }
@@ -14524,7 +14733,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> sorted(Comparator<? super T> sortFunction) {
+    public final Flowable<T> sorted(@NonNull Comparator<@NonNull ? super T> sortFunction) {
         Objects.requireNonNull(sortFunction, "sortFunction");
         return toList().toFlowable().map(Functions.listSorter(sortFunction)).flatMapIterable(Functions.<List<T>>identity());
     }
@@ -14555,7 +14764,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> startWithIterable(Iterable<? extends T> items) {
+    @NonNull
+    public final Flowable<T> startWithIterable(@NonNull Iterable<? extends T> items) {
         return concatArray(fromIterable(items), this);
     }
 
@@ -14583,7 +14793,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> startWith(Publisher<? extends T> other) {
+    public final Flowable<T> startWith(@NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concatArray(other, this);
     }
@@ -14615,7 +14825,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> startWithItem(T item) {
+    public final Flowable<T> startWithItem(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return concatArray(just(item), this);
     }
@@ -14642,11 +14852,12 @@ public abstract class Flowable<T> implements Publisher<T> {
      * @see #startWithItem(Object)
      * @see #startWithIterable(Iterable)
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> startWithArray(T... items) {
+    @SafeVarargs
+    @NonNull
+    public final Flowable<T> startWithArray(@NonNull T... items) {
         Flowable<T> fromArray = fromArray(items);
         if (fromArray == empty()) {
             return RxJavaPlugins.onAssembly(this);
@@ -14674,6 +14885,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Disposable subscribe() {
         return subscribe(Functions.emptyConsumer(), Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
@@ -14703,7 +14915,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onNext) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onNext) {
         return subscribe(onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
 
@@ -14733,7 +14946,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError) {
         return subscribe(onNext, onError, Functions.EMPTY_ACTION);
     }
 
@@ -14767,13 +14981,14 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
-            Action onComplete) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError,
+            @NonNull Action onComplete) {
         Objects.requireNonNull(onNext, "onNext is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
 
-        LambdaSubscriber<T> ls = new LambdaSubscriber<T>(onNext, onError, onComplete, FlowableInternalHelper.RequestMax.INSTANCE);
+        LambdaSubscriber<T> ls = new LambdaSubscriber<>(onNext, onError, onComplete, FlowableInternalHelper.RequestMax.INSTANCE);
 
         subscribe(ls);
 
@@ -14783,7 +14998,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
-    public final void subscribe(Subscriber<? super T> s) {
+    public final void subscribe(@NonNull Subscriber<? super T> s) {
         if (s instanceof FlowableSubscriber) {
             subscribe((FlowableSubscriber<? super T>)s);
         } else {
@@ -14831,7 +15046,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      */
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void subscribe(FlowableSubscriber<? super T> s) {
+    public final void subscribe(@NonNull FlowableSubscriber<? super T> s) {
         Objects.requireNonNull(s, "s is null");
         try {
             Subscriber<? super T> z = RxJavaPlugins.onSubscribe(this, s);
@@ -14861,7 +15076,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * applied by {@link #subscribe(Subscriber)} before this method gets called.
      * @param s the incoming Subscriber, never null
      */
-    protected abstract void subscribeActual(Subscriber<? super T> s);
+    protected abstract void subscribeActual(@NonNull Subscriber<? super T> s);
 
     /**
      * Subscribes a given Subscriber (subclass) to this Flowable and returns the given
@@ -14893,7 +15108,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <E extends Subscriber<? super T>> E subscribeWith(E subscriber) {
+    @NonNull
+    public final <@NonNull E extends Subscriber<? super T>> E subscribeWith(E subscriber) {
         subscribe(subscriber);
         return subscriber;
     }
@@ -14967,7 +15183,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<T> subscribeOn(@NonNull Scheduler scheduler, boolean requestOn) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableSubscribeOn<T>(this, scheduler, requestOn));
+        return RxJavaPlugins.onAssembly(new FlowableSubscribeOn<>(this, scheduler, requestOn));
     }
 
     /**
@@ -14996,9 +15212,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> switchIfEmpty(Publisher<? extends T> other) {
+    public final Flowable<T> switchIfEmpty(@NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableSwitchIfEmpty<T>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableSwitchIfEmpty<>(this, other));
     }
 
     /**
@@ -15031,7 +15247,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> switchMap(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> switchMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return switchMap(mapper, bufferSize());
     }
 
@@ -15067,7 +15284,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> switchMap(Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize) {
+    @NonNull
+    public final <R> Flowable<R> switchMap(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize) {
         return switchMap0(mapper, bufferSize, false);
     }
 
@@ -15114,7 +15332,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable switchMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new FlowableSwitchMapCompletable<T>(this, mapper, false));
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapCompletable<>(this, mapper, false));
     }
 
     /**
@@ -15161,7 +15379,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable switchMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new FlowableSwitchMapCompletable<T>(this, mapper, true));
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapCompletable<>(this, mapper, true));
     }
 
     /**
@@ -15196,7 +15414,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> switchMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+    @NonNull
+    public final <R> Flowable<R> switchMapDelayError(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper) {
         return switchMapDelayError(mapper, bufferSize());
     }
 
@@ -15234,7 +15453,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> switchMapDelayError(Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize) {
+    @NonNull
+    public final <R> Flowable<R> switchMapDelayError(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper, int bufferSize) {
         return switchMap0(mapper, bufferSize, true);
     }
 
@@ -15249,7 +15469,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             }
             return FlowableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new FlowableSwitchMap<T, R>(this, mapper, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMap<>(this, mapper, bufferSize, delayError));
     }
 
     /**
@@ -15290,7 +15510,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> switchMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new FlowableSwitchMapMaybe<T, R>(this, mapper, false));
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapMaybe<>(this, mapper, false));
     }
 
     /**
@@ -15321,7 +15541,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> switchMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new FlowableSwitchMapMaybe<T, R>(this, mapper, true));
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapMaybe<>(this, mapper, true));
     }
 
     /**
@@ -15362,7 +15582,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> switchMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new FlowableSwitchMapSingle<T, R>(this, mapper, false));
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapSingle<>(this, mapper, false));
     }
 
     /**
@@ -15393,7 +15613,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> switchMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new FlowableSwitchMapSingle<T, R>(this, mapper, true));
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapSingle<>(this, mapper, true));
     }
 
     /**
@@ -15439,11 +15659,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> take(long count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
         }
-        return RxJavaPlugins.onAssembly(new FlowableTake<T>(this, count));
+        return RxJavaPlugins.onAssembly(new FlowableTake<>(this, count));
     }
 
     /**
@@ -15472,7 +15693,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> take(long time, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> take(long time, @NonNull TimeUnit unit) {
         return takeUntil(timer(time, unit));
     }
 
@@ -15505,7 +15727,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> take(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> take(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return takeUntil(timer(time, unit, scheduler));
     }
 
@@ -15533,17 +15756,18 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> takeLast(int count) {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
         } else
         if (count == 0) {
-            return RxJavaPlugins.onAssembly(new FlowableIgnoreElements<T>(this));
+            return RxJavaPlugins.onAssembly(new FlowableIgnoreElements<>(this));
         } else
         if (count == 1) {
-            return RxJavaPlugins.onAssembly(new FlowableTakeLastOne<T>(this));
+            return RxJavaPlugins.onAssembly(new FlowableTakeLastOne<>(this));
         }
-        return RxJavaPlugins.onAssembly(new FlowableTakeLast<T>(this, count));
+        return RxJavaPlugins.onAssembly(new FlowableTakeLast<>(this, count));
     }
 
     /**
@@ -15573,7 +15797,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> takeLast(long count, long time, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> takeLast(long count, long time, @NonNull TimeUnit unit) {
         return takeLast(count, time, unit, Schedulers.computation(), false, bufferSize());
     }
 
@@ -15609,7 +15834,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> takeLast(long count, long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> takeLast(long count, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return takeLast(count, time, unit, scheduler, false, bufferSize());
     }
 
@@ -15651,14 +15877,14 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> takeLast(long count, long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
+    public final Flowable<T> takeLast(long count, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
         }
-        return RxJavaPlugins.onAssembly(new FlowableTakeLastTimed<T>(this, count, time, unit, scheduler, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new FlowableTakeLastTimed<>(this, count, time, unit, scheduler, bufferSize, delayError));
     }
 
     /**
@@ -15687,7 +15913,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> takeLast(long time, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> takeLast(long time, @NonNull TimeUnit unit) {
         return takeLast(time, unit, Schedulers.computation(), false, bufferSize());
     }
 
@@ -15720,7 +15947,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> takeLast(long time, TimeUnit unit, boolean delayError) {
+    @NonNull
+    public final Flowable<T> takeLast(long time, @NonNull TimeUnit unit, boolean delayError) {
         return takeLast(time, unit, Schedulers.computation(), delayError, bufferSize());
     }
 
@@ -15754,7 +15982,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> takeLast(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> takeLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return takeLast(time, unit, scheduler, false, bufferSize());
     }
 
@@ -15791,7 +16020,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> takeLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError) {
+    @NonNull
+    public final Flowable<T> takeLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         return takeLast(time, unit, scheduler, delayError, bufferSize());
     }
 
@@ -15830,7 +16060,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> takeLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
+    @NonNull
+    public final Flowable<T> takeLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
         return takeLast(Long.MAX_VALUE, time, unit, scheduler, delayError, bufferSize);
     }
 
@@ -15863,9 +16094,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> takeUntil(Predicate<? super T> stopPredicate) {
+    public final Flowable<T> takeUntil(@NonNull Predicate<? super T> stopPredicate) {
         Objects.requireNonNull(stopPredicate, "stopPredicate is null");
-        return RxJavaPlugins.onAssembly(new FlowableTakeUntilPredicate<T>(this, stopPredicate));
+        return RxJavaPlugins.onAssembly(new FlowableTakeUntilPredicate<>(this, stopPredicate));
     }
 
     /**
@@ -15893,9 +16124,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<T> takeUntil(Publisher<U> other) {
+    public final <U> Flowable<T> takeUntil(@NonNull Publisher<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new FlowableTakeUntil<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new FlowableTakeUntil<>(this, other));
     }
 
     /**
@@ -15922,9 +16153,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> takeWhile(Predicate<? super T> predicate) {
+    public final Flowable<T> takeWhile(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new FlowableTakeWhile<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableTakeWhile<>(this, predicate));
     }
 
     /**
@@ -15953,7 +16184,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> throttleFirst(long windowDuration, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> throttleFirst(long windowDuration, @NonNull TimeUnit unit) {
         return throttleFirst(windowDuration, unit, Schedulers.computation());
     }
 
@@ -15987,10 +16219,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
+    public final Flowable<T> throttleFirst(long skipDuration, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableThrottleFirstTimed<T>(this, skipDuration, unit, scheduler));
+        return RxJavaPlugins.onAssembly(new FlowableThrottleFirstTimed<>(this, skipDuration, unit, scheduler));
     }
 
     /**
@@ -16021,7 +16253,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> throttleLast(long intervalDuration, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> throttleLast(long intervalDuration, @NonNull TimeUnit unit) {
         return sample(intervalDuration, unit);
     }
 
@@ -16056,7 +16289,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> throttleLast(long intervalDuration, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> throttleLast(long intervalDuration, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return sample(intervalDuration, unit, scheduler);
     }
 
@@ -16093,7 +16327,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> throttleLatest(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> throttleLatest(long timeout, @NonNull TimeUnit unit) {
         return throttleLatest(timeout, unit, Schedulers.computation(), false);
     }
 
@@ -16130,7 +16365,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> throttleLatest(long timeout, TimeUnit unit, boolean emitLast) {
+    @NonNull
+    public final Flowable<T> throttleLatest(long timeout, @NonNull TimeUnit unit, boolean emitLast) {
         return throttleLatest(timeout, unit, Schedulers.computation(), emitLast);
     }
 
@@ -16168,7 +16404,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> throttleLatest(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return throttleLatest(timeout, unit, scheduler, false);
     }
 
@@ -16207,10 +16444,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
+    public final Flowable<T> throttleLatest(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean emitLast) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableThrottleLatest<T>(this, timeout, unit, scheduler, emitLast));
+        return RxJavaPlugins.onAssembly(new FlowableThrottleLatest<>(this, timeout, unit, scheduler, emitLast));
     }
 
     /**
@@ -16244,7 +16481,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> throttleWithTimeout(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> throttleWithTimeout(long timeout, @NonNull TimeUnit unit) {
         return debounce(timeout, unit);
     }
 
@@ -16282,7 +16520,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> throttleWithTimeout(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> throttleWithTimeout(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return debounce(timeout, unit, scheduler);
     }
 
@@ -16306,6 +16545,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<Timed<T>> timeInterval() {
         return timeInterval(TimeUnit.MILLISECONDS, Schedulers.computation());
     }
@@ -16332,7 +16572,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
-    public final Flowable<Timed<T>> timeInterval(Scheduler scheduler) {
+    @NonNull
+    public final Flowable<Timed<T>> timeInterval(@NonNull Scheduler scheduler) {
         return timeInterval(TimeUnit.MILLISECONDS, scheduler);
     }
 
@@ -16357,7 +16598,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<Timed<T>> timeInterval(TimeUnit unit) {
+    @NonNull
+    public final Flowable<Timed<T>> timeInterval(@NonNull TimeUnit unit) {
         return timeInterval(unit, Schedulers.computation());
     }
 
@@ -16384,10 +16626,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
-    public final Flowable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<Timed<T>> timeInterval(@NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableTimeInterval<T>(this, unit, scheduler));
+        return RxJavaPlugins.onAssembly(new FlowableTimeInterval<>(this, unit, scheduler));
     }
 
     /**
@@ -16422,7 +16665,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <V> Flowable<T> timeout(Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator) {
+    @NonNull
+    public final <V> Flowable<T> timeout(@NonNull Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator) {
         return timeout0(null, itemTimeoutIndicator, null);
     }
 
@@ -16461,7 +16705,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <V> Flowable<T> timeout(Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator, Flowable<? extends T> other) {
+    public final <V> Flowable<T> timeout(@NonNull Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator, @NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(null, itemTimeoutIndicator, other);
     }
@@ -16491,7 +16735,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> timeout(long timeout, TimeUnit timeUnit) {
+    @NonNull
+    public final Flowable<T> timeout(long timeout, @NonNull TimeUnit timeUnit) {
         return timeout0(timeout, timeUnit, null, Schedulers.computation());
     }
 
@@ -16524,7 +16769,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<T> timeout(long timeout, TimeUnit timeUnit, Publisher<? extends T> other) {
+    public final Flowable<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, Schedulers.computation());
     }
@@ -16562,7 +16807,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> timeout(long timeout, TimeUnit timeUnit, Scheduler scheduler, Publisher<? extends T> other) {
+    public final Flowable<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull Scheduler scheduler, @NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, scheduler);
     }
@@ -16595,7 +16840,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> timeout(long timeout, TimeUnit timeUnit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull Scheduler scheduler) {
         return timeout0(timeout, timeUnit, null, scheduler);
     }
 
@@ -16634,8 +16880,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Flowable<T> timeout(Publisher<U> firstTimeoutIndicator,
-            Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator) {
+    public final <U, V> Flowable<T> timeout(@NonNull Publisher<U> firstTimeoutIndicator,
+            @NonNull Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator) {
         Objects.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
         return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, null);
     }
@@ -16681,9 +16927,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Flowable<T> timeout(
-            Publisher<U> firstTimeoutIndicator,
-            Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator,
-                    Publisher<? extends T> other) {
+            @NonNull Publisher<U> firstTimeoutIndicator,
+            @NonNull Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator,
+            @NonNull Publisher<? extends T> other) {
         Objects.requireNonNull(firstTimeoutIndicator, "firstTimeoutSelector is null");
         Objects.requireNonNull(other, "other is null");
         return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, other);
@@ -16693,7 +16939,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Scheduler scheduler) {
         Objects.requireNonNull(timeUnit, "timeUnit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other));
+        return RxJavaPlugins.onAssembly(new FlowableTimeoutTimed<>(this, timeout, timeUnit, scheduler, other));
     }
 
     private <U, V> Flowable<T> timeout0(
@@ -16701,7 +16947,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator,
                     Publisher<? extends T> other) {
         Objects.requireNonNull(itemTimeoutIndicator, "itemTimeoutIndicator is null");
-        return RxJavaPlugins.onAssembly(new FlowableTimeout<T, U, V>(this, firstTimeoutIndicator, itemTimeoutIndicator, other));
+        return RxJavaPlugins.onAssembly(new FlowableTimeout<>(this, firstTimeoutIndicator, itemTimeoutIndicator, other));
     }
 
     /**
@@ -16724,6 +16970,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<Timed<T>> timestamp() {
         return timestamp(TimeUnit.MILLISECONDS, Schedulers.computation());
     }
@@ -16751,7 +16998,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
-    public final Flowable<Timed<T>> timestamp(Scheduler scheduler) {
+    @NonNull
+    public final Flowable<Timed<T>> timestamp(@NonNull Scheduler scheduler) {
         return timestamp(TimeUnit.MILLISECONDS, scheduler);
     }
 
@@ -16776,7 +17024,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<Timed<T>> timestamp(TimeUnit unit) {
+    @NonNull
+    public final Flowable<Timed<T>> timestamp(@NonNull TimeUnit unit) {
         return timestamp(unit, Schedulers.computation());
     }
 
@@ -16805,7 +17054,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
-    public final Flowable<Timed<T>> timestamp(final TimeUnit unit, final Scheduler scheduler) {
+    public final Flowable<Timed<T>> timestamp(@NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return map(Functions.<T>timestampWith(unit, scheduler));
@@ -16865,6 +17114,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<List<T>> toList() {
         return RxJavaPlugins.onAssembly(new FlowableToListSingle<T, List<T>>(this));
     }
@@ -16901,9 +17151,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<List<T>> toList(final int capacityHint) {
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
-        return RxJavaPlugins.onAssembly(new FlowableToListSingle<T, List<T>>(this, Functions.<T>createArrayList(capacityHint)));
+        return RxJavaPlugins.onAssembly(new FlowableToListSingle<>(this, Functions.<T>createArrayList(capacityHint)));
     }
 
     /**
@@ -16939,9 +17190,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Single<U> toList(Supplier<U> collectionSupplier) {
+    @NonNull
+    public final <U extends Collection<? super T>> Single<U> toList(@NonNull Supplier<U> collectionSupplier) {
         Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableToListSingle<T, U>(this, collectionSupplier));
+        return RxJavaPlugins.onAssembly(new FlowableToListSingle<>(this, collectionSupplier));
     }
 
     /**
@@ -16974,7 +17226,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Single<Map<K, T>> toMap(final Function<? super T, ? extends K> keySelector) {
+    public final <K> Single<Map<K, T>> toMap(@NonNull Function<? super T, ? extends K> keySelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         return collect(HashMapSupplier.<K, T>asSupplier(), Functions.toMapKeySelector(keySelector));
     }
@@ -17013,7 +17265,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Single<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector) {
+    public final <K, V> Single<Map<K, V>> toMap(@NonNull Function<? super T, ? extends K> keySelector, @NonNull Function<? super T, ? extends V> valueSelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMapSupplier.<K, V>asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
@@ -17052,9 +17304,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Single<Map<K, V>> toMap(final Function<? super T, ? extends K> keySelector,
-            final Function<? super T, ? extends V> valueSelector,
-            final Supplier<? extends Map<K, V>> mapSupplier) {
+    public final <K, V> Single<Map<K, V>> toMap(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
+            @NonNull Supplier<? extends Map<K, V>> mapSupplier) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         return collect(mapSupplier, Functions.toMapKeyValueSelector(keySelector, valueSelector));
@@ -17086,7 +17338,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Single<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
+    @NonNull
+    public final <K> Single<Map<K, Collection<T>>> toMultimap(@NonNull Function<? super T, ? extends K> keySelector) {
         Function<T, T> valueSelector = Functions.identity();
         Supplier<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<T>> collectionFactory = ArrayListSupplier.asFunction();
@@ -17124,7 +17377,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Single<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
+    @NonNull
+    public final <K, V> Single<Map<K, Collection<V>>> toMultimap(@NonNull Function<? super T, ? extends K> keySelector, @NonNull Function<? super T, ? extends V> valueSelector) {
         Supplier<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<V>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
@@ -17167,10 +17421,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
-            final Function<? super T, ? extends K> keySelector,
-            final Function<? super T, ? extends V> valueSelector,
-            final Supplier<? extends Map<K, Collection<V>>> mapSupplier,
-            final Function<? super K, ? extends Collection<? super V>> collectionFactory) {
+            @NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
+            @NonNull Supplier<? extends Map<K, Collection<V>>> mapSupplier,
+            @NonNull Function<? super K, ? extends Collection<? super V>> collectionFactory) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         Objects.requireNonNull(mapSupplier, "mapSupplier is null");
@@ -17211,10 +17465,11 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
-            Function<? super T, ? extends K> keySelector,
-            Function<? super T, ? extends V> valueSelector,
-            Supplier<Map<K, Collection<V>>> mapSupplier
+            @NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
+            @NonNull Supplier<Map<K, Collection<V>>> mapSupplier
             ) {
         return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.<V, K>asFunction());
     }
@@ -17234,8 +17489,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> toObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableFromPublisher<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableFromPublisher<>(this));
     }
 
     /**
@@ -17266,6 +17522,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<List<T>> toSortedList() {
         return toSortedList(Functions.naturalComparator());
     }
@@ -17298,7 +17555,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<List<T>> toSortedList(final Comparator<? super T> comparator) {
+    public final Single<List<T>> toSortedList(@NonNull Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
         return toList().map(Functions.listSorter(comparator));
     }
@@ -17334,7 +17591,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<List<T>> toSortedList(final Comparator<? super T> comparator, int capacityHint) {
+    public final Single<List<T>> toSortedList(@NonNull Comparator<? super T> comparator, int capacityHint) {
         Objects.requireNonNull(comparator, "comparator is null");
         return toList(capacityHint).map(Functions.listSorter(comparator));
     }
@@ -17371,6 +17628,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<List<T>> toSortedList(int capacityHint) {
         return toSortedList(Functions.naturalComparator(), capacityHint);
     }
@@ -17396,9 +17654,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<T> unsubscribeOn(Scheduler scheduler) {
+    public final Flowable<T> unsubscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableUnsubscribeOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new FlowableUnsubscribeOn<>(this, scheduler));
     }
 
     /**
@@ -17430,6 +17688,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<Flowable<T>> window(long count) {
         return window(count, count, bufferSize());
     }
@@ -17467,6 +17726,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<Flowable<T>> window(long count, long skip) {
         return window(count, skip, bufferSize());
     }
@@ -17506,11 +17766,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<Flowable<T>> window(long count, long skip, int bufferSize) {
         ObjectHelper.verifyPositive(skip, "skip");
         ObjectHelper.verifyPositive(count, "count");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableWindow<T>(this, count, skip, bufferSize));
+        return RxJavaPlugins.onAssembly(new FlowableWindow<>(this, count, skip, bufferSize));
     }
 
     /**
@@ -17549,7 +17810,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<Flowable<T>> window(long timespan, long timeskip, TimeUnit unit) {
+    @NonNull
+    public final Flowable<Flowable<T>> window(long timespan, long timeskip, @NonNull TimeUnit unit) {
         return window(timespan, timeskip, unit, Schedulers.computation(), bufferSize());
     }
 
@@ -17591,7 +17853,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<Flowable<T>> window(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<Flowable<T>> window(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return window(timespan, timeskip, unit, scheduler, bufferSize());
     }
 
@@ -17636,13 +17899,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<Flowable<T>> window(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, int bufferSize) {
+    public final Flowable<Flowable<T>> window(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         ObjectHelper.verifyPositive(timespan, "timespan");
         ObjectHelper.verifyPositive(timeskip, "timeskip");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(unit, "unit is null");
-        return RxJavaPlugins.onAssembly(new FlowableWindowTimed<T>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false));
+        return RxJavaPlugins.onAssembly(new FlowableWindowTimed<>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false));
     }
 
     /**
@@ -17679,7 +17942,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<Flowable<T>> window(long timespan, TimeUnit unit) {
+    @NonNull
+    public final Flowable<Flowable<T>> window(long timespan, @NonNull TimeUnit unit) {
         return window(timespan, unit, Schedulers.computation(), Long.MAX_VALUE, false);
     }
 
@@ -17721,7 +17985,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<Flowable<T>> window(long timespan, TimeUnit unit,
+    @NonNull
+    public final Flowable<Flowable<T>> window(long timespan, @NonNull TimeUnit unit,
             long count) {
         return window(timespan, unit, Schedulers.computation(), count, false);
     }
@@ -17766,7 +18031,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Flowable<Flowable<T>> window(long timespan, TimeUnit unit,
+    @NonNull
+    public final Flowable<Flowable<T>> window(long timespan, @NonNull TimeUnit unit,
             long count, boolean restart) {
         return window(timespan, unit, Schedulers.computation(), count, restart);
     }
@@ -17808,8 +18074,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<Flowable<T>> window(long timespan, TimeUnit unit,
-            Scheduler scheduler) {
+    @NonNull
+    public final Flowable<Flowable<T>> window(long timespan, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler) {
         return window(timespan, unit, scheduler, Long.MAX_VALUE, false);
     }
 
@@ -17853,8 +18120,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<Flowable<T>> window(long timespan, TimeUnit unit,
-            Scheduler scheduler, long count) {
+    @NonNull
+    public final Flowable<Flowable<T>> window(long timespan, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler, long count) {
         return window(timespan, unit, scheduler, count, false);
     }
 
@@ -17900,8 +18168,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Flowable<Flowable<T>> window(long timespan, TimeUnit unit,
-            Scheduler scheduler, long count, boolean restart) {
+    @NonNull
+    public final Flowable<Flowable<T>> window(long timespan, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler, long count, boolean restart) {
         return window(timespan, unit, scheduler, count, restart, bufferSize());
     }
 
@@ -17951,13 +18220,13 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Flowable<Flowable<T>> window(
-            long timespan, TimeUnit unit, Scheduler scheduler,
+            long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler,
             long count, boolean restart, int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(unit, "unit is null");
         ObjectHelper.verifyPositive(count, "count");
-        return RxJavaPlugins.onAssembly(new FlowableWindowTimed<T>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart));
+        return RxJavaPlugins.onAssembly(new FlowableWindowTimed<>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart));
     }
 
     /**
@@ -17991,7 +18260,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Flowable<Flowable<T>> window(Publisher<B> boundaryIndicator) {
+    @NonNull
+    public final <B> Flowable<Flowable<T>> window(@NonNull Publisher<B> boundaryIndicator) {
         return window(boundaryIndicator, bufferSize());
     }
 
@@ -18029,10 +18299,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Flowable<Flowable<T>> window(Publisher<B> boundaryIndicator, int bufferSize) {
+    public final <B> Flowable<Flowable<T>> window(@NonNull Publisher<B> boundaryIndicator, int bufferSize) {
         Objects.requireNonNull(boundaryIndicator, "boundaryIndicator is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableWindowBoundary<T, B>(this, boundaryIndicator, bufferSize));
+        return RxJavaPlugins.onAssembly(new FlowableWindowBoundary<>(this, boundaryIndicator, bufferSize));
     }
 
     /**
@@ -18071,9 +18341,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <U, V> Flowable<Flowable<T>> window(
-            Publisher<U> openingIndicator,
-            Function<? super U, ? extends Publisher<V>> closingIndicator) {
+            @NonNull Publisher<U> openingIndicator,
+            @NonNull Function<? super U, ? extends Publisher<V>> closingIndicator) {
         return window(openingIndicator, closingIndicator, bufferSize());
     }
 
@@ -18117,12 +18388,12 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, V> Flowable<Flowable<T>> window(
-            Publisher<U> openingIndicator,
-            Function<? super U, ? extends Publisher<V>> closingIndicator, int bufferSize) {
+            @NonNull Publisher<U> openingIndicator,
+            @NonNull Function<? super U, ? extends Publisher<V>> closingIndicator, int bufferSize) {
         Objects.requireNonNull(openingIndicator, "openingIndicator is null");
         Objects.requireNonNull(closingIndicator, "closingIndicator is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableWindowBoundarySelector<T, U, V>(this, openingIndicator, closingIndicator, bufferSize));
+        return RxJavaPlugins.onAssembly(new FlowableWindowBoundarySelector<>(this, openingIndicator, closingIndicator, bufferSize));
     }
 
     /**
@@ -18157,8 +18428,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> withLatestFrom(Publisher<? extends U> other,
-            BiFunction<? super T, ? super U, ? extends R> combiner) {
+    public final <U, @NonNull R> Flowable<R> withLatestFrom(@NonNull Publisher<? extends U> other,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(combiner, "combiner is null");
 
@@ -18195,8 +18466,8 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T1, T2, R> Flowable<R> withLatestFrom(Publisher<T1> source1, Publisher<T2> source2,
-            Function3<? super T, ? super T1, ? super T2, R> combiner) {
+    public final <T1, T2, @NonNull R> Flowable<R> withLatestFrom(@NonNull Publisher<T1> source1, @NonNull Publisher<T2> source2,
+            @NonNull Function3<? super T, ? super T1, ? super T2, R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
@@ -18235,10 +18506,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T1, T2, T3, R> Flowable<R> withLatestFrom(
-            Publisher<T1> source1, Publisher<T2> source2,
-            Publisher<T3> source3,
-            Function4<? super T, ? super T1, ? super T2, ? super T3, R> combiner) {
+    public final <T1, T2, T3, @NonNull R> Flowable<R> withLatestFrom(
+            @NonNull Publisher<T1> source1, @NonNull Publisher<T2> source2,
+            @NonNull Publisher<T3> source3,
+            @NonNull Function4<? super T, ? super T1, ? super T2, ? super T3, R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -18280,10 +18551,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <T1, T2, T3, T4, R> Flowable<R> withLatestFrom(
-            Publisher<T1> source1, Publisher<T2> source2,
-            Publisher<T3> source3, Publisher<T4> source4,
-            Function5<? super T, ? super T1, ? super T2, ? super T3, ? super T4, R> combiner) {
+    public final <T1, T2, T3, T4, @NonNull R> Flowable<R> withLatestFrom(
+            @NonNull Publisher<T1> source1, @NonNull Publisher<T2> source2,
+            @NonNull Publisher<T3> source3, @NonNull Publisher<T4> source4,
+            @NonNull Function5<? super T, ? super T1, ? super T2, ? super T3, ? super T4, R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -18319,10 +18590,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> withLatestFrom(Publisher<?>[] others, Function<? super Object[], R> combiner) {
+    public final <@NonNull R> Flowable<R> withLatestFrom(@NonNull Publisher<?>[] others, @NonNull Function<? super Object[], R> combiner) {
         Objects.requireNonNull(others, "others is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return RxJavaPlugins.onAssembly(new FlowableWithLatestFromMany<T, R>(this, others, combiner));
+        return RxJavaPlugins.onAssembly(new FlowableWithLatestFromMany<>(this, others, combiner));
     }
 
     /**
@@ -18352,10 +18623,10 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> withLatestFrom(Iterable<? extends Publisher<?>> others, Function<? super Object[], R> combiner) {
+    public final <R> Flowable<R> withLatestFrom(@NonNull Iterable<? extends Publisher<?>> others, @NonNull Function<? super Object[], R> combiner) {
         Objects.requireNonNull(others, "others is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return RxJavaPlugins.onAssembly(new FlowableWithLatestFromMany<T, R>(this, others, combiner));
+        return RxJavaPlugins.onAssembly(new FlowableWithLatestFromMany<>(this, others, combiner));
     }
 
     /**
@@ -18392,7 +18663,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> zipWith(Iterable<U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
+    public final <U, R> Flowable<R> zipWith(@NonNull Iterable<U> other,  @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(zipper, "zipper is null");
         return RxJavaPlugins.onAssembly(new FlowableZipIterable<T, U, R>(this, other, zipper));
@@ -18441,7 +18712,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> zipWith(Publisher<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
+    public final <U, R> Flowable<R> zipWith(@NonNull Publisher<? extends U> other, @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
@@ -18491,8 +18762,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> zipWith(Publisher<? extends U> other,
-            BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
+    @NonNull
+    public final <U, R> Flowable<R> zipWith(@NonNull Publisher<? extends U> other,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
         return zip(this, other, zipper, delayError);
     }
 
@@ -18543,8 +18815,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Flowable<R> zipWith(Publisher<? extends U> other,
-            BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
+    @NonNull
+    public final <U, R> Flowable<R> zipWith(@NonNull Publisher<? extends U> other,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
         return zip(this, other, zipper, delayError, bufferSize);
     }
 
@@ -18566,8 +18839,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestSubscriber<T> test() { // NoPMD
-        TestSubscriber<T> ts = new TestSubscriber<T>();
+        TestSubscriber<T> ts = new TestSubscriber<>();
         subscribe(ts);
         return ts;
     }
@@ -18588,8 +18862,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestSubscriber<T> test(long initialRequest) { // NoPMD
-        TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
+        TestSubscriber<T> ts = new TestSubscriber<>(initialRequest);
         subscribe(ts);
         return ts;
     }
@@ -18612,8 +18887,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestSubscriber<T> test(long initialRequest, boolean cancel) { // NoPMD
-        TestSubscriber<T> ts = new TestSubscriber<T>(initialRequest);
+        TestSubscriber<T> ts = new TestSubscriber<>(initialRequest);
         if (cancel) {
             ts.cancel();
         }

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -129,7 +129,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> amb(final Iterable<? extends MaybeSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new MaybeAmb<T>(null, sources));
+        return RxJavaPlugins.onAssembly(new MaybeAmb<>(null, sources));
     }
 
     /**
@@ -148,15 +148,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
-    public static <T> Maybe<T> ambArray(final MaybeSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Maybe<T> ambArray(@NonNull MaybeSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         }
         if (sources.length == 1) {
-            return wrap((MaybeSource<T>)sources[0]);
+            @SuppressWarnings("unchecked")
+            MaybeSource<T> source = (MaybeSource<T>)sources[0];
+            return wrap(source);
         }
-        return RxJavaPlugins.onAssembly(new MaybeAmb<T>(sources, null));
+        return RxJavaPlugins.onAssembly(new MaybeAmb<>(sources, null));
     }
 
     /**
@@ -178,9 +181,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concat(Iterable<? extends MaybeSource<? extends T>> sources) {
+    public static <T> Flowable<T> concat(@NonNull Iterable<? extends MaybeSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new MaybeConcatIterable<T>(sources));
+        return RxJavaPlugins.onAssembly(new MaybeConcatIterable<>(sources));
     }
 
     /**
@@ -206,8 +209,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
-    public static <T> Flowable<T> concat(MaybeSource<? extends T> source1, MaybeSource<? extends T> source2) {
+    public static <T> Flowable<T> concat(@NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return concatArray(source1, source2);
@@ -238,9 +240,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
-            MaybeSource<? extends T> source1, MaybeSource<? extends T> source2, MaybeSource<? extends T> source3) {
+            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2, @NonNull MaybeSource<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -274,9 +275,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
-            MaybeSource<? extends T> source1, MaybeSource<? extends T> source2, MaybeSource<? extends T> source3, MaybeSource<? extends T> source4) {
+            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2, @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -304,7 +304,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concat(Publisher<? extends MaybeSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> concat(@NonNull Publisher<? extends MaybeSource<? extends T>> sources) {
         return concat(sources, 2);
     }
 
@@ -331,7 +332,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Flowable<T> concat(Publisher<? extends MaybeSource<? extends T>> sources, int prefetch) {
+    public static <T> Flowable<T> concat(@NonNull Publisher<? extends MaybeSource<? extends T>> sources, int prefetch) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new FlowableConcatMapPublisher(sources, MaybeToPublisher.instance(), prefetch, ErrorMode.IMMEDIATE));
@@ -355,16 +356,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
-    public static <T> Flowable<T> concatArray(MaybeSource<? extends T>... sources) {
+    @SafeVarargs
+    public static <T> Flowable<T> concatArray(@NonNull MaybeSource<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return Flowable.empty();
         }
         if (sources.length == 1) {
-            return RxJavaPlugins.onAssembly(new MaybeToFlowable<T>((MaybeSource<T>)sources[0]));
+            @SuppressWarnings("unchecked")
+            MaybeSource<T> source = (MaybeSource<T>)sources[0];
+            return RxJavaPlugins.onAssembly(new MaybeToFlowable<>(source));
         }
-        return RxJavaPlugins.onAssembly(new MaybeConcatArray<T>(sources));
+        return RxJavaPlugins.onAssembly(new MaybeConcatArray<>(sources));
     }
 
     /**
@@ -383,18 +386,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return the new Flowable instance
      * @throws NullPointerException if sources is null
      */
-    @SuppressWarnings("unchecked")
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatArrayDelayError(MaybeSource<? extends T>... sources) {
+    @SafeVarargs
+    @NonNull
+    public static <T> Flowable<T> concatArrayDelayError(@NonNull MaybeSource<? extends T>... sources) {
         if (sources.length == 0) {
             return Flowable.empty();
         } else
         if (sources.length == 1) {
-            return RxJavaPlugins.onAssembly(new MaybeToFlowable<T>((MaybeSource<T>)sources[0]));
+            @SuppressWarnings("unchecked")
+            MaybeSource<T> source = (MaybeSource<T>)sources[0];
+            return RxJavaPlugins.onAssembly(new MaybeToFlowable<>(source));
         }
-        return RxJavaPlugins.onAssembly(new MaybeConcatArrayDelayError<T>(sources));
+        return RxJavaPlugins.onAssembly(new MaybeConcatArrayDelayError<>(sources));
     }
 
     /**
@@ -419,7 +425,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatArrayEager(MaybeSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Flowable<T> concatArrayEager(@NonNull MaybeSource<? extends T>... sources) {
         return Flowable.fromArray(sources).concatMapEager((Function)MaybeToPublisher.instance());
     }
 
@@ -469,7 +477,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatDelayError(Publisher<? extends MaybeSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> concatDelayError(@NonNull Publisher<? extends MaybeSource<? extends T>> sources) {
         return Flowable.fromPublisher(sources).concatMapDelayError((Function)MaybeToPublisher.instance());
     }
 
@@ -495,7 +504,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatEager(Iterable<? extends MaybeSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> concatEager(@NonNull Iterable<? extends MaybeSource<? extends T>> sources) {
         return Flowable.fromIterable(sources).concatMapEager((Function)MaybeToPublisher.instance());
     }
 
@@ -523,7 +533,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatEager(Publisher<? extends MaybeSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> concatEager(@NonNull Publisher<? extends MaybeSource<? extends T>> sources) {
         return Flowable.fromPublisher(sources).concatMapEager((Function)MaybeToPublisher.instance());
     }
 
@@ -574,9 +585,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> create(MaybeOnSubscribe<T> onSubscribe) {
+    public static <T> Maybe<T> create(@NonNull MaybeOnSubscribe<T> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
-        return RxJavaPlugins.onAssembly(new MaybeCreate<T>(onSubscribe));
+        return RxJavaPlugins.onAssembly(new MaybeCreate<>(onSubscribe));
     }
 
     /**
@@ -594,9 +605,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> defer(final Supplier<? extends MaybeSource<? extends T>> maybeSupplier) {
+    public static <T> Maybe<T> defer(@NonNull Supplier<? extends MaybeSource<? extends T>> maybeSupplier) {
         Objects.requireNonNull(maybeSupplier, "maybeSupplier is null");
-        return RxJavaPlugins.onAssembly(new MaybeDefer<T>(maybeSupplier));
+        return RxJavaPlugins.onAssembly(new MaybeDefer<>(maybeSupplier));
     }
 
     /**
@@ -614,6 +625,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Maybe<T> empty() {
         return RxJavaPlugins.onAssembly((Maybe<T>)MaybeEmpty.INSTANCE);
     }
@@ -639,7 +651,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> error(Throwable exception) {
+    public static <T> Maybe<T> error(@NonNull Throwable exception) {
         Objects.requireNonNull(exception, "exception is null");
         return RxJavaPlugins.onAssembly(new MaybeError<T>(exception));
     }
@@ -665,7 +677,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> error(Supplier<? extends Throwable> supplier) {
+    public static <T> Maybe<T> error(@NonNull Supplier<? extends Throwable> supplier) {
         Objects.requireNonNull(supplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new MaybeErrorCallable<T>(supplier));
     }
@@ -692,7 +704,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromAction(final Action run) {
+    public static <T> Maybe<T> fromAction(@NonNull Action run) {
         Objects.requireNonNull(run, "run is null");
         return RxJavaPlugins.onAssembly(new MaybeFromAction<T>(run));
     }
@@ -712,7 +724,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromCompletable(CompletableSource completableSource) {
+    public static <T> Maybe<T> fromCompletable(@NonNull CompletableSource completableSource) {
         Objects.requireNonNull(completableSource, "completableSource is null");
         return RxJavaPlugins.onAssembly(new MaybeFromCompletable<T>(completableSource));
     }
@@ -732,9 +744,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromSingle(SingleSource<T> singleSource) {
+    public static <T> Maybe<T> fromSingle(@NonNull SingleSource<T> singleSource) {
         Objects.requireNonNull(singleSource, "singleSource is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromSingle<T>(singleSource));
+        return RxJavaPlugins.onAssembly(new MaybeFromSingle<>(singleSource));
     }
 
     /**
@@ -776,7 +788,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromCallable(@NonNull final Callable<? extends T> callable) {
+    public static <@NonNull T> Maybe<T> fromCallable(@NonNull final Callable<? extends T> callable) {
         Objects.requireNonNull(callable, "callable is null");
         return RxJavaPlugins.onAssembly(new MaybeFromCallable<T>(callable));
     }
@@ -810,7 +822,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromFuture(Future<? extends T> future) {
+    public static <@NonNull T> Maybe<T> fromFuture(@NonNull Future<? extends T> future) {
         Objects.requireNonNull(future, "future is null");
         return RxJavaPlugins.onAssembly(new MaybeFromFuture<T>(future, 0L, null));
     }
@@ -848,7 +860,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
+    public static <@NonNull T> Maybe<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit) {
         Objects.requireNonNull(future, "future is null");
         Objects.requireNonNull(unit, "unit is null");
         return RxJavaPlugins.onAssembly(new MaybeFromFuture<T>(future, timeout, unit));
@@ -869,7 +881,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromRunnable(final Runnable run) {
+    public static <T> Maybe<T> fromRunnable(@NonNull Runnable run) {
         Objects.requireNonNull(run, "run is null");
         return RxJavaPlugins.onAssembly(new MaybeFromRunnable<T>(run));
     }
@@ -916,7 +928,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromSupplier(@NonNull final Supplier<? extends T> supplier) {
+    public static <@NonNull T> Maybe<T> fromSupplier(@NonNull final Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new MaybeFromSupplier<T>(supplier));
     }
@@ -943,9 +955,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> just(T item) {
+    public static <@NonNull T> Maybe<T> just(T item) {
         Objects.requireNonNull(item, "item is null");
-        return RxJavaPlugins.onAssembly(new MaybeJust<T>(item));
+        return RxJavaPlugins.onAssembly(new MaybeJust<>(item));
     }
 
     /**
@@ -978,7 +990,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Iterable<? extends MaybeSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> merge(@NonNull Iterable<? extends MaybeSource<? extends T>> sources) {
         return merge(Flowable.fromIterable(sources));
     }
 
@@ -1012,7 +1025,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Publisher<? extends MaybeSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> merge(@NonNull Publisher<? extends MaybeSource<? extends T>> sources) {
         return merge(sources, Integer.MAX_VALUE);
     }
 
@@ -1049,7 +1063,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Flowable<T> merge(Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
+    public static <T> Flowable<T> merge(@NonNull Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
         Objects.requireNonNull(sources, "source is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, MaybeToPublisher.instance(), false, maxConcurrency, 1));
@@ -1082,7 +1096,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Maybe<T> merge(MaybeSource<? extends MaybeSource<? extends T>> source) {
+    public static <T> Maybe<T> merge(@NonNull MaybeSource<? extends MaybeSource<? extends T>> source) {
         Objects.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new MaybeFlatten(source, Functions.identity()));
     }
@@ -1127,9 +1141,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
-            MaybeSource<? extends T> source1, MaybeSource<? extends T> source2
+            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1178,10 +1191,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
-            MaybeSource<? extends T> source1, MaybeSource<? extends T> source2,
-            MaybeSource<? extends T> source3
+            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
+            @NonNull MaybeSource<? extends T> source3
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1233,10 +1245,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
-            MaybeSource<? extends T> source1, MaybeSource<? extends T> source2,
-            MaybeSource<? extends T> source3, MaybeSource<? extends T> source4
+            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
+            @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1276,16 +1287,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
+    @SafeVarargs
     public static <T> Flowable<T> mergeArray(MaybeSource<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return Flowable.empty();
         }
         if (sources.length == 1) {
-            return RxJavaPlugins.onAssembly(new MaybeToFlowable<T>((MaybeSource<T>)sources[0]));
+            @SuppressWarnings("unchecked")
+            MaybeSource<T> source = (MaybeSource<T>)sources[0];
+            return RxJavaPlugins.onAssembly(new MaybeToFlowable<>(source));
         }
-        return RxJavaPlugins.onAssembly(new MaybeMergeArray<T>(sources));
+        return RxJavaPlugins.onAssembly(new MaybeMergeArray<>(sources));
     }
 
     /**
@@ -1319,7 +1332,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeArrayDelayError(MaybeSource<? extends T>... sources) {
+    @SafeVarargs
+    @NonNull
+    public static <T> Flowable<T> mergeArrayDelayError(@NonNull MaybeSource<? extends T>... sources) {
         if (sources.length == 0) {
             return Flowable.empty();
         }
@@ -1357,7 +1372,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Iterable<? extends MaybeSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> mergeDelayError(@NonNull Iterable<? extends MaybeSource<? extends T>> sources) {
         return Flowable.fromIterable(sources).flatMap((Function)MaybeToPublisher.instance(), true);
     }
 
@@ -1392,7 +1408,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Publisher<? extends MaybeSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends MaybeSource<? extends T>> sources) {
         return mergeDelayError(sources, Integer.MAX_VALUE);
     }
 
@@ -1431,7 +1448,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
+    public static <T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
         Objects.requireNonNull(sources, "source is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, MaybeToPublisher.instance(), true, maxConcurrency, 1));
@@ -1465,12 +1482,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits all of the items that are emitted by the two source MaybeSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({ "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(MaybeSource<? extends T> source1, MaybeSource<? extends T> source2) {
+    public static <T> Flowable<T> mergeDelayError(@NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return mergeArrayDelayError(source1, source2);
@@ -1507,13 +1523,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits all of the items that are emitted by the source MaybeSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({ "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(MaybeSource<? extends T> source1,
-            MaybeSource<? extends T> source2, MaybeSource<? extends T> source3) {
+    public static <T> Flowable<T> mergeDelayError(@NonNull MaybeSource<? extends T> source1,
+            @NonNull MaybeSource<? extends T> source2, @NonNull MaybeSource<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1553,14 +1568,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Flowable that emits all of the items that are emitted by the source MaybeSources
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
-    @SuppressWarnings({ "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> mergeDelayError(
-            MaybeSource<? extends T> source1, MaybeSource<? extends T> source2,
-            MaybeSource<? extends T> source3, MaybeSource<? extends T> source4) {
+            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
+            @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1587,6 +1601,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Maybe<T> never() {
         return RxJavaPlugins.onAssembly((Maybe<T>)MaybeNever.INSTANCE);
     }
@@ -1612,7 +1627,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(MaybeSource<? extends T> source1, MaybeSource<? extends T> source2) {
+    @NonNull
+    public static <T> Single<Boolean> sequenceEqual(@NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate());
     }
 
@@ -1642,12 +1658,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(MaybeSource<? extends T> source1, MaybeSource<? extends T> source2,
-            BiPredicate<? super T, ? super T> isEqual) {
+    public static <T> Single<Boolean> sequenceEqual(@NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
+            @NonNull BiPredicate<? super T, ? super T> isEqual) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(isEqual, "isEqual is null");
-        return RxJavaPlugins.onAssembly(new MaybeEqualSingle<T>(source1, source2, isEqual));
+        return RxJavaPlugins.onAssembly(new MaybeEqualSingle<>(source1, source2, isEqual));
     }
 
     /**
@@ -1668,7 +1684,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Maybe<Long> timer(long delay, TimeUnit unit) {
+    @NonNull
+    public static Maybe<Long> timer(long delay, @NonNull TimeUnit unit) {
         return timer(delay, unit, Schedulers.computation());
     }
 
@@ -1693,7 +1710,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Maybe<Long> timer(long delay, TimeUnit unit, Scheduler scheduler) {
+    public static Maybe<Long> timer(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
 
@@ -1714,12 +1731,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> unsafeCreate(MaybeSource<T> onSubscribe) {
+    public static <T> Maybe<T> unsafeCreate(@NonNull MaybeSource<T> onSubscribe) {
         if (onSubscribe instanceof Maybe) {
             throw new IllegalArgumentException("unsafeCreate(Maybe) should be upgraded");
         }
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
-        return RxJavaPlugins.onAssembly(new MaybeUnsafeCreate<T>(onSubscribe));
+        return RxJavaPlugins.onAssembly(new MaybeUnsafeCreate<>(onSubscribe));
     }
 
     /**
@@ -1745,9 +1762,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Maybe<T> using(Supplier<? extends D> resourceSupplier,
-            Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
-                    Consumer<? super D> resourceDisposer) {
+    @NonNull
+    public static <T, D> Maybe<T> using(@NonNull Supplier<? extends D> resourceSupplier,
+            @NonNull Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
+            @NonNull Consumer<? super D> resourceDisposer) {
         return using(resourceSupplier, sourceSupplier, resourceDisposer, true);
     }
 
@@ -1783,9 +1801,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Maybe<T> using(Supplier<? extends D> resourceSupplier,
-            Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
-                    Consumer<? super D> resourceDisposer, boolean eager) {
+    public static <T, D> Maybe<T> using(@NonNull Supplier<? extends D> resourceSupplier,
+            @NonNull Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
+            @NonNull Consumer<? super D> resourceDisposer, boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
         Objects.requireNonNull(resourceDisposer, "disposer is null");
@@ -1806,12 +1824,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> wrap(MaybeSource<T> source) {
+    public static <T> Maybe<T> wrap(@NonNull MaybeSource<T> source) {
         if (source instanceof Maybe) {
             return RxJavaPlugins.onAssembly((Maybe<T>)source);
         }
         Objects.requireNonNull(source, "onSubscribe is null");
-        return RxJavaPlugins.onAssembly(new MaybeUnsafeCreate<T>(source));
+        return RxJavaPlugins.onAssembly(new MaybeUnsafeCreate<>(source));
     }
 
     /**
@@ -1844,7 +1862,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Maybe<R> zip(Iterable<? extends MaybeSource<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
+    public static <T, R> Maybe<R> zip(@NonNull Iterable<? extends MaybeSource<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new MaybeZipIterable<T, R>(sources, zipper));
@@ -1876,13 +1894,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, R> Maybe<R> zip(
-            MaybeSource<? extends T1> source1, MaybeSource<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> zipper) {
+            @NonNull MaybeSource<? extends T1> source1, @NonNull MaybeSource<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return zipArray(Functions.toFunction(zipper), source1, source2);
@@ -1917,13 +1934,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, R> Maybe<R> zip(
-            MaybeSource<? extends T1> source1, MaybeSource<? extends T2> source2, MaybeSource<? extends T3> source3,
-            Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
+            @NonNull MaybeSource<? extends T1> source1, @NonNull MaybeSource<? extends T2> source2, @NonNull MaybeSource<? extends T3> source3,
+            @NonNull Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1962,14 +1978,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, R> Maybe<R> zip(
-            MaybeSource<? extends T1> source1, MaybeSource<? extends T2> source2, MaybeSource<? extends T3> source3,
-            MaybeSource<? extends T4> source4,
-            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
+            @NonNull MaybeSource<? extends T1> source1, @NonNull MaybeSource<? extends T2> source2, @NonNull MaybeSource<? extends T3> source3,
+            @NonNull MaybeSource<? extends T4> source4,
+            @NonNull Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2012,14 +2027,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, R> Maybe<R> zip(
-            MaybeSource<? extends T1> source1, MaybeSource<? extends T2> source2, MaybeSource<? extends T3> source3,
-            MaybeSource<? extends T4> source4, MaybeSource<? extends T5> source5,
-            Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper) {
+            @NonNull MaybeSource<? extends T1> source1, @NonNull MaybeSource<? extends T2> source2, @NonNull MaybeSource<? extends T3> source3,
+            @NonNull MaybeSource<? extends T4> source4, @NonNull MaybeSource<? extends T5> source5,
+            @NonNull Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2066,14 +2080,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Maybe<R> zip(
-            MaybeSource<? extends T1> source1, MaybeSource<? extends T2> source2, MaybeSource<? extends T3> source3,
-            MaybeSource<? extends T4> source4, MaybeSource<? extends T5> source5, MaybeSource<? extends T6> source6,
-            Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper) {
+            @NonNull MaybeSource<? extends T1> source1, @NonNull MaybeSource<? extends T2> source2, @NonNull MaybeSource<? extends T3> source3,
+            @NonNull MaybeSource<? extends T4> source4, @NonNull MaybeSource<? extends T5> source5, @NonNull MaybeSource<? extends T6> source6,
+            @NonNull Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2124,15 +2137,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Maybe<R> zip(
-            MaybeSource<? extends T1> source1, MaybeSource<? extends T2> source2, MaybeSource<? extends T3> source3,
-            MaybeSource<? extends T4> source4, MaybeSource<? extends T5> source5, MaybeSource<? extends T6> source6,
-            MaybeSource<? extends T7> source7,
-            Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper) {
+            @NonNull MaybeSource<? extends T1> source1, @NonNull MaybeSource<? extends T2> source2, @NonNull MaybeSource<? extends T3> source3,
+            @NonNull MaybeSource<? extends T4> source4, @NonNull MaybeSource<? extends T5> source5, @NonNull MaybeSource<? extends T6> source6,
+            @NonNull MaybeSource<? extends T7> source7,
+            @NonNull Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2187,15 +2199,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Maybe<R> zip(
-            MaybeSource<? extends T1> source1, MaybeSource<? extends T2> source2, MaybeSource<? extends T3> source3,
-            MaybeSource<? extends T4> source4, MaybeSource<? extends T5> source5, MaybeSource<? extends T6> source6,
-            MaybeSource<? extends T7> source7, MaybeSource<? extends T8> source8,
-            Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper) {
+            @NonNull MaybeSource<? extends T1> source1, @NonNull MaybeSource<? extends T2> source2, @NonNull MaybeSource<? extends T3> source3,
+            @NonNull MaybeSource<? extends T4> source4, @NonNull MaybeSource<? extends T5> source5, @NonNull MaybeSource<? extends T6> source6,
+            @NonNull MaybeSource<? extends T7> source7, @NonNull MaybeSource<? extends T8> source8,
+            @NonNull Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2253,15 +2264,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return a Maybe that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Maybe<R> zip(
-            MaybeSource<? extends T1> source1, MaybeSource<? extends T2> source2, MaybeSource<? extends T3> source3,
-            MaybeSource<? extends T4> source4, MaybeSource<? extends T5> source5, MaybeSource<? extends T6> source6,
-            MaybeSource<? extends T7> source7, MaybeSource<? extends T8> source8, MaybeSource<? extends T9> source9,
-            Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper) {
+            @NonNull MaybeSource<? extends T1> source1, @NonNull MaybeSource<? extends T2> source2, @NonNull MaybeSource<? extends T3> source3,
+            @NonNull MaybeSource<? extends T4> source4, @NonNull MaybeSource<? extends T5> source5, @NonNull MaybeSource<? extends T6> source6,
+            @NonNull MaybeSource<? extends T7> source7, @NonNull MaybeSource<? extends T8> source8, @NonNull MaybeSource<? extends T9> source9,
+            @NonNull Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper) {
 
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -2305,8 +2315,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Maybe<R> zipArray(Function<? super Object[], ? extends R> zipper,
-            MaybeSource<? extends T>... sources) {
+    @SafeVarargs
+    public static <T, R> Maybe<R> zipArray(@NonNull Function<? super Object[], ? extends R> zipper,
+            @NonNull MaybeSource<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return empty();
@@ -2335,11 +2346,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         signalled
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX operators documentation: Amb</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> ambWith(MaybeSource<? extends T> other) {
+    public final Maybe<T> ambWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return ambArray(this, other);
     }
@@ -2359,8 +2369,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @Nullable
     public final T blockingGet() {
-        BlockingMultiObserver<T> observer = new BlockingMultiObserver<T>();
+        BlockingMultiObserver<T> observer = new BlockingMultiObserver<>();
         subscribe(observer);
         return observer.blockingGet();
     }
@@ -2381,9 +2392,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final T blockingGet(T defaultValue) {
+    @Nullable
+    public final T blockingGet(@Nullable T defaultValue) {
         Objects.requireNonNull(defaultValue, "defaultValue is null");
-        BlockingMultiObserver<T> observer = new BlockingMultiObserver<T>();
+        BlockingMultiObserver<T> observer = new BlockingMultiObserver<>();
         subscribe(observer);
         return observer.blockingGet(defaultValue);
     }
@@ -2409,8 +2421,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> cache() {
-        return RxJavaPlugins.onAssembly(new MaybeCache<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeCache<>(this));
     }
 
     /**
@@ -2429,7 +2442,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<U> cast(final Class<? extends U> clazz) {
+    public final <U> Maybe<U> cast(@NonNull Class<? extends U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
     }
@@ -2455,7 +2468,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> compose(MaybeTransformer<? super T, ? extends R> transformer) {
+    @NonNull
+    public final <R> Maybe<R> compose(@NonNull MaybeTransformer<? super T, ? extends R> transformer) {
         return wrap(((MaybeTransformer<T, R>) Objects.requireNonNull(transformer, "transformer is null")).apply(this));
     }
 
@@ -2478,9 +2492,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> concatMap(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    public final <R> Maybe<R> concatMap(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatten<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatten<>(this, mapper));
     }
 
     /**
@@ -2505,7 +2519,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> concatWith(MaybeSource<? extends T> other) {
+    public final Flowable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concat(this, other);
     }
@@ -2529,9 +2543,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> contains(final Object item) {
+    public final Single<Boolean> contains(@NonNull Object item) {
         Objects.requireNonNull(item, "item is null");
-        return RxJavaPlugins.onAssembly(new MaybeContains<T>(this, item));
+        return RxJavaPlugins.onAssembly(new MaybeContains<>(this, item));
     }
 
     /**
@@ -2550,8 +2564,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<Long> count() {
-        return RxJavaPlugins.onAssembly(new MaybeCount<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeCount<>(this));
     }
 
     /**
@@ -2573,9 +2588,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> defaultIfEmpty(T defaultItem) {
+    public final Single<T> defaultIfEmpty(@NonNull T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem is null");
-        return RxJavaPlugins.onAssembly(new MaybeToSingle<T>(this, defaultItem));
+        return RxJavaPlugins.onAssembly(new MaybeToSingle<>(this, defaultItem));
     }
 
     /**
@@ -2598,7 +2613,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Maybe<T> delay(long delay, TimeUnit unit) {
+    @NonNull
+    public final Maybe<T> delay(long delay, @NonNull TimeUnit unit) {
         return delay(delay, unit, Schedulers.computation());
     }
 
@@ -2624,10 +2640,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Maybe<T> delay(long delay, TimeUnit unit, Scheduler scheduler) {
+    public final Maybe<T> delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new MaybeDelay<T>(this, Math.max(0L, delay), unit, scheduler));
+        return RxJavaPlugins.onAssembly(new MaybeDelay<>(this, Math.max(0L, delay), unit, scheduler));
     }
 
     /**
@@ -2644,8 +2660,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <U>
      *            the subscription delay value type (ignored)
-     * @param <V>
-     *            the item delay value type (ignored)
      * @param delayIndicator
      *            the Publisher that gets subscribed to when this Maybe signals an event and that
      *            signal is emitted when the Publisher signals an item or completes
@@ -2656,9 +2670,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
-    public final <U, V> Maybe<T> delay(Publisher<U> delayIndicator) {
+    public final <U> Maybe<T> delay(@NonNull Publisher<U> delayIndicator) {
         Objects.requireNonNull(delayIndicator, "delayIndicator is null");
-        return RxJavaPlugins.onAssembly(new MaybeDelayOtherPublisher<T, U>(this, delayIndicator));
+        return RxJavaPlugins.onAssembly(new MaybeDelayOtherPublisher<>(this, delayIndicator));
     }
 
     /**
@@ -2683,9 +2697,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<T> delaySubscription(Publisher<U> subscriptionIndicator) {
+    public final <U> Maybe<T> delaySubscription(@NonNull Publisher<U> subscriptionIndicator) {
         Objects.requireNonNull(subscriptionIndicator, "subscriptionIndicator is null");
-        return RxJavaPlugins.onAssembly(new MaybeDelaySubscriptionOtherPublisher<T, U>(this, subscriptionIndicator));
+        return RxJavaPlugins.onAssembly(new MaybeDelaySubscriptionOtherPublisher<>(this, subscriptionIndicator));
     }
 
     /**
@@ -2707,7 +2721,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Maybe<T> delaySubscription(long delay, TimeUnit unit) {
+    @NonNull
+    public final Maybe<T> delaySubscription(long delay, @NonNull TimeUnit unit) {
         return delaySubscription(delay, unit, Schedulers.computation());
     }
 
@@ -2733,7 +2748,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Maybe<T> delaySubscription(long delay, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Maybe<T> delaySubscription(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return delaySubscription(Flowable.timer(delay, unit, scheduler));
     }
 
@@ -2753,9 +2769,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doAfterSuccess(Consumer<? super T> onAfterSuccess) {
+    public final Maybe<T> doAfterSuccess(@NonNull Consumer<? super T> onAfterSuccess) {
         Objects.requireNonNull(onAfterSuccess, "onAfterSuccess is null");
-        return RxJavaPlugins.onAssembly(new MaybeDoAfterSuccess<T>(this, onAfterSuccess));
+        return RxJavaPlugins.onAssembly(new MaybeDoAfterSuccess<>(this, onAfterSuccess));
     }
 
     /**
@@ -2778,8 +2794,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doAfterTerminate(Action onAfterTerminate) {
-        return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
+    public final Maybe<T> doAfterTerminate(@NonNull Action onAfterTerminate) {
+        return RxJavaPlugins.onAssembly(new MaybePeek<>(this,
                 Functions.emptyConsumer(), // onSubscribe
                 Functions.emptyConsumer(), // onSuccess
                 Functions.emptyConsumer(), // onError
@@ -2808,9 +2824,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doFinally(Action onFinally) {
+    public final Maybe<T> doFinally(@NonNull Action onFinally) {
         Objects.requireNonNull(onFinally, "onFinally is null");
-        return RxJavaPlugins.onAssembly(new MaybeDoFinally<T>(this, onFinally));
+        return RxJavaPlugins.onAssembly(new MaybeDoFinally<>(this, onFinally));
     }
 
     /**
@@ -2827,8 +2843,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doOnDispose(Action onDispose) {
-        return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
+    public final Maybe<T> doOnDispose(@NonNull Action onDispose) {
+        return RxJavaPlugins.onAssembly(new MaybePeek<>(this,
                 Functions.emptyConsumer(), // onSubscribe
                 Functions.emptyConsumer(), // onSuccess
                 Functions.emptyConsumer(), // onError
@@ -2855,8 +2871,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doOnComplete(Action onComplete) {
-        return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
+    public final Maybe<T> doOnComplete(@NonNull Action onComplete) {
+        return RxJavaPlugins.onAssembly(new MaybePeek<>(this,
                 Functions.emptyConsumer(), // onSubscribe
                 Functions.emptyConsumer(), // onSuccess
                 Functions.emptyConsumer(), // onError
@@ -2881,8 +2897,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doOnError(Consumer<? super Throwable> onError) {
-        return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
+    public final Maybe<T> doOnError(@NonNull Consumer<? super Throwable> onError) {
+        return RxJavaPlugins.onAssembly(new MaybePeek<>(this,
                 Functions.emptyConsumer(), // onSubscribe
                 Functions.emptyConsumer(), // onSuccess
                 Objects.requireNonNull(onError, "onError is null"),
@@ -2910,9 +2926,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doOnEvent(BiConsumer<? super T, ? super Throwable> onEvent) {
+    @NonNull
+    public final Maybe<T> doOnEvent(@NonNull BiConsumer<? super T, ? super Throwable> onEvent) {
         Objects.requireNonNull(onEvent, "onEvent is null");
-        return RxJavaPlugins.onAssembly(new MaybeDoOnEvent<T>(this, onEvent));
+        return RxJavaPlugins.onAssembly(new MaybeDoOnEvent<>(this, onEvent));
     }
 
     /**
@@ -2928,8 +2945,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doOnSubscribe(Consumer<? super Disposable> onSubscribe) {
-        return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
+    public final Maybe<T> doOnSubscribe(@NonNull Consumer<? super Disposable> onSubscribe) {
+        return RxJavaPlugins.onAssembly(new MaybePeek<>(this,
                 Objects.requireNonNull(onSubscribe, "onSubscribe is null"),
                 Functions.emptyConsumer(), // onSuccess
                 Functions.emptyConsumer(), // onError
@@ -2961,9 +2978,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doOnTerminate(final Action onTerminate) {
+    public final Maybe<T> doOnTerminate(@NonNull Action onTerminate) {
         Objects.requireNonNull(onTerminate, "onTerminate is null");
-        return RxJavaPlugins.onAssembly(new MaybeDoOnTerminate<T>(this, onTerminate));
+        return RxJavaPlugins.onAssembly(new MaybeDoOnTerminate<>(this, onTerminate));
     }
 
     /**
@@ -2981,8 +2998,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> doOnSuccess(Consumer<? super T> onSuccess) {
-        return RxJavaPlugins.onAssembly(new MaybePeek<T>(this,
+    public final Maybe<T> doOnSuccess(@NonNull Consumer<? super T> onSuccess) {
+        return RxJavaPlugins.onAssembly(new MaybePeek<>(this,
                 Functions.emptyConsumer(), // onSubscribe
                 Objects.requireNonNull(onSuccess, "onSuccess is null"),
                 Functions.emptyConsumer(), // onError
@@ -3012,9 +3029,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> filter(Predicate<? super T> predicate) {
+    public final Maybe<T> filter(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new MaybeFilter<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new MaybeFilter<>(this, predicate));
     }
 
     /**
@@ -3037,9 +3054,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> flatMap(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    public final <R> Maybe<R> flatMap(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatten<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatten<>(this, mapper));
     }
 
     /**
@@ -3067,13 +3084,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> flatMap(
-            Function<? super T, ? extends MaybeSource<? extends R>> onSuccessMapper,
-            Function<? super Throwable, ? extends MaybeSource<? extends R>> onErrorMapper,
-            Supplier<? extends MaybeSource<? extends R>> onCompleteSupplier) {
+            @NonNull Function<? super T, ? extends MaybeSource<? extends R>> onSuccessMapper,
+            @NonNull Function<? super Throwable, ? extends MaybeSource<? extends R>> onErrorMapper,
+            @NonNull Supplier<? extends MaybeSource<? extends R>> onCompleteSupplier) {
         Objects.requireNonNull(onSuccessMapper, "onSuccessMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapNotification<T, R>(this, onSuccessMapper, onErrorMapper, onCompleteSupplier));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapNotification<>(this, onSuccessMapper, onErrorMapper, onCompleteSupplier));
     }
 
     /**
@@ -3101,11 +3118,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Maybe<R> flatMap(Function<? super T, ? extends MaybeSource<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+    public final <U, R> Maybe<R> flatMap(@NonNull Function<? super T, ? extends MaybeSource<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> resultSelector) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(resultSelector, "resultSelector is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapBiSelector<T, U, R>(this, mapper, resultSelector));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapBiSelector<>(this, mapper, resultSelector));
     }
 
     /**
@@ -3132,9 +3149,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> flattenAsFlowable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    public final <U> Flowable<U> flattenAsFlowable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapIterableFlowable<T, U>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapIterableFlowable<>(this, mapper));
     }
 
     /**
@@ -3158,9 +3175,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<U> flattenAsObservable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    public final <U> Observable<U> flattenAsObservable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapIterableObservable<T, U>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapIterableObservable<>(this, mapper));
     }
 
     /**
@@ -3182,9 +3199,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMapObservable(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+    public final <R> Observable<R> flatMapObservable(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapObservable<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapObservable<>(this, mapper));
     }
 
     /**
@@ -3210,9 +3227,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMapPublisher(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+    public final <R> Flowable<R> flatMapPublisher(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapPublisher<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapPublisher<>(this, mapper));
     }
 
     /**
@@ -3236,9 +3253,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> flatMapSingle(final Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    public final <R> Single<R> flatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapSingle<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapSingle<>(this, mapper));
     }
 
     /**
@@ -3264,9 +3281,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> flatMapSingleElement(final Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    public final <R> Maybe<R> flatMapSingleElement(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapSingleElement<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapSingleElement<>(this, mapper));
     }
 
     /**
@@ -3288,9 +3305,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable flatMapCompletable(final Function<? super T, ? extends CompletableSource> mapper) {
+    public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapCompletable<T>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapCompletable<>(this, mapper));
     }
 
     /**
@@ -3307,8 +3324,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> hide() {
-        return RxJavaPlugins.onAssembly(new MaybeHide<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeHide<>(this));
     }
 
     /**
@@ -3326,8 +3344,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable ignoreElement() {
-        return RxJavaPlugins.onAssembly(new MaybeIgnoreElementCompletable<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeIgnoreElementCompletable<>(this));
     }
 
     /**
@@ -3344,8 +3363,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<Boolean> isEmpty() {
-        return RxJavaPlugins.onAssembly(new MaybeIsEmptySingle<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeIsEmptySingle<>(this));
     }
 
     /**
@@ -3500,7 +3520,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> lift(final MaybeOperator<? extends R, ? super T> lift) {
+    public final <R> Maybe<R> lift(@NonNull MaybeOperator<? extends R, ? super T> lift) {
         Objects.requireNonNull(lift, "lift is null");
         return RxJavaPlugins.onAssembly(new MaybeLift<T, R>(this, lift));
     }
@@ -3524,7 +3544,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> map(Function<? super T, ? extends R> mapper) {
+    public final <R> Maybe<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new MaybeMap<T, R>(this, mapper));
     }
@@ -3545,8 +3565,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<Notification<T>> materialize() {
-        return RxJavaPlugins.onAssembly(new MaybeMaterialize<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeMaterialize<>(this));
     }
 
     /**
@@ -3572,7 +3593,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> mergeWith(MaybeSource<? extends T> other) {
+    public final Flowable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return merge(this, other);
     }
@@ -3598,9 +3619,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Maybe<T> observeOn(final Scheduler scheduler) {
+    public final Maybe<T> observeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new MaybeObserveOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new MaybeObserveOn<>(this, scheduler));
     }
 
     /**
@@ -3622,7 +3643,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<U> ofType(final Class<U> clazz) {
+    public final <U> Maybe<U> ofType(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
         return filter(Functions.isInstanceOf(clazz)).cast(clazz);
     }
@@ -3663,11 +3684,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> toFlowable() {
         if (this instanceof FuseToFlowable) {
             return ((FuseToFlowable<T>)this).fuseToFlowable();
         }
-        return RxJavaPlugins.onAssembly(new MaybeToFlowable<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeToFlowable<>(this));
     }
 
     /**
@@ -3682,11 +3704,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> toObservable() {
         if (this instanceof FuseToObservable) {
             return ((FuseToObservable<T>)this).fuseToObservable();
         }
-        return RxJavaPlugins.onAssembly(new MaybeToObservable<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeToObservable<>(this));
     }
 
     /**
@@ -3700,8 +3723,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> toSingle() {
-        return RxJavaPlugins.onAssembly(new MaybeToSingle<T>(this, null));
+        return RxJavaPlugins.onAssembly(new MaybeToSingle<>(this, null));
     }
 
     /**
@@ -3715,6 +3739,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> onErrorComplete() {
         return onErrorComplete(Functions.alwaysTrue());
     }
@@ -3733,10 +3758,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorComplete(final Predicate<? super Throwable> predicate) {
+    public final Maybe<T> onErrorComplete(@NonNull Predicate<? super Throwable> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
 
-        return RxJavaPlugins.onAssembly(new MaybeOnErrorComplete<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorComplete<>(this, predicate));
     }
 
     /**
@@ -3761,7 +3786,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorResumeWith(final MaybeSource<? extends T> next) {
+    public final Maybe<T> onErrorResumeWith(@NonNull MaybeSource<? extends T> next) {
         Objects.requireNonNull(next, "next is null");
         return onErrorResumeNext(Functions.justFunction(next));
     }
@@ -3788,9 +3813,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorResumeNext(Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction) {
+    public final Maybe<T> onErrorResumeNext(@NonNull Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction) {
         Objects.requireNonNull(resumeFunction, "resumeFunction is null");
-        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<T>(this, resumeFunction, true));
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<>(this, resumeFunction, true));
     }
 
     /**
@@ -3815,9 +3840,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
+    public final Maybe<T> onErrorReturn(@NonNull Function<? super Throwable, ? extends T> valueSupplier) {
         Objects.requireNonNull(valueSupplier, "valueSupplier is null");
-        return RxJavaPlugins.onAssembly(new MaybeOnErrorReturn<T>(this, valueSupplier));
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorReturn<>(this, valueSupplier));
     }
 
     /**
@@ -3841,7 +3866,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorReturnItem(final T item) {
+    public final Maybe<T> onErrorReturnItem(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return onErrorReturn(Functions.justFunction(item));
     }
@@ -3871,9 +3896,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onExceptionResumeNext(final MaybeSource<? extends T> next) {
+    public final Maybe<T> onExceptionResumeNext(@NonNull MaybeSource<? extends T> next) {
         Objects.requireNonNull(next, "next is null");
-        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<T>(this, Functions.justFunction(next), false));
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<>(this, Functions.justFunction(next), false));
     }
 
     /**
@@ -3890,8 +3915,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> onTerminateDetach() {
-        return RxJavaPlugins.onAssembly(new MaybeDetach<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeDetach<>(this));
     }
 
     /**
@@ -3911,6 +3937,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> repeat() {
         return repeat(Long.MAX_VALUE);
     }
@@ -3939,6 +3966,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> repeat(long times) {
         return toFlowable().repeat(times);
     }
@@ -3966,7 +3994,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> repeatUntil(BooleanSupplier stop) {
+    @NonNull
+    public final Flowable<T> repeatUntil(@NonNull BooleanSupplier stop) {
         return toFlowable().repeatUntil(stop);
     }
 
@@ -3995,7 +4024,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> repeatWhen(final Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
+    @NonNull
+    public final Flowable<T> repeatWhen(@NonNull Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
         return toFlowable().repeatWhen(handler);
     }
 
@@ -4017,6 +4047,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> retry() {
         return retry(Long.MAX_VALUE, Functions.alwaysTrue());
     }
@@ -4040,7 +4071,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
+    @NonNull
+    public final Maybe<T> retry(@NonNull BiPredicate<? super Integer, ? super Throwable> predicate) {
         return toFlowable().retry(predicate).singleElement();
     }
 
@@ -4065,6 +4097,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> retry(long count) {
         return retry(count, Functions.alwaysTrue());
     }
@@ -4082,7 +4115,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> retry(long times, Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Maybe<T> retry(long times, @NonNull Predicate<? super Throwable> predicate) {
         return toFlowable().retry(times, predicate).singleElement();
     }
 
@@ -4098,7 +4132,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> retry(Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Maybe<T> retry(@NonNull Predicate<? super Throwable> predicate) {
         return retry(Long.MAX_VALUE, predicate);
     }
 
@@ -4114,7 +4149,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> retryUntil(final BooleanSupplier stop) {
+    public final Maybe<T> retryUntil(@NonNull BooleanSupplier stop) {
         Objects.requireNonNull(stop, "stop is null");
         return retry(Long.MAX_VALUE, Functions.predicateReverseFor(stop));
     }
@@ -4194,8 +4229,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> retryWhen(
-            final Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
+            @NonNull Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         return toFlowable().retryWhen(handler).singleElement();
     }
 
@@ -4215,6 +4251,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Disposable subscribe() {
         return subscribe(Functions.emptyConsumer(), Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
@@ -4240,7 +4277,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onSuccess) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onSuccess) {
         return subscribe(onSuccess, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
 
@@ -4266,7 +4304,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onSuccess, Consumer<? super Throwable> onError) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onSuccess, @NonNull Consumer<? super Throwable> onError) {
         return subscribe(onSuccess, onError, Functions.EMPTY_ACTION);
     }
 
@@ -4297,8 +4336,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onSuccess, Consumer<? super Throwable> onError,
-            Action onComplete) {
+    public final Disposable subscribe(@NonNull Consumer<? super T> onSuccess, @NonNull Consumer<? super Throwable> onError,
+            @NonNull Action onComplete) {
         Objects.requireNonNull(onSuccess, "onSuccess is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
@@ -4307,7 +4346,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
-    public final void subscribe(MaybeObserver<? super T> observer) {
+    public final void subscribe(@NonNull MaybeObserver<? super T> observer) {
         Objects.requireNonNull(observer, "observer is null");
 
         observer = RxJavaPlugins.onSubscribe(this, observer);
@@ -4333,7 +4372,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * applied by {@link #subscribe(MaybeObserver)} before this method gets called.
      * @param observer the MaybeObserver to handle, not null
      */
-    protected abstract void subscribeActual(MaybeObserver<? super T> observer);
+    protected abstract void subscribeActual(@NonNull MaybeObserver<? super T> observer);
 
     /**
      * Asynchronously subscribes subscribers to this Maybe on the specified {@link Scheduler}.
@@ -4354,9 +4393,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Maybe<T> subscribeOn(Scheduler scheduler) {
+    public final Maybe<T> subscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new MaybeSubscribeOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new MaybeSubscribeOn<>(this, scheduler));
     }
 
     /**
@@ -4384,7 +4423,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <E extends MaybeObserver<? super T>> E subscribeWith(E observer) {
+    @NonNull
+    public final <@NonNull E extends MaybeObserver<? super T>> E subscribeWith(E observer) {
         subscribe(observer);
         return observer;
     }
@@ -4407,9 +4447,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> switchIfEmpty(MaybeSource<? extends T> other) {
+    public final Maybe<T> switchIfEmpty(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new MaybeSwitchIfEmpty<T>(this, other));
+        return RxJavaPlugins.onAssembly(new MaybeSwitchIfEmpty<>(this, other));
     }
 
     /**
@@ -4431,9 +4471,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> switchIfEmpty(SingleSource<? extends T> other) {
+    public final Single<T> switchIfEmpty(@NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new MaybeSwitchIfEmptySingle<T>(this, other));
+        return RxJavaPlugins.onAssembly(new MaybeSwitchIfEmptySingle<>(this, other));
     }
 
     /**
@@ -4457,9 +4497,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<T> takeUntil(MaybeSource<U> other) {
+    public final <U> Maybe<T> takeUntil(@NonNull MaybeSource<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new MaybeTakeUntilMaybe<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new MaybeTakeUntilMaybe<>(this, other));
     }
 
     /**
@@ -4487,9 +4527,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<T> takeUntil(Publisher<U> other) {
+    public final <U> Maybe<T> takeUntil(@NonNull Publisher<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new MaybeTakeUntilPublisher<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new MaybeTakeUntilPublisher<>(this, other));
     }
 
     /**
@@ -4512,7 +4552,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Maybe<T> timeout(long timeout, TimeUnit timeUnit) {
+    @NonNull
+    public final Maybe<T> timeout(long timeout, @NonNull TimeUnit timeUnit) {
         return timeout(timeout, timeUnit, Schedulers.computation());
     }
 
@@ -4539,7 +4580,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Maybe<T> timeout(long timeout, TimeUnit timeUnit, MaybeSource<? extends T> fallback) {
+    public final Maybe<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull MaybeSource<? extends T> fallback) {
         Objects.requireNonNull(fallback, "fallback is null");
         return timeout(timeout, timeUnit, Schedulers.computation(), fallback);
     }
@@ -4570,7 +4611,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Maybe<T> timeout(long timeout, TimeUnit timeUnit, Scheduler scheduler, MaybeSource<? extends T> fallback) {
+    public final Maybe<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull Scheduler scheduler, @NonNull MaybeSource<? extends T> fallback) {
         Objects.requireNonNull(fallback, "fallback is null");
         return timeout(timer(timeout, timeUnit, scheduler), fallback);
     }
@@ -4598,7 +4639,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Maybe<T> timeout(long timeout, TimeUnit timeUnit, Scheduler scheduler) {
+    @NonNull
+    public final Maybe<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull Scheduler scheduler) {
         return timeout(timer(timeout, timeUnit, scheduler));
     }
 
@@ -4617,9 +4659,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<T> timeout(MaybeSource<U> timeoutIndicator) {
+    public final <U> Maybe<T> timeout(@NonNull MaybeSource<U> timeoutIndicator) {
         Objects.requireNonNull(timeoutIndicator, "timeoutIndicator is null");
-        return RxJavaPlugins.onAssembly(new MaybeTimeoutMaybe<T, U>(this, timeoutIndicator, null));
+        return RxJavaPlugins.onAssembly(new MaybeTimeoutMaybe<>(this, timeoutIndicator, null));
     }
 
     /**
@@ -4639,10 +4681,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<T> timeout(MaybeSource<U> timeoutIndicator, MaybeSource<? extends T> fallback) {
+    public final <U> Maybe<T> timeout(@NonNull MaybeSource<U> timeoutIndicator, @NonNull MaybeSource<? extends T> fallback) {
         Objects.requireNonNull(timeoutIndicator, "timeoutIndicator is null");
         Objects.requireNonNull(fallback, "fallback is null");
-        return RxJavaPlugins.onAssembly(new MaybeTimeoutMaybe<T, U>(this, timeoutIndicator, fallback));
+        return RxJavaPlugins.onAssembly(new MaybeTimeoutMaybe<>(this, timeoutIndicator, fallback));
     }
 
     /**
@@ -4664,9 +4706,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<T> timeout(Publisher<U> timeoutIndicator) {
+    public final <U> Maybe<T> timeout(@NonNull Publisher<U> timeoutIndicator) {
         Objects.requireNonNull(timeoutIndicator, "timeoutIndicator is null");
-        return RxJavaPlugins.onAssembly(new MaybeTimeoutPublisher<T, U>(this, timeoutIndicator, null));
+        return RxJavaPlugins.onAssembly(new MaybeTimeoutPublisher<>(this, timeoutIndicator, null));
     }
 
     /**
@@ -4690,10 +4732,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Maybe<T> timeout(Publisher<U> timeoutIndicator, MaybeSource<? extends T> fallback) {
+    public final <U> Maybe<T> timeout(@NonNull Publisher<U> timeoutIndicator, @NonNull MaybeSource<? extends T> fallback) {
         Objects.requireNonNull(timeoutIndicator, "timeoutIndicator is null");
         Objects.requireNonNull(fallback, "fallback is null");
-        return RxJavaPlugins.onAssembly(new MaybeTimeoutPublisher<T, U>(this, timeoutIndicator, fallback));
+        return RxJavaPlugins.onAssembly(new MaybeTimeoutPublisher<>(this, timeoutIndicator, fallback));
     }
 
     /**
@@ -4712,9 +4754,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Maybe<T> unsubscribeOn(final Scheduler scheduler) {
+    public final Maybe<T> unsubscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new MaybeUnsubscribeOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new MaybeUnsubscribeOn<>(this, scheduler));
     }
 
     /**
@@ -4746,7 +4788,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Maybe<R> zipWith(MaybeSource<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
+    public final <U, R> Maybe<R> zipWith(@NonNull MaybeSource<? extends U> other, @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
@@ -4766,8 +4808,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestObserver<T> test() {
-        TestObserver<T> to = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<>();
         subscribe(to);
         return to;
     }
@@ -4784,8 +4827,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestObserver<T> test(boolean dispose) {
-        TestObserver<T> to = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<>();
 
         if (dispose) {
             to.dispose();

--- a/src/main/java/io/reactivex/rxjava3/core/Notification.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Notification.java
@@ -27,7 +27,7 @@ public final class Notification<T> {
     final Object value;
 
     /** Not meant to be implemented externally. */
-    private Notification(Object value) {
+    private Notification(@Nullable Object value) {
         this.value = value;
     }
 

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -120,7 +120,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> amb(Iterable<? extends ObservableSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new ObservableAmb<T>(null, sources));
+        return RxJavaPlugins.onAssembly(new ObservableAmb<>(null, sources));
     }
 
     /**
@@ -145,6 +145,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T> Observable<T> ambArray(ObservableSource<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         int len = sources.length;
@@ -154,7 +155,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (len == 1) {
             return (Observable<T>)wrap(sources[0]);
         }
-        return RxJavaPlugins.onAssembly(new ObservableAmb<T>(sources, null));
+        return RxJavaPlugins.onAssembly(new ObservableAmb<>(sources, null));
     }
 
     /**
@@ -1243,6 +1244,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T> Observable<T> concatArrayEager(ObservableSource<? extends T>... sources) {
         return concatArrayEager(bufferSize(), bufferSize(), sources);
     }
@@ -1294,6 +1296,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T> Observable<T> concatArrayEagerDelayError(ObservableSource<? extends T>... sources) {
         return concatArrayEagerDelayError(bufferSize(), bufferSize(), sources);
     }
@@ -1550,7 +1553,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> create(ObservableOnSubscribe<T> source) {
         Objects.requireNonNull(source, "source is null");
-        return RxJavaPlugins.onAssembly(new ObservableCreate<T>(source));
+        return RxJavaPlugins.onAssembly(new ObservableCreate<>(source));
     }
 
     /**
@@ -1582,7 +1585,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> defer(Supplier<? extends ObservableSource<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableDefer<T>(supplier));
+        return RxJavaPlugins.onAssembly(new ObservableDefer<>(supplier));
     }
 
     /**
@@ -1679,6 +1682,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
+    @SafeVarargs
     public static <T> Observable<T> fromArray(T... items) {
         Objects.requireNonNull(items, "items is null");
         if (items.length == 0) {
@@ -1687,7 +1691,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (items.length == 1) {
             return just(items[0]);
         }
-        return RxJavaPlugins.onAssembly(new ObservableFromArray<T>(items));
+        return RxJavaPlugins.onAssembly(new ObservableFromArray<>(items));
     }
 
     /**
@@ -2138,7 +2142,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(initialState, "initialState is null");
         Objects.requireNonNull(generator, "generator is null");
         Objects.requireNonNull(disposeState, "disposeState is null");
-        return RxJavaPlugins.onAssembly(new ObservableGenerate<T, S>(initialState, generator, disposeState));
+        return RxJavaPlugins.onAssembly(new ObservableGenerate<>(initialState, generator, disposeState));
     }
 
     /**
@@ -2343,7 +2347,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> just(T item) {
         Objects.requireNonNull(item, "item is null");
-        return RxJavaPlugins.onAssembly(new ObservableJust<T>(item));
+        return RxJavaPlugins.onAssembly(new ObservableJust<>(item));
     }
 
     /**
@@ -2364,7 +2368,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2395,7 +2398,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2429,7 +2431,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2466,7 +2467,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2506,7 +2506,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2549,7 +2548,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2595,7 +2593,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2644,7 +2641,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2696,7 +2692,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits each item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3713,7 +3708,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(isEqual, "isEqual is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableSequenceEqualSingle<T>(source1, source2, isEqual, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableSequenceEqualSingle<>(source1, source2, isEqual, bufferSize));
     }
 
     /**
@@ -3955,7 +3950,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (onSubscribe instanceof Observable) {
             throw new IllegalArgumentException("unsafeCreate(Observable) should be upgraded");
         }
-        return RxJavaPlugins.onAssembly(new ObservableFromUnsafeSource<T>(onSubscribe));
+        return RxJavaPlugins.onAssembly(new ObservableFromUnsafeSource<>(onSubscribe));
     }
 
     /**
@@ -4044,7 +4039,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (source instanceof Observable) {
             return RxJavaPlugins.onAssembly((Observable<T>)source);
         }
-        return RxJavaPlugins.onAssembly(new ObservableFromUnsafeSource<T>(source));
+        return RxJavaPlugins.onAssembly(new ObservableFromUnsafeSource<>(source));
     }
 
     /**
@@ -4205,7 +4200,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, R> Observable<R> zip(
@@ -4261,7 +4255,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, R> Observable<R> zip(
@@ -4318,7 +4311,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, R> Observable<R> zip(
@@ -4377,7 +4369,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, R> Observable<R> zip(
@@ -4440,7 +4431,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, R> Observable<R> zip(
@@ -4508,7 +4498,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, R> Observable<R> zip(
@@ -4579,7 +4568,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> zip(
@@ -4654,7 +4642,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> zip(
@@ -4734,7 +4721,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> zip(
@@ -4818,7 +4804,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return an Observable that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> zip(
@@ -4890,6 +4875,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @SafeVarargs
     public static <T, R> Observable<R> zipArray(Function<? super Object[], ? extends R> zipper,
             boolean delayError, int bufferSize, ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
@@ -4924,7 +4910,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<Boolean> all(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableAllSingle<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableAllSingle<>(this, predicate));
     }
 
     /**
@@ -4944,7 +4930,6 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         emitted an item or sent a termination notification
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX operators documentation: Amb</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> ambWith(ObservableSource<? extends T> other) {
@@ -4976,7 +4961,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<Boolean> any(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableAnySingle<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableAnySingle<>(this, predicate));
     }
 
     /**
@@ -4997,7 +4982,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingFirst() {
-        BlockingFirstObserver<T> observer = new BlockingFirstObserver<T>();
+        BlockingFirstObserver<T> observer = new BlockingFirstObserver<>();
         subscribe(observer);
         T v = observer.blockingGet();
         if (v != null) {
@@ -5025,7 +5010,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingFirst(T defaultItem) {
-        BlockingFirstObserver<T> observer = new BlockingFirstObserver<T>();
+        BlockingFirstObserver<T> observer = new BlockingFirstObserver<>();
         subscribe(observer);
         T v = observer.blockingGet();
         return v != null ? v : defaultItem;
@@ -5109,7 +5094,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingIterable(int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return new BlockingObservableIterable<T>(this, bufferSize);
+        return new BlockingObservableIterable<>(this, bufferSize);
     }
 
     /**
@@ -5134,7 +5119,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingLast() {
-        BlockingLastObserver<T> observer = new BlockingLastObserver<T>();
+        BlockingLastObserver<T> observer = new BlockingLastObserver<>();
         subscribe(observer);
         T v = observer.blockingGet();
         if (v != null) {
@@ -5166,7 +5151,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final T blockingLast(T defaultItem) {
-        BlockingLastObserver<T> observer = new BlockingLastObserver<T>();
+        BlockingLastObserver<T> observer = new BlockingLastObserver<>();
         subscribe(observer);
         T v = observer.blockingGet();
         return v != null ? v : defaultItem;
@@ -5194,7 +5179,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingLatest() {
-        return new BlockingObservableLatest<T>(this);
+        return new BlockingObservableLatest<>(this);
     }
 
     /**
@@ -5217,7 +5202,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingMostRecent(T initialValue) {
-        return new BlockingObservableMostRecent<T>(this, initialValue);
+        return new BlockingObservableMostRecent<>(this, initialValue);
     }
 
     /**
@@ -5237,7 +5222,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Iterable<T> blockingNext() {
-        return new BlockingObservableNext<T>(this);
+        return new BlockingObservableNext<>(this);
     }
 
     /**
@@ -5521,7 +5506,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.verifyPositive(count, "count");
         ObjectHelper.verifyPositive(skip, "skip");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableBuffer<T, U>(this, count, skip, bufferSupplier));
+        return RxJavaPlugins.onAssembly(new ObservableBuffer<>(this, count, skip, bufferSupplier));
     }
 
     /**
@@ -5653,7 +5638,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableBufferTimed<T, U>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false));
+        return RxJavaPlugins.onAssembly(new ObservableBufferTimed<>(this, timespan, timeskip, unit, scheduler, bufferSupplier, Integer.MAX_VALUE, false));
     }
 
     /**
@@ -5799,7 +5784,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         ObjectHelper.verifyPositive(count, "count");
-        return RxJavaPlugins.onAssembly(new ObservableBufferTimed<T, U>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize));
+        return RxJavaPlugins.onAssembly(new ObservableBufferTimed<>(this, timespan, timespan, unit, scheduler, bufferSupplier, count, restartTimerOnMaxSize));
     }
 
     /**
@@ -6001,7 +5986,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <B, U extends Collection<? super T>> Observable<U> buffer(ObservableSource<B> boundary, Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundary, "boundary is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableBufferExactBoundary<T, U, B>(this, boundary, bufferSupplier));
+        return RxJavaPlugins.onAssembly(new ObservableBufferExactBoundary<>(this, boundary, bufferSupplier));
     }
 
     /**
@@ -6114,7 +6099,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> cacheWithInitialCapacity(int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
-        return RxJavaPlugins.onAssembly(new ObservableCache<T>(this, initialCapacity));
+        return RxJavaPlugins.onAssembly(new ObservableCache<>(this, initialCapacity));
     }
 
     /**
@@ -6304,7 +6289,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new ObservableConcatMap<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMap<>(this, mapper, prefetch, ErrorMode.IMMEDIATE));
     }
 
     /**
@@ -6339,7 +6324,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapScheduler<T, R>(this, mapper, prefetch, ErrorMode.IMMEDIATE, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapScheduler<>(this, mapper, prefetch, ErrorMode.IMMEDIATE, scheduler));
     }
 
     /**
@@ -6409,7 +6394,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new ObservableConcatMap<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMap<>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
     }
 
     /**
@@ -6444,7 +6429,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapScheduler<T, R>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapScheduler<>(this, mapper, prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, scheduler));
     }
 
     /**
@@ -6500,7 +6485,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<T, R>(this, mapper, ErrorMode.IMMEDIATE, maxConcurrency, prefetch));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<>(this, mapper, ErrorMode.IMMEDIATE, maxConcurrency, prefetch));
     }
 
     /**
@@ -6565,7 +6550,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<T, R>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, maxConcurrency, prefetch));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, maxConcurrency, prefetch));
     }
 
     /**
@@ -6613,7 +6598,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int capacityHint) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<T>(this, mapper, ErrorMode.IMMEDIATE, capacityHint));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<>(this, mapper, ErrorMode.IMMEDIATE, capacityHint));
     }
 
     /**
@@ -6703,7 +6688,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<T>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
     }
 
     /**
@@ -6730,7 +6715,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<U> concatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlattenIterable<T, U>(this, mapper));
+        return RxJavaPlugins.onAssembly(new ObservableFlattenIterable<>(this, mapper));
     }
 
     /**
@@ -6818,7 +6803,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<T, R>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
     }
 
     /**
@@ -6913,7 +6898,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<T, R>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
     }
 
     /**
@@ -6971,7 +6956,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<T, R>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
     }
 
     /**
@@ -7066,7 +7051,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<T, R>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
     }
 
     /**
@@ -7110,7 +7095,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> concatWith(@NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableConcatWithSingle<T>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableConcatWithSingle<>(this, other));
     }
 
     /**
@@ -7131,7 +7116,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableConcatWithMaybe<T>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableConcatWithMaybe<>(this, other));
     }
 
     /**
@@ -7152,7 +7137,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> concatWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableConcatWithCompletable<T>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableConcatWithCompletable<>(this, other));
     }
 
     /**
@@ -7195,7 +7180,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<Long> count() {
-        return RxJavaPlugins.onAssembly(new ObservableCountSingle<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableCountSingle<>(this));
     }
 
     /**
@@ -7228,7 +7213,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> debounce(Function<? super T, ? extends ObservableSource<U>> debounceSelector) {
         Objects.requireNonNull(debounceSelector, "debounceSelector is null");
-        return RxJavaPlugins.onAssembly(new ObservableDebounce<T, U>(this, debounceSelector));
+        return RxJavaPlugins.onAssembly(new ObservableDebounce<>(this, debounceSelector));
     }
 
     /**
@@ -7308,7 +7293,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> debounce(long timeout, TimeUnit unit, Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableDebounceTimed<T>(this, timeout, unit, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableDebounceTimed<>(this, timeout, unit, scheduler));
     }
 
     /**
@@ -7466,7 +7451,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
 
-        return RxJavaPlugins.onAssembly(new ObservableDelay<T>(this, delay, unit, scheduler, delayError));
+        return RxJavaPlugins.onAssembly(new ObservableDelay<>(this, delay, unit, scheduler, delayError));
     }
 
     /**
@@ -7525,7 +7510,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> delaySubscription(ObservableSource<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableDelaySubscriptionOther<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableDelaySubscriptionOther<>(this, other));
     }
 
     /**
@@ -7627,7 +7612,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> dematerialize(Function<? super T, Notification<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
-        return RxJavaPlugins.onAssembly(new ObservableDematerialize<T, R>(this, selector));
+        return RxJavaPlugins.onAssembly(new ObservableDematerialize<>(this, selector));
     }
 
     /**
@@ -7737,7 +7722,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <K> Observable<T> distinct(Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableDistinct<T, K>(this, keySelector, collectionSupplier));
+        return RxJavaPlugins.onAssembly(new ObservableDistinct<>(this, keySelector, collectionSupplier));
     }
 
     /**
@@ -7817,7 +7802,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Observable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
-        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<T, K>(this, keySelector, ObjectHelper.equalsPredicate()));
+        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<>(this, keySelector, ObjectHelper.equalsPredicate()));
     }
 
     /**
@@ -7851,7 +7836,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
         Objects.requireNonNull(comparer, "comparer is null");
-        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<T, T>(this, Functions.<T>identity(), comparer));
+        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<>(this, Functions.<T>identity(), comparer));
     }
 
     /**
@@ -7875,7 +7860,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> doAfterNext(Consumer<? super T> onAfterNext) {
         Objects.requireNonNull(onAfterNext, "onAfterNext is null");
-        return RxJavaPlugins.onAssembly(new ObservableDoAfterNext<T>(this, onAfterNext));
+        return RxJavaPlugins.onAssembly(new ObservableDoAfterNext<>(this, onAfterNext));
     }
 
     /**
@@ -7926,7 +7911,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> doFinally(Action onFinally) {
         Objects.requireNonNull(onFinally, "onFinally is null");
-        return RxJavaPlugins.onAssembly(new ObservableDoFinally<T>(this, onFinally));
+        return RxJavaPlugins.onAssembly(new ObservableDoFinally<>(this, onFinally));
     }
 
     /**
@@ -7996,7 +7981,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
         Objects.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
-        return RxJavaPlugins.onAssembly(new ObservableDoOnEach<T>(this, onNext, onError, onComplete, onAfterTerminate));
+        return RxJavaPlugins.onAssembly(new ObservableDoOnEach<>(this, onNext, onError, onComplete, onAfterTerminate));
     }
 
     /**
@@ -8101,7 +8086,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> doOnLifecycle(final Consumer<? super Disposable> onSubscribe, final Action onDispose) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         Objects.requireNonNull(onDispose, "onDispose is null");
-        return RxJavaPlugins.onAssembly(new ObservableDoOnLifecycle<T>(this, onSubscribe, onDispose));
+        return RxJavaPlugins.onAssembly(new ObservableDoOnLifecycle<>(this, onSubscribe, onDispose));
     }
 
     /**
@@ -8199,7 +8184,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
-        return RxJavaPlugins.onAssembly(new ObservableElementAtMaybe<T>(this, index));
+        return RxJavaPlugins.onAssembly(new ObservableElementAtMaybe<>(this, index));
     }
 
     /**
@@ -8229,7 +8214,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
         Objects.requireNonNull(defaultItem, "defaultItem is null");
-        return RxJavaPlugins.onAssembly(new ObservableElementAtSingle<T>(this, index, defaultItem));
+        return RxJavaPlugins.onAssembly(new ObservableElementAtSingle<>(this, index, defaultItem));
     }
 
     /**
@@ -8256,7 +8241,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
-        return RxJavaPlugins.onAssembly(new ObservableElementAtSingle<T>(this, index, null));
+        return RxJavaPlugins.onAssembly(new ObservableElementAtSingle<>(this, index, null));
     }
 
     /**
@@ -8279,7 +8264,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableFilter<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableFilter<>(this, predicate));
     }
 
     /**
@@ -8473,7 +8458,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new ObservableFlatMap<T, R>(this, mapper, delayErrors, maxConcurrency, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableFlatMap<>(this, mapper, delayErrors, maxConcurrency, bufferSize));
     }
 
     /**
@@ -8509,7 +8494,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
-        return merge(new ObservableMapNotification<T, R>(this, onNextMapper, onErrorMapper, onCompleteSupplier));
+        return merge(new ObservableMapNotification<>(this, onNextMapper, onErrorMapper, onCompleteSupplier));
     }
 
     /**
@@ -8550,7 +8535,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
-        return merge(new ObservableMapNotification<T, R>(this, onNextMapper, onErrorMapper, onCompleteSupplier), maxConcurrency);
+        return merge(new ObservableMapNotification<>(this, onNextMapper, onErrorMapper, onCompleteSupplier), maxConcurrency);
     }
 
     /**
@@ -8794,7 +8779,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable flatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMapCompletableCompletable<T>(this, mapper, delayErrors));
+        return RxJavaPlugins.onAssembly(new ObservableFlatMapCompletableCompletable<>(this, mapper, delayErrors));
     }
 
     /**
@@ -8820,7 +8805,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<U> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlattenIterable<T, U>(this, mapper));
+        return RxJavaPlugins.onAssembly(new ObservableFlattenIterable<>(this, mapper));
     }
 
     /**
@@ -8895,7 +8880,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayErrors) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMapMaybe<T, R>(this, mapper, delayErrors));
+        return RxJavaPlugins.onAssembly(new ObservableFlatMapMaybe<>(this, mapper, delayErrors));
     }
 
     /**
@@ -8937,7 +8922,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> flatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean delayErrors) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMapSingle<T, R>(this, mapper, delayErrors));
+        return RxJavaPlugins.onAssembly(new ObservableFlatMapSingle<>(this, mapper, delayErrors));
     }
 
     /**
@@ -9048,7 +9033,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
 
-        ForEachWhileObserver<T> o = new ForEachWhileObserver<T>(onNext, onError, onComplete);
+        ForEachWhileObserver<T> o = new ForEachWhileObserver<>(onNext, onError, onComplete);
         subscribe(o);
         return o;
     }
@@ -9346,7 +9331,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> hide() {
-        return RxJavaPlugins.onAssembly(new ObservableHide<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableHide<>(this));
     }
 
     /**
@@ -9364,7 +9349,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable ignoreElements() {
-        return RxJavaPlugins.onAssembly(new ObservableIgnoreElementsCompletable<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableIgnoreElementsCompletable<>(this));
     }
 
     /**
@@ -9452,7 +9437,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> lastElement() {
-        return RxJavaPlugins.onAssembly(new ObservableLastMaybe<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableLastMaybe<>(this));
     }
 
     /**
@@ -9475,7 +9460,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> last(T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem is null");
-        return RxJavaPlugins.onAssembly(new ObservableLastSingle<T>(this, defaultItem));
+        return RxJavaPlugins.onAssembly(new ObservableLastSingle<>(this, defaultItem));
     }
 
     /**
@@ -9495,7 +9480,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> lastOrError() {
-        return RxJavaPlugins.onAssembly(new ObservableLastSingle<T>(this, null));
+        return RxJavaPlugins.onAssembly(new ObservableLastSingle<>(this, null));
     }
 
     /**
@@ -9689,7 +9674,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<Notification<T>> materialize() {
-        return RxJavaPlugins.onAssembly(new ObservableMaterialize<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableMaterialize<>(this));
     }
 
     /**
@@ -9736,7 +9721,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> mergeWith(@NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableMergeWithSingle<T>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableMergeWithSingle<>(this, other));
     }
 
     /**
@@ -9760,7 +9745,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableMergeWithMaybe<T>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableMergeWithMaybe<>(this, other));
     }
 
     /**
@@ -9781,7 +9766,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> mergeWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableMergeWithCompletable<T>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableMergeWithCompletable<>(this, other));
     }
 
     /**
@@ -9897,7 +9882,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableObserveOn<T>(this, scheduler, delayError, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableObserveOn<>(this, scheduler, delayError, bufferSize));
     }
 
     /**
@@ -9955,7 +9940,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onErrorResumeNext(Function<? super Throwable, ? extends ObservableSource<? extends T>> resumeFunction) {
         Objects.requireNonNull(resumeFunction, "resumeFunction is null");
-        return RxJavaPlugins.onAssembly(new ObservableOnErrorNext<T>(this, resumeFunction));
+        return RxJavaPlugins.onAssembly(new ObservableOnErrorNext<>(this, resumeFunction));
     }
 
     /**
@@ -10024,7 +10009,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
         Objects.requireNonNull(valueSupplier, "valueSupplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableOnErrorReturn<T>(this, valueSupplier));
+        return RxJavaPlugins.onAssembly(new ObservableOnErrorReturn<>(this, valueSupplier));
     }
 
     /**
@@ -10076,7 +10061,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> onTerminateDetach() {
-        return RxJavaPlugins.onAssembly(new ObservableDetach<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableDetach<>(this));
     }
 
     /**
@@ -10097,7 +10082,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final ConnectableObservable<T> publish() {
-        return RxJavaPlugins.onAssembly(new ObservablePublish<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservablePublish<>(this));
     }
 
     /**
@@ -10123,7 +10108,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
-        return RxJavaPlugins.onAssembly(new ObservablePublishSelector<T, R>(this, selector));
+        return RxJavaPlugins.onAssembly(new ObservablePublishSelector<>(this, selector));
     }
 
     /**
@@ -10158,7 +10143,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> reduce(BiFunction<T, T, T> reducer) {
         Objects.requireNonNull(reducer, "reducer is null");
-        return RxJavaPlugins.onAssembly(new ObservableReduceMaybe<T>(this, reducer));
+        return RxJavaPlugins.onAssembly(new ObservableReduceMaybe<>(this, reducer));
     }
 
     /**
@@ -10216,7 +10201,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Single<R> reduce(R seed, BiFunction<R, ? super T, R> reducer) {
         Objects.requireNonNull(seed, "seed is null");
         Objects.requireNonNull(reducer, "reducer is null");
-        return RxJavaPlugins.onAssembly(new ObservableReduceSeedSingle<T, R>(this, seed, reducer));
+        return RxJavaPlugins.onAssembly(new ObservableReduceSeedSingle<>(this, seed, reducer));
     }
 
     /**
@@ -10256,7 +10241,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Single<R> reduceWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
         Objects.requireNonNull(seedSupplier, "seedSupplier is null");
         Objects.requireNonNull(reducer, "reducer is null");
-        return RxJavaPlugins.onAssembly(new ObservableReduceWithSingle<T, R>(this, seedSupplier, reducer));
+        return RxJavaPlugins.onAssembly(new ObservableReduceWithSingle<>(this, seedSupplier, reducer));
     }
 
     /**
@@ -10305,7 +10290,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (times == 0) {
             return empty();
         }
-        return RxJavaPlugins.onAssembly(new ObservableRepeat<T>(this, times));
+        return RxJavaPlugins.onAssembly(new ObservableRepeat<>(this, times));
     }
 
     /**
@@ -10331,7 +10316,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> repeatUntil(BooleanSupplier stop) {
         Objects.requireNonNull(stop, "stop is null");
-        return RxJavaPlugins.onAssembly(new ObservableRepeatUntil<T>(this, stop));
+        return RxJavaPlugins.onAssembly(new ObservableRepeatUntil<>(this, stop));
     }
 
     /**
@@ -10357,7 +10342,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> repeatWhen(final Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
-        return RxJavaPlugins.onAssembly(new ObservableRepeatWhen<T>(this, handler));
+        return RxJavaPlugins.onAssembly(new ObservableRepeatWhen<>(this, handler));
     }
 
     /**
@@ -11048,7 +11033,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
 
-        return RxJavaPlugins.onAssembly(new ObservableRetryBiPredicate<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableRetryBiPredicate<>(this, predicate));
     }
 
     /**
@@ -11101,7 +11086,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         }
         Objects.requireNonNull(predicate, "predicate is null");
 
-        return RxJavaPlugins.onAssembly(new ObservableRetryPredicate<T>(this, times, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableRetryPredicate<>(this, times, predicate));
     }
 
     /**
@@ -11218,7 +11203,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> retryWhen(
             final Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
-        return RxJavaPlugins.onAssembly(new ObservableRetryWhen<T>(this, handler));
+        return RxJavaPlugins.onAssembly(new ObservableRetryWhen<>(this, handler));
     }
 
     /**
@@ -11325,7 +11310,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> sample(long period, TimeUnit unit, Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableSampleTimed<T>(this, period, unit, scheduler, false));
+        return RxJavaPlugins.onAssembly(new ObservableSampleTimed<>(this, period, unit, scheduler, false));
     }
 
     /**
@@ -11361,7 +11346,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> sample(long period, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableSampleTimed<T>(this, period, unit, scheduler, emitLast));
+        return RxJavaPlugins.onAssembly(new ObservableSampleTimed<>(this, period, unit, scheduler, emitLast));
     }
 
     /**
@@ -11386,7 +11371,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> sample(ObservableSource<U> sampler) {
         Objects.requireNonNull(sampler, "sampler is null");
-        return RxJavaPlugins.onAssembly(new ObservableSampleWithObservable<T>(this, sampler, false));
+        return RxJavaPlugins.onAssembly(new ObservableSampleWithObservable<>(this, sampler, false));
     }
 
     /**
@@ -11418,7 +11403,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> sample(ObservableSource<U> sampler, boolean emitLast) {
         Objects.requireNonNull(sampler, "sampler is null");
-        return RxJavaPlugins.onAssembly(new ObservableSampleWithObservable<T>(this, sampler, emitLast));
+        return RxJavaPlugins.onAssembly(new ObservableSampleWithObservable<>(this, sampler, emitLast));
     }
 
     /**
@@ -11446,7 +11431,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> scan(BiFunction<T, T, T> accumulator) {
         Objects.requireNonNull(accumulator, "accumulator is null");
-        return RxJavaPlugins.onAssembly(new ObservableScan<T>(this, accumulator));
+        return RxJavaPlugins.onAssembly(new ObservableScan<>(this, accumulator));
     }
 
     /**
@@ -11531,7 +11516,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> scanWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
         Objects.requireNonNull(seedSupplier, "seedSupplier is null");
         Objects.requireNonNull(accumulator, "accumulator is null");
-        return RxJavaPlugins.onAssembly(new ObservableScanSeed<T, R>(this, seedSupplier, accumulator));
+        return RxJavaPlugins.onAssembly(new ObservableScanSeed<>(this, seedSupplier, accumulator));
     }
 
     /**
@@ -11557,7 +11542,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> serialize() {
-        return RxJavaPlugins.onAssembly(new ObservableSerialized<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableSerialized<>(this));
     }
 
     /**
@@ -11599,7 +11584,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> singleElement() {
-        return RxJavaPlugins.onAssembly(new ObservableSingleMaybe<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableSingleMaybe<>(this));
     }
 
     /**
@@ -11622,7 +11607,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> single(T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem is null");
-        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<T>(this, defaultItem));
+        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<>(this, defaultItem));
     }
 
     /**
@@ -11643,7 +11628,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> singleOrError() {
-        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<T>(this, null));
+        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<>(this, null));
     }
 
     /**
@@ -11668,7 +11653,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count <= 0) {
             return RxJavaPlugins.onAssembly(this);
         }
-        return RxJavaPlugins.onAssembly(new ObservableSkip<T>(this, count));
+        return RxJavaPlugins.onAssembly(new ObservableSkip<>(this, count));
     }
 
     /**
@@ -11753,7 +11738,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count == 0) {
             return RxJavaPlugins.onAssembly(this);
         }
-        return RxJavaPlugins.onAssembly(new ObservableSkipLast<T>(this, count));
+        return RxJavaPlugins.onAssembly(new ObservableSkipLast<>(this, count));
     }
 
     /**
@@ -11907,7 +11892,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         // the internal buffer holds pairs of (timestamp, value) so double the default buffer size
         int s = bufferSize << 1;
-        return RxJavaPlugins.onAssembly(new ObservableSkipLastTimed<T>(this, time, unit, scheduler, s, delayError));
+        return RxJavaPlugins.onAssembly(new ObservableSkipLastTimed<>(this, time, unit, scheduler, s, delayError));
     }
 
     /**
@@ -11932,7 +11917,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> skipUntil(ObservableSource<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableSkipUntil<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableSkipUntil<>(this, other));
     }
 
     /**
@@ -11955,7 +11940,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> skipWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableSkipWhile<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableSkipWhile<>(this, predicate));
     }
 
     /**
@@ -12217,7 +12202,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
 
-        LambdaObserver<T> ls = new LambdaObserver<T>(onNext, onError, onComplete, Functions.emptyConsumer());
+        LambdaObserver<T> ls = new LambdaObserver<>(onNext, onError, onComplete, Functions.emptyConsumer());
 
         subscribe(ls);
 
@@ -12310,7 +12295,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> subscribeOn(Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableSubscribeOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableSubscribeOn<>(this, scheduler));
     }
 
     /**
@@ -12333,7 +12318,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> switchIfEmpty(ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchIfEmpty<T>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchIfEmpty<>(this, other));
     }
 
     /**
@@ -12401,7 +12386,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<T, R>(this, mapper, bufferSize, false));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<>(this, mapper, bufferSize, false));
     }
 
     /**
@@ -12442,7 +12427,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable switchMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<T>(this, mapper, false));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<>(this, mapper, false));
     }
 
     /**
@@ -12484,7 +12469,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Completable switchMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<T>(this, mapper, true));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<>(this, mapper, true));
     }
 
     /**
@@ -12520,7 +12505,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> switchMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<T, R>(this, mapper, false));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<>(this, mapper, false));
     }
 
     /**
@@ -12546,7 +12531,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Observable<R> switchMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<T, R>(this, mapper, true));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<>(this, mapper, true));
     }
 
     /**
@@ -12577,7 +12562,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final <R> Observable<R> switchMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapSingle<T, R>(this, mapper, false));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapSingle<>(this, mapper, false));
     }
 
     /**
@@ -12609,7 +12594,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final <R> Observable<R> switchMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapSingle<T, R>(this, mapper, true));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapSingle<>(this, mapper, true));
     }
 
     /**
@@ -12681,7 +12666,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<T, R>(this, mapper, bufferSize, true));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<>(this, mapper, bufferSize, true));
     }
 
     /**
@@ -12710,7 +12695,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
         }
-        return RxJavaPlugins.onAssembly(new ObservableTake<T>(this, count));
+        return RxJavaPlugins.onAssembly(new ObservableTake<>(this, count));
     }
 
     /**
@@ -12793,12 +12778,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
         }
         if (count == 0) {
-            return RxJavaPlugins.onAssembly(new ObservableIgnoreElements<T>(this));
+            return RxJavaPlugins.onAssembly(new ObservableIgnoreElements<>(this));
         }
         if (count == 1) {
-            return RxJavaPlugins.onAssembly(new ObservableTakeLastOne<T>(this));
+            return RxJavaPlugins.onAssembly(new ObservableTakeLastOne<>(this));
         }
-        return RxJavaPlugins.onAssembly(new ObservableTakeLast<T>(this, count));
+        return RxJavaPlugins.onAssembly(new ObservableTakeLast<>(this, count));
     }
 
     /**
@@ -12900,7 +12885,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
         }
-        return RxJavaPlugins.onAssembly(new ObservableTakeLastTimed<T>(this, count, time, unit, scheduler, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new ObservableTakeLastTimed<>(this, count, time, unit, scheduler, bufferSize, delayError));
     }
 
     /**
@@ -13068,7 +13053,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U> Observable<T> takeUntil(ObservableSource<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new ObservableTakeUntil<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new ObservableTakeUntil<>(this, other));
     }
 
     /**
@@ -13097,7 +13082,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> takeUntil(Predicate<? super T> stopPredicate) {
         Objects.requireNonNull(stopPredicate, "stopPredicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableTakeUntilPredicate<T>(this, stopPredicate));
+        return RxJavaPlugins.onAssembly(new ObservableTakeUntilPredicate<>(this, stopPredicate));
     }
 
     /**
@@ -13121,7 +13106,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> takeWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new ObservableTakeWhile<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableTakeWhile<>(this, predicate));
     }
 
     /**
@@ -13178,7 +13163,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableThrottleFirstTimed<T>(this, skipDuration, unit, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableThrottleFirstTimed<>(this, skipDuration, unit, scheduler));
     }
 
     /**
@@ -13365,7 +13350,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableThrottleLatest<T>(this, timeout, unit, scheduler, emitLast));
+        return RxJavaPlugins.onAssembly(new ObservableThrottleLatest<>(this, timeout, unit, scheduler, emitLast));
     }
 
     /**
@@ -13518,7 +13503,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableTimeInterval<T>(this, unit, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableTimeInterval<>(this, unit, scheduler));
     }
 
     /**
@@ -13779,7 +13764,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Scheduler scheduler) {
         Objects.requireNonNull(timeUnit, "timeUnit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableTimeoutTimed<T>(this, timeout, timeUnit, scheduler, other));
+        return RxJavaPlugins.onAssembly(new ObservableTimeoutTimed<>(this, timeout, timeUnit, scheduler, other));
     }
 
     private <U, V> Observable<T> timeout0(
@@ -13787,7 +13772,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
                     ObservableSource<? extends T> other) {
         Objects.requireNonNull(itemTimeoutIndicator, "itemTimeoutIndicator is null");
-        return RxJavaPlugins.onAssembly(new ObservableTimeout<T, U, V>(this, firstTimeoutIndicator, itemTimeoutIndicator, other));
+        return RxJavaPlugins.onAssembly(new ObservableTimeout<>(this, firstTimeoutIndicator, itemTimeoutIndicator, other));
     }
 
     /**
@@ -13995,7 +13980,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U extends Collection<? super T>> Single<U> toList(Supplier<U> collectionSupplier) {
         Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableToListSingle<T, U>(this, collectionSupplier));
+        return RxJavaPlugins.onAssembly(new ObservableToListSingle<>(this, collectionSupplier));
     }
 
     /**
@@ -14284,7 +14269,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> toFlowable(BackpressureStrategy strategy) {
-        Flowable<T> f = new FlowableFromObservable<T>(this);
+        Flowable<T> f = new FlowableFromObservable<>(this);
 
         switch (strategy) {
             case DROP:
@@ -14294,7 +14279,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             case MISSING:
                 return f;
             case ERROR:
-                return RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<T>(f));
+                return RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<>(f));
             default:
                 return f.onBackpressureBuffer();
         }
@@ -14439,7 +14424,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     public final Observable<T> unsubscribeOn(Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableUnsubscribeOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableUnsubscribeOn<>(this, scheduler));
     }
 
     /**
@@ -14525,7 +14510,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.verifyPositive(count, "count");
         ObjectHelper.verifyPositive(skip, "skip");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableWindow<T>(this, count, skip, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableWindow<>(this, count, skip, bufferSize));
     }
 
     /**
@@ -14635,7 +14620,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(unit, "unit is null");
-        return RxJavaPlugins.onAssembly(new ObservableWindowTimed<T>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false));
+        return RxJavaPlugins.onAssembly(new ObservableWindowTimed<>(this, timespan, timeskip, unit, scheduler, Long.MAX_VALUE, bufferSize, false));
     }
 
     /**
@@ -14906,7 +14891,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(unit, "unit is null");
         ObjectHelper.verifyPositive(count, "count");
-        return RxJavaPlugins.onAssembly(new ObservableWindowTimed<T>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart));
+        return RxJavaPlugins.onAssembly(new ObservableWindowTimed<>(this, timespan, timespan, unit, scheduler, count, bufferSize, restart));
     }
 
     /**
@@ -14972,7 +14957,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <B> Observable<Observable<T>> window(ObservableSource<B> boundary, int bufferSize) {
         Objects.requireNonNull(boundary, "boundary is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableWindowBoundary<T, B>(this, boundary, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableWindowBoundary<>(this, boundary, bufferSize));
     }
 
     /**
@@ -15049,7 +15034,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(openingIndicator, "openingIndicator is null");
         Objects.requireNonNull(closingIndicator, "closingIndicator is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableWindowBoundarySelector<T, U, V>(this, openingIndicator, closingIndicator, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableWindowBoundarySelector<>(this, openingIndicator, closingIndicator, bufferSize));
     }
 
     /**
@@ -15230,7 +15215,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> withLatestFrom(ObservableSource<?>[] others, Function<? super Object[], R> combiner) {
         Objects.requireNonNull(others, "others is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return RxJavaPlugins.onAssembly(new ObservableWithLatestFromMany<T, R>(this, others, combiner));
+        return RxJavaPlugins.onAssembly(new ObservableWithLatestFromMany<>(this, others, combiner));
     }
 
     /**
@@ -15259,7 +15244,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <R> Observable<R> withLatestFrom(Iterable<? extends ObservableSource<?>> others, Function<? super Object[], R> combiner) {
         Objects.requireNonNull(others, "others is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return RxJavaPlugins.onAssembly(new ObservableWithLatestFromMany<T, R>(this, others, combiner));
+        return RxJavaPlugins.onAssembly(new ObservableWithLatestFromMany<>(this, others, combiner));
     }
 
     /**
@@ -15447,7 +15432,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test() { // NoPMD
-        TestObserver<T> to = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<>();
         subscribe(to);
         return to;
     }
@@ -15467,7 +15452,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public final TestObserver<T> test(boolean dispose) { // NoPMD
-        TestObserver<T> to = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<>();
         if (dispose) {
             to.dispose();
         }

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -132,9 +132,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> amb(final Iterable<? extends SingleSource<? extends T>> sources) {
+    public static <T> Single<T> amb(@NonNull Iterable<? extends SingleSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new SingleAmb<T>(null, sources));
+        return RxJavaPlugins.onAssembly(new SingleAmb<>(null, sources));
     }
 
     /**
@@ -154,15 +154,18 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
-    public static <T> Single<T> ambArray(final SingleSource<? extends T>... sources) {
+    @SafeVarargs
+    @NonNull
+    public static <T> Single<T> ambArray(@NonNull SingleSource<? extends T>... sources) {
         if (sources.length == 0) {
             return error(SingleInternalHelper.<T>emptyThrower());
         }
         if (sources.length == 1) {
-            return wrap((SingleSource<T>)sources[0]);
+            @SuppressWarnings("unchecked")
+            SingleSource<T> source = (SingleSource<T>)sources[0];
+            return wrap(source);
         }
-        return RxJavaPlugins.onAssembly(new SingleAmb<T>(sources, null));
+        return RxJavaPlugins.onAssembly(new SingleAmb<>(sources, null));
     }
 
     /**
@@ -185,7 +188,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T> Flowable<T> concat(Iterable<? extends SingleSource<? extends T>> sources) {
+    public static <T> Flowable<T> concat(@NonNull Iterable<? extends SingleSource<? extends T>> sources) {
         return concat(Flowable.fromIterable(sources));
     }
 
@@ -207,7 +210,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Observable<T> concat(ObservableSource<? extends SingleSource<? extends T>> sources) {
+    public static <T> Observable<T> concat(@NonNull ObservableSource<? extends SingleSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatMap(sources, SingleInternalHelper.toObservable(), 2, ErrorMode.IMMEDIATE));
     }
@@ -233,7 +236,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concat(Publisher<? extends SingleSource<? extends T>> sources) {
+    public static <T> Flowable<T> concat(@NonNull Publisher<? extends SingleSource<? extends T>> sources) {
         return concat(sources, 2);
     }
 
@@ -260,7 +263,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Flowable<T> concat(Publisher<? extends SingleSource<? extends T>> sources, int prefetch) {
+    public static <T> Flowable<T> concat(@NonNull Publisher<? extends SingleSource<? extends T>> sources, int prefetch) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new FlowableConcatMapPublisher(sources, SingleInternalHelper.toFlowable(), prefetch, ErrorMode.IMMEDIATE));
@@ -289,9 +292,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -323,10 +325,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2,
-            SingleSource<? extends T> source3
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
+            @NonNull SingleSource<? extends T> source3
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -361,10 +362,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> concat(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2,
-            SingleSource<? extends T> source3, SingleSource<? extends T> source4
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
+            @NonNull SingleSource<? extends T> source3, @NonNull SingleSource<? extends T> source4
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -394,7 +394,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Flowable<T> concatArray(SingleSource<? extends T>... sources) {
+    @SafeVarargs
+    public static <T> Flowable<T> concatArray(@NonNull SingleSource<? extends T>... sources) {
         return RxJavaPlugins.onAssembly(new FlowableConcatMap(Flowable.fromArray(sources), SingleInternalHelper.toFlowable(), 2, ErrorMode.BOUNDARY));
     }
 
@@ -420,7 +421,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatArrayEager(SingleSource<? extends T>... sources) {
+    @SafeVarargs
+    public static <T> Flowable<T> concatArrayEager(@NonNull SingleSource<? extends T>... sources) {
         return Flowable.fromArray(sources).concatMapEager(SingleInternalHelper.<T>toFlowable());
     }
 
@@ -448,7 +450,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatEager(Publisher<? extends SingleSource<? extends T>> sources) {
+    public static <T> Flowable<T> concatEager(@NonNull Publisher<? extends SingleSource<? extends T>> sources) {
         return Flowable.fromPublisher(sources).concatMapEager(SingleInternalHelper.<T>toFlowable());
     }
 
@@ -474,7 +476,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatEager(Iterable<? extends SingleSource<? extends T>> sources) {
+    public static <T> Flowable<T> concatEager(@NonNull Iterable<? extends SingleSource<? extends T>> sources) {
         return Flowable.fromIterable(sources).concatMapEager(SingleInternalHelper.<T>toFlowable());
     }
 
@@ -523,9 +525,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> create(SingleOnSubscribe<T> source) {
+    public static <@NonNull T> Single<T> create(@NonNull SingleOnSubscribe<T> source) {
         Objects.requireNonNull(source, "source is null");
-        return RxJavaPlugins.onAssembly(new SingleCreate<T>(source));
+        return RxJavaPlugins.onAssembly(new SingleCreate<>(source));
     }
 
     /**
@@ -545,9 +547,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> defer(final Supplier<? extends SingleSource<? extends T>> singleSupplier) {
+    public static <T> Single<T> defer(@NonNull Supplier<? extends SingleSource<? extends T>> singleSupplier) {
         Objects.requireNonNull(singleSupplier, "singleSupplier is null");
-        return RxJavaPlugins.onAssembly(new SingleDefer<T>(singleSupplier));
+        return RxJavaPlugins.onAssembly(new SingleDefer<>(singleSupplier));
     }
 
     /**
@@ -566,7 +568,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> error(final Supplier<? extends Throwable> errorSupplier) {
+    public static <T> Single<T> error(@NonNull Supplier<? extends Throwable> errorSupplier) {
         Objects.requireNonNull(errorSupplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new SingleError<T>(errorSupplier));
     }
@@ -592,7 +594,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> error(final Throwable exception) {
+    public static <T> Single<T> error(@NonNull Throwable exception) {
         Objects.requireNonNull(exception, "exception is null");
         return error(Functions.justSupplier(exception));
     }
@@ -628,7 +630,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> fromCallable(final Callable<? extends T> callable) {
+    public static <@NonNull T> Single<T> fromCallable(@NonNull Callable<? extends T> callable) {
         Objects.requireNonNull(callable, "callable is null");
         return RxJavaPlugins.onAssembly(new SingleFromCallable<T>(callable));
     }
@@ -658,7 +660,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> fromFuture(Future<? extends T> future) {
+    @NonNull
+    public static <@NonNull T> Single<T> fromFuture(@NonNull Future<? extends T> future) {
         return toSingle(Flowable.<T>fromFuture(future));
     }
 
@@ -691,7 +694,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
+    @NonNull
+    public static <@NonNull T> Single<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit) {
         return toSingle(Flowable.<T>fromFuture(future, timeout, unit));
     }
 
@@ -726,7 +730,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static <T> Single<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public static <@NonNull T> Single<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return toSingle(Flowable.<T>fromFuture(future, timeout, unit, scheduler));
     }
 
@@ -756,7 +761,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static <T> Single<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
+    @NonNull
+    public static <@NonNull T> Single<T> fromFuture(@NonNull Future<? extends T> future, @NonNull Scheduler scheduler) {
         return toSingle(Flowable.<T>fromFuture(future, scheduler));
     }
 
@@ -793,7 +799,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> fromPublisher(final Publisher<? extends T> publisher) {
+    public static <T> Single<T> fromPublisher(@NonNull Publisher<? extends T> publisher) {
         Objects.requireNonNull(publisher, "publisher is null");
         return RxJavaPlugins.onAssembly(new SingleFromPublisher<T>(publisher));
     }
@@ -817,7 +823,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> fromObservable(ObservableSource<? extends T> observableSource) {
+    public static <T> Single<T> fromObservable(@NonNull ObservableSource<? extends T> observableSource) {
         Objects.requireNonNull(observableSource, "observableSource is null");
         return RxJavaPlugins.onAssembly(new ObservableSingleSingle<T>(observableSource, null));
     }
@@ -855,7 +861,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> fromSupplier(final Supplier<? extends T> supplier) {
+    public static <@NonNull T> Single<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new SingleFromSupplier<T>(supplier));
     }
@@ -882,9 +888,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <T> Single<T> just(final T item) {
+    public static <@NonNull T> Single<T> just(T item) {
         Objects.requireNonNull(item, "item is null");
-        return RxJavaPlugins.onAssembly(new SingleJust<T>(item));
+        return RxJavaPlugins.onAssembly(new SingleJust<>(item));
     }
 
     /**
@@ -960,7 +966,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Flowable<T> merge(Publisher<? extends SingleSource<? extends T>> sources) {
+    public static <T> Flowable<T> merge(@NonNull Publisher<? extends SingleSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, SingleInternalHelper.toFlowable(), false, Integer.MAX_VALUE, Flowable.bufferSize()));
     }
@@ -991,7 +997,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Single<T> merge(SingleSource<? extends SingleSource<? extends T>> source) {
+    public static <T> Single<T> merge(@NonNull SingleSource<? extends SingleSource<? extends T>> source) {
         Objects.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new SingleFlatMap<SingleSource<? extends T>, T>(source, (Function)Functions.identity()));
     }
@@ -1036,9 +1042,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1087,10 +1092,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2,
-            SingleSource<? extends T> source3
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
+            @NonNull SingleSource<? extends T> source3
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1142,10 +1146,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> merge(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2,
-            SingleSource<? extends T> source3, SingleSource<? extends T> source4
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
+            @NonNull SingleSource<? extends T> source3, @NonNull SingleSource<? extends T> source4
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1176,7 +1179,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> mergeDelayError(Iterable<? extends SingleSource<? extends T>> sources) {
+    public static <T> Flowable<T> mergeDelayError(@NonNull Iterable<? extends SingleSource<? extends T>> sources) {
         return mergeDelayError(Flowable.fromIterable(sources));
     }
 
@@ -1203,7 +1206,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Flowable<T> mergeDelayError(Publisher<? extends SingleSource<? extends T>> sources) {
+    public static <T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends SingleSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, SingleInternalHelper.toFlowable(), true, Integer.MAX_VALUE, Flowable.bufferSize()));
     }
@@ -1237,9 +1240,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> mergeDelayError(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1277,10 +1279,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> mergeDelayError(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2,
-            SingleSource<? extends T> source3
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
+            @NonNull SingleSource<? extends T> source3
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1321,10 +1322,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T> Flowable<T> mergeDelayError(
-            SingleSource<? extends T> source1, SingleSource<? extends T> source2,
-            SingleSource<? extends T> source3, SingleSource<? extends T> source4
+            @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
+            @NonNull SingleSource<? extends T> source3, @NonNull SingleSource<? extends T> source4
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1348,6 +1348,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Single<T> never() {
         return RxJavaPlugins.onAssembly((Single<T>) SingleNever.INSTANCE);
     }
@@ -1367,7 +1368,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Single<Long> timer(long delay, TimeUnit unit) {
+    @NonNull
+    public static Single<Long> timer(long delay, @NonNull TimeUnit unit) {
         return timer(delay, unit, Schedulers.computation());
     }
 
@@ -1391,7 +1393,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Single<Long> timer(final long delay, final TimeUnit unit, final Scheduler scheduler) {
+    public static Single<Long> timer(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new SingleTimer(delay, unit, scheduler));
@@ -1414,10 +1416,10 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> equals(final SingleSource<? extends T> first, final SingleSource<? extends T> second) { // NOPMD
+    public static <T> Single<Boolean> equals(@NonNull SingleSource<? extends T> first, @NonNull SingleSource<? extends T> second) { // NOPMD
         Objects.requireNonNull(first, "first is null");
         Objects.requireNonNull(second, "second is null");
-        return RxJavaPlugins.onAssembly(new SingleEquals<T>(first, second));
+        return RxJavaPlugins.onAssembly(new SingleEquals<>(first, second));
     }
 
     /**
@@ -1440,12 +1442,12 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> unsafeCreate(SingleSource<T> onSubscribe) {
+    public static <T> Single<T> unsafeCreate(@NonNull SingleSource<T> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         if (onSubscribe instanceof Single) {
             throw new IllegalArgumentException("unsafeCreate(Single) should be upgraded");
         }
-        return RxJavaPlugins.onAssembly(new SingleFromUnsafeSource<T>(onSubscribe));
+        return RxJavaPlugins.onAssembly(new SingleFromUnsafeSource<>(onSubscribe));
     }
 
     /**
@@ -1471,9 +1473,10 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, U> Single<T> using(Supplier<U> resourceSupplier,
-                                         Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
-                                         Consumer<? super U> disposer) {
+    @NonNull
+    public static <T, U> Single<T> using(@NonNull Supplier<U> resourceSupplier,
+            @NonNull Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
+            @NonNull Consumer<? super U> disposer) {
         return using(resourceSupplier, singleFunction, disposer, true);
     }
 
@@ -1507,15 +1510,15 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, U> Single<T> using(
-            final Supplier<U> resourceSupplier,
-            final Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
-            final Consumer<? super U> disposer,
-            final boolean eager) {
+            @NonNull Supplier<U> resourceSupplier,
+            @NonNull Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
+            @NonNull Consumer<? super U> disposer,
+            boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(singleFunction, "singleFunction is null");
         Objects.requireNonNull(disposer, "disposer is null");
 
-        return RxJavaPlugins.onAssembly(new SingleUsing<T, U>(resourceSupplier, singleFunction, disposer, eager));
+        return RxJavaPlugins.onAssembly(new SingleUsing<>(resourceSupplier, singleFunction, disposer, eager));
     }
 
     /**
@@ -1534,12 +1537,12 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> wrap(SingleSource<T> source) {
+    public static <T> Single<T> wrap(@NonNull SingleSource<T> source) {
         Objects.requireNonNull(source, "source is null");
         if (source instanceof Single) {
             return RxJavaPlugins.onAssembly((Single<T>)source);
         }
-        return RxJavaPlugins.onAssembly(new SingleFromUnsafeSource<T>(source));
+        return RxJavaPlugins.onAssembly(new SingleFromUnsafeSource<>(source));
     }
 
     /**
@@ -1574,7 +1577,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Single<R> zip(final Iterable<? extends SingleSource<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
+    public static <T, R> Single<R> zip(@NonNull Iterable<? extends SingleSource<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new SingleZipIterable<T, R>(sources, zipper));
@@ -1606,10 +1609,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T1, T2, R> Single<R> zip(
-            SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> zipper
+            @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1645,11 +1647,10 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, R> Single<R> zip(
-            SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
-            SingleSource<? extends T3> source3,
-            Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper
+            @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
+            @NonNull SingleSource<? extends T3> source3,
+            @NonNull Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1689,11 +1690,10 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, R> Single<R> zip(
-            SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
-            SingleSource<? extends T3> source3, SingleSource<? extends T4> source4,
-            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper
+            @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
+            @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
+            @NonNull Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1737,12 +1737,11 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, R> Single<R> zip(
-            SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
-            SingleSource<? extends T3> source3, SingleSource<? extends T4> source4,
-            SingleSource<? extends T5> source5,
-            Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper
+            @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
+            @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
+            @NonNull SingleSource<? extends T5> source5,
+            @NonNull Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1790,12 +1789,11 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, R> Single<R> zip(
-            SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
-            SingleSource<? extends T3> source3, SingleSource<? extends T4> source4,
-            SingleSource<? extends T5> source5, SingleSource<? extends T6> source6,
-            Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper
+            @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
+            @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
+            @NonNull SingleSource<? extends T5> source5, @NonNull SingleSource<? extends T6> source6,
+            @NonNull Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1847,13 +1845,12 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, R> Single<R> zip(
-            SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
-            SingleSource<? extends T3> source3, SingleSource<? extends T4> source4,
-            SingleSource<? extends T5> source5, SingleSource<? extends T6> source6,
-            SingleSource<? extends T7> source7,
-            Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper
+            @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
+            @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
+            @NonNull SingleSource<? extends T5> source5, @NonNull SingleSource<? extends T6> source6,
+            @NonNull SingleSource<? extends T7> source7,
+            @NonNull Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1909,13 +1906,12 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Single<R> zip(
-            SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
-            SingleSource<? extends T3> source3, SingleSource<? extends T4> source4,
-            SingleSource<? extends T5> source5, SingleSource<? extends T6> source6,
-            SingleSource<? extends T7> source7, SingleSource<? extends T8> source8,
-            Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper
+            @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
+            @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
+            @NonNull SingleSource<? extends T5> source5, @NonNull SingleSource<? extends T6> source6,
+            @NonNull SingleSource<? extends T7> source7, @NonNull SingleSource<? extends T8> source8,
+            @NonNull Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -1975,14 +1971,13 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Single<R> zip(
-            SingleSource<? extends T1> source1, SingleSource<? extends T2> source2,
-            SingleSource<? extends T3> source3, SingleSource<? extends T4> source4,
-            SingleSource<? extends T5> source5, SingleSource<? extends T6> source6,
-            SingleSource<? extends T7> source7, SingleSource<? extends T8> source8,
-            SingleSource<? extends T9> source9,
-            Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper
+            @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
+            @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
+            @NonNull SingleSource<? extends T5> source5, @NonNull SingleSource<? extends T6> source6,
+            @NonNull SingleSource<? extends T7> source7, @NonNull SingleSource<? extends T8> source8,
+            @NonNull SingleSource<? extends T9> source9,
+            @NonNull Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
@@ -2027,7 +2022,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Single<R> zipArray(Function<? super Object[], ? extends R> zipper, SingleSource<? extends T>... sources) {
+    @SafeVarargs
+    public static <T, R> Single<R> zipArray(@NonNull Function<? super Object[], ? extends R> zipper, @NonNull SingleSource<? extends T>... sources) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
@@ -2052,8 +2048,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings("unchecked")
-    public final Single<T> ambWith(SingleSource<? extends T> other) {
+    public final Single<T> ambWith(@NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return ambArray(this, other);
     }
@@ -2072,8 +2067,9 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> hide() {
-        return RxJavaPlugins.onAssembly(new SingleHide<T>(this));
+        return RxJavaPlugins.onAssembly(new SingleHide<>(this));
     }
 
     /**
@@ -2099,7 +2095,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> compose(SingleTransformer<? super T, ? extends R> transformer) {
+    @NonNull
+    public final <R> Single<R> compose(@NonNull SingleTransformer<? super T, ? extends R> transformer) {
         return wrap(((SingleTransformer<T, R>) Objects.requireNonNull(transformer, "transformer is null")).apply(this));
     }
 
@@ -2119,8 +2116,9 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> cache() {
-        return RxJavaPlugins.onAssembly(new SingleCache<T>(this));
+        return RxJavaPlugins.onAssembly(new SingleCache<>(this));
     }
 
     /**
@@ -2140,7 +2138,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<U> cast(final Class<? extends U> clazz) {
+    public final <U> Single<U> cast(@NonNull Class<? extends U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
     }
@@ -2166,7 +2164,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> concatWith(SingleSource<? extends T> other) {
+    @NonNull
+    public final Flowable<T> concatWith(@NonNull SingleSource<? extends T> other) {
         return concat(this, other);
     }
 
@@ -2187,7 +2186,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Single<T> delay(long time, TimeUnit unit) {
+    @NonNull
+    public final Single<T> delay(long time, @NonNull TimeUnit unit) {
         return delay(time, unit, Schedulers.computation(), false);
     }
 
@@ -2208,7 +2208,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Single<T> delay(long time, TimeUnit unit, boolean delayError) {
+    @NonNull
+    public final Single<T> delay(long time, @NonNull TimeUnit unit, boolean delayError) {
         return delay(time, unit, Schedulers.computation(), delayError);
     }
 
@@ -2233,7 +2234,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Single<T> delay(final long time, final TimeUnit unit, final Scheduler scheduler) {
+    @NonNull
+    public final Single<T> delay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return delay(time, unit, scheduler, false);
     }
 
@@ -2259,10 +2261,10 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Single<T> delay(final long time, final TimeUnit unit, final Scheduler scheduler, boolean delayError) {
+    public final Single<T> delay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new SingleDelay<T>(this, time, unit, scheduler, delayError));
+        return RxJavaPlugins.onAssembly(new SingleDelay<>(this, time, unit, scheduler, delayError));
     }
 
     /**
@@ -2284,9 +2286,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> delaySubscription(CompletableSource other) {
+    public final Single<T> delaySubscription(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<T>(this, other));
+        return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<>(this, other));
     }
 
     /**
@@ -2309,9 +2311,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<T> delaySubscription(SingleSource<U> other) {
+    public final <U> Single<T> delaySubscription(@NonNull SingleSource<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithSingle<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new SingleDelayWithSingle<>(this, other));
     }
 
     /**
@@ -2334,9 +2336,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<T> delaySubscription(ObservableSource<U> other) {
+    public final <U> Single<T> delaySubscription(@NonNull ObservableSource<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithObservable<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new SingleDelayWithObservable<>(this, other));
     }
 
     /**
@@ -2364,9 +2366,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<T> delaySubscription(Publisher<U> other) {
+    public final <U> Single<T> delaySubscription(@NonNull Publisher<U> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithPublisher<T, U>(this, other));
+        return RxJavaPlugins.onAssembly(new SingleDelayWithPublisher<>(this, other));
     }
 
     /**
@@ -2385,7 +2387,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Single<T> delaySubscription(long time, TimeUnit unit) {
+    @NonNull
+    public final Single<T> delaySubscription(long time, @NonNull TimeUnit unit) {
         return delaySubscription(time, unit, Schedulers.computation());
     }
 
@@ -2406,7 +2409,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Single<T> delaySubscription(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Single<T> delaySubscription(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return delaySubscription(Observable.timer(time, unit, scheduler));
     }
 
@@ -2445,9 +2449,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> dematerialize(Function<? super T, Notification<R>> selector) {
+    public final <@NonNull R> Maybe<R> dematerialize(@NonNull Function<? super T, @NonNull Notification<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
-        return RxJavaPlugins.onAssembly(new SingleDematerialize<T, R>(this, selector));
+        return RxJavaPlugins.onAssembly(new SingleDematerialize<>(this, selector));
     }
 
     /**
@@ -2469,9 +2473,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doAfterSuccess(Consumer<? super T> onAfterSuccess) {
+    public final Single<T> doAfterSuccess(@NonNull Consumer<? super T> onAfterSuccess) {
         Objects.requireNonNull(onAfterSuccess, "onAfterSuccess is null");
-        return RxJavaPlugins.onAssembly(new SingleDoAfterSuccess<T>(this, onAfterSuccess));
+        return RxJavaPlugins.onAssembly(new SingleDoAfterSuccess<>(this, onAfterSuccess));
     }
 
     /**
@@ -2498,9 +2502,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doAfterTerminate(Action onAfterTerminate) {
+    public final Single<T> doAfterTerminate(@NonNull Action onAfterTerminate) {
         Objects.requireNonNull(onAfterTerminate, "onAfterTerminate is null");
-        return RxJavaPlugins.onAssembly(new SingleDoAfterTerminate<T>(this, onAfterTerminate));
+        return RxJavaPlugins.onAssembly(new SingleDoAfterTerminate<>(this, onAfterTerminate));
     }
 
     /**
@@ -2525,9 +2529,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doFinally(Action onFinally) {
+    public final Single<T> doFinally(@NonNull Action onFinally) {
         Objects.requireNonNull(onFinally, "onFinally is null");
-        return RxJavaPlugins.onAssembly(new SingleDoFinally<T>(this, onFinally));
+        return RxJavaPlugins.onAssembly(new SingleDoFinally<>(this, onFinally));
     }
 
     /**
@@ -2547,9 +2551,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doOnSubscribe(final Consumer<? super Disposable> onSubscribe) {
+    public final Single<T> doOnSubscribe(@NonNull Consumer<? super Disposable> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
-        return RxJavaPlugins.onAssembly(new SingleDoOnSubscribe<T>(this, onSubscribe));
+        return RxJavaPlugins.onAssembly(new SingleDoOnSubscribe<>(this, onSubscribe));
     }
 
     /**
@@ -2574,9 +2578,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doOnTerminate(final Action onTerminate) {
+    public final Single<T> doOnTerminate(@NonNull Action onTerminate) {
         Objects.requireNonNull(onTerminate, "onTerminate is null");
-        return RxJavaPlugins.onAssembly(new SingleDoOnTerminate<T>(this, onTerminate));
+        return RxJavaPlugins.onAssembly(new SingleDoOnTerminate<>(this, onTerminate));
     }
 
     /**
@@ -2596,9 +2600,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doOnSuccess(final Consumer<? super T> onSuccess) {
+    public final Single<T> doOnSuccess(@NonNull Consumer<? super T> onSuccess) {
         Objects.requireNonNull(onSuccess, "onSuccess is null");
-        return RxJavaPlugins.onAssembly(new SingleDoOnSuccess<T>(this, onSuccess));
+        return RxJavaPlugins.onAssembly(new SingleDoOnSuccess<>(this, onSuccess));
     }
 
     /**
@@ -2617,9 +2621,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doOnEvent(final BiConsumer<? super T, ? super Throwable> onEvent) {
+    public final Single<T> doOnEvent(@NonNull BiConsumer<? super T, ? super Throwable> onEvent) {
         Objects.requireNonNull(onEvent, "onEvent is null");
-        return RxJavaPlugins.onAssembly(new SingleDoOnEvent<T>(this, onEvent));
+        return RxJavaPlugins.onAssembly(new SingleDoOnEvent<>(this, onEvent));
     }
 
     /**
@@ -2639,9 +2643,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doOnError(final Consumer<? super Throwable> onError) {
+    public final Single<T> doOnError(@NonNull Consumer<? super Throwable> onError) {
         Objects.requireNonNull(onError, "onError is null");
-        return RxJavaPlugins.onAssembly(new SingleDoOnError<T>(this, onError));
+        return RxJavaPlugins.onAssembly(new SingleDoOnError<>(this, onError));
     }
 
     /**
@@ -2662,9 +2666,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doOnDispose(final Action onDispose) {
+    public final Single<T> doOnDispose(@NonNull Action onDispose) {
         Objects.requireNonNull(onDispose, "onDispose is null");
-        return RxJavaPlugins.onAssembly(new SingleDoOnDispose<T>(this, onDispose));
+        return RxJavaPlugins.onAssembly(new SingleDoOnDispose<>(this, onDispose));
     }
 
     /**
@@ -2687,9 +2691,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> filter(Predicate<? super T> predicate) {
+    public final Maybe<T> filter(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return RxJavaPlugins.onAssembly(new MaybeFilterSingle<T>(this, predicate));
+        return RxJavaPlugins.onAssembly(new MaybeFilterSingle<>(this, predicate));
     }
 
     /**
@@ -2711,9 +2715,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> flatMap(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    public final <R> Single<R> flatMap(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new SingleFlatMap<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new SingleFlatMap<>(this, mapper));
     }
 
     /**
@@ -2735,9 +2739,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Maybe<R> flatMapMaybe(final Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    public final <R> Maybe<R> flatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new SingleFlatMapMaybe<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new SingleFlatMapMaybe<>(this, mapper));
     }
 
     /**
@@ -2764,9 +2768,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> flatMapPublisher(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+    public final <R> Flowable<R> flatMapPublisher(@NonNull Function<? super T, ? extends Publisher<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new SingleFlatMapPublisher<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new SingleFlatMapPublisher<>(this, mapper));
     }
 
     /**
@@ -2793,9 +2797,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Flowable<U> flattenAsFlowable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    public final <U> Flowable<U> flattenAsFlowable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new SingleFlatMapIterableFlowable<T, U>(this, mapper));
+        return RxJavaPlugins.onAssembly(new SingleFlatMapIterableFlowable<>(this, mapper));
     }
 
     /**
@@ -2819,9 +2823,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<U> flattenAsObservable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    public final <@NonNull U> Observable<U> flattenAsObservable(@NonNull Function<@NonNull ? super T, @NonNull ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new SingleFlatMapIterableObservable<T, U>(this, mapper));
+        return RxJavaPlugins.onAssembly(new SingleFlatMapIterableObservable<>(this, mapper));
     }
 
     /**
@@ -2843,9 +2847,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMapObservable(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+    public final <@NonNull R> Observable<R> flatMapObservable(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new SingleFlatMapObservable<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new SingleFlatMapObservable<>(this, mapper));
     }
 
     /**
@@ -2868,9 +2872,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable flatMapCompletable(final Function<? super T, ? extends CompletableSource> mapper) {
+    public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new SingleFlatMapCompletable<T>(this, mapper));
+        return RxJavaPlugins.onAssembly(new SingleFlatMapCompletable<>(this, mapper));
     }
 
     /**
@@ -2890,8 +2894,9 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final T blockingGet() {
-        BlockingMultiObserver<T> observer = new BlockingMultiObserver<T>();
+        BlockingMultiObserver<T> observer = new BlockingMultiObserver<>();
         subscribe(observer);
         return observer.blockingGet();
     }
@@ -3042,7 +3047,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> lift(final SingleOperator<? extends R, ? super T> lift) {
+    public final <R> Single<R> lift(@NonNull SingleOperator<? extends R, ? super T> lift) {
         Objects.requireNonNull(lift, "lift is null");
         return RxJavaPlugins.onAssembly(new SingleLift<T, R>(this, lift));
     }
@@ -3066,7 +3071,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> map(Function<? super T, ? extends R> mapper) {
+    public final <@NonNull R> Single<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new SingleMap<T, R>(this, mapper));
     }
@@ -3087,8 +3092,9 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<Notification<T>> materialize() {
-        return RxJavaPlugins.onAssembly(new SingleMaterialize<T>(this));
+        return RxJavaPlugins.onAssembly(new SingleMaterialize<>(this));
     }
 
     /**
@@ -3108,7 +3114,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> contains(Object value) {
+    @NonNull
+    public final Single<Boolean> contains(@NonNull Object value) {
         return contains(value, ObjectHelper.equalsPredicate());
     }
 
@@ -3130,10 +3137,10 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> contains(final Object value, final BiPredicate<Object, Object> comparer) {
+    public final Single<Boolean> contains(@NonNull Object value, @NonNull BiPredicate<Object, Object> comparer) {
         Objects.requireNonNull(value, "value is null");
         Objects.requireNonNull(comparer, "comparer is null");
-        return RxJavaPlugins.onAssembly(new SingleContains<T>(this, value, comparer));
+        return RxJavaPlugins.onAssembly(new SingleContains<>(this, value, comparer));
     }
 
     /**
@@ -3158,7 +3165,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> mergeWith(SingleSource<? extends T> other) {
+    @NonNull
+    public final Flowable<T> mergeWith(@NonNull SingleSource<? extends T> other) {
         return merge(this, other);
     }
 
@@ -3184,9 +3192,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Single<T> observeOn(final Scheduler scheduler) {
+    public final Single<T> observeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new SingleObserveOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new SingleObserveOn<>(this, scheduler));
     }
 
     /**
@@ -3218,9 +3226,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> onErrorReturn(final Function<Throwable, ? extends T> resumeFunction) {
+    public final Single<T> onErrorReturn(@NonNull Function<Throwable, ? extends T> resumeFunction) {
         Objects.requireNonNull(resumeFunction, "resumeFunction is null");
-        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<T>(this, resumeFunction, null));
+        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<>(this, resumeFunction, null));
     }
 
     /**
@@ -3238,9 +3246,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> onErrorReturnItem(final T value) {
+    public final Single<T> onErrorReturnItem(@NonNull T value) {
         Objects.requireNonNull(value, "value is null");
-        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<T>(this, null, value));
+        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<>(this, null, value));
     }
 
     /**
@@ -3273,7 +3281,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> onErrorResumeWith(final SingleSource<? extends T> resumeSingleInCaseOfError) {
+    public final Single<T> onErrorResumeWith(@NonNull SingleSource<? extends T> resumeSingleInCaseOfError) {
         Objects.requireNonNull(resumeSingleInCaseOfError, "resumeSingleInCaseOfError is null");
         return onErrorResumeNext(Functions.justFunction(resumeSingleInCaseOfError));
     }
@@ -3310,9 +3318,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> onErrorResumeNext(
-            final Function<? super Throwable, ? extends SingleSource<? extends T>> resumeFunctionInCaseOfError) {
+            @NonNull Function<? super Throwable, ? extends SingleSource<? extends T>> resumeFunctionInCaseOfError) {
         Objects.requireNonNull(resumeFunctionInCaseOfError, "resumeFunctionInCaseOfError is null");
-        return RxJavaPlugins.onAssembly(new SingleResumeNext<T>(this, resumeFunctionInCaseOfError));
+        return RxJavaPlugins.onAssembly(new SingleResumeNext<>(this, resumeFunctionInCaseOfError));
     }
 
     /**
@@ -3331,8 +3339,9 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> onTerminateDetach() {
-        return RxJavaPlugins.onAssembly(new SingleDetach<T>(this));
+        return RxJavaPlugins.onAssembly(new SingleDetach<>(this));
     }
 
     /**
@@ -3351,6 +3360,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> repeat() {
         return toFlowable().repeat();
     }
@@ -3372,6 +3382,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Flowable<T> repeat(long times) {
         return toFlowable().repeat(times);
     }
@@ -3399,7 +3410,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> repeatWhen(Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
+    @NonNull
+    public final Flowable<T> repeatWhen(@NonNull Function<? super Flowable<Object>, ? extends Publisher<?>> handler) {
         return toFlowable().repeatWhen(handler);
     }
 
@@ -3421,7 +3433,8 @@ public abstract class Single<T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> repeatUntil(BooleanSupplier stop) {
+    @NonNull
+    public final Flowable<T> repeatUntil(@NonNull BooleanSupplier stop) {
         return toFlowable().repeatUntil(stop);
     }
 
@@ -3438,6 +3451,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> retry() {
         return toSingle(toFlowable().retry());
     }
@@ -3457,6 +3471,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> retry(long times) {
         return toSingle(toFlowable().retry(times));
     }
@@ -3477,7 +3492,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
+    @NonNull
+    public final Single<T> retry(@NonNull BiPredicate<? super Integer, ? super Throwable> predicate) {
         return toSingle(toFlowable().retry(predicate));
     }
 
@@ -3499,7 +3515,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> retry(long times, Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Single<T> retry(long times, @NonNull Predicate<? super Throwable> predicate) {
         return toSingle(toFlowable().retry(times, predicate));
     }
 
@@ -3519,7 +3536,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> retry(Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Single<T> retry(@NonNull Predicate<? super Throwable> predicate) {
         return toSingle(toFlowable().retry(predicate));
     }
 
@@ -3568,7 +3586,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> retryWhen(Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
+    @NonNull
+    public final Single<T> retryWhen(@NonNull Function<? super Flowable<Throwable>, ? extends Publisher<?>> handler) {
         return toSingle(toFlowable().retryWhen(handler));
     }
 
@@ -3589,6 +3608,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Disposable subscribe() {
         return subscribe(Functions.emptyConsumer(), Functions.ON_ERROR_MISSING);
     }
@@ -3614,10 +3634,10 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(final BiConsumer<? super T, ? super Throwable> onCallback) {
+    public final Disposable subscribe(@NonNull BiConsumer<? super T, ? super Throwable> onCallback) {
         Objects.requireNonNull(onCallback, "onCallback is null");
 
-        BiConsumerSingleObserver<T> observer = new BiConsumerSingleObserver<T>(onCallback);
+        BiConsumerSingleObserver<T> observer = new BiConsumerSingleObserver<>(onCallback);
         subscribe(observer);
         return observer;
     }
@@ -3644,7 +3664,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onSuccess) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onSuccess) {
         return subscribe(onSuccess, Functions.ON_ERROR_MISSING);
     }
 
@@ -3672,18 +3693,18 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(final Consumer<? super T> onSuccess, final Consumer<? super Throwable> onError) {
+    public final Disposable subscribe(@NonNull Consumer<? super T> onSuccess, @NonNull Consumer<? super Throwable> onError) {
         Objects.requireNonNull(onSuccess, "onSuccess is null");
         Objects.requireNonNull(onError, "onError is null");
 
-        ConsumerSingleObserver<T> observer = new ConsumerSingleObserver<T>(onSuccess, onError);
+        ConsumerSingleObserver<T> observer = new ConsumerSingleObserver<>(onSuccess, onError);
         subscribe(observer);
         return observer;
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
-    public final void subscribe(SingleObserver<? super T> observer) {
+    public final void subscribe(@NonNull SingleObserver<? super T> observer) {
         Objects.requireNonNull(observer, "observer is null");
 
         observer = RxJavaPlugins.onSubscribe(this, observer);
@@ -3739,7 +3760,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <E extends SingleObserver<? super T>> E subscribeWith(E observer) {
+    @NonNull
+    public final <@NonNull E extends SingleObserver<? super T>> E subscribeWith(E observer) {
         subscribe(observer);
         return observer;
     }
@@ -3763,9 +3785,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Single<T> subscribeOn(final Scheduler scheduler) {
+    public final Single<T> subscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new SingleSubscribeOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new SingleSubscribeOn<>(this, scheduler));
     }
 
     /**
@@ -3788,7 +3810,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> takeUntil(final CompletableSource other) {
+    public final Single<T> takeUntil(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return takeUntil(new CompletableToFlowable<T>(other));
     }
@@ -3820,9 +3842,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <E> Single<T> takeUntil(final Publisher<E> other) {
+    public final <E> Single<T> takeUntil(@NonNull Publisher<E> other) {
         Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleTakeUntil<T, E>(this, other));
+        return RxJavaPlugins.onAssembly(new SingleTakeUntil<>(this, other));
     }
 
     /**
@@ -3846,7 +3868,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <E> Single<T> takeUntil(final SingleSource<? extends E> other) {
+    public final <E> Single<T> takeUntil(@NonNull SingleSource<? extends E> other) {
         Objects.requireNonNull(other, "other is null");
         return takeUntil(new SingleToFlowable<E>(other));
     }
@@ -3867,7 +3889,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Single<T> timeout(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Single<T> timeout(long timeout, @NonNull TimeUnit unit) {
         return timeout0(timeout, unit, Schedulers.computation(), null);
     }
 
@@ -3889,7 +3912,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Single<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Single<T> timeout(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return timeout0(timeout, unit, scheduler, null);
     }
 
@@ -3912,7 +3936,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Single<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler, SingleSource<? extends T> other) {
+    public final Single<T> timeout(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, @NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, scheduler, other);
     }
@@ -3940,7 +3964,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Single<T> timeout(long timeout, TimeUnit unit, SingleSource<? extends T> other) {
+    public final Single<T> timeout(long timeout, @NonNull TimeUnit unit, @NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, unit, Schedulers.computation(), other);
     }
@@ -3948,7 +3972,7 @@ public abstract class Single<T> implements SingleSource<T> {
     private Single<T> timeout0(final long timeout, final TimeUnit unit, final Scheduler scheduler, final SingleSource<? extends T> other) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new SingleTimeout<T>(this, timeout, unit, scheduler, other));
+        return RxJavaPlugins.onAssembly(new SingleTimeout<>(this, timeout, unit, scheduler, other));
     }
 
     /**
@@ -3990,8 +4014,9 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable ignoreElement() {
-        return RxJavaPlugins.onAssembly(new CompletableFromSingle<T>(this));
+        return RxJavaPlugins.onAssembly(new CompletableFromSingle<>(this));
     }
 
     /**
@@ -4011,11 +4036,12 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public final Flowable<T> toFlowable() {
         if (this instanceof FuseToFlowable) {
             return ((FuseToFlowable<T>)this).fuseToFlowable();
         }
-        return RxJavaPlugins.onAssembly(new SingleToFlowable<T>(this));
+        return RxJavaPlugins.onAssembly(new SingleToFlowable<>(this));
     }
 
     /**
@@ -4032,6 +4058,7 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Future<T> toFuture() {
         return subscribeWith(new FutureSingleObserver<T>());
     }
@@ -4050,11 +4077,12 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public final Maybe<T> toMaybe() {
         if (this instanceof FuseToMaybe) {
             return ((FuseToMaybe<T>)this).fuseToMaybe();
         }
-        return RxJavaPlugins.onAssembly(new MaybeFromSingle<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeFromSingle<>(this));
     }
     /**
      * Converts this Single into an {@link Observable}.
@@ -4070,11 +4098,12 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public final Observable<T> toObservable() {
         if (this instanceof FuseToObservable) {
             return ((FuseToObservable<T>)this).fuseToObservable();
         }
-        return RxJavaPlugins.onAssembly(new SingleToObservable<T>(this));
+        return RxJavaPlugins.onAssembly(new SingleToObservable<>(this));
     }
 
     /**
@@ -4095,9 +4124,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Single<T> unsubscribeOn(final Scheduler scheduler) {
+    public final Single<T> unsubscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new SingleUnsubscribeOn<T>(this, scheduler));
+        return RxJavaPlugins.onAssembly(new SingleUnsubscribeOn<>(this, scheduler));
     }
 
     /**
@@ -4125,7 +4154,8 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Single<R> zipWith(SingleSource<U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
+    @NonNull
+    public final <U, R> Single<R> zipWith(@NonNull SingleSource<U> other, @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
         return zip(this, other, zipper);
     }
 
@@ -4146,8 +4176,9 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestObserver<T> test() {
-        TestObserver<T> to = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<>();
         subscribe(to);
         return to;
     }
@@ -4167,8 +4198,9 @@ public abstract class Single<T> implements SingleSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestObserver<T> test(boolean dispose) {
-        TestObserver<T> to = new TestObserver<T>();
+        TestObserver<T> to = new TestObserver<>();
 
         if (dispose) {
             to.dispose();
@@ -4178,8 +4210,9 @@ public abstract class Single<T> implements SingleSource<T> {
         return to;
     }
 
-    private static <T> Single<T> toSingle(Flowable<T> source) {
-        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<T>(source, null));
+    @NonNull
+    private static <T> Single<T> toSingle(@NonNull Flowable<T> source) {
+        return RxJavaPlugins.onAssembly(new FlowableSingleSingle<>(source, null));
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableNullTests.java
@@ -483,7 +483,6 @@ public class FlowableNullTests extends RxJavaTest {
         Flowable.mergeArray(128, 128, (Publisher<Object>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeArrayOneIsNull() {
         Flowable.mergeArray(128, 128, just1, null).blockingLast();
@@ -514,7 +513,6 @@ public class FlowableNullTests extends RxJavaTest {
         Flowable.mergeArrayDelayError(128, 128, (Publisher<Object>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorArrayOneIsNull() {
         Flowable.mergeArrayDelayError(128, 128, just1, null).blockingLast();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -1210,7 +1210,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
         PublishProcessor<Integer> pp3 = PublishProcessor.create();
 
-        @SuppressWarnings("unchecked")
         TestSubscriber<Integer> ts = Flowable.concatArrayEagerDelayError(2, 2, pp1, pp2, pp3)
         .test();
 
@@ -1246,7 +1245,6 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
         PublishProcessor<Integer> pp3 = PublishProcessor.create();
 
-        @SuppressWarnings("unchecked")
         TestSubscriber<Integer> ts = Flowable.concatArrayEagerDelayError(2, 2, pp1, pp2, pp3)
         .test();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -622,7 +622,6 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayDelayError() {
         Flowable.mergeArrayDelayError(Flowable.just(1), Flowable.just(2))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeTest.java
@@ -1518,7 +1518,6 @@ public class FlowableMergeTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArray2() {
         Flowable.mergeArray(Flowable.just(1), Flowable.just(2))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -464,7 +464,6 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
     public void longFlow() {
         Flowable.range(1, 1000000)
         .publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @SuppressWarnings("unchecked")
             @Override
             public Publisher<Integer> apply(Flowable<Integer> v) throws Exception {
                 return Flowable.mergeArray(
@@ -491,7 +490,6 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
     public void longFlow2() {
         Flowable.range(1, 100000)
         .publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @SuppressWarnings("unchecked")
             @Override
             public Publisher<Integer> apply(Flowable<Integer> v) throws Exception {
                 return Flowable.mergeArray(
@@ -519,7 +517,6 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
     public void longFlowHidden() {
         Flowable.range(1, 1000000).hide()
         .publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @SuppressWarnings("unchecked")
             @Override
             public Publisher<Integer> apply(Flowable<Integer> v) throws Exception {
                 return Flowable.mergeArray(

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeAmbTest.java
@@ -116,7 +116,6 @@ public class MaybeAmbTest extends RxJavaTest {
 
     @Test
     public void disposeNoFurtherSignals() {
-        @SuppressWarnings("unchecked")
         TestObserver<Integer> to = Maybe.ambArray(new Maybe<Integer>() {
             @Override
             protected void subscribeActual(
@@ -134,7 +133,6 @@ public class MaybeAmbTest extends RxJavaTest {
         to.assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerSuccessDispose() throws Exception {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
@@ -160,7 +158,6 @@ public class MaybeAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerErrorDispose() throws Exception {
         final TestException ex = new TestException();
@@ -187,7 +184,6 @@ public class MaybeAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerCompleteDispose() throws Exception {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
@@ -223,7 +219,6 @@ public class MaybeAmbTest extends RxJavaTest {
                 final Subject<Integer> ps = ReplaySubject.create();
                 ps.onNext(1);
 
-                @SuppressWarnings("unchecked")
                 final Maybe<Integer> source = Maybe.ambArray(ps.singleElement(),
                         Maybe.<Integer>never(), Maybe.<Integer>never(), null);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -29,7 +29,6 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class MaybeConcatArrayTest extends RxJavaTest {
 
-    @SuppressWarnings("unchecked")
     @Test
     public void cancel() {
         Maybe.concatArray(Maybe.just(1), Maybe.just(2))
@@ -38,7 +37,6 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void cancelDelayError() {
         Maybe.concatArrayDelayError(Maybe.just(1), Maybe.just(2))
@@ -47,7 +45,6 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void backpressure() {
         TestSubscriber<Integer> ts = Maybe.concatArray(Maybe.just(1), Maybe.just(2))
@@ -64,7 +61,6 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         ts.assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void backpressureDelayError() {
         TestSubscriber<Integer> ts = Maybe.concatArrayDelayError(Maybe.just(1), Maybe.just(2))
@@ -81,7 +77,6 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         ts.assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void requestCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -106,7 +101,6 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void requestCancelRaceDelayError() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -131,7 +125,6 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -158,7 +151,6 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
@@ -178,7 +170,6 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionDelayError() {
         final int[] calls = { 0 };

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -32,7 +32,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class MaybeMergeArrayTest extends RxJavaTest {
 
-    @SuppressWarnings("unchecked")
     @Test
     public void normal() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.SYNC);
@@ -45,7 +44,6 @@ public class MaybeMergeArrayTest extends RxJavaTest {
         .assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void fusedPollMixed() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
@@ -92,7 +90,6 @@ public class MaybeMergeArrayTest extends RxJavaTest {
         });
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void cancel() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
@@ -106,7 +103,6 @@ public class MaybeMergeArrayTest extends RxJavaTest {
         ts.assertEmpty();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void firstErrors() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
@@ -117,7 +113,6 @@ public class MaybeMergeArrayTest extends RxJavaTest {
         ts.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorFused() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
@@ -130,7 +125,6 @@ public class MaybeMergeArrayTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void errorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -172,7 +166,6 @@ public class MaybeMergeArrayTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeBadSource() {
         Maybe.mergeArray(new Maybe<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipArrayTest.java
@@ -151,7 +151,6 @@ public class MaybeZipArrayTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipArrayOneIsNull() {
         Maybe.zipArray(new Function<Object[], Object>() {
@@ -163,7 +162,6 @@ public class MaybeZipArrayTest extends RxJavaTest {
         .blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleSourceZipperReturnsNull() {
         Maybe.zipArray(Functions.justFunction(null), Maybe.just(1))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterableTest.java
@@ -205,7 +205,6 @@ public class MaybeZipIterableTest extends RxJavaTest {
         .blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleSourceZipperReturnsNull() {
         Maybe.zipArray(Functions.justFunction(null), Maybe.just(1))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -399,7 +399,6 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     public void checkUnboundedInnerQueue() {
         MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        @SuppressWarnings("unchecked")
         TestObserver<Integer> to = Observable
                 .fromArray(ms, Maybe.just(2), Maybe.just(3), Maybe.just(4))
                 .concatMapMaybe(Functions.<Maybe<Integer>>identity(), 2)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -339,7 +339,6 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     public void checkUnboundedInnerQueue() {
         SingleSubject<Integer> ss = SingleSubject.create();
 
-        @SuppressWarnings("unchecked")
         TestObserver<Integer> to = Observable
                 .fromArray(ss, Single.just(2), Single.just(3), Single.just(4))
                 .concatMapSingle(Functions.<Single<Integer>>identity(), 2)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
@@ -92,7 +92,6 @@ public class ObservableAmbTest extends RxJavaTest {
         Observable<String> observable3 = createObservable(new String[] {
                 "3", "33", "333", "3333" }, 3000, null);
 
-        @SuppressWarnings("unchecked")
         Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
@@ -121,7 +120,6 @@ public class ObservableAmbTest extends RxJavaTest {
         Observable<String> observable3 = createObservable(new String[] {},
                 3000, new IOException("fake exception"));
 
-        @SuppressWarnings("unchecked")
         Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
@@ -148,7 +146,6 @@ public class ObservableAmbTest extends RxJavaTest {
         Observable<String> observable3 = createObservable(new String[] {
                 "3" }, 3000, null);
 
-        @SuppressWarnings("unchecked")
         Observable<String> o = Observable.ambArray(observable1,
                 observable2, observable3);
 
@@ -161,7 +158,6 @@ public class ObservableAmbTest extends RxJavaTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void subscriptionOnlyHappensOnce() throws InterruptedException {
         final AtomicLong count = new AtomicLong();
@@ -205,7 +201,6 @@ public class ObservableAmbTest extends RxJavaTest {
         assertEquals(1, result);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambCancelsOthers() {
         PublishSubject<Integer> source1 = PublishSubject.create();
@@ -228,13 +223,11 @@ public class ObservableAmbTest extends RxJavaTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayEmpty() {
         assertSame(Observable.empty(), Observable.ambArray());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArraySingleElement() {
         assertSame(Observable.never(), Observable.ambArray(Observable.never()));
@@ -265,7 +258,6 @@ public class ObservableAmbTest extends RxJavaTest {
         .assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void disposed() {
         TestHelper.checkDisposed(Observable.ambArray(Observable.never(), Observable.never()));
@@ -277,7 +269,6 @@ public class ObservableAmbTest extends RxJavaTest {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
             final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-            @SuppressWarnings("unchecked")
             TestObserverEx<Integer> to = Observable.ambArray(ps1, ps2).to(TestHelper.<Integer>testConsumer());
 
             Runnable r1 = new Runnable() {
@@ -308,7 +299,6 @@ public class ObservableAmbTest extends RxJavaTest {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
             final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-            @SuppressWarnings("unchecked")
             TestObserver<Integer> to = Observable.ambArray(ps1, ps2).test();
 
             Runnable r1 = new Runnable() {
@@ -336,7 +326,6 @@ public class ObservableAmbTest extends RxJavaTest {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
             final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-            @SuppressWarnings("unchecked")
             TestObserver<Integer> to = Observable.ambArray(ps1, ps2).test();
 
             final Throwable ex = new TestException();
@@ -380,14 +369,12 @@ public class ObservableAmbTest extends RxJavaTest {
         Observable.amb(Arrays.asList(Observable.just(1), error)).test().assertValue(1).assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayOrder() {
         Observable<Integer> error = Observable.error(new RuntimeException());
         Observable.ambArray(Observable.just(1), error).test().assertValue(1).assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerSuccessDispose() throws Exception {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
@@ -413,7 +400,6 @@ public class ObservableAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerErrorDispose() throws Exception {
         final TestException ex = new TestException();
@@ -440,7 +426,6 @@ public class ObservableAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerCompleteDispose() throws Exception {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -218,7 +218,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness2() {
         final AtomicInteger count = new AtomicInteger();
@@ -238,7 +237,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness3() {
         final AtomicInteger count = new AtomicInteger();
@@ -258,7 +256,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness4() {
         final AtomicInteger count = new AtomicInteger();
@@ -278,7 +275,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness5() {
         final AtomicInteger count = new AtomicInteger();
@@ -298,7 +294,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness6() {
         final AtomicInteger count = new AtomicInteger();
@@ -318,7 +313,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness7() {
         final AtomicInteger count = new AtomicInteger();
@@ -338,7 +332,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness8() {
         final AtomicInteger count = new AtomicInteger();
@@ -358,7 +351,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void eagerness9() {
         final AtomicInteger count = new AtomicInteger();
@@ -387,7 +379,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertNotComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void innerError() {
         // TODO verify: concatMapEager subscribes first then consumes the sources is okay
@@ -404,7 +395,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         to.assertNotComplete();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void innerEmpty() {
         Observable.concatArrayEager(Observable.empty(), Observable.empty()).subscribe(to);
@@ -870,7 +860,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         PublishSubject<Integer> ps2 = PublishSubject.create();
         PublishSubject<Integer> ps3 = PublishSubject.create();
 
-        @SuppressWarnings("unchecked")
         TestObserver<Integer> to = Observable.concatArrayEagerDelayError(ps1, ps2, ps3)
         .test();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapTest.java
@@ -372,7 +372,6 @@ public class ObservableConcatMapTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatReportsDisposedOnComplete() {
         final Disposable[] disposable = { null };
@@ -404,7 +403,6 @@ public class ObservableConcatMapTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void concatReportsDisposedOnError() {
         final Disposable[] disposable = { null };
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
@@ -1299,7 +1299,6 @@ public class ObservableZipTest extends RxJavaTest {
         .assertFailure(TestException.class, "929");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void zipArrayEmpty() {
         assertSame(Observable.empty(), Observable.zipArray(Functions.<Object[]>identity(), false, 16));

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleAmbTest.java
@@ -112,7 +112,6 @@ public class SingleAmbTest extends RxJavaTest {
         to.assertResult(2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayEmpty() {
         Single.ambArray()
@@ -120,13 +119,11 @@ public class SingleAmbTest extends RxJavaTest {
         .assertFailure(NoSuchElementException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambSingleSource() {
         assertSame(Single.never(), Single.ambArray(Single.never()));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error() {
         Single.ambArray(Single.error(new TestException()), Single.just(1))
@@ -144,7 +141,6 @@ public class SingleAmbTest extends RxJavaTest {
                 final Subject<Integer> ps = ReplaySubject.create();
                 ps.onNext(1);
 
-                @SuppressWarnings("unchecked")
                 final Single<Integer> source = Single.ambArray(ps.singleOrError(), Single.<Integer>never(), Single.<Integer>never(), null);
 
                 Runnable r1 = new Runnable() {
@@ -172,7 +168,6 @@ public class SingleAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void multipleErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -212,7 +207,6 @@ public class SingleAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void successErrorRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -276,14 +270,12 @@ public class SingleAmbTest extends RxJavaTest {
         Single.amb(Arrays.asList(Single.just(1), error)).test().assertValue(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayOrder() {
         Single<Integer> error = Single.error(new RuntimeException());
         Single.ambArray(Single.just(1), error).test().assertValue(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerSuccessDispose() throws Exception {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
@@ -311,7 +303,6 @@ public class SingleAmbTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noWinnerErrorDispose() throws Exception {
         final TestException ex = new TestException();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleConcatTest.java
@@ -70,7 +70,6 @@ public class SingleConcatTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayEagerTest() {
         PublishProcessor<String> pp1 = PublishProcessor.create();
@@ -142,7 +141,6 @@ public class SingleConcatTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleZipArrayTest.java
@@ -151,7 +151,6 @@ public class SingleZipArrayTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipArrayOneIsNull() {
         Single.zipArray(new Function<Object[], Object>() {
@@ -176,7 +175,6 @@ public class SingleZipArrayTest extends RxJavaTest {
         .assertFailure(NoSuchElementException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void oneArray() {
         Single.zipArray(new Function<Object[], Object>() {
@@ -189,7 +187,6 @@ public class SingleZipArrayTest extends RxJavaTest {
         .assertResult(2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleSourceZipperReturnsNull() {
         Single.zipArray(Functions.justFunction(null), Single.just(1))

--- a/src/test/java/io/reactivex/rxjava3/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/maybe/MaybeTest.java
@@ -1382,13 +1382,11 @@ public class MaybeTest extends RxJavaTest {
         ts.assertResult(1, 2, 3);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayZero() {
         assertSame(Flowable.empty(), Maybe.concatArray());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayOne() {
         Maybe.concatArray(Maybe.just(1)).test().assertResult(1);
@@ -1594,7 +1592,6 @@ public class MaybeTest extends RxJavaTest {
         TestHelper.checkEnum(MaybeToPublisher.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayOneIsNull() {
         Maybe.ambArray(null, Maybe.just(1))
@@ -1602,13 +1599,11 @@ public class MaybeTest extends RxJavaTest {
                 .assertError(NullPointerException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayEmpty() {
         assertSame(Maybe.empty(), Maybe.ambArray());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayOne() {
         assertSame(Maybe.never(), Maybe.ambArray(Maybe.never()));
@@ -1626,14 +1621,12 @@ public class MaybeTest extends RxJavaTest {
         Maybe.amb(Arrays.asList(Maybe.just(1), error)).test().assertValue(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayOrder() {
         Maybe<Integer> error = Maybe.error(new RuntimeException());
         Maybe.ambArray(Maybe.just(1), error).test().assertValue(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArray1SignalsSuccess() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1656,7 +1649,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArray2SignalsSuccess() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1679,7 +1671,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertResult(2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArray1SignalsError() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1701,7 +1692,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArray2SignalsError() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1723,7 +1713,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArray1SignalsComplete() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1745,7 +1734,6 @@ public class MaybeTest extends RxJavaTest {
         to.assertResult();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArray2SignalsComplete() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -1972,7 +1960,6 @@ public class MaybeTest extends RxJavaTest {
         Maybe.amb(Collections.singleton(Maybe.just(1))).test().assertResult(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArray() {
         Maybe.mergeArray(Maybe.just(1), Maybe.just(2), Maybe.just(3))
@@ -2009,7 +1996,6 @@ public class MaybeTest extends RxJavaTest {
         .assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayBackpressured() {
         TestSubscriber<Integer> ts = Maybe.mergeArray(Maybe.just(1), Maybe.just(2), Maybe.just(3))
@@ -2029,7 +2015,6 @@ public class MaybeTest extends RxJavaTest {
         ts.assertResult(1, 2, 3);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayBackpressuredMixed1() {
         TestSubscriber<Integer> ts = Maybe.mergeArray(Maybe.just(1), Maybe.<Integer>empty(), Maybe.just(3))
@@ -2046,7 +2031,6 @@ public class MaybeTest extends RxJavaTest {
         ts.assertResult(1, 3);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayBackpressuredMixed2() {
         TestSubscriber<Integer> ts = Maybe.mergeArray(Maybe.just(1), Maybe.just(2), Maybe.<Integer>empty())
@@ -2063,7 +2047,6 @@ public class MaybeTest extends RxJavaTest {
         ts.assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayBackpressuredMixed3() {
         TestSubscriber<Integer> ts = Maybe.mergeArray(Maybe.<Integer>empty(), Maybe.just(2), Maybe.just(3))
@@ -2080,7 +2063,6 @@ public class MaybeTest extends RxJavaTest {
         ts.assertResult(2, 3);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayFused() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
@@ -2093,7 +2075,6 @@ public class MaybeTest extends RxJavaTest {
         .assertResult(1, 2, 3);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayFusedRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -2129,13 +2110,11 @@ public class MaybeTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayZero() {
         assertSame(Flowable.empty(), Maybe.mergeArray());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayOne() {
         Maybe.mergeArray(Maybe.just(1)).test().assertResult(1);
@@ -2462,7 +2441,6 @@ public class MaybeTest extends RxJavaTest {
         .assertFailure(TestException.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayDelayError() {
         Maybe.concatArrayDelayError(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException()))
@@ -2500,7 +2478,6 @@ public class MaybeTest extends RxJavaTest {
         .assertFailure(TestException.class, 1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatEagerArray() {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
@@ -2607,7 +2584,6 @@ public class MaybeTest extends RxJavaTest {
         ;
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayDelayError() {
         Maybe.mergeArrayDelayError(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException()))

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
@@ -45,7 +45,6 @@ public class ObservableNullTests extends RxJavaTest {
         Observable.ambArray((Observable<Object>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void ambVarargsOneIsNull() {
         Observable.ambArray(Observable.never(), null).blockingLast();

--- a/src/test/java/io/reactivex/rxjava3/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/single/SingleNullTests.java
@@ -61,7 +61,6 @@ public class SingleNullTests extends RxJavaTest {
         Single.ambArray((Single<Integer>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ambArrayOneIsNull() {
         Single.ambArray(null, just1)
@@ -534,7 +533,6 @@ public class SingleNullTests extends RxJavaTest {
         .blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipArrayOneIsNull() {
         Single.zipArray(new Function<Object[], Object>() {
@@ -546,13 +544,11 @@ public class SingleNullTests extends RxJavaTest {
         .blockingGet();
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipArrayFunctionNull() {
         Single.zipArray(null, just1, just1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void zipArrayFunctionReturnsNull() {
         Single.zipArray(new Function<Object[], Object>() {

--- a/src/test/java/io/reactivex/rxjava3/validators/SourceAnnotationCheck.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/SourceAnnotationCheck.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.validators;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+/**
+ * Parse the given files and check if all public final and public static methods have
+ * &#64;NonNull or &#64;Nullable annotations specified on their return type and object-type parameters
+ * as well as &#64;SafeVarargs for varargs.
+ */
+public class SourceAnnotationCheck {
+
+    @Test
+    public void checkCompletable() throws Exception {
+        processFile(Completable.class);
+    }
+
+    @Test
+    public void checkSingle() throws Exception {
+        processFile(Single.class);
+    }
+
+    @Test
+    public void checkMaybe() throws Exception {
+        processFile(Maybe.class);
+    }
+
+    // TODO later
+    // @Test
+    public void checkObservable() throws Exception {
+        processFile(Observable.class);
+    }
+
+    @Test
+    public void checkFlowable() throws Exception {
+        processFile(Flowable.class);
+    }
+
+    // TODO later
+    // @Test
+    public void checkParallelFlowable() throws Exception {
+        processFile(ParallelFlowable.class);
+    }
+
+    static void processFile(Class<?> clazz) throws Exception {
+        String baseClassName = clazz.getSimpleName();
+        File f = TestHelper.findSource(baseClassName);
+        if (f == null) {
+            return;
+        }
+        String fullClassName = clazz.getName();
+
+        int errorCount = 0;
+        StringBuilder errors = new StringBuilder();
+
+        List<String> lines = Files.readAllLines(f.toPath());
+
+        for (int j = 0; j < lines.size(); j++) {
+            String line = lines.get(j).trim();
+
+            if (line.startsWith("public static") || line.startsWith("public final")) {
+                int methodArgStart = line.indexOf("(");
+
+                int isBoolean = line.indexOf(" boolean ");
+                int isInt = line.indexOf(" int ");
+                int isLong = line.indexOf(" long ");
+                int isVoid = line.indexOf(" void ");
+                int isElementType = line.indexOf(" R ");
+
+                boolean hasSafeVarargsAnnotation = false;
+
+                if (!((isBoolean > 0 && isBoolean < methodArgStart)
+                        || (isInt > 0 && isInt < methodArgStart)
+                        || (isLong > 0 && isLong < methodArgStart)
+                        || (isVoid > 0 && isVoid < methodArgStart)
+                        || (isElementType > 0 && isElementType < methodArgStart)
+                    )) {
+
+                    boolean annotationFound = false;
+                    for (int k = j - 1; k >= 0; k--) {
+
+                        String prevLine = lines.get(k).trim();
+
+                        if (prevLine.startsWith("}") || prevLine.startsWith("*/")) {
+                            break;
+                        }
+                        if (prevLine.startsWith("@NonNull") || prevLine.startsWith("@Nullable")) {
+                            annotationFound = true;
+                        }
+                        if (prevLine.startsWith("@SafeVarargs")) {
+                            hasSafeVarargsAnnotation = true;
+                        }
+                    }
+
+                    if (!annotationFound) {
+                        errorCount++;
+                        errors.append("L")
+                        .append(j)
+                        .append(" : Missing return type nullability annotation | ")
+                        .append(line)
+                        .append("\r\n")
+                        .append(" at ")
+                        .append(fullClassName)
+                        .append(".method(")
+                        .append(f.getName())
+                        .append(":")
+                        .append(j + 1)
+                        .append(")\r\n")
+                        ;
+                    }
+                }
+
+                // Extract arguments
+                StringBuilder arguments = new StringBuilder();
+                int methodArgEnd = line.indexOf(")", methodArgStart);
+                if (methodArgEnd > 0) {
+                    arguments.append(line.substring(methodArgStart + 1, methodArgEnd));
+                } else {
+                    arguments.append(line.substring(methodArgStart + 1));
+                    for (int k = j + 1; k < lines.size(); k++) {
+                        String ln = lines.get(k).trim();
+                        int idx = ln.indexOf(")");
+                        if (idx > 0) {
+                            arguments.append(ln.substring(0, idx));
+                            break;
+                        }
+                        arguments.append(ln).append(" ");
+                    }
+                }
+
+                // Strip generics arguments
+                StringBuilder strippedArguments = new StringBuilder();
+                int skippingDepth = 0;
+                for (int k = 0; k < arguments.length(); k++) {
+                    char c = arguments.charAt(k);
+                    if (c == '<') {
+                        skippingDepth++;
+                    }
+                    else if (c == '>') {
+                        skippingDepth--;
+                    }
+                    else if (skippingDepth == 0) {
+                        strippedArguments.append(c);
+                    }
+                }
+
+                String strippedArgumentsStr = strippedArguments.toString();
+                String[] args = strippedArgumentsStr.split("\\s*,\\s*");
+
+                for (String typeName : CLASS_NAMES) {
+                    String typeNameSpaced = typeName + " ";
+                    for (int k = 0; k < args.length; k++) {
+                        String typeDef = args[k];
+                        if (typeDef.contains(typeNameSpaced)
+                                && !typeDef.contains("@NonNull")
+                                && !typeDef.contains("@Nullable")) {
+
+                            if (!line.contains("@Nullable " + typeName)
+                                    && !line.contains("@NonNull " + typeName)) {
+                                errorCount++;
+                                errors.append("L")
+                                .append(j)
+                                .append(" - argument ").append(k + 1).append(" - ").append(typeDef)
+                                .append(" : Missing argument type nullability annotation |\r\n    ")
+                                .append(strippedArgumentsStr)
+                                .append("\r\n")
+                                .append(" at ")
+                                .append(fullClassName)
+                                .append(".method(")
+                                .append(f.getName())
+                                .append(":")
+                                .append(j + 1)
+                                .append(")\r\n")
+                                ;
+                            }
+                        }
+                    }
+                }
+
+                if (strippedArgumentsStr.contains("...") && !hasSafeVarargsAnnotation) {
+                    errorCount++;
+                    errors.append("L")
+                    .append(j)
+                    .append(" : Missing @SafeVarargs annotation |\r\n    ")
+                    .append(strippedArgumentsStr)
+                    .append("\r\n")
+                    .append(" at ")
+                    .append(fullClassName)
+                    .append(".method(")
+                    .append(f.getName())
+                    .append(":")
+                    .append(j + 1)
+                    .append(")\r\n")
+                    ;
+                }
+            }
+        }
+
+        if (errorCount != 0) {
+            errors.insert(0, errorCount + " missing annotations\r\n");
+            errors.setLength(errors.length() - 2);
+            throw new AssertionError(errors.toString());
+        }
+    }
+
+    static final List<String> CLASS_NAMES = Arrays.asList(
+            "TimeUnit", "Scheduler", "Emitter",
+
+            "Completable", "CompletableSource", "CompletableObserver", "CompletableOnSubscribe",
+            "CompletableTransformer", "CompletableOperator", "CompletableEmitter", "CompletableConverter",
+
+            "Single", "SingleSource", "SingleObserver", "SingleOnSubscribe",
+            "SingleTransformer", "SingleOperator", "SingleEmitter", "SingleConverter",
+
+            "Maybe", "MaybeSource", "MaybeObserver", "MaybeOnSubscribe",
+            "MaybeTransformer", "MaybeOperator", "MaybeEmitter", "MaybeConverter",
+
+            "Observable", "ObservableSource", "Observer", "ObservableOnSubscribe",
+            "ObservableTransformer", "ObservableOperator", "ObservableEmitter", "ObservableConverter",
+
+            "Flowable", "Publisher", "Subscriber", "FlowableSubscriber", "FlowableOnSubscribe",
+            "FlowableTransformer", "FlowableOperator", "FlowableEmitter", "FlowableConverter",
+
+            "Function", "BiFunction", "Function3", "Function4", "Function5", "Function6",
+            "Function7", "Function8", "Function9",
+
+            "Action", "Runnable", "Consumer", "BiConsumer", "Supplier", "Callable", "Void",
+            "Throwable", "Optional", "CompletionStage", "BooleanSupplier", "LongConsumer",
+            "Predicate", "BiPredicate", "Object",
+
+            "BackpressureOverflowStrategy", "BackpressureStrategy",
+            "Subject", "Processor", "FlowableProcessor",
+
+            "T", "R", "U", "V"
+    );
+}


### PR DESCRIPTION
This PR cleans up the main classes:

- Add missing `@NonNull` annotations
- Add missing `@SafeVarargs` annotations
- Add validator code that scans the sources to verify the annotations are present
- Remove unnecessary `@SuppressWarnings` annotations
- Fix a few type arguments.

Related #6766