### PR TITLE
3.x: Add missing annotations, fix many diamonds

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -2335,7 +2335,7 @@ public abstract class Completable implements CompletableSource {
      * applied by {@link #subscribe(CompletableObserver)} before this method gets called.
      * @param observer the CompletableObserver instance, never null
      */
-    protected abstract void subscribeActual(CompletableObserver observer);
+    protected abstract void subscribeActual(@NonNull CompletableObserver observer);
 
     /**
      * Subscribes a given CompletableObserver (subclass) to this Completable and returns the given

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -183,7 +183,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> amb(Iterable<? extends Publisher<? extends T>> sources) {
+    public static <T> Flowable<T> amb(@NonNull Iterable<? extends Publisher<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new FlowableAmb<>(null, sources));
     }
@@ -232,6 +232,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <em>before</em> the Flowable class is loaded.
      * @return the default internal buffer size.
      */
+    @CheckReturnValue
     public static int bufferSize() {
         return BUFFER_SIZE;
     }
@@ -673,6 +674,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             @NonNull BiFunction<? super T1, ? super T2, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new Publisher[] { source1, source2 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -723,6 +725,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new Publisher[] { source1, source2, source3 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -777,6 +780,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new Publisher[] { source1, source2, source3, source4 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -836,6 +840,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new Publisher[] { source1, source2, source3, source4, source5 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -899,6 +904,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new Publisher[] { source1, source2, source3, source4, source5, source6 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -967,6 +973,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new Publisher[] { source1, source2, source3, source4, source5, source6, source7 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -1039,6 +1046,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new Publisher[] { source1, source2, source3, source4, source5, source6, source7, source8 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -1116,6 +1124,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new Publisher[] { source1, source2, source3, source4, source5, source6, source7, source8, source9 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -4735,6 +4744,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2);
     }
 
@@ -4796,6 +4806,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize(), source1, source2);
     }
 
@@ -4858,6 +4869,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError, int bufferSize) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize, source1, source2);
     }
 
@@ -4923,6 +4935,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3);
     }
 
@@ -4993,6 +5006,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4);
     }
 
@@ -5067,6 +5081,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5);
     }
 
@@ -5144,6 +5159,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6);
     }
 
@@ -5226,6 +5242,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7);
     }
 
@@ -5312,6 +5329,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7, source8);
     }
 
@@ -5403,6 +5421,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7, source8, source9);
     }
 
@@ -6791,7 +6810,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <B> Flowable<List<T>> buffer(@NonNull Publisher<B> boundaryIndicator, final int initialCapacity) {
+    public final <B> Flowable<List<T>> buffer(@NonNull Publisher<B> boundaryIndicator, int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
         return buffer(boundaryIndicator, Functions.<T>createArrayList(initialCapacity));
     }
@@ -12899,7 +12918,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, int bufferSize) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this, bufferSize, false), selector);
@@ -12942,7 +12961,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, final int bufferSize, boolean eagerTruncate) {
+    public final <R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, ? extends Publisher<R>> selector, int bufferSize, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return FlowableReplay.multicastSelector(FlowableInternalHelper.replaySupplier(this, bufferSize, eagerTruncate), selector);
@@ -13551,7 +13570,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final ConnectableFlowable<T> replay(final long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
+    public final ConnectableFlowable<T> replay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return FlowableReplay.create(this, time, unit, scheduler, eagerTruncate);
@@ -16930,7 +16949,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             @NonNull Publisher<U> firstTimeoutIndicator,
             @NonNull Function<? super T, ? extends Publisher<V>> itemTimeoutIndicator,
             @NonNull Publisher<? extends T> other) {
-        Objects.requireNonNull(firstTimeoutIndicator, "firstTimeoutSelector is null");
+        Objects.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
         Objects.requireNonNull(other, "other is null");
         return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, other);
     }
@@ -17152,7 +17171,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final Single<List<T>> toList(final int capacityHint) {
+    public final Single<List<T>> toList(int capacityHint) {
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
         return RxJavaPlugins.onAssembly(new FlowableToListSingle<>(this, Functions.<T>createArrayList(capacityHint)));
     }
@@ -18470,6 +18489,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             @NonNull Function3<? super T, ? super T1, ? super T2, R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new Publisher[] { source1, source2 }, f);
     }
@@ -18513,6 +18533,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new Publisher[] { source1, source2, source3 }, f);
     }
@@ -18559,6 +18580,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
         return withLatestFrom(new Publisher[] { source1, source2, source3, source4 }, f);
     }

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -127,7 +127,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> amb(final Iterable<? extends MaybeSource<? extends T>> sources) {
+    public static <T> Maybe<T> amb(@NonNull Iterable<? extends MaybeSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new MaybeAmb<>(null, sources));
     }
@@ -452,7 +452,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> concatDelayError(Iterable<? extends MaybeSource<? extends T>> sources) {
+    public static <T> Flowable<T> concatDelayError(@NonNull Iterable<? extends MaybeSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return Flowable.fromIterable(sources).concatMapDelayError((Function)MaybeToPublisher.instance());
     }
@@ -678,7 +678,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> error(@NonNull Supplier<? extends Throwable> supplier) {
-        Objects.requireNonNull(supplier, "errorSupplier is null");
+        Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new MaybeErrorCallable<T>(supplier));
     }
 
@@ -788,7 +788,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Maybe<T> fromCallable(@NonNull final Callable<? extends T> callable) {
+    public static <@NonNull T> Maybe<T> fromCallable(@NonNull Callable<? extends T> callable) {
         Objects.requireNonNull(callable, "callable is null");
         return RxJavaPlugins.onAssembly(new MaybeFromCallable<T>(callable));
     }
@@ -928,7 +928,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Maybe<T> fromSupplier(@NonNull final Supplier<? extends T> supplier) {
+    public static <@NonNull T> Maybe<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new MaybeFromSupplier<T>(supplier));
     }
@@ -1064,7 +1064,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Flowable<T> merge(@NonNull Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        Objects.requireNonNull(sources, "source is null");
+        Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, MaybeToPublisher.instance(), false, maxConcurrency, 1));
     }
@@ -1449,7 +1449,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        Objects.requireNonNull(sources, "source is null");
+        Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         return RxJavaPlugins.onAssembly(new FlowableFlatMapPublisher(sources, MaybeToPublisher.instance(), true, maxConcurrency, 1));
     }
@@ -1806,7 +1806,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
             @NonNull Consumer<? super D> resourceDisposer, boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
-        Objects.requireNonNull(resourceDisposer, "disposer is null");
+        Objects.requireNonNull(resourceDisposer, "resourceDisposer is null");
         return RxJavaPlugins.onAssembly(new MaybeUsing<T, D>(resourceSupplier, sourceSupplier, resourceDisposer, eager));
     }
 
@@ -1828,7 +1828,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         if (source instanceof Maybe) {
             return RxJavaPlugins.onAssembly((Maybe<T>)source);
         }
-        Objects.requireNonNull(source, "onSubscribe is null");
+        Objects.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new MaybeUnsafeCreate<>(source));
     }
 
@@ -1902,6 +1902,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
             @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2);
     }
 
@@ -1943,6 +1944,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3);
     }
 
@@ -1989,6 +1991,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4);
     }
 
@@ -2039,6 +2042,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5);
     }
 
@@ -2093,6 +2097,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5, source6);
     }
 
@@ -2152,6 +2157,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5, source6, source7);
     }
 
@@ -2215,6 +2221,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5, source6, source7, source8);
     }
 
@@ -2282,6 +2289,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5, source6, source7, source8, source9);
     }
 

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -118,7 +118,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> amb(Iterable<? extends ObservableSource<? extends T>> sources) {
+    public static <T> Observable<T> amb(@NonNull Iterable<? extends ObservableSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableAmb<>(null, sources));
     }
@@ -146,7 +146,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T> Observable<T> ambArray(ObservableSource<? extends T>... sources) {
+    public static <T> Observable<T> ambArray(@NonNull ObservableSource<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         int len = sources.length;
         if (len == 0) {
@@ -165,6 +165,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <em>before</em> the {@link Flowable} class is loaded.
      * @return the default 'island' size or capacity-increment hint
      */
+    @CheckReturnValue
     public static int bufferSize() {
         return Flowable.bufferSize();
     }
@@ -206,8 +207,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableSource<? extends T>> sources,
-            Function<? super Object[], ? extends R> combiner) {
+    @NonNull
+    public static <T, R> Observable<R> combineLatest(
+            @NonNull Iterable<? extends ObservableSource<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatest(sources, combiner, bufferSize());
     }
 
@@ -251,8 +254,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatest(Iterable<? extends ObservableSource<? extends T>> sources,
-            Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    public static <T, R> Observable<R> combineLatest(
+            @NonNull Iterable<? extends ObservableSource<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -299,8 +303,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatestArray(ObservableSource<? extends T>[] sources,
-            Function<? super Object[], ? extends R> combiner) {
+    @NonNull
+    public static <T, R> Observable<R> combineLatestArray(
+            @NonNull ObservableSource<? extends T>[] sources,
+            @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatestArray(sources, combiner, bufferSize());
     }
 
@@ -344,8 +350,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatestArray(ObservableSource<? extends T>[] sources,
-            Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    public static <T, R> Observable<R> combineLatestArray(
+            @NonNull ObservableSource<? extends T>[] sources,
+            @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return empty();
@@ -391,10 +398,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, R> Observable<R> combineLatest(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> combiner) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new ObservableSource[] { source1, source2 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -434,12 +442,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, R> Observable<R> combineLatest(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            ObservableSource<? extends T3> source3,
-            Function3<? super T1, ? super T2, ? super T3, ? extends R> combiner) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3,
+            @NonNull Function3<? super T1, ? super T2, ? super T3, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new ObservableSource[] { source1, source2, source3 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -482,13 +491,14 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, R> Observable<R> combineLatest(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            ObservableSource<? extends T3> source3, ObservableSource<? extends T4> source4,
-            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combiner) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
+            @NonNull Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new ObservableSource[] { source1, source2, source3, source4 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -534,15 +544,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, R> Observable<R> combineLatest(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            ObservableSource<? extends T3> source3, ObservableSource<? extends T4> source4,
-            ObservableSource<? extends T5> source5,
-            Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combiner) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
+            @NonNull ObservableSource<? extends T5> source5,
+            @NonNull Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new ObservableSource[] { source1, source2, source3, source4, source5 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -591,16 +602,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> combineLatest(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            ObservableSource<? extends T3> source3, ObservableSource<? extends T4> source4,
-            ObservableSource<? extends T5> source5, ObservableSource<? extends T6> source6,
-            Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combiner) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
+            @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
+            @NonNull Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new ObservableSource[] { source1, source2, source3, source4, source5, source6 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -652,11 +664,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> combineLatest(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            ObservableSource<? extends T3> source3, ObservableSource<? extends T4> source4,
-            ObservableSource<? extends T5> source5, ObservableSource<? extends T6> source6,
-            ObservableSource<? extends T7> source7,
-            Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combiner) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
+            @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
+            @NonNull ObservableSource<? extends T7> source7,
+            @NonNull Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -664,6 +676,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new ObservableSource[] { source1, source2, source3, source4, source5, source6, source7 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -718,11 +731,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> combineLatest(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            ObservableSource<? extends T3> source3, ObservableSource<? extends T4> source4,
-            ObservableSource<? extends T5> source5, ObservableSource<? extends T6> source6,
-            ObservableSource<? extends T7> source7, ObservableSource<? extends T8> source8,
-            Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combiner) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
+            @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
+            @NonNull ObservableSource<? extends T7> source7, @NonNull ObservableSource<? extends T8> source8,
+            @NonNull Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -731,6 +744,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new ObservableSource[] { source1, source2, source3, source4, source5, source6, source7, source8 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -788,12 +802,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> combineLatest(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            ObservableSource<? extends T3> source3, ObservableSource<? extends T4> source4,
-            ObservableSource<? extends T5> source5, ObservableSource<? extends T6> source6,
-            ObservableSource<? extends T7> source7, ObservableSource<? extends T8> source8,
-            ObservableSource<? extends T9> source9,
-            Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combiner) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
+            @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
+            @NonNull ObservableSource<? extends T7> source7, @NonNull ObservableSource<? extends T8> source8,
+            @NonNull ObservableSource<? extends T9> source9,
+            @NonNull Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> combiner) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -803,6 +817,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return combineLatestArray(new ObservableSource[] { source1, source2, source3, source4, source5, source6, source7, source8, source9 }, Functions.toFunction(combiner), bufferSize());
     }
 
@@ -843,8 +858,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatestDelayError(ObservableSource<? extends T>[] sources,
-            Function<? super Object[], ? extends R> combiner) {
+    @NonNull
+    public static <T, R> Observable<R> combineLatestDelayError(
+            @NonNull ObservableSource<? extends T>[] sources,
+            @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatestDelayError(sources, combiner, bufferSize());
     }
 
@@ -889,8 +906,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatestDelayError(ObservableSource<? extends T>[] sources,
-            Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    public static <T, R> Observable<R> combineLatestDelayError(@NonNull ObservableSource<? extends T>[] sources,
+            @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(combiner, "combiner is null");
         if (sources.length == 0) {
@@ -939,8 +956,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatestDelayError(Iterable<? extends ObservableSource<? extends T>> sources,
-            Function<? super Object[], ? extends R> combiner) {
+    @NonNull
+    public static <T, R> Observable<R> combineLatestDelayError(@NonNull Iterable<? extends ObservableSource<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatestDelayError(sources, combiner, bufferSize());
     }
 
@@ -985,8 +1003,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatestDelayError(Iterable<? extends ObservableSource<? extends T>> sources,
-            Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    public static <T, R> Observable<R> combineLatestDelayError(@NonNull Iterable<? extends ObservableSource<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -1013,7 +1031,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concat(Iterable<? extends ObservableSource<? extends T>> sources) {
+    public static <T> Observable<T> concat(@NonNull Iterable<? extends ObservableSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return fromIterable(sources).concatMapDelayError((Function)Functions.identity(), false, bufferSize());
     }
@@ -1037,7 +1055,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concat(ObservableSource<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> concat(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
         return concat(sources, bufferSize());
     }
 
@@ -1064,7 +1083,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concat(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
+    public static <T> Observable<T> concat(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableConcatMap(sources, Functions.identity(), prefetch, ErrorMode.IMMEDIATE));
@@ -1089,11 +1108,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concat(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
+    public static <T> Observable<T> concat(@NonNull ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return concatArray(source1, source2);
@@ -1120,13 +1138,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concat(
-            ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-            ObservableSource<? extends T> source3) {
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
+            @NonNull ObservableSource<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1156,13 +1173,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         without interleaving them
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> concat(
-            ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-            ObservableSource<? extends T> source3, ObservableSource<? extends T> source4) {
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
+            @NonNull ObservableSource<? extends T> source3, @NonNull ObservableSource<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1188,7 +1204,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatArray(ObservableSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Observable<T> concatArray(@NonNull ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         }
@@ -1212,15 +1230,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @return the new Observable instance
      * @throws NullPointerException if sources is null
      */
-    @SuppressWarnings({ "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatArrayDelayError(ObservableSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Observable<T> concatArrayDelayError(@NonNull ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         }
         if (sources.length == 1) {
-            return (Observable<T>)wrap(sources[0]);
+            @SuppressWarnings("unchecked")
+            Observable<T> source = (Observable<T>)wrap(sources[0]);
+            return source;
         }
         return concatDelayError(fromArray(sources));
     }
@@ -1245,7 +1266,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T> Observable<T> concatArrayEager(ObservableSource<? extends T>... sources) {
+    @NonNull
+    public static <T> Observable<T> concatArrayEager(@NonNull ObservableSource<? extends T>... sources) {
         return concatArrayEager(bufferSize(), bufferSize(), sources);
     }
 
@@ -1272,7 +1294,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatArrayEager(int maxConcurrency, int prefetch, ObservableSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Observable<T> concatArrayEager(int maxConcurrency, int prefetch, @NonNull ObservableSource<? extends T>... sources) {
         return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(), false, maxConcurrency, prefetch);
     }
 
@@ -1297,7 +1321,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T> Observable<T> concatArrayEagerDelayError(ObservableSource<? extends T>... sources) {
+    @NonNull
+    public static <T> Observable<T> concatArrayEagerDelayError(@NonNull ObservableSource<? extends T>... sources) {
         return concatArrayEagerDelayError(bufferSize(), bufferSize(), sources);
     }
 
@@ -1325,7 +1350,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatArrayEagerDelayError(int maxConcurrency, int prefetch, ObservableSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Observable<T> concatArrayEagerDelayError(int maxConcurrency, int prefetch, @NonNull ObservableSource<? extends T>... sources) {
         return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(), true, maxConcurrency, prefetch);
     }
 
@@ -1346,7 +1373,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatDelayError(Iterable<? extends ObservableSource<? extends T>> sources) {
+    public static <T> Observable<T> concatDelayError(@NonNull Iterable<? extends ObservableSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return concatDelayError(fromIterable(sources));
     }
@@ -1367,7 +1394,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> concatDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
         return concatDelayError(sources, bufferSize(), true);
     }
 
@@ -1392,7 +1420,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch, boolean tillTheEnd) {
+    public static <T> Observable<T> concatDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch, boolean tillTheEnd) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatMap(sources, Functions.identity(), prefetch, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
@@ -1417,7 +1445,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatEager(ObservableSource<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> concatEager(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
         return concatEager(sources, bufferSize(), bufferSize());
     }
 
@@ -1444,7 +1473,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatEager(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
+    @NonNull
+    public static <T> Observable<T> concatEager(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
         return wrap(sources).concatMapEager((Function)Functions.identity(), maxConcurrency, prefetch);
     }
 
@@ -1467,7 +1497,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatEager(Iterable<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> concatEager(@NonNull Iterable<? extends ObservableSource<? extends T>> sources) {
         return concatEager(sources, bufferSize(), bufferSize());
     }
 
@@ -1494,7 +1525,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> concatEager(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
+    @NonNull
+    public static <T> Observable<T> concatEager(@NonNull Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int prefetch) {
         return fromIterable(sources).concatMapEagerDelayError((Function)Functions.identity(), false, maxConcurrency, prefetch);
     }
 
@@ -1551,7 +1583,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> create(ObservableOnSubscribe<T> source) {
+    public static <T> Observable<T> create(@NonNull ObservableOnSubscribe<T> source) {
         Objects.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new ObservableCreate<>(source));
     }
@@ -1583,7 +1615,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> defer(Supplier<? extends ObservableSource<? extends T>> supplier) {
+    public static <T> Observable<T> defer(@NonNull Supplier<? extends ObservableSource<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new ObservableDefer<>(supplier));
     }
@@ -1607,6 +1639,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Observable<T> empty() {
         return RxJavaPlugins.onAssembly((Observable<T>) ObservableEmpty.INSTANCE);
     }
@@ -1632,7 +1665,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> error(Supplier<? extends Throwable> errorSupplier) {
+    public static <T> Observable<T> error(@NonNull Supplier<? extends Throwable> errorSupplier) {
         Objects.requireNonNull(errorSupplier, "errorSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableError<T>(errorSupplier));
     }
@@ -1658,7 +1691,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> error(final Throwable exception) {
+    public static <T> Observable<T> error(@NonNull Throwable exception) {
         Objects.requireNonNull(exception, "exception is null");
         return error(Functions.justSupplier(exception));
     }
@@ -1683,7 +1716,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     @SafeVarargs
-    public static <T> Observable<T> fromArray(T... items) {
+    public static <T> Observable<T> fromArray(@NonNull T... items) {
         Objects.requireNonNull(items, "items is null");
         if (items.length == 0) {
             return empty();
@@ -1726,7 +1759,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> fromCallable(Callable<? extends T> supplier) {
+    public static <T> Observable<T> fromCallable(@NonNull Callable<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new ObservableFromCallable<T>(supplier));
     }
@@ -1760,7 +1793,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> fromFuture(Future<? extends T> future) {
+    public static <T> Observable<T> fromFuture(@NonNull Future<? extends T> future) {
         Objects.requireNonNull(future, "future is null");
         return RxJavaPlugins.onAssembly(new ObservableFromFuture<T>(future, 0L, null));
     }
@@ -1798,7 +1831,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit) {
+    public static <T> Observable<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit) {
         Objects.requireNonNull(future, "future is null");
         Objects.requireNonNull(unit, "unit is null");
         return RxJavaPlugins.onAssembly(new ObservableFromFuture<T>(future, timeout, unit));
@@ -1840,7 +1873,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static <T> Observable<T> fromFuture(Future<? extends T> future, long timeout, TimeUnit unit, Scheduler scheduler) {
+    public static <T> Observable<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         Observable<T> o = fromFuture(future, timeout, unit);
         return o.subscribeOn(scheduler);
@@ -1876,7 +1909,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static <T> Observable<T> fromFuture(Future<? extends T> future, Scheduler scheduler) {
+    public static <T> Observable<T> fromFuture(@NonNull Future<? extends T> future, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         Observable<T> o = fromFuture(future);
         return o.subscribeOn(scheduler);
@@ -1902,7 +1935,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> fromIterable(Iterable<? extends T> source) {
+    public static <T> Observable<T> fromIterable(@NonNull Iterable<? extends T> source) {
         Objects.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new ObservableFromIterable<T>(source));
     }
@@ -1939,7 +1972,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> fromPublisher(Publisher<? extends T> publisher) {
+    public static <T> Observable<T> fromPublisher(@NonNull Publisher<? extends T> publisher) {
         Objects.requireNonNull(publisher, "publisher is null");
         return RxJavaPlugins.onAssembly(new ObservableFromPublisher<T>(publisher));
     }
@@ -1976,7 +2009,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> fromSupplier(Supplier<? extends T> supplier) {
+    public static <T> Observable<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new ObservableFromSupplier<T>(supplier));
     }
@@ -2005,7 +2038,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> generate(final Consumer<Emitter<T>> generator) {
+    public static <T> Observable<T> generate(@NonNull Consumer<Emitter<T>> generator) {
         Objects.requireNonNull(generator, "generator is null");
         return generate(Functions.<Object>nullSupplier(),
                 ObservableInternalHelper.simpleGenerator(generator), Functions.<Object>emptyConsumer());
@@ -2037,7 +2070,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Supplier<S> initialState, final BiConsumer<S, Emitter<T>> generator) {
+    public static <T, S> Observable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiConsumer<S, Emitter<T>> generator) {
         Objects.requireNonNull(generator, "generator is null");
         return generate(initialState, ObservableInternalHelper.simpleBiGenerator(generator), Functions.emptyConsumer());
     }
@@ -2071,9 +2104,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Observable<T> generate(
-            final Supplier<S> initialState,
-            final BiConsumer<S, Emitter<T>> generator,
-            Consumer<? super S> disposeState) {
+            @NonNull Supplier<S> initialState,
+            @NonNull BiConsumer<S, Emitter<T>> generator,
+            @NonNull Consumer<? super S> disposeState) {
         Objects.requireNonNull(generator, "generator is null");
         return generate(initialState, ObservableInternalHelper.simpleBiGenerator(generator), disposeState);
     }
@@ -2104,7 +2137,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Supplier<S> initialState, BiFunction<S, Emitter<T>, S> generator) {
+    @NonNull
+    public static <T, S> Observable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiFunction<S, Emitter<T>, S> generator) {
         return generate(initialState, generator, Functions.emptyConsumer());
     }
 
@@ -2137,8 +2171,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, S> Observable<T> generate(Supplier<S> initialState, BiFunction<S, Emitter<T>, S> generator,
-            Consumer<? super S> disposeState) {
+    public static <T, S> Observable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiFunction<S, Emitter<T>, S> generator,
+            @NonNull Consumer<? super S> disposeState) {
         Objects.requireNonNull(initialState, "initialState is null");
         Objects.requireNonNull(generator, "generator is null");
         Objects.requireNonNull(disposeState, "disposeState is null");
@@ -2168,7 +2202,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Observable<Long> interval(long initialDelay, long period, TimeUnit unit) {
+    @NonNull
+    public static Observable<Long> interval(long initialDelay, long period, @NonNull TimeUnit unit) {
         return interval(initialDelay, period, unit, Schedulers.computation());
     }
 
@@ -2198,7 +2233,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Observable<Long> interval(long initialDelay, long period, TimeUnit unit, Scheduler scheduler) {
+    public static Observable<Long> interval(long initialDelay, long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
 
@@ -2223,7 +2258,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Observable<Long> interval(long period, TimeUnit unit) {
+    @NonNull
+    public static Observable<Long> interval(long period, @NonNull TimeUnit unit) {
         return interval(period, period, unit, Schedulers.computation());
     }
 
@@ -2248,7 +2284,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Observable<Long> interval(long period, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public static Observable<Long> interval(long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return interval(period, period, unit, scheduler);
     }
 
@@ -2271,7 +2308,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Observable<Long> intervalRange(long start, long count, long initialDelay, long period, TimeUnit unit) {
+    @NonNull
+    public static Observable<Long> intervalRange(long start, long count, long initialDelay, long period, @NonNull TimeUnit unit) {
         return intervalRange(start, count, initialDelay, period, unit, Schedulers.computation());
     }
 
@@ -2295,7 +2333,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Observable<Long> intervalRange(long start, long count, long initialDelay, long period, TimeUnit unit, Scheduler scheduler) {
+    public static Observable<Long> intervalRange(long start, long count, long initialDelay, long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
         }
@@ -2345,7 +2383,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item) {
+    public static <T> Observable<T> just(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return RxJavaPlugins.onAssembly(new ObservableJust<>(item));
     }
@@ -2371,7 +2409,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
 
@@ -2401,7 +2439,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2, T item3) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2434,7 +2472,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2, T item3, T item4) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2470,7 +2508,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2, T item3, T item4, T item5) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2509,7 +2547,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2, T item3, T item4, T item5, T item6) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2551,7 +2589,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2596,7 +2634,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2644,7 +2682,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8, T item9) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8, @NonNull T item9) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2695,7 +2733,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> just(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8, T item9, T item10) {
+    public static <T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8, @NonNull T item9, @NonNull T item10) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2753,7 +2791,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> merge(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
+    @NonNull
+    public static <T> Observable<T> merge(@NonNull Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
@@ -2800,7 +2839,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeArray(int maxConcurrency, int bufferSize, ObservableSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Observable<T> mergeArray(int maxConcurrency, int bufferSize, @NonNull ObservableSource<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
     }
 
@@ -2840,7 +2881,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> merge(Iterable<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> merge(@NonNull Iterable<? extends ObservableSource<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity());
     }
 
@@ -2885,7 +2927,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> merge(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
+    @NonNull
+    public static <T> Observable<T> merge(@NonNull Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), maxConcurrency);
     }
 
@@ -2926,7 +2969,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Observable<T> merge(ObservableSource<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> merge(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), false, Integer.MAX_VALUE, bufferSize()));
     }
@@ -2974,7 +3018,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> merge(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
+    @NonNull
+    public static <T> Observable<T> merge(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), false, maxConcurrency, bufferSize()));
@@ -3017,7 +3062,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> merge(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
+    @NonNull
+    public static <T> Observable<T> merge(@NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return fromArray(source1, source2).flatMap((Function)Functions.identity(), false, 2);
@@ -3062,7 +3108,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> merge(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2, ObservableSource<? extends T> source3) {
+    @NonNull
+    public static <T> Observable<T> merge(
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
+            @NonNull ObservableSource<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -3110,9 +3159,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T> Observable<T> merge(
-            ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-            ObservableSource<? extends T> source3, ObservableSource<? extends T> source4) {
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
+            @NonNull ObservableSource<? extends T> source3, @NonNull ObservableSource<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -3155,7 +3205,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeArray(ObservableSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Observable<T> mergeArray(@NonNull ObservableSource<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), sources.length);
     }
 
@@ -3187,7 +3239,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeDelayError(Iterable<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> mergeDelayError(@NonNull Iterable<? extends ObservableSource<? extends T>> sources) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true);
     }
 
@@ -3223,7 +3276,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeDelayError(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
+    @NonNull
+    public static <T> Observable<T> mergeDelayError(@NonNull Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
@@ -3259,7 +3313,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeArrayDelayError(int maxConcurrency, int bufferSize, ObservableSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Observable<T> mergeArrayDelayError(int maxConcurrency, int bufferSize, @NonNull ObservableSource<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
@@ -3293,7 +3349,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeDelayError(Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
+    @NonNull
+    public static <T> Observable<T> mergeDelayError(@NonNull Iterable<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
         return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
     }
 
@@ -3325,7 +3382,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Observable<T> mergeDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> mergeDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), true, Integer.MAX_VALUE, bufferSize()));
     }
@@ -3362,7 +3420,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
+    @NonNull
+    public static <T> Observable<T> mergeDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), true, maxConcurrency, bufferSize()));
@@ -3397,7 +3456,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeDelayError(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
+    @NonNull
+    public static <T> Observable<T> mergeDelayError(
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return fromArray(source1, source2).flatMap((Function)Functions.identity(), true, 2);
@@ -3435,7 +3496,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeDelayError(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2, ObservableSource<? extends T> source3) {
+    @NonNull
+    public static <T> Observable<T> mergeDelayError(
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
+            @NonNull ObservableSource<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -3476,9 +3540,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T> Observable<T> mergeDelayError(
-            ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-            ObservableSource<? extends T> source3, ObservableSource<? extends T> source4) {
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
+            @NonNull ObservableSource<? extends T> source3, @NonNull ObservableSource<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -3514,7 +3579,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> mergeArrayDelayError(ObservableSource<? extends T>... sources) {
+    @NonNull
+    @SafeVarargs
+    public static <T> Observable<T> mergeArrayDelayError(@NonNull ObservableSource<? extends T>... sources) {
         return fromArray(sources).flatMap((Function)Functions.identity(), true, sources.length);
     }
 
@@ -3537,6 +3604,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Observable<T> never() {
         return RxJavaPlugins.onAssembly((Observable<T>) ObservableNever.INSTANCE);
     }
@@ -3562,7 +3630,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Observable<Integer> range(final int start, final int count) {
+    @NonNull
+    public static Observable<Integer> range(int start, int count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
         }
@@ -3599,6 +3668,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static Observable<Long> rangeLong(long start, long count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
@@ -3641,7 +3711,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2) {
+    @NonNull
+    public static <T> Single<Boolean> sequenceEqual(@NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize());
     }
 
@@ -3670,8 +3741,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-            BiPredicate<? super T, ? super T> isEqual) {
+    @NonNull
+    public static <T> Single<Boolean> sequenceEqual(
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
+            @NonNull BiPredicate<? super T, ? super T> isEqual) {
         return sequenceEqual(source1, source2, isEqual, bufferSize());
     }
 
@@ -3702,8 +3775,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
-            BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
+    @NonNull
+    public static <T> Single<Boolean> sequenceEqual(
+            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
+            @NonNull BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(isEqual, "isEqual is null");
@@ -3734,7 +3809,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(ObservableSource<? extends T> source1, ObservableSource<? extends T> source2,
+    @NonNull
+    public static <T> Single<Boolean> sequenceEqual(@NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
             int bufferSize) {
         return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize);
     }
@@ -3769,7 +3845,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> switchOnNext(ObservableSource<? extends ObservableSource<? extends T>> sources, int bufferSize) {
+    @NonNull
+    public static <T> Observable<T> switchOnNext(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMap(sources, Functions.identity(), bufferSize, false));
@@ -3802,7 +3879,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> switchOnNext(ObservableSource<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> switchOnNext(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
         return switchOnNext(sources, bufferSize());
     }
 
@@ -3835,7 +3913,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> switchOnNextDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources) {
+    @NonNull
+    public static <T> Observable<T> switchOnNextDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
         return switchOnNextDelayError(sources, bufferSize());
     }
 
@@ -3871,7 +3950,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> switchOnNextDelayError(ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
+    @NonNull
+    public static <T> Observable<T> switchOnNextDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int prefetch) {
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMap(sources, Functions.identity(), prefetch, true));
@@ -3895,7 +3975,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public static Observable<Long> timer(long delay, TimeUnit unit) {
+    @NonNull
+    public static Observable<Long> timer(long delay, @NonNull TimeUnit unit) {
         return timer(delay, unit, Schedulers.computation());
     }
 
@@ -3924,7 +4005,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public static Observable<Long> timer(long delay, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public static Observable<Long> timer(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
 
@@ -3945,7 +4027,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> unsafeCreate(ObservableSource<T> onSubscribe) {
+    @NonNull
+    public static <T> Observable<T> unsafeCreate(@NonNull ObservableSource<T> onSubscribe) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         if (onSubscribe instanceof Observable) {
             throw new IllegalArgumentException("unsafeCreate(Observable) should be upgraded");
@@ -3976,7 +4059,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier, Consumer<? super D> disposer) {
+    @NonNull
+    public static <T, D> Observable<T> using(
+            @NonNull Supplier<? extends D> resourceSupplier,
+            @NonNull Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier,
+            @NonNull Consumer<? super D> disposer) {
         return using(resourceSupplier, sourceSupplier, disposer, true);
     }
 
@@ -4012,7 +4099,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, D> Observable<T> using(Supplier<? extends D> resourceSupplier, Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier, Consumer<? super D> disposer, boolean eager) {
+    @NonNull
+    public static <T, D> Observable<T> using(
+            @NonNull Supplier<? extends D> resourceSupplier,
+            @NonNull Function<? super D, ? extends ObservableSource<? extends T>> sourceSupplier,
+            @NonNull Consumer<? super D> disposer, boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
         Objects.requireNonNull(disposer, "disposer is null");
@@ -4034,7 +4125,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Observable<T> wrap(ObservableSource<T> source) {
+    @NonNull
+    public static <T> Observable<T> wrap(@NonNull ObservableSource<T> source) {
         Objects.requireNonNull(source, "source is null");
         if (source instanceof Observable) {
             return RxJavaPlugins.onAssembly((Observable<T>)source);
@@ -4089,7 +4181,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> zip(Iterable<? extends ObservableSource<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
+    @NonNull
+    public static <T, R> Observable<R> zip(@NonNull Iterable<? extends ObservableSource<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(null, sources, zipper, bufferSize(), false));
@@ -4147,8 +4240,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> zip(Iterable<? extends ObservableSource<? extends T>> sources,
-            Function<? super Object[], ? extends R> zipper, boolean delayError,
+    @NonNull
+    public static <T, R> Observable<R> zip(@NonNull Iterable<? extends ObservableSource<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> zipper, boolean delayError,
             int bufferSize) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
@@ -4202,11 +4296,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> zipper) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2);
     }
 
@@ -4257,11 +4353,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize(), source1, source2);
     }
 
@@ -4313,11 +4411,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2,
-            BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError, int bufferSize) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError, int bufferSize) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), delayError, bufferSize, source1, source2);
     }
 
@@ -4371,12 +4471,15 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, T3, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2, ObservableSource<? extends T3> source3,
-            Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3,
+            @NonNull Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3);
     }
 
@@ -4433,14 +4536,16 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, T3, T4, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2, ObservableSource<? extends T3> source3,
-            ObservableSource<? extends T4> source4,
-            Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
+            @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
+            @NonNull Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4);
     }
 
@@ -4500,15 +4605,17 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, T3, T4, T5, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2, ObservableSource<? extends T3> source3,
-            ObservableSource<? extends T4> source4, ObservableSource<? extends T5> source5,
-            Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2, @NonNull ObservableSource<? extends T3> source3,
+            @NonNull ObservableSource<? extends T4> source4, @NonNull ObservableSource<? extends T5> source5,
+            @NonNull Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5);
     }
 
@@ -4570,16 +4677,18 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, T3, T4, T5, T6, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2, ObservableSource<? extends T3> source3,
-            ObservableSource<? extends T4> source4, ObservableSource<? extends T5> source5, ObservableSource<? extends T6> source6,
-            Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2, @NonNull ObservableSource<? extends T3> source3,
+            @NonNull ObservableSource<? extends T4> source4, @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
+            @NonNull Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6);
     }
 
@@ -4644,11 +4753,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2, ObservableSource<? extends T3> source3,
-            ObservableSource<? extends T4> source4, ObservableSource<? extends T5> source5, ObservableSource<? extends T6> source6,
-            ObservableSource<? extends T7> source7,
-            Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2, @NonNull ObservableSource<? extends T3> source3,
+            @NonNull ObservableSource<? extends T4> source4, @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
+            @NonNull ObservableSource<? extends T7> source7,
+            @NonNull Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -4656,6 +4766,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7);
     }
 
@@ -4723,11 +4834,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2, ObservableSource<? extends T3> source3,
-            ObservableSource<? extends T4> source4, ObservableSource<? extends T5> source5, ObservableSource<? extends T6> source6,
-            ObservableSource<? extends T7> source7, ObservableSource<? extends T8> source8,
-            Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2, @NonNull ObservableSource<? extends T3> source3,
+            @NonNull ObservableSource<? extends T4> source4, @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
+            @NonNull ObservableSource<? extends T7> source7, @NonNull ObservableSource<? extends T8> source8,
+            @NonNull Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -4736,6 +4848,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7, source8);
     }
 
@@ -4806,11 +4919,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Observable<R> zip(
-            ObservableSource<? extends T1> source1, ObservableSource<? extends T2> source2, ObservableSource<? extends T3> source3,
-            ObservableSource<? extends T4> source4, ObservableSource<? extends T5> source5, ObservableSource<? extends T6> source6,
-            ObservableSource<? extends T7> source7, ObservableSource<? extends T8> source8, ObservableSource<? extends T9> source9,
-            Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper) {
+            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2, @NonNull ObservableSource<? extends T3> source3,
+            @NonNull ObservableSource<? extends T4> source4, @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
+            @NonNull ObservableSource<? extends T7> source7, @NonNull ObservableSource<? extends T8> source8, @NonNull ObservableSource<? extends T9> source9,
+            @NonNull Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -4820,6 +4934,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7, source8, source9);
     }
 
@@ -4876,8 +4991,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T, R> Observable<R> zipArray(Function<? super Object[], ? extends R> zipper,
-            boolean delayError, int bufferSize, ObservableSource<? extends T>... sources) {
+    @NonNull
+    public static <T, R> Observable<R> zipArray(
+            @NonNull Function<? super Object[], ? extends R> zipper,
+            boolean delayError, int bufferSize,
+            @NonNull ObservableSource<? extends T>... sources) {
         if (sources.length == 0) {
             return empty();
         }
@@ -4908,7 +5026,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> all(Predicate<? super T> predicate) {
+    @NonNull
+    public final Single<Boolean> all(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return RxJavaPlugins.onAssembly(new ObservableAllSingle<>(this, predicate));
     }
@@ -4932,7 +5051,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> ambWith(ObservableSource<? extends T> other) {
+    @NonNull
+    public final Observable<T> ambWith(@NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return ambArray(this, other);
     }
@@ -4959,7 +5079,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> any(Predicate<? super T> predicate) {
+    @NonNull
+    public final Single<Boolean> any(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return RxJavaPlugins.onAssembly(new ObservableAnySingle<>(this, predicate));
     }
@@ -4981,6 +5102,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final T blockingFirst() {
         BlockingFirstObserver<T> observer = new BlockingFirstObserver<>();
         subscribe(observer);
@@ -5009,7 +5131,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final T blockingFirst(T defaultItem) {
+    @NonNull
+    public final T blockingFirst(@NonNull T defaultItem) {
         BlockingFirstObserver<T> observer = new BlockingFirstObserver<>();
         subscribe(observer);
         T v = observer.blockingGet();
@@ -5046,7 +5169,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see #subscribe(Consumer)
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingForEach(Consumer<? super T> onNext) {
+    @NonNull
+    public final void blockingForEach(@NonNull Consumer<? super T> onNext) {
         Iterator<T> it = blockingIterable().iterator();
         while (it.hasNext()) {
             try {
@@ -5073,6 +5197,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Iterable<T> blockingIterable() {
         return blockingIterable(bufferSize());
     }
@@ -5092,6 +5217,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Iterable<T> blockingIterable(int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return new BlockingObservableIterable<>(this, bufferSize);
@@ -5118,6 +5244,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final T blockingLast() {
         BlockingLastObserver<T> observer = new BlockingLastObserver<>();
         subscribe(observer);
@@ -5150,7 +5277,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final T blockingLast(T defaultItem) {
+    @NonNull
+    public final T blockingLast(@NonNull T defaultItem) {
         BlockingLastObserver<T> observer = new BlockingLastObserver<>();
         subscribe(observer);
         T v = observer.blockingGet();
@@ -5178,6 +5306,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Iterable<T> blockingLatest() {
         return new BlockingObservableLatest<>(this);
     }
@@ -5201,7 +5330,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Iterable<T> blockingMostRecent(T initialValue) {
+    @NonNull
+    public final Iterable<T> blockingMostRecent(@NonNull T initialValue) {
         return new BlockingObservableMostRecent<>(this, initialValue);
     }
 
@@ -5221,6 +5351,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Iterable<T> blockingNext() {
         return new BlockingObservableNext<>(this);
     }
@@ -5244,6 +5375,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final T blockingSingle() {
         T v = singleElement().blockingGet();
         if (v == null) {
@@ -5275,7 +5407,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final T blockingSingle(T defaultItem) {
+    @NonNull
+    public final T blockingSingle(@NonNull T defaultItem) {
         return single(defaultItem).blockingGet();
     }
 
@@ -5300,6 +5433,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Future<T> toFuture() {
         return subscribeWith(new FutureObserver<T>());
     }
@@ -5350,7 +5484,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see #blockingSubscribe(Consumer, Consumer, Action)
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext) {
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext) {
         ObservableBlockingSubscribe.subscribe(this, onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
 
@@ -5372,7 +5506,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see #blockingSubscribe(Consumer, Consumer, Action)
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError) {
         ObservableBlockingSubscribe.subscribe(this, onNext, onError, Functions.EMPTY_ACTION);
     }
 
@@ -5394,7 +5528,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete) {
+    public final void blockingSubscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError, @NonNull Action onComplete) {
         ObservableBlockingSubscribe.subscribe(this, onNext, onError, onComplete);
     }
 
@@ -5415,7 +5549,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @since 2.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void blockingSubscribe(Observer<? super T> observer) {
+    public final void blockingSubscribe(@NonNull Observer<? super T> observer) {
         ObservableBlockingSubscribe.subscribe(this, observer);
     }
 
@@ -5440,7 +5574,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<List<T>> buffer(int count) {
+    @NonNull
+    public final Observable<@NonNull List<T>> buffer(int count) {
         return buffer(count, count);
     }
 
@@ -5469,7 +5604,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<List<T>> buffer(int count, int skip) {
+    @NonNull
+    public final Observable<@NonNull List<T>> buffer(int count, int skip) {
         return buffer(count, skip, ArrayListSupplier.<T>asSupplier());
     }
 
@@ -5502,7 +5638,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Observable<U> buffer(int count, int skip, Supplier<U> bufferSupplier) {
+    @NonNull
+    public final <U extends Collection<? super T>> Observable<U> buffer(int count, int skip, @NonNull Supplier<U> bufferSupplier) {
         ObjectHelper.verifyPositive(count, "count");
         ObjectHelper.verifyPositive(skip, "skip");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -5534,7 +5671,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Observable<U> buffer(int count, Supplier<U> bufferSupplier) {
+    @NonNull
+    public final <@NonNull U extends Collection<? super T>> Observable<U> buffer(int count, @NonNull Supplier<U> bufferSupplier) {
         return buffer(count, count, bufferSupplier);
     }
 
@@ -5564,7 +5702,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<List<T>> buffer(long timespan, long timeskip, TimeUnit unit) {
+    @NonNull
+    public final Observable<@NonNull List<T>> buffer(long timespan, long timeskip, @NonNull TimeUnit unit) {
         return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.<T>asSupplier());
     }
 
@@ -5597,7 +5736,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<List<T>> buffer(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<@NonNull List<T>> buffer(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.<T>asSupplier());
     }
 
@@ -5634,7 +5774,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <U extends Collection<? super T>> Observable<U> buffer(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, Supplier<U> bufferSupplier) {
+    @NonNull
+    public final <@NonNull U extends Collection<? super T>> Observable<U> buffer(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, @NonNull Supplier<U> bufferSupplier) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -5666,7 +5807,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<List<T>> buffer(long timespan, TimeUnit unit) {
+    @NonNull
+    public final Observable<@NonNull List<T>> buffer(long timespan, @NonNull TimeUnit unit) {
         return buffer(timespan, unit, Schedulers.computation(), Integer.MAX_VALUE);
     }
 
@@ -5699,7 +5841,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<List<T>> buffer(long timespan, TimeUnit unit, int count) {
+    @NonNull
+    public final Observable<@NonNull List<T>> buffer(long timespan, @NonNull TimeUnit unit, int count) {
         return buffer(timespan, unit, Schedulers.computation(), count);
     }
 
@@ -5734,7 +5877,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler, int count) {
+    @NonNull
+    public final Observable<@NonNull List<T>> buffer(long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int count) {
         return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asSupplier(), false);
     }
 
@@ -5775,10 +5919,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <U extends Collection<? super T>> Observable<U> buffer(
-            long timespan, TimeUnit unit,
-            Scheduler scheduler, int count,
-            Supplier<U> bufferSupplier,
+    @NonNull
+    public final <@NonNull U extends Collection<? super T>> Observable<U> buffer(
+            long timespan, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler, int count,
+            @NonNull Supplier<U> bufferSupplier,
             boolean restartTimerOnMaxSize) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -5814,7 +5959,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<List<T>> buffer(long timespan, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<@NonNull List<T>> buffer(long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asSupplier(), false);
     }
 
@@ -5844,9 +5990,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <TOpening, TClosing> Observable<List<T>> buffer(
-            ObservableSource<? extends TOpening> openingIndicator,
-            Function<? super TOpening, ? extends ObservableSource<? extends TClosing>> closingIndicator) {
+    @NonNull
+    public final <TOpening, TClosing> Observable<@NonNull List<T>> buffer(
+            @NonNull ObservableSource<? extends TOpening> openingIndicator,
+            @NonNull Function<? super TOpening, ? extends ObservableSource<? extends TClosing>> closingIndicator) {
         return buffer(openingIndicator, closingIndicator, ArrayListSupplier.<T>asSupplier());
     }
 
@@ -5880,10 +6027,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <TOpening, TClosing, U extends Collection<? super T>> Observable<U> buffer(
-            ObservableSource<? extends TOpening> openingIndicator,
-            Function<? super TOpening, ? extends ObservableSource<? extends TClosing>> closingIndicator,
-            Supplier<U> bufferSupplier) {
+    @NonNull
+    public final <TOpening, TClosing, @NonNull U extends Collection<? super T>> Observable<U> buffer(
+            @NonNull ObservableSource<? extends TOpening> openingIndicator,
+            @NonNull Function<? super TOpening, ? extends ObservableSource<? extends TClosing>> closingIndicator,
+            @NonNull Supplier<U> bufferSupplier) {
         Objects.requireNonNull(openingIndicator, "openingIndicator is null");
         Objects.requireNonNull(closingIndicator, "closingIndicator is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -5916,7 +6064,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Observable<List<T>> buffer(ObservableSource<B> boundary) {
+    @NonNull
+    public final <B> Observable<@NonNull List<T>> buffer(@NonNull ObservableSource<B> boundary) {
         return buffer(boundary, ArrayListSupplier.<T>asSupplier());
     }
 
@@ -5948,7 +6097,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Observable<List<T>> buffer(ObservableSource<B> boundary, final int initialCapacity) {
+    @NonNull
+    public final <B> Observable<@NonNull List<T>> buffer(@NonNull ObservableSource<B> boundary, int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
         return buffer(boundary, Functions.<T>createArrayList(initialCapacity));
     }
@@ -5983,7 +6133,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B, U extends Collection<? super T>> Observable<U> buffer(ObservableSource<B> boundary, Supplier<U> bufferSupplier) {
+    @NonNull
+    public final <B, @NonNull U extends Collection<? super T>> Observable<U> buffer(@NonNull ObservableSource<B> boundary, @NonNull Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundary, "boundary is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableBufferExactBoundary<>(this, boundary, bufferSupplier));
@@ -6039,6 +6190,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> cache() {
         return cacheWithInitialCapacity(16);
     }
@@ -6097,6 +6249,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> cacheWithInitialCapacity(int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
         return RxJavaPlugins.onAssembly(new ObservableCache<>(this, initialCapacity));
@@ -6122,7 +6275,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<U> cast(final Class<U> clazz) {
+    @NonNull
+    public final <U> Observable<U> cast(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
         return map(Functions.castFunction(clazz));
     }
@@ -6155,7 +6309,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<U> collect(Supplier<? extends U> initialValueSupplier, BiConsumer<? super U, ? super T> collector) {
+    @NonNull
+    public final <U> Single<U> collect(@NonNull Supplier<? extends U> initialValueSupplier, @NonNull BiConsumer<? super U, ? super T> collector) {
         Objects.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
         Objects.requireNonNull(collector, "collector is null");
         return RxJavaPlugins.onAssembly(new ObservableCollectSingle<T, U>(this, initialValueSupplier, collector));
@@ -6189,7 +6344,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<U> collectInto(final U initialValue, BiConsumer<? super U, ? super T> collector) {
+    @NonNull
+    public final <U> Single<U> collectInto(@NonNull U initialValue, @NonNull BiConsumer<? super U, ? super T> collector) {
         Objects.requireNonNull(initialValue, "initialValue is null");
         return collect(Functions.justSupplier(initialValue), collector);
     }
@@ -6216,7 +6372,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> compose(ObservableTransformer<? super T, ? extends R> composer) {
+    @NonNull
+    public final <R> Observable<R> compose(@NonNull ObservableTransformer<? super T, ? extends R> composer) {
         return wrap(((ObservableTransformer<T, R>) Objects.requireNonNull(composer, "composer is null")).apply(this));
     }
 
@@ -6246,7 +6403,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return concatMap(mapper, 2);
     }
 
@@ -6278,7 +6436,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int prefetch) {
+    @NonNull
+    public final <R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         if (this instanceof ScalarSupplier) {
@@ -6320,7 +6479,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Observable<R> concatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int prefetch, Scheduler scheduler) {
+    @NonNull
+    public final <R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int prefetch, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -6350,7 +6510,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> concatMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return concatMapDelayError(mapper, true, bufferSize());
     }
 
@@ -6382,7 +6543,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+    @NonNull
+    public final <R> Observable<R> concatMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
             boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
@@ -6424,8 +6586,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Observable<R> concatMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            boolean tillTheEnd, int prefetch, Scheduler scheduler) {
+    @NonNull
+    public final <R> Observable<R> concatMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+            boolean tillTheEnd, int prefetch, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -6453,7 +6616,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapEager(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> concatMapEager(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return concatMapEager(mapper, Integer.MAX_VALUE, bufferSize());
     }
 
@@ -6480,7 +6644,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapEager(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+    @NonNull
+    public final <R> Observable<R> concatMapEager(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
             int maxConcurrency, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
@@ -6512,7 +6677,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+    @NonNull
+    public final <R> Observable<R> concatMapEagerDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
             boolean tillTheEnd) {
         return concatMapEagerDelayError(mapper, tillTheEnd, Integer.MAX_VALUE, bufferSize());
     }
@@ -6545,7 +6711,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapEagerDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+    @NonNull
+    public final <R> Observable<R> concatMapEagerDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
             boolean tillTheEnd, int maxConcurrency, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
@@ -6570,7 +6737,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
+    @NonNull
+    public final Completable concatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         return concatMapCompletable(mapper, 2);
     }
 
@@ -6595,7 +6763,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, int capacityHint) {
+    @NonNull
+    public final Completable concatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper, int capacityHint) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<>(this, mapper, ErrorMode.IMMEDIATE, capacityHint));
@@ -6621,7 +6790,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper) {
+    @NonNull
+    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         return concatMapCompletableDelayError(mapper, true, 2);
     }
 
@@ -6651,7 +6821,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd) {
+    @NonNull
+    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd) {
         return concatMapCompletableDelayError(mapper, tillTheEnd, 2);
     }
 
@@ -6685,7 +6856,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable concatMapCompletableDelayError(Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd, int prefetch) {
+    @NonNull
+    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
@@ -6713,7 +6885,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<U> concatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    @NonNull
+    public final <U> Observable<U> concatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableFlattenIterable<>(this, mapper));
     }
@@ -6742,7 +6915,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<U> concatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper, int prefetch) {
+    @NonNull
+    public final <U> Observable<U> concatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return concatMap(ObservableInternalHelper.flatMapIntoIterable(mapper), prefetch);
@@ -6770,7 +6944,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> concatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return concatMapMaybe(mapper, 2);
     }
 
@@ -6800,7 +6975,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper, int prefetch) {
+    @NonNull
+    public final <R> Observable<R> concatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
@@ -6828,7 +7004,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return concatMapMaybeDelayError(mapper, true, 2);
     }
 
@@ -6860,7 +7037,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd) {
+    @NonNull
+    public final <R> Observable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd) {
         return concatMapMaybeDelayError(mapper, tillTheEnd, 2);
     }
 
@@ -6895,7 +7073,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapMaybeDelayError(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
+    @NonNull
+    public final <R> Observable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
@@ -6923,7 +7102,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> concatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return concatMapSingle(mapper, 2);
     }
 
@@ -6953,7 +7133,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper, int prefetch) {
+    @NonNull
+    public final <R> Observable<R> concatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<>(this, mapper, ErrorMode.IMMEDIATE, prefetch));
@@ -6981,7 +7162,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return concatMapSingleDelayError(mapper, true, 2);
     }
 
@@ -7013,7 +7195,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd) {
+    @NonNull
+    public final <R> Observable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd) {
         return concatMapSingleDelayError(mapper, tillTheEnd, 2);
     }
 
@@ -7048,7 +7231,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> concatMapSingleDelayError(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
+    @NonNull
+    public final <R> Observable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
@@ -7072,7 +7256,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> concatWith(ObservableSource<? extends T> other) {
+    @NonNull
+    public final Observable<T> concatWith(@NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concat(this, other);
     }
@@ -7093,6 +7278,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> concatWith(@NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatWithSingle<>(this, other));
@@ -7114,6 +7300,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatWithMaybe<>(this, other));
@@ -7135,6 +7322,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> concatWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatWithCompletable<>(this, other));
@@ -7158,7 +7346,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> contains(final Object element) {
+    @NonNull
+    public final Single<Boolean> contains(@NonNull Object element) {
         Objects.requireNonNull(element, "element is null");
         return any(Functions.equalsWith(element));
     }
@@ -7179,6 +7368,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<Long> count() {
         return RxJavaPlugins.onAssembly(new ObservableCountSingle<>(this));
     }
@@ -7211,7 +7401,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<T> debounce(Function<? super T, ? extends ObservableSource<U>> debounceSelector) {
+    @NonNull
+    public final <U> Observable<T> debounce(@NonNull Function<? super T, ? extends ObservableSource<U>> debounceSelector) {
         Objects.requireNonNull(debounceSelector, "debounceSelector is null");
         return RxJavaPlugins.onAssembly(new ObservableDebounce<>(this, debounceSelector));
     }
@@ -7250,7 +7441,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> debounce(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> debounce(long timeout, @NonNull TimeUnit unit) {
         return debounce(timeout, unit, Schedulers.computation());
     }
 
@@ -7290,7 +7482,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> debounce(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> debounce(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableDebounceTimed<>(this, timeout, unit, scheduler));
@@ -7314,7 +7507,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> defaultIfEmpty(T defaultItem) {
+    @NonNull
+    public final Observable<T> defaultIfEmpty(@NonNull T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem is null");
         return switchIfEmpty(just(defaultItem));
     }
@@ -7344,7 +7538,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<T> delay(final Function<? super T, ? extends ObservableSource<U>> itemDelay) {
+    @NonNull
+    public final <U> Observable<T> delay(@NonNull Function<? super T, ? extends ObservableSource<U>> itemDelay) {
         Objects.requireNonNull(itemDelay, "itemDelay is null");
         return flatMap(ObservableInternalHelper.itemDelay(itemDelay));
     }
@@ -7368,7 +7563,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> delay(long delay, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> delay(long delay, @NonNull TimeUnit unit) {
         return delay(delay, unit, Schedulers.computation(), false);
     }
 
@@ -7394,7 +7590,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> delay(long delay, TimeUnit unit, boolean delayError) {
+    @NonNull
+    public final Observable<T> delay(long delay, @NonNull TimeUnit unit, boolean delayError) {
         return delay(delay, unit, Schedulers.computation(), delayError);
     }
 
@@ -7419,7 +7616,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> delay(long delay, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return delay(delay, unit, scheduler, false);
     }
 
@@ -7447,7 +7645,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> delay(long delay, TimeUnit unit, Scheduler scheduler, boolean delayError) {
+    @NonNull
+    public final Observable<T> delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
 
@@ -7484,8 +7683,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Observable<T> delay(ObservableSource<U> subscriptionDelay,
-            Function<? super T, ? extends ObservableSource<V>> itemDelay) {
+    @NonNull
+    public final <U, V> Observable<T> delay(@NonNull ObservableSource<U> subscriptionDelay,
+            @NonNull Function<? super T, ? extends ObservableSource<V>> itemDelay) {
         return delaySubscription(subscriptionDelay).delay(itemDelay);
     }
 
@@ -7508,7 +7708,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<T> delaySubscription(ObservableSource<U> other) {
+    @NonNull
+    public final <U> Observable<T> delaySubscription(@NonNull ObservableSource<U> other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableDelaySubscriptionOther<>(this, other));
     }
@@ -7531,7 +7732,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> delaySubscription(long delay, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> delaySubscription(long delay, @NonNull TimeUnit unit) {
         return delaySubscription(delay, unit, Schedulers.computation());
     }
 
@@ -7557,7 +7759,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> delaySubscription(long delay, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> delaySubscription(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return delaySubscription(timer(delay, unit, scheduler));
     }
 
@@ -7610,7 +7813,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> dematerialize(Function<? super T, Notification<R>> selector) {
+    @NonNull
+    public final <R> Observable<R> dematerialize(@NonNull Function<? super T, Notification<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
         return RxJavaPlugins.onAssembly(new ObservableDematerialize<>(this, selector));
     }
@@ -7648,6 +7852,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> distinct() {
         return distinct(Functions.identity(), Functions.createHashSet());
     }
@@ -7688,7 +7893,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Observable<T> distinct(Function<? super T, K> keySelector) {
+    @NonNull
+    public final <K> Observable<T> distinct(@NonNull Function<? super T, K> keySelector) {
         return distinct(keySelector, Functions.createHashSet());
     }
 
@@ -7719,7 +7925,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Observable<T> distinct(Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
+    @NonNull
+    public final <K> Observable<T> distinct(@NonNull Function<? super T, K> keySelector, @NonNull Supplier<? extends Collection<? super K>> collectionSupplier) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableDistinct<>(this, keySelector, collectionSupplier));
@@ -7758,6 +7965,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> distinctUntilChanged() {
         return distinctUntilChanged(Functions.identity());
     }
@@ -7800,7 +8008,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Observable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
+    @NonNull
+    public final <K> Observable<T> distinctUntilChanged(@NonNull Function<? super T, K> keySelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<>(this, keySelector, ObjectHelper.equalsPredicate()));
     }
@@ -7834,7 +8043,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> distinctUntilChanged(BiPredicate<? super T, ? super T> comparer) {
+    @NonNull
+    public final Observable<T> distinctUntilChanged(@NonNull BiPredicate<? super T, ? super T> comparer) {
         Objects.requireNonNull(comparer, "comparer is null");
         return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<>(this, Functions.<T>identity(), comparer));
     }
@@ -7858,7 +8068,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doAfterNext(Consumer<? super T> onAfterNext) {
+    @NonNull
+    public final Observable<T> doAfterNext(@NonNull Consumer<? super T> onAfterNext) {
         Objects.requireNonNull(onAfterNext, "onAfterNext is null");
         return RxJavaPlugins.onAssembly(new ObservableDoAfterNext<>(this, onAfterNext));
     }
@@ -7882,7 +8093,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doAfterTerminate(Action onFinally) {
+    @NonNull
+    public final Observable<T> doAfterTerminate(@NonNull Action onFinally) {
         Objects.requireNonNull(onFinally, "onFinally is null");
         return doOnEach(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_ACTION, onFinally);
     }
@@ -7909,7 +8121,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doFinally(Action onFinally) {
+    @NonNull
+    public final Observable<T> doFinally(@NonNull Action onFinally) {
         Objects.requireNonNull(onFinally, "onFinally is null");
         return RxJavaPlugins.onAssembly(new ObservableDoFinally<>(this, onFinally));
     }
@@ -7937,7 +8150,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnDispose(Action onDispose) {
+    @NonNull
+    public final Observable<T> doOnDispose(@NonNull Action onDispose) {
         return doOnLifecycle(Functions.emptyConsumer(), onDispose);
     }
 
@@ -7957,7 +8171,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnComplete(Action onComplete) {
+    @NonNull
+    public final Observable<T> doOnComplete(@NonNull Action onComplete) {
         return doOnEach(Functions.emptyConsumer(), Functions.emptyConsumer(), onComplete, Functions.EMPTY_ACTION);
     }
 
@@ -7976,7 +8191,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    private Observable<T> doOnEach(Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete, Action onAfterTerminate) {
+    @NonNull
+    private Observable<T> doOnEach(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError, @NonNull Action onComplete, @NonNull Action onAfterTerminate) {
         Objects.requireNonNull(onNext, "onNext is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
@@ -8000,7 +8216,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnEach(final Consumer<? super Notification<T>> onNotification) {
+    @NonNull
+    public final Observable<T> doOnEach(@NonNull Consumer<? super Notification<T>> onNotification) {
         Objects.requireNonNull(onNotification, "onNotification is null");
         return doOnEach(
                 Functions.notificationOnNext(onNotification),
@@ -8032,7 +8249,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnEach(final Observer<? super T> observer) {
+    @NonNull
+    public final Observable<T> doOnEach(@NonNull Observer<? super T> observer) {
         Objects.requireNonNull(observer, "observer is null");
         return doOnEach(
                 ObservableInternalHelper.observerOnNext(observer),
@@ -8060,7 +8278,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnError(Consumer<? super Throwable> onError) {
+    @NonNull
+    public final Observable<T> doOnError(@NonNull Consumer<? super Throwable> onError) {
         return doOnEach(Functions.emptyConsumer(), onError, Functions.EMPTY_ACTION, Functions.EMPTY_ACTION);
     }
 
@@ -8083,7 +8302,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnLifecycle(final Consumer<? super Disposable> onSubscribe, final Action onDispose) {
+    @NonNull
+    public final Observable<T> doOnLifecycle(@NonNull Consumer<? super Disposable> onSubscribe, @NonNull Action onDispose) {
         Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         Objects.requireNonNull(onDispose, "onDispose is null");
         return RxJavaPlugins.onAssembly(new ObservableDoOnLifecycle<>(this, onSubscribe, onDispose));
@@ -8105,7 +8325,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnNext(Consumer<? super T> onNext) {
+    @NonNull
+    public final Observable<T> doOnNext(@NonNull Consumer<? super T> onNext) {
         return doOnEach(onNext, Functions.emptyConsumer(), Functions.EMPTY_ACTION, Functions.EMPTY_ACTION);
     }
 
@@ -8128,7 +8349,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnSubscribe(Consumer<? super Disposable> onSubscribe) {
+    @NonNull
+    public final Observable<T> doOnSubscribe(@NonNull Consumer<? super Disposable> onSubscribe) {
         return doOnLifecycle(onSubscribe, Functions.EMPTY_ACTION);
     }
 
@@ -8153,7 +8375,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> doOnTerminate(final Action onTerminate) {
+    @NonNull
+    public final Observable<T> doOnTerminate(@NonNull Action onTerminate) {
         Objects.requireNonNull(onTerminate, "onTerminate is null");
         return doOnEach(Functions.emptyConsumer(),
                 Functions.actionConsumer(onTerminate), onTerminate,
@@ -8180,6 +8403,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> elementAt(long index) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
@@ -8209,7 +8433,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> elementAt(long index, T defaultItem) {
+    @NonNull
+    public final Single<T> elementAt(long index, @NonNull T defaultItem) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
         }
@@ -8237,6 +8462,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> elementAtOrError(long index) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("index >= 0 required but it was " + index);
@@ -8262,7 +8488,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> filter(Predicate<? super T> predicate) {
+    @NonNull
+    public final Observable<T> filter(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return RxJavaPlugins.onAssembly(new ObservableFilter<>(this, predicate));
     }
@@ -8282,6 +8509,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> firstElement() {
         return elementAt(0L);
     }
@@ -8303,7 +8531,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> first(T defaultItem) {
+    @NonNull
+    public final Single<T> first(@NonNull T defaultItem) {
         return elementAt(0L, defaultItem);
     }
 
@@ -8322,6 +8551,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> firstOrError() {
         return elementAtOrError(0L);
     }
@@ -8348,7 +8578,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return flatMap(mapper, false);
     }
 
@@ -8377,7 +8608,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, boolean delayErrors) {
+    @NonNull
+    public final <R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, boolean delayErrors) {
         return flatMap(mapper, delayErrors, Integer.MAX_VALUE);
     }
 
@@ -8410,7 +8642,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
+    @NonNull
+    public final <R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
         return flatMap(mapper, delayErrors, maxConcurrency, bufferSize());
     }
 
@@ -8445,7 +8678,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+    @NonNull
+    public final <R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
             boolean delayErrors, int maxConcurrency, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
@@ -8487,10 +8721,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <R> Observable<R> flatMap(
-            Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
-            Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
-            Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier) {
+            @NonNull Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
+            @NonNull Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
+            @NonNull Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
@@ -8527,10 +8762,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <R> Observable<R> flatMap(
-            Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
-            Function<Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
-            Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier,
+            @NonNull Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
+            @NonNull Function<Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
+            @NonNull Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier,
             int maxConcurrency) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
@@ -8564,7 +8800,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int maxConcurrency) {
+    @NonNull
+    public final <R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int maxConcurrency) {
         return flatMap(mapper, false, maxConcurrency, bufferSize());
     }
 
@@ -8593,8 +8830,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+    @NonNull
+    public final <U, R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> resultSelector) {
         return flatMap(mapper, resultSelector, false, bufferSize(), bufferSize());
     }
 
@@ -8626,8 +8864,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors) {
+    @NonNull
+    public final <U, R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors) {
         return flatMap(mapper, combiner, delayErrors, bufferSize(), bufferSize());
     }
 
@@ -8663,8 +8902,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency) {
+    @NonNull
+    public final <U, R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency) {
         return flatMap(mapper, combiner, delayErrors, maxConcurrency, bufferSize());
     }
 
@@ -8702,8 +8942,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> flatMap(final Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            final BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
+    @NonNull
+    public final <U, R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(combiner, "combiner is null");
         return flatMap(ObservableInternalHelper.flatMapWithCombiner(mapper, combiner), delayErrors, maxConcurrency, bufferSize);
@@ -8738,8 +8979,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> flatMap(Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
+    @NonNull
+    public final <U, R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
         return flatMap(mapper, combiner, false, maxConcurrency, bufferSize());
     }
 
@@ -8757,7 +8999,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable flatMapCompletable(Function<? super T, ? extends CompletableSource> mapper) {
+    @NonNull
+    public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         return flatMapCompletable(mapper, false);
     }
 
@@ -8777,7 +9020,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable flatMapCompletable(Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
+    @NonNull
+    public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableFlatMapCompletableCompletable<>(this, mapper, delayErrors));
     }
@@ -8803,7 +9047,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<U> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    @NonNull
+    public final <U> Observable<U> flatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableFlattenIterable<>(this, mapper));
     }
@@ -8834,8 +9079,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Observable<V> flatMapIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper,
-            BiFunction<? super T, ? super U, ? extends V> resultSelector) {
+    @NonNull
+    public final <U, V> Observable<V> flatMapIterable(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper,
+            @NonNull BiFunction<? super T, ? super U, ? extends V> resultSelector) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(resultSelector, "resultSelector is null");
         return flatMap(ObservableInternalHelper.flatMapIntoIterable(mapper), resultSelector, false, bufferSize(), bufferSize());
@@ -8856,7 +9102,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> flatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         return flatMapMaybe(mapper, false);
     }
 
@@ -8878,7 +9125,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMapMaybe(Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayErrors) {
+    @NonNull
+    public final <R> Observable<R> flatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayErrors) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableFlatMapMaybe<>(this, mapper, delayErrors));
     }
@@ -8898,7 +9146,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> flatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
         return flatMapSingle(mapper, false);
     }
 
@@ -8920,7 +9169,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> flatMapSingle(Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean delayErrors) {
+    @NonNull
+    public final <R> Observable<R> flatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean delayErrors) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableFlatMapSingle<>(this, mapper, delayErrors));
     }
@@ -8946,7 +9196,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable forEach(Consumer<? super T> onNext) {
+    @NonNull
+    public final Disposable forEach(@NonNull Consumer<? super T> onNext) {
         return subscribe(onNext);
     }
 
@@ -8974,7 +9225,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable forEachWhile(Predicate<? super T> onNext) {
+    @NonNull
+    public final Disposable forEachWhile(@NonNull Predicate<? super T> onNext) {
         return forEachWhile(onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
 
@@ -8999,7 +9251,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable forEachWhile(Predicate<? super T> onNext, Consumer<? super Throwable> onError) {
+    @NonNull
+    public final Disposable forEachWhile(@NonNull Predicate<? super T> onNext, @NonNull Consumer<? super Throwable> onError) {
         return forEachWhile(onNext, onError, Functions.EMPTY_ACTION);
     }
 
@@ -9027,8 +9280,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable forEachWhile(final Predicate<? super T> onNext, Consumer<? super Throwable> onError,
-            final Action onComplete) {
+    @NonNull
+    public final Disposable forEachWhile(@NonNull Predicate<? super T> onNext, @NonNull Consumer<? super Throwable> onError,
+            @NonNull Action onComplete) {
         Objects.requireNonNull(onNext, "onNext is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
@@ -9074,7 +9328,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Observable<GroupedObservable<K, T>> groupBy(Function<? super T, ? extends K> keySelector) {
+    @NonNull
+    public final <K> Observable<GroupedObservable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector) {
         return groupBy(keySelector, (Function)Functions.identity(), false, bufferSize());
     }
 
@@ -9117,7 +9372,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Observable<GroupedObservable<K, T>> groupBy(Function<? super T, ? extends K> keySelector, boolean delayError) {
+    @NonNull
+    public final <K> Observable<GroupedObservable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector, boolean delayError) {
         return groupBy(keySelector, (Function)Functions.identity(), delayError, bufferSize());
     }
 
@@ -9160,7 +9416,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Observable<GroupedObservable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
+    @NonNull
+    public final <K, V> Observable<GroupedObservable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector) {
         return groupBy(keySelector, valueSelector, false, bufferSize());
     }
@@ -9207,8 +9464,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Observable<GroupedObservable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-            Function<? super T, ? extends V> valueSelector, boolean delayError) {
+    @NonNull
+    public final <K, V> Observable<GroupedObservable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector, boolean delayError) {
         return groupBy(keySelector, valueSelector, delayError, bufferSize());
     }
 
@@ -9256,8 +9514,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Observable<GroupedObservable<K, V>> groupBy(Function<? super T, ? extends K> keySelector,
-            Function<? super T, ? extends V> valueSelector,
+    @NonNull
+    public final <K, V> Observable<GroupedObservable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
             boolean delayError, int bufferSize) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
@@ -9299,12 +9558,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <TRight, TLeftEnd, TRightEnd, R> Observable<R> groupJoin(
-            ObservableSource<? extends TRight> other,
-            Function<? super T, ? extends ObservableSource<TLeftEnd>> leftEnd,
-            Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
-            BiFunction<? super T, ? super Observable<TRight>, ? extends R> resultSelector
-                    ) {
+            @NonNull ObservableSource<? extends TRight> other,
+            @NonNull Function<? super T, ? extends ObservableSource<TLeftEnd>> leftEnd,
+            @NonNull Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
+            @NonNull BiFunction<? super T, ? super Observable<TRight>, ? extends R> resultSelector
+    ) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(leftEnd, "leftEnd is null");
         Objects.requireNonNull(rightEnd, "rightEnd is null");
@@ -9330,6 +9590,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> hide() {
         return RxJavaPlugins.onAssembly(new ObservableHide<>(this));
     }
@@ -9348,6 +9609,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable ignoreElements() {
         return RxJavaPlugins.onAssembly(new ObservableIgnoreElementsCompletable<>(this));
     }
@@ -9369,6 +9631,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<Boolean> isEmpty() {
         return all(Functions.alwaysFalse());
     }
@@ -9406,12 +9669,13 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <TRight, TLeftEnd, TRightEnd, R> Observable<R> join(
-            ObservableSource<? extends TRight> other,
-            Function<? super T, ? extends ObservableSource<TLeftEnd>> leftEnd,
-            Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
-            BiFunction<? super T, ? super TRight, ? extends R> resultSelector
-                    ) {
+            @NonNull ObservableSource<? extends TRight> other,
+            @NonNull Function<? super T, ? extends ObservableSource<TLeftEnd>> leftEnd,
+            @NonNull Function<? super TRight, ? extends ObservableSource<TRightEnd>> rightEnd,
+            @NonNull BiFunction<? super T, ? super TRight, ? extends R> resultSelector
+    ) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(leftEnd, "leftEnd is null");
         Objects.requireNonNull(rightEnd, "rightEnd is null");
@@ -9436,6 +9700,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> lastElement() {
         return RxJavaPlugins.onAssembly(new ObservableLastMaybe<>(this));
     }
@@ -9458,7 +9723,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> last(T defaultItem) {
+    @NonNull
+    public final Single<T> last(@NonNull T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem is null");
         return RxJavaPlugins.onAssembly(new ObservableLastSingle<>(this, defaultItem));
     }
@@ -9479,6 +9745,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> lastOrError() {
         return RxJavaPlugins.onAssembly(new ObservableLastSingle<>(this, null));
     }
@@ -9627,7 +9894,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> lift(ObservableOperator<? extends R, ? super T> lifter) {
+    @NonNull
+    public final <R> Observable<R> lift(@NonNull ObservableOperator<? extends R, ? super T> lifter) {
         Objects.requireNonNull(lifter, "lifter is null");
         return RxJavaPlugins.onAssembly(new ObservableLift<R, T>(this, lifter));
     }
@@ -9651,7 +9919,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> map(Function<? super T, ? extends R> mapper) {
+    @NonNull
+    public final <R> Observable<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableMap<T, R>(this, mapper));
     }
@@ -9673,6 +9942,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<Notification<T>> materialize() {
         return RxJavaPlugins.onAssembly(new ObservableMaterialize<>(this));
     }
@@ -9696,7 +9966,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> mergeWith(ObservableSource<? extends T> other) {
+    @NonNull
+    public final Observable<T> mergeWith(@NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return merge(this, other);
     }
@@ -9719,6 +9990,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> mergeWith(@NonNull SingleSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableMergeWithSingle<>(this, other));
@@ -9743,6 +10015,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableMergeWithMaybe<>(this, other));
@@ -9764,6 +10037,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> mergeWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableMergeWithCompletable<>(this, other));
@@ -9802,7 +10076,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> observeOn(Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> observeOn(@NonNull Scheduler scheduler) {
         return observeOn(scheduler, false, bufferSize());
     }
 
@@ -9840,7 +10115,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> observeOn(Scheduler scheduler, boolean delayError) {
+    @NonNull
+    public final Observable<T> observeOn(@NonNull Scheduler scheduler, boolean delayError) {
         return observeOn(scheduler, delayError, bufferSize());
     }
 
@@ -9879,7 +10155,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> observeOn(Scheduler scheduler, boolean delayError, int bufferSize) {
+    @NonNull
+    public final Observable<T> observeOn(@NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return RxJavaPlugins.onAssembly(new ObservableObserveOn<>(this, scheduler, delayError, bufferSize));
@@ -9902,7 +10179,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<U> ofType(final Class<U> clazz) {
+    @NonNull
+    public final <U> Observable<U> ofType(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
         return filter(Functions.isInstanceOf(clazz)).cast(clazz);
     }
@@ -9938,7 +10216,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> onErrorResumeNext(Function<? super Throwable, ? extends ObservableSource<? extends T>> resumeFunction) {
+    @NonNull
+    public final Observable<T> onErrorResumeNext(@NonNull Function<? super Throwable, ? extends ObservableSource<? extends T>> resumeFunction) {
         Objects.requireNonNull(resumeFunction, "resumeFunction is null");
         return RxJavaPlugins.onAssembly(new ObservableOnErrorNext<>(this, resumeFunction));
     }
@@ -9974,7 +10253,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> onErrorResumeWith(final ObservableSource<? extends T> next) {
+    @NonNull
+    public final Observable<T> onErrorResumeWith(@NonNull ObservableSource<? extends T> next) {
         Objects.requireNonNull(next, "next is null");
         return onErrorResumeNext(Functions.justFunction(next));
     }
@@ -10007,7 +10287,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> onErrorReturn(Function<? super Throwable, ? extends T> valueSupplier) {
+    @NonNull
+    public final Observable<T> onErrorReturn(@NonNull Function<? super Throwable, ? extends T> valueSupplier) {
         Objects.requireNonNull(valueSupplier, "valueSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableOnErrorReturn<>(this, valueSupplier));
     }
@@ -10040,7 +10321,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> onErrorReturnItem(final T item) {
+    @NonNull
+    public final Observable<T> onErrorReturnItem(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return onErrorReturn(Functions.justFunction(item));
     }
@@ -10060,6 +10342,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> onTerminateDetach() {
         return RxJavaPlugins.onAssembly(new ObservableDetach<>(this));
     }
@@ -10081,6 +10364,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final ConnectableObservable<T> publish() {
         return RxJavaPlugins.onAssembly(new ObservablePublish<>(this));
     }
@@ -10106,7 +10390,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> publish(Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
+    @NonNull
+    public final <R> Observable<R> publish(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
         return RxJavaPlugins.onAssembly(new ObservablePublishSelector<>(this, selector));
     }
@@ -10141,7 +10426,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> reduce(BiFunction<T, T, T> reducer) {
+    @NonNull
+    public final Maybe<T> reduce(@NonNull BiFunction<T, T, T> reducer) {
         Objects.requireNonNull(reducer, "reducer is null");
         return RxJavaPlugins.onAssembly(new ObservableReduceMaybe<>(this, reducer));
     }
@@ -10198,7 +10484,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> reduce(R seed, BiFunction<R, ? super T, R> reducer) {
+    @NonNull
+    public final <@NonNull R> Single<R> reduce(R seed, @NonNull BiFunction<R, ? super T, R> reducer) {
         Objects.requireNonNull(seed, "seed is null");
         Objects.requireNonNull(reducer, "reducer is null");
         return RxJavaPlugins.onAssembly(new ObservableReduceSeedSingle<>(this, seed, reducer));
@@ -10238,7 +10525,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Single<R> reduceWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> reducer) {
+    @NonNull
+    public final <@NonNull R> Single<R> reduceWith(@NonNull Supplier<R> seedSupplier, @NonNull BiFunction<R, ? super T, R> reducer) {
         Objects.requireNonNull(seedSupplier, "seedSupplier is null");
         Objects.requireNonNull(reducer, "reducer is null");
         return RxJavaPlugins.onAssembly(new ObservableReduceWithSingle<>(this, seedSupplier, reducer));
@@ -10258,6 +10546,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> repeat() {
         return repeat(Long.MAX_VALUE);
     }
@@ -10283,6 +10572,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> repeat(long times) {
         if (times < 0) {
             throw new IllegalArgumentException("times >= 0 required but it was " + times);
@@ -10314,7 +10604,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> repeatUntil(BooleanSupplier stop) {
+    @NonNull
+    public final Observable<T> repeatUntil(@NonNull BooleanSupplier stop) {
         Objects.requireNonNull(stop, "stop is null");
         return RxJavaPlugins.onAssembly(new ObservableRepeatUntil<>(this, stop));
     }
@@ -10340,7 +10631,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> repeatWhen(final Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
+    @NonNull
+    public final Observable<T> repeatWhen(@NonNull Function<? super Observable<Object>, ? extends ObservableSource<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
         return RxJavaPlugins.onAssembly(new ObservableRepeatWhen<>(this, handler));
     }
@@ -10363,6 +10655,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final ConnectableObservable<T> replay() {
         return ObservableReplay.createFrom(this);
     }
@@ -10388,7 +10681,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector) {
         Objects.requireNonNull(selector, "selector is null");
         return ObservableReplay.multicastSelector(ObservableInternalHelper.replaySupplier(this), selector);
     }
@@ -10422,7 +10716,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final int bufferSize) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return ObservableReplay.multicastSelector(ObservableInternalHelper.replaySupplier(this, bufferSize, false), selector);
@@ -10459,7 +10754,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final int bufferSize, boolean eagerTruncate) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return ObservableReplay.multicastSelector(ObservableInternalHelper.replaySupplier(this, bufferSize, eagerTruncate), selector);
@@ -10498,7 +10794,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize, long time, TimeUnit unit) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit) {
         return replay(selector, bufferSize, time, unit, Schedulers.computation());
     }
 
@@ -10540,7 +10837,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(unit, "unit is null");
@@ -10588,7 +10886,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(unit, "unit is null");
@@ -10624,7 +10923,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, long time, TimeUnit unit) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, long time, @NonNull TimeUnit unit) {
         return replay(selector, time, unit, Schedulers.computation());
     }
 
@@ -10658,7 +10958,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -10697,7 +10998,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends ObservableSource<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    @NonNull
+    public final <R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -10730,7 +11032,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final ConnectableObservable<T> replay(final int bufferSize) {
+    @NonNull
+    public final ConnectableObservable<T> replay(int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return ObservableReplay.create(this, bufferSize, false);
     }
@@ -10762,7 +11065,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final ConnectableObservable<T> replay(final int bufferSize, boolean eagerTruncate) {
+    @NonNull
+    public final ConnectableObservable<T> replay(int bufferSize, boolean eagerTruncate) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return ObservableReplay.create(this, bufferSize, eagerTruncate);
     }
@@ -10798,7 +11102,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final ConnectableObservable<T> replay(int bufferSize, long time, TimeUnit unit) {
+    @NonNull
+    public final ConnectableObservable<T> replay(int bufferSize, long time, @NonNull TimeUnit unit) {
         return replay(bufferSize, time, unit, Schedulers.computation());
     }
 
@@ -10837,7 +11142,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final ConnectableObservable<T> replay(final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
+    @NonNull
+    public final ConnectableObservable<T> replay(int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -10881,7 +11187,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final ConnectableObservable<T> replay(final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    @NonNull
+    public final ConnectableObservable<T> replay(int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -10910,7 +11217,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final ConnectableObservable<T> replay(long time, TimeUnit unit) {
+    @NonNull
+    public final ConnectableObservable<T> replay(long time, @NonNull TimeUnit unit) {
         return replay(time, unit, Schedulers.computation());
     }
 
@@ -10942,7 +11250,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final ConnectableObservable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler) {
+    @NonNull
+    public final ConnectableObservable<T> replay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return ObservableReplay.create(this, time, unit, scheduler, false);
@@ -10978,7 +11287,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final ConnectableObservable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    @NonNull
+    public final ConnectableObservable<T> replay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return ObservableReplay.create(this, time, unit, scheduler, eagerTruncate);
@@ -11007,6 +11317,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> retry() {
         return retry(Long.MAX_VALUE, Functions.alwaysTrue());
     }
@@ -11030,7 +11341,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> retry(BiPredicate<? super Integer, ? super Throwable> predicate) {
+    @NonNull
+    public final Observable<T> retry(@NonNull BiPredicate<? super Integer, ? super Throwable> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
 
         return RxJavaPlugins.onAssembly(new ObservableRetryBiPredicate<>(this, predicate));
@@ -11062,6 +11374,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> retry(long times) {
         return retry(times, Functions.alwaysTrue());
     }
@@ -11080,7 +11393,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> retry(long times, Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Observable<T> retry(long times, @NonNull Predicate<? super Throwable> predicate) {
         if (times < 0) {
             throw new IllegalArgumentException("times >= 0 required but it was " + times);
         }
@@ -11103,7 +11417,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> retry(Predicate<? super Throwable> predicate) {
+    @NonNull
+    public final Observable<T> retry(@NonNull Predicate<? super Throwable> predicate) {
         return retry(Long.MAX_VALUE, predicate);
     }
 
@@ -11120,7 +11435,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> retryUntil(final BooleanSupplier stop) {
+    @NonNull
+    public final Observable<T> retryUntil(@NonNull BooleanSupplier stop) {
         Objects.requireNonNull(stop, "stop is null");
         return retry(Long.MAX_VALUE, Functions.predicateReverseFor(stop));
     }
@@ -11200,8 +11516,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> retryWhen(
-            final Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler) {
+            @NonNull Function<? super Observable<Throwable>, ? extends ObservableSource<?>> handler) {
         Objects.requireNonNull(handler, "handler is null");
         return RxJavaPlugins.onAssembly(new ObservableRetryWhen<>(this, handler));
     }
@@ -11219,7 +11536,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @throws NullPointerException if s is null
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final void safeSubscribe(Observer<? super T> observer) {
+    @NonNull
+    public final void safeSubscribe(@NonNull Observer<? super T> observer) {
         Objects.requireNonNull(observer, "observer is null");
         if (observer instanceof SafeObserver) {
             subscribe(observer);
@@ -11249,7 +11567,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> sample(long period, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> sample(long period, @NonNull TimeUnit unit) {
         return sample(period, unit, Schedulers.computation());
     }
 
@@ -11280,7 +11599,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> sample(long period, TimeUnit unit, boolean emitLast) {
+    @NonNull
+    public final Observable<T> sample(long period, @NonNull TimeUnit unit, boolean emitLast) {
         return sample(period, unit, Schedulers.computation(), emitLast);
     }
 
@@ -11307,7 +11627,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> sample(long period, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> sample(long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableSampleTimed<>(this, period, unit, scheduler, false));
@@ -11343,7 +11664,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> sample(long period, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
+    @NonNull
+    public final Observable<T> sample(long period, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean emitLast) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableSampleTimed<>(this, period, unit, scheduler, emitLast));
@@ -11369,7 +11691,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<T> sample(ObservableSource<U> sampler) {
+    @NonNull
+    public final <U> Observable<T> sample(@NonNull ObservableSource<U> sampler) {
         Objects.requireNonNull(sampler, "sampler is null");
         return RxJavaPlugins.onAssembly(new ObservableSampleWithObservable<>(this, sampler, false));
     }
@@ -11401,7 +11724,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<T> sample(ObservableSource<U> sampler, boolean emitLast) {
+    @NonNull
+    public final <U> Observable<T> sample(@NonNull ObservableSource<U> sampler, boolean emitLast) {
         Objects.requireNonNull(sampler, "sampler is null");
         return RxJavaPlugins.onAssembly(new ObservableSampleWithObservable<>(this, sampler, emitLast));
     }
@@ -11429,7 +11753,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> scan(BiFunction<T, T, T> accumulator) {
+    @NonNull
+    public final Observable<T> scan(@NonNull BiFunction<T, T, T> accumulator) {
         Objects.requireNonNull(accumulator, "accumulator is null");
         return RxJavaPlugins.onAssembly(new ObservableScan<>(this, accumulator));
     }
@@ -11478,7 +11803,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> scan(final R initialValue, BiFunction<R, ? super T, R> accumulator) {
+    @NonNull
+    public final <R> Observable<R> scan(@NonNull R initialValue, @NonNull BiFunction<R, ? super T, R> accumulator) {
         Objects.requireNonNull(initialValue, "initialValue is null");
         return scanWith(Functions.justSupplier(initialValue), accumulator);
     }
@@ -11513,7 +11839,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> scanWith(Supplier<R> seedSupplier, BiFunction<R, ? super T, R> accumulator) {
+    @NonNull
+    public final <R> Observable<R> scanWith(@NonNull Supplier<R> seedSupplier, @NonNull BiFunction<R, ? super T, R> accumulator) {
         Objects.requireNonNull(seedSupplier, "seedSupplier is null");
         Objects.requireNonNull(accumulator, "accumulator is null");
         return RxJavaPlugins.onAssembly(new ObservableScanSeed<>(this, seedSupplier, accumulator));
@@ -11541,6 +11868,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> serialize() {
         return RxJavaPlugins.onAssembly(new ObservableSerialized<>(this));
     }
@@ -11564,6 +11892,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> share() {
         return publish().refCount();
     }
@@ -11583,6 +11912,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Maybe<T> singleElement() {
         return RxJavaPlugins.onAssembly(new ObservableSingleMaybe<>(this));
     }
@@ -11605,7 +11935,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> single(T defaultItem) {
+    @NonNull
+    public final Single<T> single(@NonNull T defaultItem) {
         Objects.requireNonNull(defaultItem, "defaultItem is null");
         return RxJavaPlugins.onAssembly(new ObservableSingleSingle<>(this, defaultItem));
     }
@@ -11627,6 +11958,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Single<T> singleOrError() {
         return RxJavaPlugins.onAssembly(new ObservableSingleSingle<>(this, null));
     }
@@ -11649,6 +11981,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> skip(long count) {
         if (count <= 0) {
             return RxJavaPlugins.onAssembly(this);
@@ -11677,7 +12010,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> skip(long time, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> skip(long time, @NonNull TimeUnit unit) {
         return skipUntil(timer(time, unit));
     }
 
@@ -11703,7 +12037,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> skip(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> skip(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return skipUntil(timer(time, unit, scheduler));
     }
 
@@ -11731,6 +12066,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> skipLast(int count) {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
@@ -11764,7 +12100,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.TRAMPOLINE)
-    public final Observable<T> skipLast(long time, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> skipLast(long time, @NonNull TimeUnit unit) {
         return skipLast(time, unit, Schedulers.trampoline(), false, bufferSize());
     }
 
@@ -11794,7 +12131,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.TRAMPOLINE)
-    public final Observable<T> skipLast(long time, TimeUnit unit, boolean delayError) {
+    @NonNull
+    public final Observable<T> skipLast(long time, @NonNull TimeUnit unit, boolean delayError) {
         return skipLast(time, unit, Schedulers.trampoline(), delayError, bufferSize());
     }
 
@@ -11822,7 +12160,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> skipLast(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> skipLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return skipLast(time, unit, scheduler, false, bufferSize());
     }
 
@@ -11853,7 +12192,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> skipLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError) {
+    @NonNull
+    public final Observable<T> skipLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         return skipLast(time, unit, scheduler, delayError, bufferSize());
     }
 
@@ -11886,7 +12226,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> skipLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
+    @NonNull
+    public final Observable<T> skipLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -11915,7 +12256,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<T> skipUntil(ObservableSource<U> other) {
+    @NonNull
+    public final <U> Observable<T> skipUntil(@NonNull ObservableSource<U> other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableSkipUntil<>(this, other));
     }
@@ -11938,7 +12280,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> skipWhile(Predicate<? super T> predicate) {
+    @NonNull
+    public final Observable<T> skipWhile(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return RxJavaPlugins.onAssembly(new ObservableSkipWhile<>(this, predicate));
     }
@@ -11965,6 +12308,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> sorted() {
         return toList().toObservable().map(Functions.listSorter(Functions.<T>naturalComparator())).flatMapIterable(Functions.<List<T>>identity());
     }
@@ -11988,7 +12332,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> sorted(Comparator<? super T> sortFunction) {
+    @NonNull
+    public final Observable<T> sorted(@NonNull Comparator<? super T> sortFunction) {
         Objects.requireNonNull(sortFunction, "sortFunction is null");
         return toList().toObservable().map(Functions.listSorter(sortFunction)).flatMapIterable(Functions.<List<T>>identity());
     }
@@ -12012,10 +12357,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see #startWithItem(Object)
      * @see #startWithArray(Object...)
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> startWithIterable(Iterable<? extends T> items) {
+    @NonNull
+    public final Observable<T> startWithIterable(@NonNull Iterable<? extends T> items) {
         return concatArray(fromIterable(items), this);
     }
 
@@ -12035,10 +12380,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *         emitted by the source ObservableSource
      * @see <a href="http://reactivex.io/documentation/operators/startwith.html">ReactiveX operators documentation: StartWith</a>
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> startWith(ObservableSource<? extends T> other) {
+    @NonNull
+    public final Observable<T> startWith(@NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return concatArray(other, this);
     }
@@ -12062,10 +12407,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see #startWithIterable(Iterable)
      * @since 3.0.0
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> startWithItem(T item) {
+    @NonNull
+    public final Observable<T> startWithItem(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return concatArray(just(item), this);
     }
@@ -12088,10 +12433,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see #startWithItem(Object)
      * @see #startWithIterable(Iterable)
      */
-    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> startWithArray(T... items) {
+    @SafeVarargs
+    @NonNull
+    public final Observable<T> startWithArray(@NonNull T... items) {
         Observable<T> fromArray = fromArray(items);
         if (fromArray == empty()) {
             return RxJavaPlugins.onAssembly(this);
@@ -12115,6 +12461,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Disposable subscribe() {
         return subscribe(Functions.emptyConsumer(), Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
@@ -12140,7 +12487,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onNext) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onNext) {
         return subscribe(onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
     }
 
@@ -12166,7 +12514,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError) {
         return subscribe(onNext, onError, Functions.EMPTY_ACTION);
     }
 
@@ -12196,8 +12545,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
-            Action onComplete) {
+    @NonNull
+    public final Disposable subscribe(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError,
+            @NonNull Action onComplete) {
         Objects.requireNonNull(onNext, "onNext is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
@@ -12211,7 +12561,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
     @SchedulerSupport(SchedulerSupport.NONE)
     @Override
-    public final void subscribe(Observer<? super T> observer) {
+    public final void subscribe(@NonNull Observer<? super T> observer) {
         Objects.requireNonNull(observer, "observer is null");
         try {
             observer = RxJavaPlugins.onSubscribe(this, observer);
@@ -12241,7 +12591,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * applied by {@link #subscribe(Observer)} before this method gets called.
      * @param observer the incoming Observer, never null
      */
-    protected abstract void subscribeActual(Observer<? super T> observer);
+    protected abstract void subscribeActual(@NonNull Observer<? super T> observer);
 
     /**
      * Subscribes a given Observer (subclass) to this Observable and returns the given
@@ -12269,7 +12619,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <E extends Observer<? super T>> E subscribeWith(E observer) {
+    @NonNull
+    public final <@NonNull E extends Observer<? super T>> E subscribeWith(E observer) {
         subscribe(observer);
         return observer;
     }
@@ -12293,7 +12644,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> subscribeOn(Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> subscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableSubscribeOn<>(this, scheduler));
     }
@@ -12316,7 +12668,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> switchIfEmpty(ObservableSource<? extends T> other) {
+    @NonNull
+    public final Observable<T> switchIfEmpty(@NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchIfEmpty<>(this, other));
     }
@@ -12345,7 +12698,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> switchMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> switchMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return switchMap(mapper, bufferSize());
     }
 
@@ -12375,7 +12729,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> switchMap(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
+    @NonNull
+    public final <R> Observable<R> switchMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         if (this instanceof ScalarSupplier) {
@@ -12425,6 +12780,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable switchMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<>(this, mapper, false));
@@ -12467,6 +12823,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Completable switchMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<>(this, mapper, true));
@@ -12503,6 +12860,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <R> Observable<R> switchMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<>(this, mapper, false));
@@ -12529,6 +12887,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <R> Observable<R> switchMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<>(this, mapper, true));
@@ -12623,7 +12982,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> switchMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
+    @NonNull
+    public final <R> Observable<R> switchMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
         return switchMapDelayError(mapper, bufferSize());
     }
 
@@ -12655,7 +13015,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> switchMapDelayError(Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
+    @NonNull
+    public final <R> Observable<R> switchMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         if (this instanceof ScalarSupplier) {
@@ -12691,6 +13052,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> take(long count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
@@ -12720,7 +13082,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> take(long time, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> take(long time, @NonNull TimeUnit unit) {
         return takeUntil(timer(time, unit));
     }
 
@@ -12749,7 +13112,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> take(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> take(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return takeUntil(timer(time, unit, scheduler));
     }
 
@@ -12773,6 +13137,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> takeLast(int count) {
         if (count < 0) {
             throw new IndexOutOfBoundsException("count >= 0 required but it was " + count);
@@ -12809,7 +13174,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.TRAMPOLINE)
-    public final Observable<T> takeLast(long count, long time, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> takeLast(long count, long time, @NonNull TimeUnit unit) {
         return takeLast(count, time, unit, Schedulers.trampoline(), false, bufferSize());
     }
 
@@ -12841,7 +13207,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> takeLast(long count, long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> takeLast(long count, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return takeLast(count, time, unit, scheduler, false, bufferSize());
     }
 
@@ -12878,7 +13245,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> takeLast(long count, long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
+    @NonNull
+    public final Observable<T> takeLast(long count, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -12908,7 +13276,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.TRAMPOLINE)
-    public final Observable<T> takeLast(long time, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> takeLast(long time, @NonNull TimeUnit unit) {
         return takeLast(time, unit, Schedulers.trampoline(), false, bufferSize());
     }
 
@@ -12935,7 +13304,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.TRAMPOLINE)
-    public final Observable<T> takeLast(long time, TimeUnit unit, boolean delayError) {
+    @NonNull
+    public final Observable<T> takeLast(long time, @NonNull TimeUnit unit, boolean delayError) {
         return takeLast(time, unit, Schedulers.trampoline(), delayError, bufferSize());
     }
 
@@ -12963,7 +13333,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> takeLast(long time, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> takeLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return takeLast(time, unit, scheduler, false, bufferSize());
     }
 
@@ -12994,7 +13365,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> takeLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError) {
+    @NonNull
+    public final Observable<T> takeLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         return takeLast(time, unit, scheduler, delayError, bufferSize());
     }
 
@@ -13027,7 +13399,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> takeLast(long time, TimeUnit unit, Scheduler scheduler, boolean delayError, int bufferSize) {
+    @NonNull
+    public final Observable<T> takeLast(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
         return takeLast(Long.MAX_VALUE, time, unit, scheduler, delayError, bufferSize);
     }
 
@@ -13051,7 +13424,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Observable<T> takeUntil(ObservableSource<U> other) {
+    @NonNull
+    public final <U> Observable<T> takeUntil(@NonNull ObservableSource<U> other) {
         Objects.requireNonNull(other, "other is null");
         return RxJavaPlugins.onAssembly(new ObservableTakeUntil<>(this, other));
     }
@@ -13080,7 +13454,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> takeUntil(Predicate<? super T> stopPredicate) {
+    @NonNull
+    public final Observable<T> takeUntil(@NonNull Predicate<? super T> stopPredicate) {
         Objects.requireNonNull(stopPredicate, "stopPredicate is null");
         return RxJavaPlugins.onAssembly(new ObservableTakeUntilPredicate<>(this, stopPredicate));
     }
@@ -13104,7 +13479,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<T> takeWhile(Predicate<? super T> predicate) {
+    @NonNull
+    public final Observable<T> takeWhile(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return RxJavaPlugins.onAssembly(new ObservableTakeWhile<>(this, predicate));
     }
@@ -13131,7 +13507,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> throttleFirst(long windowDuration, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> throttleFirst(long windowDuration, @NonNull TimeUnit unit) {
         return throttleFirst(windowDuration, unit, Schedulers.computation());
     }
 
@@ -13160,7 +13537,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> throttleFirst(long skipDuration, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableThrottleFirstTimed<>(this, skipDuration, unit, scheduler));
@@ -13190,7 +13568,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> throttleLast(long intervalDuration, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> throttleLast(long intervalDuration, @NonNull TimeUnit unit) {
         return sample(intervalDuration, unit);
     }
 
@@ -13221,7 +13600,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> throttleLast(long intervalDuration, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> throttleLast(long intervalDuration, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return sample(intervalDuration, unit, scheduler);
     }
 
@@ -13252,7 +13632,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> throttleLatest(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> throttleLatest(long timeout, @NonNull TimeUnit unit) {
         return throttleLatest(timeout, unit, Schedulers.computation(), false);
     }
 
@@ -13283,7 +13664,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> throttleLatest(long timeout, TimeUnit unit, boolean emitLast) {
+    @NonNull
+    public final Observable<T> throttleLatest(long timeout, @NonNull TimeUnit unit, boolean emitLast) {
         return throttleLatest(timeout, unit, Schedulers.computation(), emitLast);
     }
 
@@ -13315,7 +13697,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> throttleLatest(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return throttleLatest(timeout, unit, scheduler, false);
     }
 
@@ -13347,7 +13730,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> throttleLatest(long timeout, TimeUnit unit, Scheduler scheduler, boolean emitLast) {
+    @NonNull
+    public final Observable<T> throttleLatest(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean emitLast) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableThrottleLatest<>(this, timeout, unit, scheduler, emitLast));
@@ -13380,7 +13764,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> throttleWithTimeout(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> throttleWithTimeout(long timeout, @NonNull TimeUnit unit) {
         return debounce(timeout, unit);
     }
 
@@ -13414,7 +13799,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> throttleWithTimeout(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> throttleWithTimeout(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return debounce(timeout, unit, scheduler);
     }
 
@@ -13434,6 +13820,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<Timed<T>> timeInterval() {
         return timeInterval(TimeUnit.MILLISECONDS, Schedulers.computation());
     }
@@ -13456,7 +13843,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
-    public final Observable<Timed<T>> timeInterval(Scheduler scheduler) {
+    @NonNull
+    public final Observable<Timed<T>> timeInterval(@NonNull Scheduler scheduler) {
         return timeInterval(TimeUnit.MILLISECONDS, scheduler);
     }
 
@@ -13477,7 +13865,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<Timed<T>> timeInterval(TimeUnit unit) {
+    @NonNull
+    public final Observable<Timed<T>> timeInterval(@NonNull TimeUnit unit) {
         return timeInterval(unit, Schedulers.computation());
     }
 
@@ -13500,7 +13889,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
-    public final Observable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<Timed<T>> timeInterval(@NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableTimeInterval<>(this, unit, scheduler));
@@ -13532,7 +13922,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
+    @NonNull
+    public final <V> Observable<T> timeout(@NonNull Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
         return timeout0(null, itemTimeoutIndicator, null);
     }
 
@@ -13564,8 +13955,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <V> Observable<T> timeout(Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
-            ObservableSource<? extends T> other) {
+    @NonNull
+    public final <V> Observable<T> timeout(@NonNull Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
+            @NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(null, itemTimeoutIndicator, other);
     }
@@ -13591,7 +13983,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit) {
+    @NonNull
+    public final Observable<T> timeout(long timeout, @NonNull TimeUnit timeUnit) {
         return timeout0(timeout, timeUnit, null, Schedulers.computation());
     }
 
@@ -13618,7 +14011,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, ObservableSource<? extends T> other) {
+    @NonNull
+    public final Observable<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, Schedulers.computation());
     }
@@ -13649,7 +14043,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, Scheduler scheduler, ObservableSource<? extends T> other) {
+    @NonNull
+    public final Observable<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull Scheduler scheduler, @NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return timeout0(timeout, timeUnit, other, scheduler);
     }
@@ -13678,7 +14073,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> timeout(long timeout, TimeUnit timeUnit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> timeout(long timeout, @NonNull TimeUnit timeUnit, @NonNull Scheduler scheduler) {
         return timeout0(timeout, timeUnit, null, scheduler);
     }
 
@@ -13711,8 +14107,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, V> Observable<T> timeout(ObservableSource<U> firstTimeoutIndicator,
-            Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
+    @NonNull
+    public final <U, V> Observable<T> timeout(@NonNull ObservableSource<U> firstTimeoutIndicator,
+            @NonNull Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator) {
         Objects.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
         return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, null);
     }
@@ -13751,26 +14148,30 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <U, V> Observable<T> timeout(
-            ObservableSource<U> firstTimeoutIndicator,
-            Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
-                    ObservableSource<? extends T> other) {
+            @NonNull ObservableSource<U> firstTimeoutIndicator,
+            @NonNull Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
+            @NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(firstTimeoutIndicator, "firstTimeoutIndicator is null");
         Objects.requireNonNull(other, "other is null");
         return timeout0(firstTimeoutIndicator, itemTimeoutIndicator, other);
     }
 
-    private Observable<T> timeout0(long timeout, TimeUnit timeUnit, ObservableSource<? extends T> other,
-            Scheduler scheduler) {
+    @NonNull
+    private Observable<T> timeout0(long timeout, @NonNull TimeUnit timeUnit,
+            @Nullable ObservableSource<? extends T> other,
+            @NonNull Scheduler scheduler) {
         Objects.requireNonNull(timeUnit, "timeUnit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableTimeoutTimed<>(this, timeout, timeUnit, scheduler, other));
     }
 
+    @NonNull
     private <U, V> Observable<T> timeout0(
-            ObservableSource<U> firstTimeoutIndicator,
-            Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
-                    ObservableSource<? extends T> other) {
+            @NonNull ObservableSource<U> firstTimeoutIndicator,
+            @NonNull Function<? super T, ? extends ObservableSource<V>> itemTimeoutIndicator,
+            @Nullable ObservableSource<? extends T> other) {
         Objects.requireNonNull(itemTimeoutIndicator, "itemTimeoutIndicator is null");
         return RxJavaPlugins.onAssembly(new ObservableTimeout<>(this, firstTimeoutIndicator, itemTimeoutIndicator, other));
     }
@@ -13791,6 +14192,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<Timed<T>> timestamp() {
         return timestamp(TimeUnit.MILLISECONDS, Schedulers.computation());
     }
@@ -13814,7 +14216,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
-    public final Observable<Timed<T>> timestamp(Scheduler scheduler) {
+    @NonNull
+    public final Observable<Timed<T>> timestamp(@NonNull Scheduler scheduler) {
         return timestamp(TimeUnit.MILLISECONDS, scheduler);
     }
 
@@ -13835,7 +14238,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Observable<Timed<T>> timestamp(TimeUnit unit) {
+    @NonNull
+    public final Observable<Timed<T>> timestamp(@NonNull TimeUnit unit) {
         return timestamp(unit, Schedulers.computation());
     }
 
@@ -13859,7 +14263,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE) // Supplied scheduler is only used for creating timestamps.
-    public final Observable<Timed<T>> timestamp(final TimeUnit unit, final Scheduler scheduler) {
+    @NonNull
+    public final Observable<Timed<T>> timestamp(@NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         return map(Functions.<T>timestampWith(unit, scheduler));
@@ -13882,6 +14287,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <R> R to(@NonNull ObservableConverter<T, ? extends R> converter) {
         return Objects.requireNonNull(converter, "converter is null").apply(this);
     }
@@ -13912,7 +14318,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<List<T>> toList() {
+    @NonNull
+    public final Single<@NonNull List<T>> toList() {
         return toList(16);
     }
 
@@ -13944,7 +14351,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<List<T>> toList(final int capacityHint) {
+    @NonNull
+    public final Single<@NonNull List<T>> toList(int capacityHint) {
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
         return RxJavaPlugins.onAssembly(new ObservableToListSingle<T, List<T>>(this, capacityHint));
     }
@@ -13978,7 +14386,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U extends Collection<? super T>> Single<U> toList(Supplier<U> collectionSupplier) {
+    @NonNull
+    public final <@NonNull U extends Collection<? super T>> Single<U> toList(@NonNull Supplier<U> collectionSupplier) {
         Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableToListSingle<>(this, collectionSupplier));
     }
@@ -14009,7 +14418,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Single<Map<K, T>> toMap(final Function<? super T, ? extends K> keySelector) {
+    @NonNull
+    public final <K> Single<@NonNull Map<K, T>> toMap(@NonNull Function<? super T, ? extends K> keySelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         return collect(HashMapSupplier.<K, T>asSupplier(), Functions.toMapKeySelector(keySelector));
     }
@@ -14043,9 +14453,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <K, V> Single<Map<K, V>> toMap(
-            final Function<? super T, ? extends K> keySelector,
-            final Function<? super T, ? extends V> valueSelector) {
+            @NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMapSupplier.<K, V>asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
@@ -14079,10 +14490,11 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <K, V> Single<Map<K, V>> toMap(
-            final Function<? super T, ? extends K> keySelector,
-            final Function<? super T, ? extends V> valueSelector,
-            Supplier<? extends Map<K, V>> mapSupplier) {
+            @NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
+            @NonNull Supplier<? extends Map<K, V>> mapSupplier) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         Objects.requireNonNull(mapSupplier, "mapSupplier is null");
@@ -14112,7 +14524,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K> Single<Map<K, Collection<T>>> toMultimap(Function<? super T, ? extends K> keySelector) {
+    @NonNull
+    public final <K> Single<@NonNull Map<K, Collection<T>>> toMultimap(@NonNull Function<? super T, ? extends K> keySelector) {
         @SuppressWarnings({ "rawtypes", "unchecked" })
         Function<? super T, ? extends T> valueSelector = (Function)Functions.identity();
         Supplier<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asSupplier();
@@ -14147,7 +14560,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Single<Map<K, Collection<V>>> toMultimap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
+    @NonNull
+    public final <K, V> Single<@NonNull Map<K, Collection<V>>> toMultimap(@NonNull Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
         Supplier<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<V>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
@@ -14180,11 +14594,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
-            final Function<? super T, ? extends K> keySelector,
-            final Function<? super T, ? extends V> valueSelector,
-            final Supplier<? extends Map<K, Collection<V>>> mapSupplier,
-            final Function<? super K, ? extends Collection<? super V>> collectionFactory) {
+    @NonNull
+    public final <K, V> Single<@NonNull Map<K, Collection<V>>> toMultimap(
+            @NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
+            @NonNull Supplier<? extends Map<K, Collection<V>>> mapSupplier,
+            @NonNull Function<? super K, ? extends Collection<? super V>> collectionFactory) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         Objects.requireNonNull(mapSupplier, "mapSupplier is null");
@@ -14221,11 +14636,12 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <K, V> Single<Map<K, Collection<V>>> toMultimap(
-            Function<? super T, ? extends K> keySelector,
-            Function<? super T, ? extends V> valueSelector,
-            Supplier<Map<K, Collection<V>>> mapSupplier
-            ) {
+    @NonNull
+    public final <K, V> Single<@NonNull Map<K, Collection<V>>> toMultimap(
+            @NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector,
+            @NonNull Supplier<Map<K, Collection<V>>> mapSupplier
+    ) {
         return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.<V, K>asFunction());
     }
 
@@ -14268,7 +14684,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Flowable<T> toFlowable(BackpressureStrategy strategy) {
+    @NonNull
+    public final Flowable<T> toFlowable(@NonNull BackpressureStrategy strategy) {
         Flowable<T> f = new FlowableFromObservable<>(this);
 
         switch (strategy) {
@@ -14309,7 +14726,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<List<T>> toSortedList() {
+    @NonNull
+    public final Single<@NonNull List<T>> toSortedList() {
         return toSortedList(Functions.naturalOrder());
     }
 
@@ -14336,7 +14754,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<List<T>> toSortedList(final Comparator<? super T> comparator) {
+    @NonNull
+    public final Single<@NonNull List<T>> toSortedList(@NonNull Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
         return toList().map(Functions.listSorter(comparator));
     }
@@ -14367,7 +14786,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<List<T>> toSortedList(final Comparator<? super T> comparator, int capacityHint) {
+    @NonNull
+    public final Single<@NonNull List<T>> toSortedList(@NonNull Comparator<? super T> comparator, int capacityHint) {
         Objects.requireNonNull(comparator, "comparator is null");
         return toList(capacityHint).map(Functions.listSorter(comparator));
     }
@@ -14400,7 +14820,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<List<T>> toSortedList(int capacityHint) {
+    @NonNull
+    public final Single<@NonNull List<T>> toSortedList(int capacityHint) {
         return toSortedList(Functions.<T>naturalOrder(), capacityHint);
     }
 
@@ -14422,7 +14843,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> unsubscribeOn(Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> unsubscribeOn(@NonNull Scheduler scheduler) {
         Objects.requireNonNull(scheduler, "scheduler is null");
         return RxJavaPlugins.onAssembly(new ObservableUnsubscribeOn<>(this, scheduler));
     }
@@ -14448,6 +14870,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<Observable<T>> window(long count) {
         return window(count, count, bufferSize());
     }
@@ -14476,6 +14899,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<Observable<T>> window(long count, long skip) {
         return window(count, skip, bufferSize());
     }
@@ -14506,6 +14930,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<Observable<T>> window(long count, long skip, int bufferSize) {
         ObjectHelper.verifyPositive(count, "count");
         ObjectHelper.verifyPositive(skip, "skip");
@@ -14542,7 +14967,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<Observable<T>> window(long timespan, long timeskip, TimeUnit unit) {
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, long timeskip, @NonNull TimeUnit unit) {
         return window(timespan, timeskip, unit, Schedulers.computation(), bufferSize());
     }
 
@@ -14577,7 +15003,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<Observable<T>> window(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return window(timespan, timeskip, unit, scheduler, bufferSize());
     }
 
@@ -14614,7 +15041,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<Observable<T>> window(long timespan, long timeskip, TimeUnit unit, Scheduler scheduler, int bufferSize) {
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int bufferSize) {
         ObjectHelper.verifyPositive(timespan, "timespan");
         ObjectHelper.verifyPositive(timeskip, "timeskip");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -14651,7 +15079,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<Observable<T>> window(long timespan, TimeUnit unit) {
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, @NonNull TimeUnit unit) {
         return window(timespan, unit, Schedulers.computation(), Long.MAX_VALUE, false);
     }
 
@@ -14687,7 +15116,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, @NonNull TimeUnit unit,
             long count) {
         return window(timespan, unit, Schedulers.computation(), count, false);
     }
@@ -14726,7 +15156,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, @NonNull TimeUnit unit,
             long count, boolean restart) {
         return window(timespan, unit, Schedulers.computation(), count, restart);
     }
@@ -14761,8 +15192,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
-            Scheduler scheduler) {
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler) {
         return window(timespan, unit, scheduler, Long.MAX_VALUE, false);
     }
 
@@ -14800,8 +15232,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
-            Scheduler scheduler, long count) {
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler, long count) {
         return window(timespan, unit, scheduler, count, false);
     }
 
@@ -14841,8 +15274,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<Observable<T>> window(long timespan, TimeUnit unit,
-            Scheduler scheduler, long count, boolean restart) {
+    @NonNull
+    public final Observable<Observable<T>> window(long timespan, @NonNull TimeUnit unit,
+            @NonNull Scheduler scheduler, long count, boolean restart) {
         return window(timespan, unit, scheduler, count, restart, bufferSize());
     }
 
@@ -14884,8 +15318,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
+    @NonNull
     public final Observable<Observable<T>> window(
-            long timespan, TimeUnit unit, Scheduler scheduler,
+            long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler,
             long count, boolean restart, int bufferSize) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -14921,7 +15356,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Observable<Observable<T>> window(ObservableSource<B> boundary) {
+    @NonNull
+    public final <B> Observable<Observable<T>> window(@NonNull ObservableSource<B> boundary) {
         return window(boundary, bufferSize());
     }
 
@@ -14954,7 +15390,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <B> Observable<Observable<T>> window(ObservableSource<B> boundary, int bufferSize) {
+    @NonNull
+    public final <B> Observable<Observable<T>> window(@NonNull ObservableSource<B> boundary, int bufferSize) {
         Objects.requireNonNull(boundary, "boundary is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return RxJavaPlugins.onAssembly(new ObservableWindowBoundary<>(this, boundary, bufferSize));
@@ -14990,9 +15427,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <U, V> Observable<Observable<T>> window(
-            ObservableSource<U> openingIndicator,
-            Function<? super U, ? extends ObservableSource<V>> closingIndicator) {
+            @NonNull ObservableSource<U> openingIndicator,
+            @NonNull Function<? super U, ? extends ObservableSource<V>> closingIndicator) {
         return window(openingIndicator, closingIndicator, bufferSize());
     }
 
@@ -15028,9 +15466,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <U, V> Observable<Observable<T>> window(
-            ObservableSource<U> openingIndicator,
-            Function<? super U, ? extends ObservableSource<V>> closingIndicator, int bufferSize) {
+            @NonNull ObservableSource<U> openingIndicator,
+            @NonNull Function<? super U, ? extends ObservableSource<V>> closingIndicator, int bufferSize) {
         Objects.requireNonNull(openingIndicator, "openingIndicator is null");
         Objects.requireNonNull(closingIndicator, "closingIndicator is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -15063,7 +15502,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> withLatestFrom(ObservableSource<? extends U> other, BiFunction<? super T, ? super U, ? extends R> combiner) {
+    @NonNull
+    public final <U, R> Observable<R> withLatestFrom(@NonNull ObservableSource<? extends U> other, @NonNull BiFunction<? super T, ? super U, ? extends R> combiner) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(combiner, "combiner is null");
 
@@ -15088,22 +15528,23 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <T1> the first other source's value type
      * @param <T2> the second other source's value type
      * @param <R> the result value type
-     * @param o1 the first other ObservableSource
-     * @param o2 the second other ObservableSource
+     * @param source1 the first other ObservableSource
+     * @param source2 the second other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
      * @since 2.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <T1, T2, R> Observable<R> withLatestFrom(
-            ObservableSource<T1> o1, ObservableSource<T2> o2,
-            Function3<? super T, ? super T1, ? super T2, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
+            @NonNull ObservableSource<T1> source1, @NonNull ObservableSource<T2> source2,
+            @NonNull Function3<? super T, ? super T1, ? super T2, R> combiner) {
+        Objects.requireNonNull(source1, "source1 is null");
+        Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
-        return withLatestFrom(new ObservableSource[] { o1, o2 }, f);
+        return withLatestFrom(new ObservableSource[] { source1, source2 }, f);
     }
 
     /**
@@ -15125,25 +15566,26 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <T2> the second other source's value type
      * @param <T3> the third other source's value type
      * @param <R> the result value type
-     * @param o1 the first other ObservableSource
-     * @param o2 the second other ObservableSource
-     * @param o3 the third other ObservableSource
+     * @param source1 the first other ObservableSource
+     * @param source2 the second other ObservableSource
+     * @param source3 the third other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
      * @since 2.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <T1, T2, T3, R> Observable<R> withLatestFrom(
-            ObservableSource<T1> o1, ObservableSource<T2> o2,
-            ObservableSource<T3> o3,
-            Function4<? super T, ? super T1, ? super T2, ? super T3, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(o3, "o3 is null");
+            @NonNull ObservableSource<T1> source1, @NonNull ObservableSource<T2> source2,
+            @NonNull ObservableSource<T3> source3,
+            @NonNull Function4<? super T, ? super T1, ? super T2, ? super T3, R> combiner) {
+        Objects.requireNonNull(source1, "source1 is null");
+        Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
-        return withLatestFrom(new ObservableSource[] { o1, o2, o3 }, f);
+        return withLatestFrom(new ObservableSource[] { source1, source2, source3 }, f);
     }
 
     /**
@@ -15166,27 +15608,28 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * @param <T3> the third other source's value type
      * @param <T4> the fourth other source's value type
      * @param <R> the result value type
-     * @param o1 the first other ObservableSource
-     * @param o2 the second other ObservableSource
-     * @param o3 the third other ObservableSource
-     * @param o4 the fourth other ObservableSource
+     * @param source1 the first other ObservableSource
+     * @param source2 the second other ObservableSource
+     * @param source3 the third other ObservableSource
+     * @param source4 the fourth other ObservableSource
      * @param combiner the function called with an array of values from each participating ObservableSource
      * @return the new ObservableSource instance
      * @since 2.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final <T1, T2, T3, T4, R> Observable<R> withLatestFrom(
-            ObservableSource<T1> o1, ObservableSource<T2> o2,
-            ObservableSource<T3> o3, ObservableSource<T4> o4,
-            Function5<? super T, ? super T1, ? super T2, ? super T3, ? super T4, R> combiner) {
-        Objects.requireNonNull(o1, "o1 is null");
-        Objects.requireNonNull(o2, "o2 is null");
-        Objects.requireNonNull(o3, "o3 is null");
-        Objects.requireNonNull(o4, "o4 is null");
+            @NonNull ObservableSource<T1> source1, @NonNull ObservableSource<T2> source2,
+            @NonNull ObservableSource<T3> source3, @NonNull ObservableSource<T4> source4,
+            @NonNull Function5<? super T, ? super T1, ? super T2, ? super T3, ? super T4, R> combiner) {
+        Objects.requireNonNull(source1, "source1 is null");
+        Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(source3, "source3 is null");
+        Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(combiner, "combiner is null");
         Function<Object[], R> f = Functions.toFunction(combiner);
-        return withLatestFrom(new ObservableSource[] { o1, o2, o3, o4 }, f);
+        return withLatestFrom(new ObservableSource[] { source1, source2, source3, source4 }, f);
     }
 
     /**
@@ -15212,7 +15655,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> withLatestFrom(ObservableSource<?>[] others, Function<? super Object[], R> combiner) {
+    @NonNull
+    public final <R> Observable<R> withLatestFrom(@NonNull ObservableSource<?>[] others, @NonNull Function<? super Object[], R> combiner) {
         Objects.requireNonNull(others, "others is null");
         Objects.requireNonNull(combiner, "combiner is null");
         return RxJavaPlugins.onAssembly(new ObservableWithLatestFromMany<>(this, others, combiner));
@@ -15241,7 +15685,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <R> Observable<R> withLatestFrom(Iterable<? extends ObservableSource<?>> others, Function<? super Object[], R> combiner) {
+    @NonNull
+    public final <R> Observable<R> withLatestFrom(@NonNull Iterable<? extends ObservableSource<?>> others, @NonNull Function<? super Object[], R> combiner) {
         Objects.requireNonNull(others, "others is null");
         Objects.requireNonNull(combiner, "combiner is null");
         return RxJavaPlugins.onAssembly(new ObservableWithLatestFromMany<>(this, others, combiner));
@@ -15275,7 +15720,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> zipWith(Iterable<U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
+    @NonNull
+    public final <U, R> Observable<R> zipWith(@NonNull Iterable<U> other, @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(zipper, "zipper is null");
         return RxJavaPlugins.onAssembly(new ObservableZipIterable<T, U, R>(this, other, zipper));
@@ -15318,8 +15764,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other,
-            BiFunction<? super T, ? super U, ? extends R> zipper) {
+    @NonNull
+    public final <U, R> Observable<R> zipWith(@NonNull ObservableSource<? extends U> other,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
@@ -15364,8 +15811,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other,
-            BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
+    @NonNull
+    public final <U, R> Observable<R> zipWith(@NonNull ObservableSource<? extends U> other,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
         return zip(this, other, zipper, delayError);
     }
 
@@ -15411,8 +15859,9 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U, R> Observable<R> zipWith(ObservableSource<? extends U> other,
-            BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
+    @NonNull
+    public final <U, R> Observable<R> zipWith(@NonNull ObservableSource<? extends U> other,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
         return zip(this, other, zipper, delayError, bufferSize);
     }
 
@@ -15431,6 +15880,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestObserver<T> test() { // NoPMD
         TestObserver<T> to = new TestObserver<>();
         subscribe(to);
@@ -15451,6 +15901,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final TestObserver<T> test(boolean dispose) { // NoPMD
         TestObserver<T> to = new TestObserver<>();
         if (dispose) {

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -927,7 +927,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Flowable<T> merge(Iterable<? extends SingleSource<? extends T>> sources) {
+    public static <T> Flowable<T> merge(@NonNull Iterable<? extends SingleSource<? extends T>> sources) {
         return merge(Flowable.fromIterable(sources));
     }
 
@@ -1615,6 +1615,7 @@ public abstract class Single<T> implements SingleSource<T> {
      ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2);
     }
 
@@ -1655,6 +1656,7 @@ public abstract class Single<T> implements SingleSource<T> {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3);
     }
 
@@ -1699,6 +1701,7 @@ public abstract class Single<T> implements SingleSource<T> {
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4);
     }
 
@@ -1748,6 +1751,7 @@ public abstract class Single<T> implements SingleSource<T> {
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5);
     }
 
@@ -1801,6 +1805,7 @@ public abstract class Single<T> implements SingleSource<T> {
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5, source6);
     }
 
@@ -1859,6 +1864,7 @@ public abstract class Single<T> implements SingleSource<T> {
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5, source6, source7);
     }
 
@@ -1921,6 +1927,7 @@ public abstract class Single<T> implements SingleSource<T> {
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5, source6, source7, source8);
     }
 
@@ -1988,6 +1995,7 @@ public abstract class Single<T> implements SingleSource<T> {
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return zipArray(Functions.toFunction(zipper), source1, source2, source3, source4, source5, source6, source7, source8, source9);
     }
 

--- a/src/main/java/io/reactivex/rxjava3/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/disposables/CompositeDisposable.java
@@ -41,7 +41,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      */
     public CompositeDisposable(@NonNull Disposable... disposables) {
         Objects.requireNonNull(disposables, "disposables is null");
-        this.resources = new OpenHashSet<Disposable>(disposables.length + 1);
+        this.resources = new OpenHashSet<>(disposables.length + 1);
         for (Disposable d : disposables) {
             Objects.requireNonNull(d, "A Disposable in the disposables array is null");
             this.resources.add(d);
@@ -55,7 +55,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
      */
     public CompositeDisposable(@NonNull Iterable<? extends Disposable> disposables) {
         Objects.requireNonNull(disposables, "disposables is null");
-        this.resources = new OpenHashSet<Disposable>();
+        this.resources = new OpenHashSet<>();
         for (Disposable d : disposables) {
             Objects.requireNonNull(d, "A Disposable item in the disposables sequence is null");
             this.resources.add(d);
@@ -100,7 +100,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
                 if (!disposed) {
                     OpenHashSet<Disposable> set = resources;
                     if (set == null) {
-                        set = new OpenHashSet<Disposable>();
+                        set = new OpenHashSet<>();
                         resources = set;
                     }
                     set.add(disposable);
@@ -126,7 +126,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
                 if (!disposed) {
                     OpenHashSet<Disposable> set = resources;
                     if (set == null) {
-                        set = new OpenHashSet<Disposable>(disposables.length + 1);
+                        set = new OpenHashSet<>(disposables.length + 1);
                         resources = set;
                     }
                     for (Disposable d : disposables) {
@@ -239,7 +239,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     if (errors == null) {
-                        errors = new ArrayList<Throwable>();
+                        errors = new ArrayList<>();
                     }
                     errors.add(ex);
                 }

--- a/src/main/java/io/reactivex/rxjava3/disposables/SerialDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/disposables/SerialDisposable.java
@@ -30,7 +30,7 @@ public final class SerialDisposable implements Disposable {
      * Constructs an empty SerialDisposable.
      */
     public SerialDisposable() {
-        this.resource = new AtomicReference<Disposable>();
+        this.resource = new AtomicReference<>();
     }
 
     /**
@@ -38,7 +38,7 @@ public final class SerialDisposable implements Disposable {
      * @param initialDisposable the initial Disposable instance to use, null allowed
      */
     public SerialDisposable(@Nullable Disposable initialDisposable) {
-        this.resource = new AtomicReference<Disposable>(initialDisposable);
+        this.resource = new AtomicReference<>(initialDisposable);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/CompositeException.java
@@ -62,8 +62,8 @@ public final class CompositeException extends RuntimeException {
      * @throws IllegalArgumentException if <code>errors</code> is empty.
      */
     public CompositeException(@NonNull Iterable<? extends Throwable> errors) {
-        Set<Throwable> deDupedExceptions = new LinkedHashSet<Throwable>();
-        List<Throwable> localExceptions = new ArrayList<Throwable>();
+        Set<Throwable> deDupedExceptions = new LinkedHashSet<>();
+        List<Throwable> localExceptions = new ArrayList<>();
         if (errors != null) {
             for (Throwable ex : errors) {
                 if (ex instanceof CompositeException) {
@@ -108,7 +108,7 @@ public final class CompositeException extends RuntimeException {
         if (cause == null) {
             String separator = System.getProperty("line.separator");
             if (exceptions.size() > 1) {
-                Map<Throwable, Boolean> seenCauses = new IdentityHashMap<Throwable, Boolean>();
+                Map<Throwable, Boolean> seenCauses = new IdentityHashMap<>();
 
                 StringBuilder aggregateMessage = new StringBuilder();
                 aggregateMessage.append("Multiple exceptions (").append(exceptions.size()).append(")").append(separator);

--- a/src/main/java/io/reactivex/rxjava3/flowables/ConnectableFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/flowables/ConnectableFlowable.java
@@ -59,20 +59,30 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     /**
      * Instructs the {@code ConnectableFlowable} to begin emitting the items from its underlying
      * {@link Flowable} to its {@link Subscriber}s.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The behavior is determined by the implementor of this abstract class.</dd>
+     * </dl>
      *
      * @param connection
      *          the action that receives the connection subscription before the subscription to source happens
      *          allowing the caller to synchronously disconnect a synchronous source
      * @see <a href="http://reactivex.io/documentation/operators/connect.html">ReactiveX documentation: Connect</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public abstract void connect(@NonNull Consumer<? super Disposable> connection);
 
     /**
      * Resets this ConnectableFlowable into its fresh state if it has terminated.
      * <p>
      * Calling this method on a fresh or active {@code ConnectableFlowable} has no effect.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The behavior is determined by the implementor of this abstract class.</dd>
+     * </dl>
      * @since 3.0.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public abstract void reset();
 
     /**
@@ -80,10 +90,16 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * {@link Flowable} to its {@link Subscriber}s.
      * <p>
      * To disconnect from a synchronous source, use the {@link #connect(io.reactivex.rxjava3.functions.Consumer)} method.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The behavior is determined by the implementor of this abstract class.</dd>
+     * </dl>
      *
      * @return the subscription representing the connection
      * @see <a href="http://reactivex.io/documentation/operators/connect.html">ReactiveX documentation: Connect</a>
      */
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable connect() {
         ConnectConsumer cc = new ConnectConsumer();
         connect(cc);
@@ -111,7 +127,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     public Flowable<T> refCount() {
-        return RxJavaPlugins.onAssembly(new FlowableRefCount<T>(this));
+        return RxJavaPlugins.onAssembly(new FlowableRefCount<>(this));
     }
 
     /**
@@ -132,6 +148,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @NonNull
     public final Flowable<T> refCount(int subscriberCount) {
         return refCount(subscriberCount, 0, TimeUnit.NANOSECONDS, Schedulers.trampoline());
     }
@@ -157,7 +174,8 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final Flowable<T> refCount(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> refCount(long timeout, @NonNull TimeUnit unit) {
         return refCount(1, timeout, unit, Schedulers.computation());
     }
 
@@ -182,7 +200,8 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final Flowable<T> refCount(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> refCount(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return refCount(1, timeout, unit, scheduler);
     }
 
@@ -208,7 +227,8 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final Flowable<T> refCount(int subscriberCount, long timeout, TimeUnit unit) {
+    @NonNull
+    public final Flowable<T> refCount(int subscriberCount, long timeout, @NonNull TimeUnit unit) {
         return refCount(subscriberCount, timeout, unit, Schedulers.computation());
     }
 
@@ -234,11 +254,12 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final Flowable<T> refCount(int subscriberCount, long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Flowable<T> refCount(int subscriberCount, long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         ObjectHelper.verifyPositive(subscriberCount, "subscriberCount");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new FlowableRefCount<T>(this, subscriberCount, timeout, unit, scheduler));
+        return RxJavaPlugins.onAssembly(new FlowableRefCount<>(this, subscriberCount, timeout, unit, scheduler));
     }
 
     /**
@@ -256,6 +277,13 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * This overload does not allow disconnecting the connection established via
      * {@link #connect(Consumer)}. Use the {@link #autoConnect(int, Consumer)} overload
      * to gain access to the {@code Disposable} representing the only connection.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator itself doesn't interfere with backpressure which is determined by
+     *  the upstream {@code ConnectableFlowable}'s behavior.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code autoConnect} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      *
      * @return a Flowable that automatically connects to this ConnectableFlowable
      *         when the first Subscriber subscribes
@@ -263,6 +291,9 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * @see #autoConnect(int, Consumer)
      */
     @NonNull
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public Flowable<T> autoConnect() {
         return autoConnect(1);
     }
@@ -281,6 +312,13 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * This overload does not allow disconnecting the connection established via
      * {@link #connect(Consumer)}. Use the {@link #autoConnect(int, Consumer)} overload
      * to gain access to the {@code Disposable} representing the only connection.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator itself doesn't interfere with backpressure which is determined by
+     *  the upstream {@code ConnectableFlowable}'s behavior.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code autoConnect} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      *
      * @param numberOfSubscribers the number of subscribers to await before calling connect
      *                            on the ConnectableFlowable. A non-positive value indicates
@@ -289,6 +327,9 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *         when the specified number of Subscribers subscribe to it
      */
     @NonNull
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public Flowable<T> autoConnect(int numberOfSubscribers) {
         return autoConnect(numberOfSubscribers, Functions.emptyConsumer());
     }
@@ -305,6 +346,13 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * terminates, the connection is never renewed, no matter how Subscribers come
      * and go. Use {@link #refCount()} to renew a connection or dispose an active
      * connection when all {@code Subscriber}s have cancelled their {@code Subscription}s.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator itself doesn't interfere with backpressure which is determined by
+     *  the upstream {@code ConnectableFlowable}'s behavior.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code autoConnect} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
      *
      * @param numberOfSubscribers the number of subscribers to await before calling connect
      *                            on the ConnectableFlowable. A non-positive value indicates
@@ -316,11 +364,14 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      *         specified callback with the Subscription associated with the established connection
      */
     @NonNull
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
     public Flowable<T> autoConnect(int numberOfSubscribers, @NonNull Consumer<? super Disposable> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);
             return RxJavaPlugins.onAssembly(this);
         }
-        return RxJavaPlugins.onAssembly(new FlowableAutoConnect<T>(this, numberOfSubscribers, connection));
+        return RxJavaPlugins.onAssembly(new FlowableAutoConnect<>(this, numberOfSubscribers, connection));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/functions/Functions.java
@@ -17,6 +17,7 @@ import java.util.concurrent.*;
 
 import org.reactivestreams.Subscription;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.OnErrorNotImplementedException;
 import io.reactivex.rxjava3.functions.*;
@@ -33,47 +34,47 @@ public final class Functions {
         throw new IllegalStateException("No instances!");
     }
 
-    public static <T1, T2, R> Function<Object[], R> toFunction(final BiFunction<? super T1, ? super T2, ? extends R> f) {
-        Objects.requireNonNull(f, "f is null");
+    @NonNull
+    public static <T1, T2, R> Function<Object[], R> toFunction(@NonNull BiFunction<? super T1, ? super T2, ? extends R> f) {
         return new Array2Func<T1, T2, R>(f);
     }
 
-    public static <T1, T2, T3, R> Function<Object[], R> toFunction(final Function3<T1, T2, T3, R> f) {
-        Objects.requireNonNull(f, "f is null");
+    @NonNull
+    public static <T1, T2, T3, R> Function<Object[], R> toFunction(@NonNull Function3<T1, T2, T3, R> f) {
         return new Array3Func<T1, T2, T3, R>(f);
     }
 
-    public static <T1, T2, T3, T4, R> Function<Object[], R> toFunction(final Function4<T1, T2, T3, T4, R> f) {
-        Objects.requireNonNull(f, "f is null");
+    @NonNull
+    public static <T1, T2, T3, T4, R> Function<Object[], R> toFunction(@NonNull Function4<T1, T2, T3, T4, R> f) {
         return new Array4Func<T1, T2, T3, T4, R>(f);
     }
 
-    public static <T1, T2, T3, T4, T5, R> Function<Object[], R> toFunction(final Function5<T1, T2, T3, T4, T5, R> f) {
-        Objects.requireNonNull(f, "f is null");
+    @NonNull
+    public static <T1, T2, T3, T4, T5, R> Function<Object[], R> toFunction(@NonNull Function5<T1, T2, T3, T4, T5, R> f) {
         return new Array5Func<T1, T2, T3, T4, T5, R>(f);
     }
 
+    @NonNull
     public static <T1, T2, T3, T4, T5, T6, R> Function<Object[], R> toFunction(
-            final Function6<T1, T2, T3, T4, T5, T6, R> f) {
-        Objects.requireNonNull(f, "f is null");
+            @NonNull Function6<T1, T2, T3, T4, T5, T6, R> f) {
         return new Array6Func<T1, T2, T3, T4, T5, T6, R>(f);
     }
 
+    @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, R> Function<Object[], R> toFunction(
-            final Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-        Objects.requireNonNull(f, "f is null");
+            @NonNull Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
         return new Array7Func<T1, T2, T3, T4, T5, T6, T7, R>(f);
     }
 
+    @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function<Object[], R> toFunction(
-            final Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-        Objects.requireNonNull(f, "f is null");
+            @NonNull Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
         return new Array8Func<T1, T2, T3, T4, T5, T6, T7, T8, R>(f);
     }
 
+    @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Function<Object[], R> toFunction(
-            final Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> f) {
-        Objects.requireNonNull(f, "f is null");
+            @NonNull Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> f) {
         return new Array9Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, R>(f);
     }
 
@@ -86,6 +87,7 @@ public final class Functions {
      * @return the identity function
      */
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Function<T, T> identity() {
         return (Function<T, T>)IDENTITY;
     }
@@ -125,16 +127,19 @@ public final class Functions {
     static final Comparator<Object> NATURAL_COMPARATOR = new NaturalObjectComparator();
 
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Predicate<T> alwaysTrue() {
         return (Predicate<T>)ALWAYS_TRUE;
     }
 
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Predicate<T> alwaysFalse() {
         return (Predicate<T>)ALWAYS_FALSE;
     }
 
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Supplier<T> nullSupplier() {
         return (Supplier<T>)NULL_SUPPLIER;
     }
@@ -145,6 +150,7 @@ public final class Functions {
      * @return a natural order comparator which casts the parameters to Comparable
      */
     @SuppressWarnings("unchecked")
+    @NonNull
     public static <T> Comparator<T> naturalOrder() {
         return (Comparator<T>)NATURAL_COMPARATOR;
     }
@@ -167,7 +173,8 @@ public final class Functions {
      * @param future the future to call get() on, not null
      * @return the new Action instance
      */
-    public static Action futureAction(Future<?> future) {
+    @NonNull
+    public static Action futureAction(@NonNull Future<?> future) {
         return new FutureAction(future);
     }
 
@@ -200,7 +207,8 @@ public final class Functions {
      * @param value the value to return
      * @return the new Callable instance
      */
-    public static <T> Callable<T> justCallable(T value) {
+    @NonNull
+    public static <T> Callable<T> justCallable(@NonNull T value) {
         return new JustValue<Object, T>(value);
     }
 
@@ -210,7 +218,8 @@ public final class Functions {
      * @param value the value to return
      * @return the new Callable instance
      */
-    public static <T> Supplier<T> justSupplier(T value) {
+    @NonNull
+    public static <T> Supplier<T> justSupplier(@NonNull T value) {
         return new JustValue<Object, T>(value);
     }
 
@@ -221,7 +230,8 @@ public final class Functions {
      * @param value the value to return
      * @return the new Function instance
      */
-    public static <T, U> Function<T, U> justFunction(U value) {
+    @NonNull
+    public static <T, U> Function<T, U> justFunction(@NonNull U value) {
         return new JustValue<T, U>(value);
     }
 
@@ -245,7 +255,8 @@ public final class Functions {
      * @param target the target class
      * @return the new Function instance
      */
-    public static <T, U> Function<T, U> castFunction(Class<U> target) {
+    @NonNull
+    public static <T, U> Function<T, U> castFunction(@NonNull Class<U> target) {
         return new CastToClass<T, U>(target);
     }
 

--- a/src/main/java/io/reactivex/rxjava3/observables/ConnectableObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/observables/ConnectableObservable.java
@@ -56,12 +56,17 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
     /**
      * Instructs the {@code ConnectableObservable} to begin emitting the items from its underlying
      * {@link Observable} to its {@link Observer}s.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The behavior is determined by the implementor of this abstract class.</dd>
+     * </dl>
      *
      * @param connection
      *          the action that receives the connection subscription before the subscription to source happens
      *          allowing the caller to synchronously disconnect a synchronous source
      * @see <a href="http://reactivex.io/documentation/operators/connect.html">ReactiveX documentation: Connect</a>
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public abstract void connect(@NonNull Consumer<? super Disposable> connection);
 
     /**
@@ -69,8 +74,13 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * or has been disposed.
      * <p>
      * Calling this method on a fresh or active {@code ConnectableObservable} has no effect.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The behavior is determined by the implementor of this abstract class.</dd>
+     * </dl>
      * @since 3.0.0
      */
+    @SchedulerSupport(SchedulerSupport.NONE)
     public abstract void reset();
 
     /**
@@ -78,10 +88,16 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * {@link Observable} to its {@link Observer}s.
      * <p>
      * To disconnect from a synchronous source, use the {@link #connect(Consumer)} method.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The behavior is determined by the implementor of this abstract class.</dd>
+     * </dl>
      *
      * @return the subscription representing the connection
      * @see <a href="http://reactivex.io/documentation/operators/connect.html">ReactiveX documentation: Connect</a>
      */
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable connect() {
         ConnectConsumer cc = new ConnectConsumer();
         connect(cc);
@@ -105,7 +121,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     public Observable<T> refCount() {
-        return RxJavaPlugins.onAssembly(new ObservableRefCount<T>(this));
+        return RxJavaPlugins.onAssembly(new ObservableRefCount<>(this));
     }
 
     /**
@@ -122,6 +138,7 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
     public final Observable<T> refCount(int subscriberCount) {
         return refCount(subscriberCount, 0, TimeUnit.NANOSECONDS, Schedulers.trampoline());
     }
@@ -143,7 +160,8 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> refCount(long timeout, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> refCount(long timeout, @NonNull TimeUnit unit) {
         return refCount(1, timeout, unit, Schedulers.computation());
     }
 
@@ -164,7 +182,8 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> refCount(long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> refCount(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         return refCount(1, timeout, unit, scheduler);
     }
 
@@ -186,7 +205,8 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Observable<T> refCount(int subscriberCount, long timeout, TimeUnit unit) {
+    @NonNull
+    public final Observable<T> refCount(int subscriberCount, long timeout, @NonNull TimeUnit unit) {
         return refCount(subscriberCount, timeout, unit, Schedulers.computation());
     }
 
@@ -208,11 +228,12 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Observable<T> refCount(int subscriberCount, long timeout, TimeUnit unit, Scheduler scheduler) {
+    @NonNull
+    public final Observable<T> refCount(int subscriberCount, long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         ObjectHelper.verifyPositive(subscriberCount, "subscriberCount");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableRefCount<T>(this, subscriberCount, timeout, unit, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableRefCount<>(this, subscriberCount, timeout, unit, scheduler));
     }
 
     /**
@@ -230,11 +251,17 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * This overload does not allow disconnecting the connection established via
      * {@link #connect(Consumer)}. Use the {@link #autoConnect(int, Consumer)} overload
      * to gain access to the {@code Disposable} representing the only connection.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code autoConnect} overload does not operate on any particular {@link Scheduler}.</dd>
+     * </dl>
      *
      * @return an Observable that automatically connects to this ConnectableObservable
      *         when the first Observer subscribes
      */
     @NonNull
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
     public Observable<T> autoConnect() {
         return autoConnect(1);
     }
@@ -254,6 +281,10 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * This overload does not allow disconnecting the connection established via
      * {@link #connect(Consumer)}. Use the {@link #autoConnect(int, Consumer)} overload
      * to gain access to the {@code Disposable} representing the only connection.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code autoConnect} overload does not operate on any particular {@link Scheduler}.</dd>
+     * </dl>
      *
      * @param numberOfSubscribers the number of subscribers to await before calling connect
      *                            on the ConnectableObservable. A non-positive value indicates
@@ -262,6 +293,8 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *         when the specified number of Subscribers subscribe to it
      */
     @NonNull
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
     public Observable<T> autoConnect(int numberOfSubscribers) {
         return autoConnect(numberOfSubscribers, Functions.emptyConsumer());
     }
@@ -278,6 +311,10 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      * terminates, the connection is never renewed, no matter how Observers come
      * and go. Use {@link #refCount()} to renew a connection or dispose an active
      * connection when all {@code Observer}s have disposed their {@code Disposable}s.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code autoConnect} overload does not operate on any particular {@link Scheduler}.</dd>
+     * </dl>
      *
      * @param numberOfSubscribers the number of subscribers to await before calling connect
      *                            on the ConnectableObservable. A non-positive value indicates
@@ -289,11 +326,13 @@ public abstract class ConnectableObservable<T> extends Observable<T> {
      *         specified callback with the Subscription associated with the established connection
      */
     @NonNull
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
     public Observable<T> autoConnect(int numberOfSubscribers, @NonNull Consumer<? super Disposable> connection) {
         if (numberOfSubscribers <= 0) {
             this.connect(connection);
             return RxJavaPlugins.onAssembly(this);
         }
-        return RxJavaPlugins.onAssembly(new ObservableAutoConnect<T>(this, numberOfSubscribers, connection));
+        return RxJavaPlugins.onAssembly(new ObservableAutoConnect<>(this, numberOfSubscribers, connection));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/AsyncProcessor.java
@@ -137,7 +137,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> AsyncProcessor<T> create() {
-        return new AsyncProcessor<T>();
+        return new AsyncProcessor<>();
     }
 
     /**
@@ -146,7 +146,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      */
     @SuppressWarnings("unchecked")
     AsyncProcessor() {
-        this.subscribers = new AtomicReference<AsyncSubscription<T>[]>(EMPTY);
+        this.subscribers = new AtomicReference<>(EMPTY);
     }
 
     @Override
@@ -203,29 +203,33 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasSubscribers() {
         return subscribers.get().length != 0;
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasThrowable() {
         return subscribers.get() == TERMINATED && error != null;
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasComplete() {
         return subscribers.get() == TERMINATED && error == null;
     }
 
     @Override
     @Nullable
+    @CheckReturnValue
     public Throwable getThrowable() {
         return subscribers.get() == TERMINATED ? error : null;
     }
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        AsyncSubscription<T> as = new AsyncSubscription<T>(s, this);
+        AsyncSubscription<T> as = new AsyncSubscription<>(s, this);
         s.onSubscribe(as);
         if (add(as)) {
             if (as.isCancelled()) {
@@ -316,6 +320,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      * <p>The method is thread-safe.
      * @return true if this processor has any value
      */
+    @CheckReturnValue
     public boolean hasValue() {
         return subscribers.get() == TERMINATED && value != null;
     }
@@ -326,6 +331,7 @@ public final class AsyncProcessor<T> extends FlowableProcessor<T> {
      * @return a single value this processor currently has or null if no such value exists
      */
     @Nullable
+    @CheckReturnValue
     public T getValue() {
         return subscribers.get() == TERMINATED ? value : null;
     }

--- a/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
@@ -191,7 +191,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> BehaviorProcessor<T> create() {
-        return new BehaviorProcessor<T>();
+        return new BehaviorProcessor<>();
     }
 
     /**
@@ -207,9 +207,9 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      */
     @CheckReturnValue
     @NonNull
-    public static <T> BehaviorProcessor<T> createDefault(T defaultValue) {
+    public static <@NonNull T> BehaviorProcessor<T> createDefault(T defaultValue) {
         Objects.requireNonNull(defaultValue, "defaultValue is null");
-        return new BehaviorProcessor<T>(defaultValue);
+        return new BehaviorProcessor<>(defaultValue);
     }
 
     /**
@@ -218,12 +218,12 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      */
     @SuppressWarnings("unchecked")
     BehaviorProcessor() {
-        this.value = new AtomicReference<Object>();
+        this.value = new AtomicReference<>();
         this.lock = new ReentrantReadWriteLock();
         this.readLock = lock.readLock();
         this.writeLock = lock.writeLock();
-        this.subscribers = new AtomicReference<BehaviorSubscription<T>[]>(EMPTY);
-        this.terminalEvent = new AtomicReference<Throwable>();
+        this.subscribers = new AtomicReference<>(EMPTY);
+        this.terminalEvent = new AtomicReference<>();
     }
 
     /**
@@ -239,7 +239,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        BehaviorSubscription<T> bs = new BehaviorSubscription<T>(s, this);
+        BehaviorSubscription<T> bs = new BehaviorSubscription<>(s, this);
         s.onSubscribe(bs);
         if (add(bs)) {
             if (bs.cancelled) {
@@ -318,6 +318,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * @return true if the item was emitted to all Subscribers
      * @since 2.2
      */
+    @CheckReturnValue
     public boolean offer(T t) {
         if (t == null) {
             onError(ExceptionHelper.createNullPointerException("offer called with a null value."));
@@ -340,16 +341,19 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasSubscribers() {
         return subscribers.get().length != 0;
     }
 
+    @CheckReturnValue
     /* test support*/ int subscriberCount() {
         return subscribers.get().length;
     }
 
     @Override
     @Nullable
+    @CheckReturnValue
     public Throwable getThrowable() {
         Object o = value.get();
         if (NotificationLite.isError(o)) {
@@ -364,6 +368,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * @return a single value the BehaviorProcessor currently has or null if no such value exists
      */
     @Nullable
+    @CheckReturnValue
     public T getValue() {
         Object o = value.get();
         if (NotificationLite.isComplete(o) || NotificationLite.isError(o)) {
@@ -373,12 +378,14 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasComplete() {
         Object o = value.get();
         return NotificationLite.isComplete(o);
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasThrowable() {
         Object o = value.get();
         return NotificationLite.isError(o);
@@ -389,6 +396,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * <p>The method is thread-safe.
      * @return true if the BehaviorProcessor has any value
      */
+    @CheckReturnValue
     public boolean hasValue() {
         Object o = value.get();
         return o != null && !NotificationLite.isComplete(o) && !NotificationLite.isError(o);
@@ -554,7 +562,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
                     if (emitting) {
                         AppendOnlyLinkedArrayList<Object> q = queue;
                         if (q == null) {
-                            q = new AppendOnlyLinkedArrayList<Object>(4);
+                            q = new AppendOnlyLinkedArrayList<>(4);
                             queue = q;
                         }
                         q.add(value);

--- a/src/main/java/io/reactivex/rxjava3/processors/FlowableProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/FlowableProcessor.java
@@ -33,6 +33,7 @@ public abstract class FlowableProcessor<T> extends Flowable<T> implements Proces
      * <p>The method is thread-safe.
      * @return true if the FlowableProcessor has subscribers
      */
+    @CheckReturnValue
     public abstract boolean hasSubscribers();
 
     /**
@@ -42,6 +43,7 @@ public abstract class FlowableProcessor<T> extends Flowable<T> implements Proces
      * @see #getThrowable()
      * @see #hasComplete()
      */
+    @CheckReturnValue
     public abstract boolean hasThrowable();
 
     /**
@@ -50,6 +52,7 @@ public abstract class FlowableProcessor<T> extends Flowable<T> implements Proces
      * @return true if the FlowableProcessor has reached a terminal state through a complete event
      * @see #hasThrowable()
      */
+    @CheckReturnValue
     public abstract boolean hasComplete();
 
     /**
@@ -60,6 +63,7 @@ public abstract class FlowableProcessor<T> extends Flowable<T> implements Proces
      * hasn't terminated yet
      */
     @Nullable
+    @CheckReturnValue
     public abstract Throwable getThrowable();
 
     /**
@@ -74,6 +78,6 @@ public abstract class FlowableProcessor<T> extends Flowable<T> implements Proces
         if (this instanceof SerializedProcessor) {
             return this;
         }
-        return new SerializedProcessor<T>(this);
+        return new SerializedProcessor<>(this);
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
@@ -170,7 +170,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> MulticastProcessor<T> create() {
-        return new MulticastProcessor<T>(bufferSize(), false);
+        return new MulticastProcessor<>(bufferSize(), false);
     }
 
     /**
@@ -184,7 +184,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> MulticastProcessor<T> create(boolean refCount) {
-        return new MulticastProcessor<T>(bufferSize(), refCount);
+        return new MulticastProcessor<>(bufferSize(), refCount);
     }
 
     /**
@@ -196,7 +196,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> MulticastProcessor<T> create(int bufferSize) {
-        return new MulticastProcessor<T>(bufferSize, false);
+        return new MulticastProcessor<>(bufferSize, false);
     }
 
     /**
@@ -211,7 +211,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> MulticastProcessor<T> create(int bufferSize, boolean refCount) {
-        return new MulticastProcessor<T>(bufferSize, refCount);
+        return new MulticastProcessor<>(bufferSize, refCount);
     }
 
     /**
@@ -227,8 +227,8 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
         this.bufferSize = bufferSize;
         this.limit = bufferSize - (bufferSize >> 2);
         this.wip = new AtomicInteger();
-        this.subscribers = new AtomicReference<MulticastSubscription<T>[]>(EMPTY);
-        this.upstream = new AtomicReference<Subscription>();
+        this.subscribers = new AtomicReference<>(EMPTY);
+        this.upstream = new AtomicReference<>();
         this.refcount = refCount;
         this.once = new AtomicBoolean();
     }
@@ -241,7 +241,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
      */
     public void start() {
         if (SubscriptionHelper.setOnce(upstream, EmptySubscription.INSTANCE)) {
-            queue = new SpscArrayQueue<T>(bufferSize);
+            queue = new SpscArrayQueue<>(bufferSize);
         }
     }
 
@@ -253,7 +253,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
      */
     public void startUnbounded() {
         if (SubscriptionHelper.setOnce(upstream, EmptySubscription.INSTANCE)) {
-            queue = new SpscLinkedArrayQueue<T>(bufferSize);
+            queue = new SpscLinkedArrayQueue<>(bufferSize);
         }
     }
 
@@ -281,7 +281,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
                 }
             }
 
-            queue = new SpscArrayQueue<T>(bufferSize);
+            queue = new SpscArrayQueue<>(bufferSize);
 
             s.request(bufferSize);
         }
@@ -309,6 +309,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
      * @param t the item to offer, not null
      * @return true if successful, false if the queue is full
      */
+    @CheckReturnValue
     public boolean offer(T t) {
         if (once.get()) {
             return false;
@@ -344,28 +345,32 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasSubscribers() {
         return subscribers.get().length != 0;
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasThrowable() {
         return once.get() && error != null;
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasComplete() {
         return once.get() && error == null;
     }
 
     @Override
+    @CheckReturnValue
     public Throwable getThrowable() {
         return once.get() ? error : null;
     }
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        MulticastSubscription<T> ms = new MulticastSubscription<T>(s, this);
+        MulticastSubscription<T> ms = new MulticastSubscription<>(s, this);
         s.onSubscribe(ms);
         if (add(ms)) {
             if (ms.get() == Long.MIN_VALUE) {

--- a/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
@@ -128,7 +128,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> PublishProcessor<T> create() {
-        return new PublishProcessor<T>();
+        return new PublishProcessor<>();
     }
 
     /**
@@ -137,12 +137,12 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
      */
     @SuppressWarnings("unchecked")
     PublishProcessor() {
-        subscribers = new AtomicReference<PublishSubscription<T>[]>(EMPTY);
+        subscribers = new AtomicReference<>(EMPTY);
     }
 
     @Override
     protected void subscribeActual(Subscriber<? super T> t) {
-        PublishSubscription<T> ps = new PublishSubscription<T>(t, this);
+        PublishSubscription<T> ps = new PublishSubscription<>(t, this);
         t.onSubscribe(ps);
         if (add(ps)) {
             // if cancellation happened while a successful add, the remove() didn't work
@@ -283,6 +283,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
      * @return true if the item was emitted to all Subscribers
      * @since 2.2
      */
+    @CheckReturnValue
     public boolean offer(T t) {
         if (t == null) {
             onError(ExceptionHelper.createNullPointerException("offer called with a null value."));
@@ -303,12 +304,14 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasSubscribers() {
         return subscribers.get().length != 0;
     }
 
     @Override
     @Nullable
+    @CheckReturnValue
     public Throwable getThrowable() {
         if (subscribers.get() == TERMINATED) {
             return error;
@@ -317,11 +320,13 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasThrowable() {
         return subscribers.get() == TERMINATED && error != null;
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasComplete() {
         return subscribers.get() == TERMINATED && error == null;
     }

--- a/src/main/java/io/reactivex/rxjava3/processors/SerializedProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/SerializedProcessor.java
@@ -59,7 +59,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
                     if (emitting) {
                         AppendOnlyLinkedArrayList<Object> q = queue;
                         if (q == null) {
-                            q = new AppendOnlyLinkedArrayList<Object>(4);
+                            q = new AppendOnlyLinkedArrayList<>(4);
                             queue = q;
                         }
                         q.add(NotificationLite.subscription(s));
@@ -92,7 +92,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
             if (emitting) {
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(4);
+                    q = new AppendOnlyLinkedArrayList<>(4);
                     queue = q;
                 }
                 q.add(NotificationLite.next(t));
@@ -119,7 +119,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
                 if (emitting) {
                     AppendOnlyLinkedArrayList<Object> q = queue;
                     if (q == null) {
-                        q = new AppendOnlyLinkedArrayList<Object>(4);
+                        q = new AppendOnlyLinkedArrayList<>(4);
                         queue = q;
                     }
                     q.setFirst(NotificationLite.error(t));
@@ -149,7 +149,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
             if (emitting) {
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(4);
+                    q = new AppendOnlyLinkedArrayList<>(4);
                     queue = q;
                 }
                 q.add(NotificationLite.complete());

--- a/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.*;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.functions.*;
 import io.reactivex.rxjava3.internal.fuseable.QueueSubscription;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.*;
@@ -179,7 +179,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> UnicastProcessor<T> create() {
-        return new UnicastProcessor<>(bufferSize());
+        return create(bufferSize(), Functions.EMPTY_RUNNABLE, true);
     }
 
     /**
@@ -191,7 +191,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> UnicastProcessor<T> create(int capacityHint) {
-        return new UnicastProcessor<>(capacityHint);
+        return create(capacityHint, Functions.EMPTY_RUNNABLE, true);
     }
 
     /**
@@ -205,7 +205,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> UnicastProcessor<T> create(boolean delayError) {
-        return new UnicastProcessor<>(bufferSize(), null, delayError);
+        return create(bufferSize(), Functions.EMPTY_RUNNABLE, delayError);
     }
 
     /**
@@ -224,7 +224,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> UnicastProcessor<T> create(int capacityHint, @NonNull Runnable onTerminate) {
-        return new UnicastProcessor<>(capacityHint, onTerminate);
+        return create(capacityHint, onTerminate, true);
     }
 
     /**
@@ -246,26 +246,6 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     @NonNull
     public static <T> UnicastProcessor<T> create(int capacityHint, @NonNull Runnable onTerminate, boolean delayError) {
         return new UnicastProcessor<>(capacityHint, onTerminate, delayError);
-    }
-
-    /**
-     * Creates an UnicastProcessor with the given capacity hint.
-     * @param capacityHint the capacity hint for the internal, unbounded queue
-     * @since 2.0
-     */
-    UnicastProcessor(int capacityHint) {
-        this(capacityHint, null, true);
-    }
-
-    /**
-     * Creates an UnicastProcessor with the given capacity hint and callback
-     * for when the Processor is terminated normally or its single Subscriber cancels.
-     * @param capacityHint the capacity hint for the internal, unbounded queue
-     * @param onTerminate the callback to run when the Processor is terminated or cancelled, null not allowed
-     * @since 2.0
-     */
-    UnicastProcessor(int capacityHint, Runnable onTerminate) {
-        this(capacityHint, onTerminate, true);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/schedulers/TestScheduler.java
@@ -28,7 +28,7 @@ import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
  */
 public final class TestScheduler extends Scheduler {
     /** The ordered queue for the runnable tasks. */
-    final Queue<TimedRunnable> queue = new PriorityBlockingQueue<TimedRunnable>(11);
+    final Queue<TimedRunnable> queue = new PriorityBlockingQueue<>(11);
     /** The per-scheduler global order counter. */
     long counter;
     // Storing time in nanoseconds internally.

--- a/src/main/java/io/reactivex/rxjava3/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/AsyncSubject.java
@@ -129,7 +129,7 @@ public final class AsyncSubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> AsyncSubject<T> create() {
-        return new AsyncSubject<T>();
+        return new AsyncSubject<>();
     }
 
     /**
@@ -138,7 +138,7 @@ public final class AsyncSubject<T> extends Subject<T> {
      */
     @SuppressWarnings("unchecked")
     AsyncSubject() {
-        this.subscribers = new AtomicReference<AsyncDisposable<T>[]>(EMPTY);
+        this.subscribers = new AtomicReference<>(EMPTY);
     }
 
     @Override
@@ -192,28 +192,32 @@ public final class AsyncSubject<T> extends Subject<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasObservers() {
         return subscribers.get().length != 0;
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasThrowable() {
         return subscribers.get() == TERMINATED && error != null;
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasComplete() {
         return subscribers.get() == TERMINATED && error == null;
     }
 
     @Override
+    @CheckReturnValue
     public Throwable getThrowable() {
         return subscribers.get() == TERMINATED ? error : null;
     }
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        AsyncDisposable<T> as = new AsyncDisposable<T>(observer, this);
+        AsyncDisposable<T> as = new AsyncDisposable<>(observer, this);
         observer.onSubscribe(as);
         if (add(as)) {
             if (as.isDisposed()) {
@@ -304,6 +308,7 @@ public final class AsyncSubject<T> extends Subject<T> {
      * <p>The method is thread-safe.
      * @return true if the subject has any value
      */
+    @CheckReturnValue
     public boolean hasValue() {
         return subscribers.get() == TERMINATED && value != null;
     }
@@ -314,6 +319,7 @@ public final class AsyncSubject<T> extends Subject<T> {
      * @return a single value the Subject currently has or null if no such value exists
      */
     @Nullable
+    @CheckReturnValue
     public T getValue() {
         return subscribers.get() == TERMINATED ? value : null;
     }

--- a/src/main/java/io/reactivex/rxjava3/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/BehaviorSubject.java
@@ -176,7 +176,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> BehaviorSubject<T> create() {
-        return new BehaviorSubject<T>();
+        return new BehaviorSubject<>();
     }
 
     /**
@@ -192,8 +192,8 @@ public final class BehaviorSubject<T> extends Subject<T> {
      */
     @CheckReturnValue
     @NonNull
-    public static <T> BehaviorSubject<T> createDefault(T defaultValue) {
-        return new BehaviorSubject<T>(defaultValue);
+    public static <@NonNull T> BehaviorSubject<T> createDefault(T defaultValue) {
+        return new BehaviorSubject<>(defaultValue);
     }
 
     /**
@@ -205,9 +205,9 @@ public final class BehaviorSubject<T> extends Subject<T> {
         this.lock = new ReentrantReadWriteLock();
         this.readLock = lock.readLock();
         this.writeLock = lock.writeLock();
-        this.subscribers = new AtomicReference<BehaviorDisposable<T>[]>(EMPTY);
-        this.value = new AtomicReference<Object>();
-        this.terminalEvent = new AtomicReference<Throwable>();
+        this.subscribers = new AtomicReference<>(EMPTY);
+        this.value = new AtomicReference<>();
+        this.terminalEvent = new AtomicReference<>();
     }
 
     /**
@@ -223,7 +223,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        BehaviorDisposable<T> bs = new BehaviorDisposable<T>(observer, this);
+        BehaviorDisposable<T> bs = new BehaviorDisposable<>(observer, this);
         observer.onSubscribe(bs);
         if (add(bs)) {
             if (bs.cancelled) {
@@ -287,16 +287,19 @@ public final class BehaviorSubject<T> extends Subject<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasObservers() {
         return subscribers.get().length != 0;
     }
 
+    @CheckReturnValue
     /* test support*/ int subscriberCount() {
         return subscribers.get().length;
     }
 
     @Override
     @Nullable
+    @CheckReturnValue
     public Throwable getThrowable() {
         Object o = value.get();
         if (NotificationLite.isError(o)) {
@@ -311,6 +314,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
      * @return a single value the Subject currently has or null if no such value exists
      */
     @Nullable
+    @CheckReturnValue
     public T getValue() {
         Object o = value.get();
         if (NotificationLite.isComplete(o) || NotificationLite.isError(o)) {
@@ -320,12 +324,14 @@ public final class BehaviorSubject<T> extends Subject<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasComplete() {
         Object o = value.get();
         return NotificationLite.isComplete(o);
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasThrowable() {
         Object o = value.get();
         return NotificationLite.isError(o);
@@ -336,6 +342,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
      * <p>The method is thread-safe.
      * @return true if the subject has any value
      */
+    @CheckReturnValue
     public boolean hasValue() {
         Object o = value.get();
         return o != null && !NotificationLite.isComplete(o) && !NotificationLite.isError(o);
@@ -493,7 +500,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
                     if (emitting) {
                         AppendOnlyLinkedArrayList<Object> q = queue;
                         if (q == null) {
-                            q = new AppendOnlyLinkedArrayList<Object>(4);
+                            q = new AppendOnlyLinkedArrayList<>(4);
                             queue = q;
                         }
                         q.add(value);

--- a/src/main/java/io/reactivex/rxjava3/subjects/CompletableSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/CompletableSubject.java
@@ -107,7 +107,7 @@ public final class CompletableSubject extends Completable implements Completable
 
     CompletableSubject() {
         once = new AtomicBoolean();
-        observers = new AtomicReference<CompletableDisposable[]>(EMPTY);
+        observers = new AtomicReference<>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava3/subjects/MaybeSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/MaybeSubject.java
@@ -131,13 +131,13 @@ public final class MaybeSubject<T> extends Maybe<T> implements MaybeObserver<T> 
     @CheckReturnValue
     @NonNull
     public static <T> MaybeSubject<T> create() {
-        return new MaybeSubject<T>();
+        return new MaybeSubject<>();
     }
 
     @SuppressWarnings("unchecked")
     MaybeSubject() {
         once = new AtomicBoolean();
-        observers = new AtomicReference<MaybeDisposable<T>[]>(EMPTY);
+        observers = new AtomicReference<>(EMPTY);
     }
 
     @Override
@@ -185,7 +185,7 @@ public final class MaybeSubject<T> extends Maybe<T> implements MaybeObserver<T> 
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        MaybeDisposable<T> md = new MaybeDisposable<T>(observer, this);
+        MaybeDisposable<T> md = new MaybeDisposable<>(observer, this);
         observer.onSubscribe(md);
         if (add(md)) {
             if (md.isDisposed()) {

--- a/src/main/java/io/reactivex/rxjava3/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/PublishSubject.java
@@ -115,7 +115,7 @@ public final class PublishSubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> PublishSubject<T> create() {
-        return new PublishSubject<T>();
+        return new PublishSubject<>();
     }
 
     /**
@@ -124,12 +124,12 @@ public final class PublishSubject<T> extends Subject<T> {
      */
     @SuppressWarnings("unchecked")
     PublishSubject() {
-        subscribers = new AtomicReference<PublishDisposable<T>[]>(EMPTY);
+        subscribers = new AtomicReference<>(EMPTY);
     }
 
     @Override
     protected void subscribeActual(Observer<? super T> t) {
-        PublishDisposable<T> ps = new PublishDisposable<T>(t, this);
+        PublishDisposable<T> ps = new PublishDisposable<>(t, this);
         t.onSubscribe(ps);
         if (add(ps)) {
             // if cancellation happened while a successful add, the remove() didn't work
@@ -254,12 +254,14 @@ public final class PublishSubject<T> extends Subject<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasObservers() {
         return subscribers.get().length != 0;
     }
 
     @Override
     @Nullable
+    @CheckReturnValue
     public Throwable getThrowable() {
         if (subscribers.get() == TERMINATED) {
             return error;
@@ -268,11 +270,13 @@ public final class PublishSubject<T> extends Subject<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasThrowable() {
         return subscribers.get() == TERMINATED && error != null;
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasComplete() {
         return subscribers.get() == TERMINATED && error == null;
     }

--- a/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
@@ -160,7 +160,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplaySubject<T> create() {
-        return new ReplaySubject<T>(new UnboundedReplayBuffer<T>(16));
+        return new ReplaySubject<>(new UnboundedReplayBuffer<T>(16));
     }
 
     /**
@@ -181,7 +181,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplaySubject<T> create(int capacityHint) {
-        return new ReplaySubject<T>(new UnboundedReplayBuffer<T>(capacityHint));
+        return new ReplaySubject<>(new UnboundedReplayBuffer<T>(capacityHint));
     }
 
     /**
@@ -207,7 +207,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplaySubject<T> createWithSize(int maxSize) {
-        return new ReplaySubject<T>(new SizeBoundReplayBuffer<T>(maxSize));
+        return new ReplaySubject<>(new SizeBoundReplayBuffer<T>(maxSize));
     }
 
     /**
@@ -224,7 +224,7 @@ public final class ReplaySubject<T> extends Subject<T> {
      * @return the created subject
      */
     /* test */ static <T> ReplaySubject<T> createUnbounded() {
-        return new ReplaySubject<T>(new SizeBoundReplayBuffer<T>(Integer.MAX_VALUE));
+        return new ReplaySubject<>(new SizeBoundReplayBuffer<T>(Integer.MAX_VALUE));
     }
 
     /**
@@ -261,8 +261,8 @@ public final class ReplaySubject<T> extends Subject<T> {
      */
     @CheckReturnValue
     @NonNull
-    public static <T> ReplaySubject<T> createWithTime(long maxAge, TimeUnit unit, Scheduler scheduler) {
-        return new ReplaySubject<T>(new SizeAndTimeBoundReplayBuffer<T>(Integer.MAX_VALUE, maxAge, unit, scheduler));
+    public static <T> ReplaySubject<T> createWithTime(long maxAge, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+        return new ReplaySubject<>(new SizeAndTimeBoundReplayBuffer<T>(Integer.MAX_VALUE, maxAge, unit, scheduler));
     }
 
     /**
@@ -301,8 +301,8 @@ public final class ReplaySubject<T> extends Subject<T> {
      */
     @CheckReturnValue
     @NonNull
-    public static <T> ReplaySubject<T> createWithTimeAndSize(long maxAge, TimeUnit unit, Scheduler scheduler, int maxSize) {
-        return new ReplaySubject<T>(new SizeAndTimeBoundReplayBuffer<T>(maxSize, maxAge, unit, scheduler));
+    public static <T> ReplaySubject<T> createWithTimeAndSize(long maxAge, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int maxSize) {
+        return new ReplaySubject<>(new SizeAndTimeBoundReplayBuffer<T>(maxSize, maxAge, unit, scheduler));
     }
 
     /**
@@ -312,12 +312,12 @@ public final class ReplaySubject<T> extends Subject<T> {
     @SuppressWarnings("unchecked")
     ReplaySubject(ReplayBuffer<T> buffer) {
         this.buffer = buffer;
-        this.observers = new AtomicReference<ReplayDisposable<T>[]>(EMPTY);
+        this.observers = new AtomicReference<>(EMPTY);
     }
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        ReplayDisposable<T> rs = new ReplayDisposable<T>(observer, this);
+        ReplayDisposable<T> rs = new ReplayDisposable<>(observer, this);
         observer.onSubscribe(rs);
 
         if (!rs.cancelled) {
@@ -392,16 +392,19 @@ public final class ReplaySubject<T> extends Subject<T> {
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasObservers() {
         return observers.get().length != 0;
     }
 
+    @CheckReturnValue
     /* test */ int observerCount() {
         return observers.get().length;
     }
 
     @Override
     @Nullable
+    @CheckReturnValue
     public Throwable getThrowable() {
         Object o = buffer.get();
         if (NotificationLite.isError(o)) {
@@ -416,6 +419,7 @@ public final class ReplaySubject<T> extends Subject<T> {
      * @return a single value the Subject currently has or null if no such value exists
      */
     @Nullable
+    @CheckReturnValue
     public T getValue() {
         return buffer.getValue();
     }
@@ -446,6 +450,7 @@ public final class ReplaySubject<T> extends Subject<T> {
      * <p>The method is thread-safe.
      * @return the array containing the snapshot of all values of the Subject
      */
+    @CheckReturnValue
     public Object[] getValues() {
         @SuppressWarnings("unchecked")
         T[] a = (T[])EMPTY_ARRAY;
@@ -465,17 +470,20 @@ public final class ReplaySubject<T> extends Subject<T> {
      * @param array the target array to copy values into if it fits
      * @return the given array if the values fit into it or a new array containing all values
      */
+    @CheckReturnValue
     public T[] getValues(T[] array) {
         return buffer.getValues(array);
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasComplete() {
         Object o = buffer.get();
         return NotificationLite.isComplete(o);
     }
 
     @Override
+    @CheckReturnValue
     public boolean hasThrowable() {
         Object o = buffer.get();
         return NotificationLite.isError(o);
@@ -486,10 +494,12 @@ public final class ReplaySubject<T> extends Subject<T> {
      * <p>The method is thread-safe.
      * @return true if the subject has any value
      */
+    @CheckReturnValue
     public boolean hasValue() {
         return buffer.size() != 0; // NOPMD
     }
 
+    @CheckReturnValue
     /* test*/ int size() {
         return buffer.size();
     }
@@ -636,7 +646,7 @@ public final class ReplaySubject<T> extends Subject<T> {
         volatile int size;
 
         UnboundedReplayBuffer(int capacityHint) {
-            this.buffer = new ArrayList<Object>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));
+            this.buffer = new ArrayList<>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));
         }
 
         @Override
@@ -839,7 +849,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
         SizeBoundReplayBuffer(int maxSize) {
             this.maxSize = ObjectHelper.verifyPositive(maxSize, "maxSize");
-            Node<Object> h = new Node<Object>(null);
+            Node<Object> h = new Node<>(null);
             this.tail = h;
             this.head = h;
         }
@@ -854,7 +864,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
         @Override
         public void add(T value) {
-            Node<Object> n = new Node<Object>(value);
+            Node<Object> n = new Node<>(value);
             Node<Object> t = tail;
 
             tail = n;
@@ -866,7 +876,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
         @Override
         public void addFinal(Object notificationLite) {
-            Node<Object> n = new Node<Object>(notificationLite);
+            Node<Object> n = new Node<>(notificationLite);
             Node<Object> t = tail;
 
             tail = n;
@@ -885,7 +895,7 @@ public final class ReplaySubject<T> extends Subject<T> {
         public void trimHead() {
             Node<Object> h = head;
             if (h.value != null) {
-                Node<Object> n = new Node<Object>(null);
+                Node<Object> n = new Node<>(null);
                 n.lazySet(h.get());
                 head = n;
             }
@@ -1055,7 +1065,7 @@ public final class ReplaySubject<T> extends Subject<T> {
             this.maxAge = ObjectHelper.verifyPositive(maxAge, "maxAge");
             this.unit = Objects.requireNonNull(unit, "unit is null");
             this.scheduler = Objects.requireNonNull(scheduler, "scheduler is null");
-            TimedNode<Object> h = new TimedNode<Object>(null, 0L);
+            TimedNode<Object> h = new TimedNode<>(null, 0L);
             this.tail = h;
             this.head = h;
         }
@@ -1101,7 +1111,7 @@ public final class ReplaySubject<T> extends Subject<T> {
                 TimedNode<Object> next = h.get();
                 if (next.get() == null) {
                     if (h.value != null) {
-                        TimedNode<Object> lasth = new TimedNode<Object>(null, 0L);
+                        TimedNode<Object> lasth = new TimedNode<>(null, 0L);
                         lasth.lazySet(h.get());
                         head = lasth;
                     } else {
@@ -1112,7 +1122,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
                 if (next.time > limit) {
                     if (h.value != null) {
-                        TimedNode<Object> lasth = new TimedNode<Object>(null, 0L);
+                        TimedNode<Object> lasth = new TimedNode<>(null, 0L);
                         lasth.lazySet(h.get());
                         head = lasth;
                     } else {
@@ -1127,7 +1137,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
         @Override
         public void add(T value) {
-            TimedNode<Object> n = new TimedNode<Object>(value, scheduler.now(unit));
+            TimedNode<Object> n = new TimedNode<>(value, scheduler.now(unit));
             TimedNode<Object> t = tail;
 
             tail = n;
@@ -1139,7 +1149,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
         @Override
         public void addFinal(Object notificationLite) {
-            TimedNode<Object> n = new TimedNode<Object>(notificationLite, Long.MAX_VALUE);
+            TimedNode<Object> n = new TimedNode<>(notificationLite, Long.MAX_VALUE);
             TimedNode<Object> t = tail;
 
             tail = n;
@@ -1158,7 +1168,7 @@ public final class ReplaySubject<T> extends Subject<T> {
         public void trimHead() {
             TimedNode<Object> h = head;
             if (h.value != null) {
-                TimedNode<Object> n = new TimedNode<Object>(null, 0);
+                TimedNode<Object> n = new TimedNode<>(null, 0);
                 n.lazySet(h.get());
                 head = n;
             }

--- a/src/main/java/io/reactivex/rxjava3/subjects/SerializedSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/SerializedSubject.java
@@ -60,7 +60,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
                     if (emitting) {
                         AppendOnlyLinkedArrayList<Object> q = queue;
                         if (q == null) {
-                            q = new AppendOnlyLinkedArrayList<Object>(4);
+                            q = new AppendOnlyLinkedArrayList<>(4);
                             queue = q;
                         }
                         q.add(NotificationLite.disposable(d));
@@ -93,7 +93,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
             if (emitting) {
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(4);
+                    q = new AppendOnlyLinkedArrayList<>(4);
                     queue = q;
                 }
                 q.add(NotificationLite.next(t));
@@ -120,7 +120,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
                 if (emitting) {
                     AppendOnlyLinkedArrayList<Object> q = queue;
                     if (q == null) {
-                        q = new AppendOnlyLinkedArrayList<Object>(4);
+                        q = new AppendOnlyLinkedArrayList<>(4);
                         queue = q;
                     }
                     q.setFirst(NotificationLite.error(t));
@@ -150,7 +150,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
             if (emitting) {
                 AppendOnlyLinkedArrayList<Object> q = queue;
                 if (q == null) {
-                    q = new AppendOnlyLinkedArrayList<Object>(4);
+                    q = new AppendOnlyLinkedArrayList<>(4);
                     queue = q;
                 }
                 q.add(NotificationLite.complete());

--- a/src/main/java/io/reactivex/rxjava3/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/SingleSubject.java
@@ -115,13 +115,13 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
     @CheckReturnValue
     @NonNull
     public static <T> SingleSubject<T> create() {
-        return new SingleSubject<T>();
+        return new SingleSubject<>();
     }
 
     @SuppressWarnings("unchecked")
     SingleSubject() {
         once = new AtomicBoolean();
-        observers = new AtomicReference<SingleDisposable<T>[]>(EMPTY);
+        observers = new AtomicReference<>(EMPTY);
     }
 
     @Override
@@ -159,7 +159,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
 
     @Override
     protected void subscribeActual(@NonNull SingleObserver<? super T> observer) {
-        SingleDisposable<T> md = new SingleDisposable<T>(observer, this);
+        SingleDisposable<T> md = new SingleDisposable<>(observer, this);
         observer.onSubscribe(md);
         if (add(md)) {
             if (md.isDisposed()) {

--- a/src/main/java/io/reactivex/rxjava3/subjects/Subject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/Subject.java
@@ -32,6 +32,7 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * <p>The method is thread-safe.
      * @return true if the subject has any Observers
      */
+    @CheckReturnValue
     public abstract boolean hasObservers();
 
     /**
@@ -41,6 +42,7 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * @see #getThrowable()
      * @see #hasComplete()
      */
+    @CheckReturnValue
     public abstract boolean hasThrowable();
 
     /**
@@ -49,6 +51,7 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * @return true if the subject has reached a terminal state through a complete event
      * @see #hasThrowable()
      */
+    @CheckReturnValue
     public abstract boolean hasComplete();
 
     /**
@@ -59,6 +62,7 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * hasn't terminated yet
      */
     @Nullable
+    @CheckReturnValue
     public abstract Throwable getThrowable();
 
     /**
@@ -68,10 +72,11 @@ public abstract class Subject<T> extends Observable<T> implements Observer<T> {
      * @return the wrapped and serialized subject
      */
     @NonNull
+    @CheckReturnValue
     public final Subject<T> toSerialized() {
         if (this instanceof SerializedSubject) {
             return this;
         }
-        return new SerializedSubject<T>(this);
+        return new SerializedSubject<>(this);
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
@@ -20,7 +20,7 @@ import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
-import io.reactivex.rxjava3.internal.functions.ObjectHelper;
+import io.reactivex.rxjava3.internal.functions.*;
 import io.reactivex.rxjava3.internal.fuseable.SimpleQueue;
 import io.reactivex.rxjava3.internal.observers.BasicIntQueueDisposable;
 import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
@@ -180,7 +180,7 @@ public final class UnicastSubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> UnicastSubject<T> create() {
-        return new UnicastSubject<>(bufferSize(), true);
+        return create(bufferSize(), Functions.EMPTY_RUNNABLE, true);
     }
 
     /**
@@ -192,7 +192,7 @@ public final class UnicastSubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> UnicastSubject<T> create(int capacityHint) {
-        return new UnicastSubject<>(capacityHint, true);
+        return create(capacityHint, Functions.EMPTY_RUNNABLE, true);
     }
 
     /**
@@ -211,7 +211,7 @@ public final class UnicastSubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> UnicastSubject<T> create(int capacityHint, @NonNull Runnable onTerminate) {
-        return new UnicastSubject<>(capacityHint, onTerminate, true);
+        return create(capacityHint, onTerminate, true);
     }
 
     /**
@@ -249,35 +249,7 @@ public final class UnicastSubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> UnicastSubject<T> create(boolean delayError) {
-        return new UnicastSubject<>(bufferSize(), delayError);
-    }
-
-    /**
-     * Creates an UnicastSubject with the given capacity hint and delay error flag.
-     * <p>History: 2.0.8 - experimental
-     * @param capacityHint the capacity hint for the internal, unbounded queue
-     * @param delayError deliver pending onNext events before onError
-     * @since 2.2
-     */
-    UnicastSubject(int capacityHint, boolean delayError) {
-        this.queue = new SpscLinkedArrayQueue<>(ObjectHelper.verifyPositive(capacityHint, "capacityHint"));
-        this.onTerminate = new AtomicReference<>();
-        this.delayError = delayError;
-        this.downstream = new AtomicReference<>();
-        this.once = new AtomicBoolean();
-        this.wip = new UnicastQueueDisposable();
-    }
-
-    /**
-     * Creates an UnicastSubject with the given capacity hint and callback
-     * for when the Subject is terminated normally or its single Subscriber cancels.
-     * @param capacityHint the capacity hint for the internal, unbounded queue
-     * @param onTerminate the callback to run when the Subject is terminated or cancelled, null not allowed
-     * @since 2.0
-     *
-     * */
-    UnicastSubject(int capacityHint, Runnable onTerminate) {
-        this(capacityHint, onTerminate, true);
+        return create(bufferSize(), Functions.EMPTY_RUNNABLE, delayError);
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava3/core/ConverterTest.java
+++ b/src/test/java/io/reactivex/rxjava3/core/ConverterTest.java
@@ -175,7 +175,17 @@ public final class ConverterTest extends RxJavaTest {
         .assertValue(1);
     }
 
+    /**
+     * Two argument type.
+     * @param <T> the input type
+     * @param <R> the output type
+     */
     interface A<T, R> { }
+
+    /**
+     * One argument type.
+     * @param <T> the type
+     */
     interface B<T> { }
 
     private static <T> ObservableConverter<A<T, ?>, B<T>> testObservableConverterCreator() {

--- a/src/test/java/io/reactivex/rxjava3/core/TransformerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/core/TransformerTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 
+import io.reactivex.rxjava3.core.ConverterTest.*;
 import io.reactivex.rxjava3.exceptions.TestException;
 
 public class TransformerTest extends RxJavaTest {
@@ -126,9 +127,6 @@ public class TransformerTest extends RxJavaTest {
 
         Flowable.just(a).compose(TransformerTest.<String>testFlowableTransformerCreator());
     }
-
-    interface A<T, R> { }
-    interface B<T> { }
 
     private static <T> ObservableTransformer<A<T, ?>, B<T>> testObservableTransformerCreator() {
         return new ObservableTransformer<A<T, ?>, B<T>>() {

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableConversionTest.java
@@ -59,7 +59,7 @@ public class FlowableConversionTest extends RxJavaTest {
             return x(new RobotConversionFunc<>(operator));
         }
 
-        public <R, O> O x(Function<Publisher<T>, O> operator) {
+        public <O> O x(Function<Publisher<T>, O> operator) {
             try {
                 return operator.apply(onSubscribe);
             } catch (Throwable ex) {

--- a/src/test/java/io/reactivex/rxjava3/internal/functions/FunctionsTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/functions/FunctionsTest.java
@@ -173,62 +173,6 @@ public class FunctionsTest extends RxJavaTest {
         }).apply(new Object[20]);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Test(expected = NullPointerException.class)
-    public void biFunctionFail() throws Exception {
-        BiFunction biFunction = null;
-        Functions.toFunction(biFunction);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Test(expected = NullPointerException.class)
-    public void function3Fail() throws Exception {
-        Function3 function3 = null;
-        Functions.toFunction(function3);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Test(expected = NullPointerException.class)
-    public void function4Fail() throws Exception {
-        Function4 function4 = null;
-        Functions.toFunction(function4);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Test(expected = NullPointerException.class)
-    public void function5Fail() throws Exception {
-        Function5 function5 = null;
-        Functions.toFunction(function5);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Test(expected = NullPointerException.class)
-    public void function6Fail() throws Exception {
-        Function6 function6 = null;
-        Functions.toFunction(function6);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Test(expected = NullPointerException.class)
-    public void function7Fail() throws Exception {
-        Function7 function7 = null;
-        Functions.toFunction(function7);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Test(expected = NullPointerException.class)
-    public void function8Fail() throws Exception {
-        Function8 function8 = null;
-        Functions.toFunction(function8);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Test(expected = NullPointerException.class)
-    public void function9Fail() throws Exception {
-        Function9 function9 = null;
-        Functions.toFunction(function9);
-    }
-
     @Test
     public void identityFunctionToString() {
         assertEquals("IdentityFunction", Functions.identity().toString());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1046,7 +1046,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
                     if (j < i) {
                         assertEquals("source" + (j + 1) + " is null", ex.getCause().getMessage());
                     } else {
-                        assertEquals("f is null", ex.getCause().getMessage());
+                        assertEquals("combiner is null", ex.getCause().getMessage());
                     }
                 }
             }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryTest.java
@@ -73,7 +73,7 @@ public class FlowableRetryTest extends RxJavaTest {
                     .map(new Function<Throwable, Tuple>() {
                         @Override
                         public Tuple apply(Throwable n) {
-                            return new Tuple(new Long(1), n);
+                            return new Tuple(1L, n);
                         }})
                     .scan(new BiFunction<Tuple, Tuple, Tuple>() {
                         @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
@@ -1297,7 +1297,7 @@ public class FlowableZipTest extends RxJavaTest {
                     if (j < i) {
                         assertEquals("source" + (j + 1) + " is null", ex.getCause().getMessage());
                     } else {
-                        assertEquals("f is null", ex.getCause().getMessage());
+                        assertEquals("zipper is null", ex.getCause().getMessage());
                     }
                 }
             }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -893,7 +893,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         PublishSubject<Integer> ps2 = PublishSubject.create();
         PublishSubject<Integer> ps3 = PublishSubject.create();
 
-        @SuppressWarnings("unchecked")
         TestObserver<Integer> to = Observable.concatArrayEagerDelayError(2, 2, ps1, ps2, ps3)
         .test();
 
@@ -929,7 +928,6 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         PublishSubject<Integer> ps2 = PublishSubject.create();
         PublishSubject<Integer> ps3 = PublishSubject.create();
 
-        @SuppressWarnings("unchecked")
         TestObserver<Integer> to = Observable.concatArrayEagerDelayError(2, 2, ps1, ps2, ps3)
         .test();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
@@ -780,7 +780,6 @@ public class ObservableConcatTest extends RxJavaTest {
         .assertResult(1, 2, 3, 4);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayDelayError() {
         Observable.concatArrayDelayError(Observable.just(1), Observable.just(2),
@@ -789,7 +788,6 @@ public class ObservableConcatTest extends RxJavaTest {
         .assertResult(1, 2, 3, 4);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayDelayErrorWithError() {
         Observable.concatArrayDelayError(Observable.just(1), Observable.just(2),
@@ -886,13 +884,11 @@ public class ObservableConcatTest extends RxJavaTest {
         .assertResult(1, 2, 3, 4, 5, 1, 2, 3, 4, 5);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void emptyArray() {
         assertSame(Observable.empty(), Observable.concatArrayDelayError());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void singleElementArray() {
         assertSame(Observable.never(), Observable.concatArrayDelayError(Observable.never()));
@@ -923,13 +919,11 @@ public class ObservableConcatTest extends RxJavaTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArrayEmpty() {
         assertSame(Observable.empty(), Observable.concatArray());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void concatArraySingleElement() {
         assertSame(Observable.never(), Observable.concatArray(Observable.never()));
@@ -960,7 +954,6 @@ public class ObservableConcatTest extends RxJavaTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
@@ -981,7 +974,6 @@ public class ObservableConcatTest extends RxJavaTest {
         assertEquals(1, calls[0]);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noSubsequentSubscriptionDelayError() {
         final int[] calls = { 0 };
@@ -1071,7 +1063,6 @@ public class ObservableConcatTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void concatReportsDisposedOnCompleteDelayError() {
         final Disposable[] disposable = { null };
 
@@ -1128,7 +1119,6 @@ public class ObservableConcatTest extends RxJavaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void concatReportsDisposedOnErrorDelayError() {
         final Disposable[] disposable = { null };
 
@@ -1156,7 +1146,6 @@ public class ObservableConcatTest extends RxJavaTest {
         assertTrue(disposable[0].isDisposed());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void noCancelPreviousArray() {
         final AtomicInteger counter = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -506,7 +506,6 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         .assertResult(1, 2);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArrayDelayError() {
         Observable.mergeArrayDelayError(Observable.just(1), Observable.just(2))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeTest.java
@@ -1065,7 +1065,6 @@ public class ObservableMergeTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void mergeArray2() {
         Observable.mergeArray(Observable.just(1), Observable.just(2))

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryTest.java
@@ -74,7 +74,7 @@ public class ObservableRetryTest extends RxJavaTest {
                     .map(new Function<Throwable, Tuple>() {
                         @Override
                         public Tuple apply(Throwable n) {
-                            return new Tuple(new Long(1), n);
+                            return new Tuple(1L, n);
                         }})
                     .scan(new BiFunction<Tuple, Tuple, Tuple>() {
                         @Override

--- a/src/test/java/io/reactivex/rxjava3/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/maybe/MaybeTest.java
@@ -2662,7 +2662,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void sequenceEqual() {
-        Maybe.sequenceEqual(Maybe.just(1), Maybe.just(new Integer(1))).test().assertResult(true);
+        Maybe.sequenceEqual(Maybe.just(1_000_000), Maybe.just(Integer.valueOf(1_000_000))).test().assertResult(true);
 
         Maybe.sequenceEqual(Maybe.just(1), Maybe.just(2)).test().assertResult(false);
 

--- a/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava3/observable/ObservableNullTests.java
@@ -202,7 +202,6 @@ public class ObservableNullTests extends RxJavaTest {
         Observable.concatArray((Observable<Object>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void concatArrayOneIsNull() {
         Observable.concatArray(just1, null).blockingLast();
@@ -521,7 +520,6 @@ public class ObservableNullTests extends RxJavaTest {
         Observable.mergeArray(128, 128, (Observable<Object>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeArrayOneIsNull() {
         Observable.mergeArray(128, 128, just1, null).blockingLast();
@@ -552,7 +550,6 @@ public class ObservableNullTests extends RxJavaTest {
         Observable.mergeArrayDelayError(128, 128, (Observable<Object>[])null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorArrayOneIsNull() {
         Observable.mergeArrayDelayError(128, 128, just1, null).blockingLast();

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelFlowableTest.java
@@ -306,7 +306,6 @@ public class ParallelFlowableTest extends RxJavaTest {
         TestHelper.assertValueSet(ts, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void from() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelReduceFullTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelReduceFullTest.java
@@ -73,7 +73,6 @@ public class ParallelReduceFullTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error2() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelSortedJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelSortedJoinTest.java
@@ -82,7 +82,6 @@ public class ParallelSortedJoinTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void error2() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
@@ -368,7 +368,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
             public void run() {
                 calls[0]++;
             }
-        });
+        }, true);
 
         TestHelper.checkDisposed(us);
 

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -3257,10 +3257,23 @@ public enum TestHelper {
      * @throws Exception on error
      */
     public static File findSource(String baseClassName) throws Exception {
+        return findSource(baseClassName, "io.reactivex.rxjava3.core");
+    }
+
+    /**
+     * Given a base reactive type name, try to find its source in the current runtime
+     * path and return a file to it or null if not found.
+     * @param baseClassName the class name such as {@code Maybe}
+     * @param parentPackage the parent package such as {@code io.reactivex.rxjava3.core}
+     * @return the File pointing to the source
+     * @throws Exception on error
+     */
+    public static File findSource(String baseClassName, String parentPackage) throws Exception {
         URL u = TestHelper.class.getResource(TestHelper.class.getSimpleName() + ".class");
 
         String path = new File(u.toURI()).toString().replace('\\', '/');
 
+        parentPackage = parentPackage.replace(".", "/");
 //        System.out.println(path);
 
         int i = path.toLowerCase().indexOf("/rxjava");
@@ -3272,16 +3285,18 @@ public enum TestHelper {
         // find end of any potential postfix to /RxJava
         int j = path.indexOf("/", i + 6);
 
-        String p = path.substring(0, j + 1) + "src/main/java/io/reactivex/rxjava3/core/" + baseClassName + ".java";
+        String basePackage = path.substring(0, j + 1) + "src/main/java";
+
+        String p = basePackage + "/" + parentPackage + "/" + baseClassName + ".java";
 
         File f = new File(p);
 
-        if (!f.canRead()) {
-            System.out.println("Can't read " + p);
-            return null;
+        if (f.canRead()) {
+            return f;
         }
 
-        return f;
+        System.out.println("Can't read " + p);
+        return null;
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava3/validators/BaseTypeAnnotations.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/BaseTypeAnnotations.java
@@ -22,6 +22,11 @@ import org.reactivestreams.Publisher;
 
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.flowables.ConnectableFlowable;
+import io.reactivex.rxjava3.observables.ConnectableObservable;
+import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.subjects.*;
 
 /**
  * Verifies several properties.
@@ -38,16 +43,14 @@ public class BaseTypeAnnotations {
         StringBuilder b = new StringBuilder();
 
         for (Method m : clazz.getMethods()) {
-            if (m.getName().equals("bufferSize")) {
-                continue;
-            }
             if (m.getDeclaringClass() == clazz) {
                 boolean isSubscribeMethod = "subscribe".equals(m.getName()) && m.getParameterTypes().length == 0;
+                boolean isConnectMethod = "connect".equals(m.getName()) && m.getParameterTypes().length == 0;
                 boolean isAnnotationPresent = m.isAnnotationPresent(CheckReturnValue.class);
 
-                if (isSubscribeMethod) {
+                if (isSubscribeMethod || isConnectMethod) {
                     if (isAnnotationPresent) {
-                        b.append("subscribe() method has @CheckReturnValue: ").append(m).append("\r\n");
+                        b.append(m.getName()).append(" method has @CheckReturnValue: ").append(m).append("\r\n");
                     }
                     continue;
                 }
@@ -83,7 +86,8 @@ public class BaseTypeAnnotations {
         StringBuilder b = new StringBuilder();
 
         for (Method m : clazz.getMethods()) {
-            if (m.getName().equals("bufferSize")) {
+            if (m.getName().equals("bufferSize")
+                    || m.getName().equals("parallelism")) {
                 continue;
             }
             if (m.getDeclaringClass() == clazz) {
@@ -130,18 +134,24 @@ public class BaseTypeAnnotations {
         StringBuilder b = new StringBuilder();
 
         for (Method m : clazz.getMethods()) {
-            if (m.getName().equals("bufferSize")) {
+            if (m.getName().equals("bufferSize")
+                    || m.getName().equals("parallelism")) {
                 continue;
             }
             if (m.getDeclaringClass() == clazz) {
-                if (clazz == Flowable.class) {
+                if (clazz == Flowable.class || clazz == ParallelFlowable.class) {
                     if (!m.isAnnotationPresent(BackpressureSupport.class)) {
-                        b.append("No @BackpressureSupport annotation (being Flowable): ").append(m).append("\r\n");
+                        b.append("No @BackpressureSupport annotation (being ")
+                        .append(clazz.getSimpleName())
+                        .append("): ").append(m).append("\r\n");
                     }
                 } else {
-                    if (m.getReturnType() == Flowable.class) {
+                    if (m.getReturnType() == Flowable.class
+                            || m.getReturnType() == ParallelFlowable.class) {
                         if (!m.isAnnotationPresent(BackpressureSupport.class)) {
-                            b.append("No @BackpressureSupport annotation (having Flowable return): ").append(m).append("\r\n");
+                            b.append("No @BackpressureSupport annotation (having ")
+                            .append(m.getReturnType().getSimpleName())
+                            .append(" return): ").append(m).append("\r\n");
                         }
                     } else {
                         boolean found = false;
@@ -201,6 +211,86 @@ public class BaseTypeAnnotations {
     }
 
     @Test
+    public void checkReturnValueConnectableObservable() {
+        checkCheckReturnValueSupport(ConnectableObservable.class);
+    }
+
+    @Test
+    public void checkReturnValueConnectableFlowable() {
+        checkCheckReturnValueSupport(ConnectableFlowable.class);
+    }
+
+    @Test
+    public void checkReturnValueParallelFlowable() {
+        checkCheckReturnValueSupport(ParallelFlowable.class);
+    }
+
+    @Test
+    public void checkReturnValueAsyncSubject() {
+        checkCheckReturnValueSupport(AsyncSubject.class);
+    }
+
+    @Test
+    public void checkReturnValueBehaviorSubject() {
+        checkCheckReturnValueSupport(BehaviorSubject.class);
+    }
+
+    @Test
+    public void checkReturnValuePublishSubject() {
+        checkCheckReturnValueSupport(PublishSubject.class);
+    }
+
+    @Test
+    public void checkReturnValueReplaySubject() {
+        checkCheckReturnValueSupport(ReplaySubject.class);
+    }
+
+    @Test
+    public void checkReturnValueUnicastSubject() {
+        checkCheckReturnValueSupport(UnicastSubject.class);
+    }
+
+    @Test
+    public void checkReturnValueAsyncProcessor() {
+        checkCheckReturnValueSupport(AsyncProcessor.class);
+    }
+
+    @Test
+    public void checkReturnValueBehaviorProcessor() {
+        checkCheckReturnValueSupport(BehaviorProcessor.class);
+    }
+
+    @Test
+    public void checkReturnValuePublishProcessor() {
+        checkCheckReturnValueSupport(PublishProcessor.class);
+    }
+
+    @Test
+    public void checkReturnValueReplayProcessor() {
+        checkCheckReturnValueSupport(ReplayProcessor.class);
+    }
+
+    @Test
+    public void checkReturnValueUnicastProcessor() {
+        checkCheckReturnValueSupport(UnicastProcessor.class);
+    }
+
+    @Test
+    public void checkReturnValueMulticastProcessor() {
+        checkCheckReturnValueSupport(MulticastProcessor.class);
+    }
+
+    @Test
+    public void checkReturnValueSubject() {
+        checkCheckReturnValueSupport(Subject.class);
+    }
+
+    @Test
+    public void checkReturnValueFlowableProcessor() {
+        checkCheckReturnValueSupport(FlowableProcessor.class);
+    }
+
+    @Test
     public void schedulerSupportFlowable() {
         checkSchedulerSupport(Flowable.class);
     }
@@ -226,6 +316,21 @@ public class BaseTypeAnnotations {
     }
 
     @Test
+    public void schedulerSupportConnectableObservable() {
+        checkSchedulerSupport(ConnectableObservable.class);
+    }
+
+    @Test
+    public void schedulerSupportConnectableFlowable() {
+        checkSchedulerSupport(ConnectableFlowable.class);
+    }
+
+    @Test
+    public void schedulerSupportParallelFlowable() {
+        checkSchedulerSupport(ParallelFlowable.class);
+    }
+
+    @Test
     public void backpressureSupportFlowable() {
         checkBackpressureSupport(Flowable.class);
     }
@@ -248,5 +353,20 @@ public class BaseTypeAnnotations {
     @Test
     public void backpressureSupportMaybe() {
         checkBackpressureSupport(Maybe.class);
+    }
+
+    @Test
+    public void backpressureSupportConnectableFlowable() {
+        checkBackpressureSupport(ConnectableFlowable.class);
+    }
+
+    @Test
+    public void backpressureSupportConnectableObservable() {
+        checkBackpressureSupport(ConnectableObservable.class);
+    }
+
+    @Test
+    public void backpressureSupportParallelFlowable() {
+        checkBackpressureSupport(ParallelFlowable.class);
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.validators;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.flowables.ConnectableFlowable;
+import io.reactivex.rxjava3.observables.ConnectableObservable;
+import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.subjects.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+/**
+ * Check if the parameter name in Objects.requireNonNull
+ * and ObjectHelper.verifyPositive calls match the parameter
+ *  name in the message.
+ */
+public class ParamValidationNaming {
+
+    @Test
+    public void checkCompletable() throws Exception {
+        processFile(Completable.class);
+    }
+
+    @Test
+    public void checkSingle() throws Exception {
+        processFile(Single.class);
+    }
+
+    @Test
+    public void checkMaybe() throws Exception {
+        processFile(Maybe.class);
+    }
+
+    @Test
+    public void checkObservable() throws Exception {
+        processFile(Observable.class);
+    }
+
+    @Test
+    public void checkFlowable() throws Exception {
+        processFile(Flowable.class);
+    }
+
+    @Test
+    public void checkParallelFlowable() throws Exception {
+        processFile(ParallelFlowable.class);
+    }
+
+    @Test
+    public void checkConnectableObservable() throws Exception {
+        processFile(ConnectableObservable.class);
+    }
+
+    @Test
+    public void checkConnectableFlowable() throws Exception {
+        processFile(ConnectableFlowable.class);
+    }
+
+    @Test
+    public void checkSubject() throws Exception {
+        processFile(Subject.class);
+    }
+
+    @Test
+    public void checkFlowableProcessor() throws Exception {
+        processFile(FlowableProcessor.class);
+    }
+
+    @Test
+    public void checkDisposable() throws Exception {
+        processFile(Disposable.class);
+    }
+
+    @Test
+    public void checkScheduler() throws Exception {
+        processFile(Scheduler.class);
+    }
+
+    @Test
+    public void checkSchedulers() throws Exception {
+        processFile(Schedulers.class);
+    }
+
+    @Test
+    public void checkAsyncSubject() throws Exception {
+        processFile(AsyncSubject.class);
+    }
+
+    @Test
+    public void checkBehaviorSubject() throws Exception {
+        processFile(BehaviorSubject.class);
+    }
+
+    @Test
+    public void checkPublishSubject() throws Exception {
+        processFile(PublishSubject.class);
+    }
+
+    @Test
+    public void checkReplaySubject() throws Exception {
+        processFile(ReplaySubject.class);
+    }
+
+    @Test
+    public void checkUnicastSubject() throws Exception {
+        processFile(UnicastSubject.class);
+    }
+
+    @Test
+    public void checkSingleSubject() throws Exception {
+        processFile(SingleSubject.class);
+    }
+
+    @Test
+    public void checkMaybeSubject() throws Exception {
+        processFile(MaybeSubject.class);
+    }
+
+    @Test
+    public void checkCompletableSubject() throws Exception {
+        processFile(CompletableSubject.class);
+    }
+
+    @Test
+    public void checkAsyncProcessor() throws Exception {
+        processFile(AsyncProcessor.class);
+    }
+
+    @Test
+    public void checkBehaviorProcessor() throws Exception {
+        processFile(BehaviorProcessor.class);
+    }
+
+    @Test
+    public void checkPublishProcessor() throws Exception {
+        processFile(PublishProcessor.class);
+    }
+
+    @Test
+    public void checkReplayProcessor() throws Exception {
+        processFile(ReplayProcessor.class);
+    }
+
+    @Test
+    public void checkUnicastProcessor() throws Exception {
+        processFile(UnicastProcessor.class);
+    }
+
+    @Test
+    public void checkMulticastProcessor() throws Exception {
+        processFile(MulticastProcessor.class);
+    }
+
+    static void processFile(Class<?> clazz) throws Exception {
+        String baseClassName = clazz.getSimpleName();
+        File f = TestHelper.findSource(baseClassName, clazz.getPackageName());
+        if (f == null) {
+            return;
+        }
+        String fullClassName = clazz.getName();
+
+        int errorCount = 0;
+        StringBuilder errors = new StringBuilder();
+
+        List<String> lines = Files.readAllLines(f.toPath());
+
+        for (int j = 0; j < lines.size(); j++) {
+            String line = lines.get(j).trim();
+
+            for (String validatorStr : VALIDATOR_STRINGS)
+            if (line.startsWith(validatorStr)) {
+
+                int comma = line.indexOf(',');
+
+                String paramName = line.substring(validatorStr.length(), comma);
+
+                int quote = line.indexOf('"', comma);
+
+                String message = line.substring(quote + 1, quote + 2 + paramName.length());
+
+                if (!line.contains("The RxJavaPlugins")
+                        && !(message.startsWith(paramName)
+                        && (message.endsWith(" ") || message.endsWith("\"")))) {
+                    errorCount++;
+                    errors.append("L")
+                    .append(j)
+                    .append(" : Wrong validator message parameter name\r\n    ")
+                    .append(line)
+                    .append("\r\n")
+                    .append("    ").append(paramName).append(" != ").append(message)
+                    .append("\r\n at ")
+                    .append(fullClassName)
+                    .append(".method(")
+                    .append(f.getName())
+                    .append(":")
+                    .append(j + 1)
+                    .append(")\r\n")
+                    ;
+                }
+            }
+        }
+
+        if (errorCount != 0) {
+            errors.insert(0, errorCount + " problems\r\n");
+            errors.setLength(errors.length() - 2);
+            throw new AssertionError(errors.toString());
+        }
+    }
+
+    static final List<String> VALIDATOR_STRINGS = Arrays.asList(
+            "Objects.requireNonNull(",
+            "ObjectHelper.requirePositive("
+    );
+}

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
@@ -174,7 +174,7 @@ public class ParamValidationNaming {
 
     static void processFile(Class<?> clazz) throws Exception {
         String baseClassName = clazz.getSimpleName();
-        File f = TestHelper.findSource(baseClassName, clazz.getPackageName());
+        File f = TestHelper.findSource(baseClassName, clazz.getPackage().getName());
         if (f == null) {
             return;
         }

--- a/src/test/java/io/reactivex/rxjava3/validators/SourceAnnotationCheck.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/SourceAnnotationCheck.java
@@ -174,7 +174,7 @@ public class SourceAnnotationCheck {
 
     static void processFile(Class<?> clazz) throws Exception {
         String baseClassName = clazz.getSimpleName();
-        File f = TestHelper.findSource(baseClassName, clazz.getPackageName());
+        File f = TestHelper.findSource(baseClassName, clazz.getPackage().getName());
         if (f == null) {
             return;
         }

--- a/src/test/java/io/reactivex/rxjava3/validators/SourceAnnotationCheck.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/SourceAnnotationCheck.java
@@ -21,7 +21,13 @@ import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.flowables.ConnectableFlowable;
+import io.reactivex.rxjava3.observables.ConnectableObservable;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
 /**
@@ -46,8 +52,7 @@ public class SourceAnnotationCheck {
         processFile(Maybe.class);
     }
 
-    // TODO later
-    // @Test
+    @Test
     public void checkObservable() throws Exception {
         processFile(Observable.class);
     }
@@ -57,15 +62,119 @@ public class SourceAnnotationCheck {
         processFile(Flowable.class);
     }
 
-    // TODO later
-    // @Test
+    @Test
     public void checkParallelFlowable() throws Exception {
         processFile(ParallelFlowable.class);
     }
 
+    @Test
+    public void checkConnectableObservable() throws Exception {
+        processFile(ConnectableObservable.class);
+    }
+
+    @Test
+    public void checkConnectableFlowable() throws Exception {
+        processFile(ConnectableFlowable.class);
+    }
+
+    @Test
+    public void checkSubject() throws Exception {
+        processFile(Subject.class);
+    }
+
+    @Test
+    public void checkFlowableProcessor() throws Exception {
+        processFile(FlowableProcessor.class);
+    }
+
+    @Test
+    public void checkDisposable() throws Exception {
+        processFile(Disposable.class);
+    }
+
+    @Test
+    public void checkScheduler() throws Exception {
+        processFile(Scheduler.class);
+    }
+
+    @Test
+    public void checkSchedulers() throws Exception {
+        processFile(Schedulers.class);
+    }
+
+    @Test
+    public void checkAsyncSubject() throws Exception {
+        processFile(AsyncSubject.class);
+    }
+
+    @Test
+    public void checkBehaviorSubject() throws Exception {
+        processFile(BehaviorSubject.class);
+    }
+
+    @Test
+    public void checkPublishSubject() throws Exception {
+        processFile(PublishSubject.class);
+    }
+
+    @Test
+    public void checkReplaySubject() throws Exception {
+        processFile(ReplaySubject.class);
+    }
+
+    @Test
+    public void checkUnicastSubject() throws Exception {
+        processFile(UnicastSubject.class);
+    }
+
+    @Test
+    public void checkSingleSubject() throws Exception {
+        processFile(SingleSubject.class);
+    }
+
+    @Test
+    public void checkMaybeSubject() throws Exception {
+        processFile(MaybeSubject.class);
+    }
+
+    @Test
+    public void checkCompletableSubject() throws Exception {
+        processFile(CompletableSubject.class);
+    }
+
+    @Test
+    public void checkAsyncProcessor() throws Exception {
+        processFile(AsyncProcessor.class);
+    }
+
+    @Test
+    public void checkBehaviorProcessor() throws Exception {
+        processFile(BehaviorProcessor.class);
+    }
+
+    @Test
+    public void checkPublishProcessor() throws Exception {
+        processFile(PublishProcessor.class);
+    }
+
+    @Test
+    public void checkReplayProcessor() throws Exception {
+        processFile(ReplayProcessor.class);
+    }
+
+    @Test
+    public void checkUnicastProcessor() throws Exception {
+        processFile(UnicastProcessor.class);
+    }
+
+    @Test
+    public void checkMulticastProcessor() throws Exception {
+        processFile(MulticastProcessor.class);
+    }
+
     static void processFile(Class<?> clazz) throws Exception {
         String baseClassName = clazz.getSimpleName();
-        File f = TestHelper.findSource(baseClassName);
+        File f = TestHelper.findSource(baseClassName, clazz.getPackageName());
         if (f == null) {
             return;
         }
@@ -79,7 +188,14 @@ public class SourceAnnotationCheck {
         for (int j = 0; j < lines.size(); j++) {
             String line = lines.get(j).trim();
 
-            if (line.startsWith("public static") || line.startsWith("public final")) {
+            if (line.contains("class")) {
+                continue;
+            }
+            if (line.startsWith("public static")
+                    || line.startsWith("public final")
+                    || line.startsWith("protected final")
+                    || line.startsWith("protected abstract")
+                    || line.startsWith("public abstract")) {
                 int methodArgStart = line.indexOf("(");
 
                 int isBoolean = line.indexOf(" boolean ");
@@ -168,10 +284,12 @@ public class SourceAnnotationCheck {
                 String strippedArgumentsStr = strippedArguments.toString();
                 String[] args = strippedArgumentsStr.split("\\s*,\\s*");
 
-                for (String typeName : CLASS_NAMES) {
-                    String typeNameSpaced = typeName + " ";
-                    for (int k = 0; k < args.length; k++) {
-                        String typeDef = args[k];
+                for (int k = 0; k < args.length; k++) {
+                    String typeDef = args[k];
+
+                    for (String typeName : CLASS_NAMES) {
+                        String typeNameSpaced = typeName + " ";
+
                         if (typeDef.contains(typeNameSpaced)
                                 && !typeDef.contains("@NonNull")
                                 && !typeDef.contains("@Nullable")) {
@@ -181,8 +299,9 @@ public class SourceAnnotationCheck {
                                 errorCount++;
                                 errors.append("L")
                                 .append(j)
-                                .append(" - argument ").append(k + 1).append(" - ").append(typeDef)
-                                .append(" : Missing argument type nullability annotation |\r\n    ")
+                                .append(" - argument ").append(k + 1)
+                                .append(" : Missing argument type nullability annotation\r\n    ")
+                                .append(typeDef).append("\r\n    ")
                                 .append(strippedArgumentsStr)
                                 .append("\r\n")
                                 .append(" at ")
@@ -196,13 +315,55 @@ public class SourceAnnotationCheck {
                             }
                         }
                     }
+
+                    if (typeDef.contains("final ")) {
+                        errorCount++;
+                        errors.append("L")
+                        .append(j)
+                        .append(" - argument ").append(k + 1)
+                        .append(" : unnecessary final on argument\r\n    ")
+                        .append(typeDef).append("\r\n    ")
+                        .append(strippedArgumentsStr)
+                        .append("\r\n")
+                        .append(" at ")
+                        .append(fullClassName)
+                        .append(".method(")
+                        .append(f.getName())
+                        .append(":")
+                        .append(j + 1)
+                        .append(")\r\n")
+                        ;
+                    }
+                    if (typeDef.contains("@NonNull int")
+                            || typeDef.contains("@NonNull long")
+                            || typeDef.contains("@Nullable int")
+                            || typeDef.contains("@Nullable long")
+                        ) {
+                        errorCount++;
+                        errors.append("L")
+                        .append(j)
+                        .append(" - argument ").append(k + 1)
+                        .append(" : unnecessary nullability annotation\r\n    ")
+                        .append(typeDef).append("\r\n    ")
+                        .append(strippedArgumentsStr)
+                        .append("\r\n")
+                        .append(" at ")
+                        .append(fullClassName)
+                        .append(".method(")
+                        .append(f.getName())
+                        .append(":")
+                        .append(j + 1)
+                        .append(")\r\n")
+                        ;
+                    }
+
                 }
 
                 if (strippedArgumentsStr.contains("...") && !hasSafeVarargsAnnotation) {
                     errorCount++;
                     errors.append("L")
                     .append(j)
-                    .append(" : Missing @SafeVarargs annotation |\r\n    ")
+                    .append(" : Missing @SafeVarargs annotation\r\n    ")
                     .append(strippedArgumentsStr)
                     .append("\r\n")
                     .append(" at ")
@@ -218,7 +379,7 @@ public class SourceAnnotationCheck {
         }
 
         if (errorCount != 0) {
-            errors.insert(0, errorCount + " missing annotations\r\n");
+            errors.insert(0, errorCount + " problems\r\n");
             errors.setLength(errors.length() - 2);
             throw new AssertionError(errors.toString());
         }
@@ -248,6 +409,8 @@ public class SourceAnnotationCheck {
             "Action", "Runnable", "Consumer", "BiConsumer", "Supplier", "Callable", "Void",
             "Throwable", "Optional", "CompletionStage", "BooleanSupplier", "LongConsumer",
             "Predicate", "BiPredicate", "Object",
+
+            "Iterable", "Stream", "Iterator",
 
             "BackpressureOverflowStrategy", "BackpressureStrategy",
             "Subject", "Processor", "FlowableProcessor",


### PR DESCRIPTION
- Improve validation code and extend them to other classes/sources.
- Add `@NonNull` annotations
- Add `@SafeVarargs` annotations
- Add `@CheckReturnValue` annotations
- Add more `@BackpressureSupport` & `@SchedulerSupport` annotations.
- Add backpressure and scheduler descriptions in `ParallelFlowable`
- Remove now unnecessary `@SuppressWarnings("unchecked")`
- Fix wording in some javadocs
- Move `toFunction` nullcheck into the caller method so the validation refers to the proper parameter name
- Use diamond arguments where possible
- Remove unused type arguments.
