### PR TITLE
3.x: [Java 8] Add Observable operators + cleanup

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFromStream.java
@@ -69,7 +69,7 @@ public final class FlowableFromStream<T> extends Flowable<T> {
         }
 
         if (s instanceof ConditionalSubscriber) {
-            s.onSubscribe(new StreamConditionalSubscription<T>((ConditionalSubscriber<? super T>)s, iterator, stream));
+            s.onSubscribe(new StreamConditionalSubscription<>((ConditionalSubscriber<? super T>)s, iterator, stream));
         } else {
             s.onSubscribe(new StreamSubscription<>(s, iterator, stream));
         }
@@ -147,15 +147,23 @@ public final class FlowableFromStream<T> extends Flowable<T> {
                 once = true;
             } else {
                 if (!iterator.hasNext()) {
+                    clear();
                     return null;
                 }
             }
-            return Objects.requireNonNull(iterator.next(), "Iterator.next() returned a null value");
+            return Objects.requireNonNull(iterator.next(), "The Stream's Iterator.next() returned a null value");
         }
 
         @Override
         public boolean isEmpty() {
-            return iterator == null || !iterator.hasNext();
+            Iterator<T> it = iterator;
+            if (it != null) {
+                if (!once || it.hasNext()) {
+                    return false;
+                }
+                clear();
+            }
+            return true;
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableCollectWithCollector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableCollectWithCollector.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.Objects;
+import java.util.function.*;
+import java.util.stream.Collector;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.internal.disposables.*;
+import io.reactivex.rxjava3.internal.observers.DeferredScalarDisposable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Collect items into a container defined by a Stream {@link Collector} callback set.
+ *
+ * @param <T> the upstream value type
+ * @param <A> the intermediate accumulator type
+ * @param <R> the result type
+ * @since 3.0.0
+ */
+public final class ObservableCollectWithCollector<T, A, R> extends Observable<R> {
+
+    final Observable<T> source;
+
+    final Collector<T, A, R> collector;
+
+    public ObservableCollectWithCollector(Observable<T> source, Collector<T, A, R> collector) {
+        this.source = source;
+        this.collector = collector;
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull Observer<? super R> observer) {
+        A container;
+        BiConsumer<A, T> accumulator;
+        Function<A, R> finisher;
+
+        try {
+            container = collector.supplier().get();
+            accumulator = collector.accumulator();
+            finisher = collector.finisher();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        source.subscribe(new CollectorObserver<>(observer, container, accumulator, finisher));
+    }
+
+    static final class CollectorObserver<T, A, R>
+    extends DeferredScalarDisposable<R>
+    implements Observer<T> {
+
+        private static final long serialVersionUID = -229544830565448758L;
+
+        final BiConsumer<A, T> accumulator;
+
+        final Function<A, R> finisher;
+
+        Disposable upstream;
+
+        boolean done;
+
+        A container;
+
+        CollectorObserver(Observer<? super R> downstream, A container, BiConsumer<A, T> accumulator, Function<A, R> finisher) {
+            super(downstream);
+            this.container = container;
+            this.accumulator = accumulator;
+            this.finisher = finisher;
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            try {
+                accumulator.accept(container, t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                upstream.dispose();
+                onError(ex);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+            } else {
+                done = true;
+                upstream = DisposableHelper.DISPOSED;
+                this.container = null;
+                downstream.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+
+            done = true;
+            upstream = DisposableHelper.DISPOSED;
+            A container = this.container;
+            this.container = null;
+            R result;
+            try {
+                result = Objects.requireNonNull(finisher.apply(container), "The finisher returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            complete(result);
+        }
+
+        @Override
+        public void dispose() {
+            super.dispose();
+            upstream.dispose();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableCollectWithCollectorSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableCollectWithCollectorSingle.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.Objects;
+import java.util.function.*;
+import java.util.stream.Collector;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.internal.disposables.*;
+import io.reactivex.rxjava3.internal.fuseable.FuseToObservable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Collect items into a container defined by a Stream {@link Collector} callback set.
+ *
+ * @param <T> the upstream value type
+ * @param <A> the intermediate accumulator type
+ * @param <R> the result type
+ * @since 3.0.0
+ */
+public final class ObservableCollectWithCollectorSingle<T, A, R> extends Single<R> implements FuseToObservable<R> {
+
+    final Observable<T> source;
+
+    final Collector<T, A, R> collector;
+
+    public ObservableCollectWithCollectorSingle(Observable<T> source, Collector<T, A, R> collector) {
+        this.source = source;
+        this.collector = collector;
+    }
+
+    @Override
+    public Observable<R> fuseToObservable() {
+        return new ObservableCollectWithCollector<>(source, collector);
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull SingleObserver<? super R> observer) {
+        A container;
+        BiConsumer<A, T> accumulator;
+        Function<A, R> finisher;
+
+        try {
+            container = collector.supplier().get();
+            accumulator = collector.accumulator();
+            finisher = collector.finisher();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        source.subscribe(new CollectorSingleObserver<>(observer, container, accumulator, finisher));
+    }
+
+    static final class CollectorSingleObserver<T, A, R> implements Observer<T>, Disposable {
+
+        final SingleObserver<? super R> downstream;
+
+        final BiConsumer<A, T> accumulator;
+
+        final Function<A, R> finisher;
+
+        Disposable upstream;
+
+        boolean done;
+
+        A container;
+
+        CollectorSingleObserver(SingleObserver<? super R> downstream, A container, BiConsumer<A, T> accumulator, Function<A, R> finisher) {
+            this.downstream = downstream;
+            this.container = container;
+            this.accumulator = accumulator;
+            this.finisher = finisher;
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+            try {
+                accumulator.accept(container, t);
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                upstream.dispose();
+                onError(ex);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (done) {
+                RxJavaPlugins.onError(t);
+            } else {
+                done = true;
+                upstream = DisposableHelper.DISPOSED;
+                this.container = null;
+                downstream.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (done) {
+                return;
+            }
+
+            done = true;
+            upstream = DisposableHelper.DISPOSED;
+            A container = this.container;
+            this.container = null;
+            R result;
+            try {
+                result = Objects.requireNonNull(finisher.apply(container), "The finisher returned a null value");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+
+            downstream.onSuccess(result);
+        }
+
+        @Override
+        public void dispose() {
+            upstream.dispose();
+            upstream = DisposableHelper.DISPOSED;
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return upstream == DisposableHelper.DISPOSED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFirstStageObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFirstStageObserver.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Signals the first element of the source via the underlying CompletableFuture,
+ * signals the a default item if the upstream is empty or signals {@link NoSuchElementException}.
+ *
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class ObservableFirstStageObserver<T> extends ObservableStageObserver<T> {
+
+    final boolean hasDefault;
+
+    final T defaultItem;
+
+    public ObservableFirstStageObserver(boolean hasDefault, T defaultItem) {
+        this.hasDefault = hasDefault;
+        this.defaultItem = defaultItem;
+    }
+
+    @Override
+    public void onNext(T t) {
+        complete(t);
+    }
+
+    @Override
+    public void onComplete() {
+        if (!isDone()) {
+            clear();
+            if (hasDefault) {
+                complete(defaultItem);
+            } else {
+                completeExceptionally(new NoSuchElementException());
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFlatMapStream.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.disposables.*;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Maps the upstream values onto {@link Stream}s and emits their items in order to the downstream.
+ *
+ * @param <T> the upstream element type
+ * @param <R> the inner {@code Stream} and result element type
+ * @since 3.0.0
+ */
+public final class ObservableFlatMapStream<T, R> extends Observable<R> {
+
+    final Observable<T> source;
+
+    final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+    public ObservableFlatMapStream(Observable<T> source, Function<? super T, ? extends Stream<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> observer) {
+        if (source instanceof Supplier) {
+            Stream<? extends R> stream = null;
+            try {
+                @SuppressWarnings("unchecked")
+                T t = ((Supplier<T>)source).get();
+                if (t != null) {
+                    stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
+                }
+            } catch (Throwable ex) {
+                EmptyDisposable.error(ex, observer);
+                return;
+            }
+
+            if (stream != null) {
+                ObservableFromStream.subscribeStream(observer, stream);
+            } else {
+                EmptyDisposable.complete(observer);
+            }
+        } else {
+            source.subscribe(new FlatMapStreamObserver<>(observer, mapper));
+        }
+    }
+
+    static final class FlatMapStreamObserver<T, R> extends AtomicInteger
+    implements Observer<T>, Disposable {
+
+        private static final long serialVersionUID = -5127032662980523968L;
+
+        final Observer<? super R> downstream;
+
+        final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+        Disposable upstream;
+
+        volatile boolean disposed;
+
+        boolean done;
+
+        FlatMapStreamObserver(Observer<? super R> downstream, Function<? super T, ? extends Stream<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(@NonNull T t) {
+            if (done) {
+                return;
+            }
+            try {
+                try (Stream<? extends R> stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream")) {
+                    Iterator<? extends R> it = stream.iterator();
+                    while (it.hasNext()) {
+                        if (disposed) {
+                            done = true;
+                            break;
+                        }
+                        R value = Objects.requireNonNull(it.next(), "The Stream's Iterator.next retuned a null value");
+                        if (disposed) {
+                            done = true;
+                            break;
+                        }
+                        downstream.onNext(value);
+                        if (disposed) {
+                            done = true;
+                            break;
+                        }
+                    }
+                }
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                upstream.dispose();
+                onError(ex);
+            }
+        }
+
+        @Override
+        public void onError(@NonNull Throwable e) {
+            if (done) {
+                RxJavaPlugins.onError(e);
+            } else {
+                done = true;
+                downstream.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (!done) {
+                done = true;
+                downstream.onComplete();
+            }
+        }
+
+        @Override
+        public void dispose() {
+            disposed = true;
+            upstream.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromCompletionStage.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.internal.observers.DeferredScalarDisposable;
+
+/**
+ * Wrap a CompletionStage and signal its outcome.
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class ObservableFromCompletionStage<T> extends Observable<T> {
+
+    final CompletionStage<T> stage;
+
+    public ObservableFromCompletionStage(CompletionStage<T> stage) {
+        this.stage = stage;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        // We need an indirection because one can't detach from a whenComplete
+        // and cancellation should not hold onto the stage.
+        BiConsumerAtomicReference<T> whenReference = new BiConsumerAtomicReference<>();
+        CompletionStageHandler<T> handler = new CompletionStageHandler<>(observer, whenReference);
+        whenReference.lazySet(handler);
+
+        observer.onSubscribe(handler);
+        stage.whenComplete(whenReference);
+    }
+
+    static final class CompletionStageHandler<T>
+    extends DeferredScalarDisposable<T>
+    implements BiConsumer<T, Throwable> {
+
+        private static final long serialVersionUID = 4665335664328839859L;
+
+        final BiConsumerAtomicReference<T> whenReference;
+
+        CompletionStageHandler(Observer<? super T> downstream, BiConsumerAtomicReference<T> whenReference) {
+            super(downstream);
+            this.whenReference = whenReference;
+        }
+
+        @Override
+        public void accept(T item, Throwable error) {
+            if (error != null) {
+                downstream.onError(error);
+            }
+            else if (item != null) {
+                complete(item);
+            } else {
+                downstream.onError(new NullPointerException("The CompletionStage terminated with null."));
+            }
+        }
+
+        @Override
+        public void dispose() {
+            super.dispose();
+            whenReference.set(null);
+        }
+    }
+
+    static final class BiConsumerAtomicReference<T> extends AtomicReference<BiConsumer<T, Throwable>>
+    implements BiConsumer<T, Throwable> {
+
+        private static final long serialVersionUID = 45838553147237545L;
+
+        @Override
+        public void accept(T t, Throwable u) {
+            BiConsumer<T, Throwable> biConsumer = get();
+            if (biConsumer != null) {
+                biConsumer.accept(t, u);
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromStream.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
+import io.reactivex.rxjava3.internal.fuseable.QueueDisposable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Wraps a {@link Stream} and emits its values as an {@link Observable} sequence.
+ * @param <T> the element type of the Stream
+ * @since 3.0.0
+ */
+public final class ObservableFromStream<T> extends Observable<T> {
+
+    final Stream<T> stream;
+
+    public ObservableFromStream(Stream<T> stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super T> observer) {
+        subscribeStream(observer, stream);
+    }
+
+    /**
+     * Subscribes to the Stream.
+     * @param <T> the element type of the flow
+     * @param observer the observer to drive
+     * @param stream the sequence to consume
+     */
+    public static <T> void subscribeStream(Observer<? super T> observer, Stream<T> stream) {
+        Iterator<T> iterator;
+        try {
+            iterator = stream.iterator();
+
+            if (!iterator.hasNext()) {
+                EmptyDisposable.complete(observer);
+                closeSafely(stream);
+                return;
+            }
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            closeSafely(stream);
+            return;
+        }
+
+        StreamDisposable<T> disposable = new StreamDisposable<>(observer, iterator, stream);
+        observer.onSubscribe(disposable);
+        disposable.run();
+    }
+
+    static void closeSafely(AutoCloseable c) {
+        try {
+            c.close();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    }
+
+    static final class StreamDisposable<T> implements QueueDisposable<T> {
+
+        final Observer<? super T> downstream;
+
+        Iterator<T> iterator;
+
+        AutoCloseable closeable;
+
+        volatile boolean disposed;
+
+        boolean once;
+
+        boolean outputFused;
+
+        StreamDisposable(Observer<? super T> downstream, Iterator<T> iterator, AutoCloseable closeable) {
+            this.downstream = downstream;
+            this.iterator = iterator;
+            this.closeable = closeable;
+        }
+
+        @Override
+        public void dispose() {
+            disposed = true;
+            run();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            if ((mode & SYNC) != 0) {
+                outputFused = true;
+                return SYNC;
+            }
+            return NONE;
+        }
+
+        @Override
+        public boolean offer(@NonNull T value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean offer(@NonNull T v1, @NonNull T v2) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nullable
+        @Override
+        public T poll() {
+            if (iterator == null) {
+                return null;
+            }
+            if (!once) {
+                once = true;
+            } else {
+                if (!iterator.hasNext()) {
+                    clear();
+                    return null;
+                }
+            }
+            return Objects.requireNonNull(iterator.next(), "The Stream's Iterator.next() returned a null value");
+        }
+
+        @Override
+        public boolean isEmpty() {
+            Iterator<T> it = iterator;
+            if (it != null) {
+                if (!once || it.hasNext()) {
+                    return false;
+                }
+                clear();
+            }
+            return true;
+        }
+
+        @Override
+        public void clear() {
+            iterator = null;
+            AutoCloseable c = closeable;
+            closeable = null;
+            if (c != null) {
+                closeSafely(c);
+            }
+        }
+
+        public void run() {
+            if (outputFused) {
+                return;
+            }
+            Iterator<T> iterator = this.iterator;
+            Observer<? super T> downstream = this.downstream;
+
+            for (;;) {
+                if (disposed) {
+                    clear();
+                    break;
+                }
+
+                T next;
+                try {
+                    next = Objects.requireNonNull(iterator.next(), "The Stream's Iterator.next returned a null value");
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    downstream.onError(ex);
+                    disposed = true;
+                    continue;
+                }
+
+                if (disposed) {
+                    continue;
+                }
+
+                downstream.onNext(next);
+
+                if (disposed) {
+                    continue;
+                }
+
+                try {
+                    if (iterator.hasNext()) {
+                        continue;
+                    }
+                } catch (Throwable ex) {
+                    Exceptions.throwIfFatal(ex);
+                    downstream.onError(ex);
+                    disposed = true;
+                    continue;
+                }
+
+                downstream.onComplete();
+                disposed = true;
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableLastStageObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableLastStageObserver.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Signals the last element of the source via the underlying CompletableFuture,
+ * signals the a default item if the upstream is empty or signals {@link NoSuchElementException}.
+ *
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class ObservableLastStageObserver<T> extends ObservableStageObserver<T> {
+
+    final boolean hasDefault;
+
+    final T defaultItem;
+
+    public ObservableLastStageObserver(boolean hasDefault, T defaultItem) {
+        this.hasDefault = hasDefault;
+        this.defaultItem = defaultItem;
+    }
+
+    @Override
+    public void onNext(T t) {
+        value = t;
+    }
+
+    @Override
+    public void onComplete() {
+        if (!isDone()) {
+            T v = value;
+            clear();
+            if (v != null) {
+                complete(v);
+            } else if (hasDefault) {
+                complete(defaultItem);
+            } else {
+                completeExceptionally(new NoSuchElementException());
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableMapOptional.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableMapOptional.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.observers.BasicFuseableObserver;
+
+/**
+ * Map the upstream values into an Optional and emit its value if any.
+ * @param <T> the upstream element type
+ * @param <R> the output element type
+ * @since 3.0.0
+ */
+public final class ObservableMapOptional<T, R> extends Observable<R> {
+
+    final Observable<T> source;
+
+    final Function<? super T, Optional<? extends R>> mapper;
+
+    public ObservableMapOptional(Observable<T> source, Function<? super T, Optional<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(Observer<? super R> observer) {
+        source.subscribe(new MapOptionalObserver<>(observer, mapper));
+    }
+
+    static final class MapOptionalObserver<T, R> extends BasicFuseableObserver<T, R> {
+
+        final Function<? super T, Optional<? extends R>> mapper;
+
+        MapOptionalObserver(Observer<? super R> downstream, Function<? super T, Optional<? extends R>> mapper) {
+            super(downstream);
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done) {
+                return;
+            }
+
+            if (sourceMode != NONE) {
+                downstream.onNext(null);
+                return;
+            }
+
+            Optional<? extends R> result;
+            try {
+                result = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Optional");
+            } catch (Throwable ex) {
+                fail(ex);
+                return;
+            }
+
+            if (result.isPresent()) {
+                downstream.onNext(result.get());
+            }
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            return transitiveBoundaryFusion(mode);
+        }
+
+        @Override
+        public R poll() throws Throwable {
+            for (;;) {
+                T item = qd.poll();
+                if (item == null) {
+                    return null;
+                }
+                Optional<? extends R> result = Objects.requireNonNull(mapper.apply(item), "The mapper returned a null Optional");
+                if (result.isPresent()) {
+                    return result.get();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableSingleStageObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableSingleStageObserver.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Signals the only element of the source via the underlying CompletableFuture,
+ * signals the a default item if the upstream is empty or signals {@link IllegalArgumentException}
+ * if the upstream has more than one item.
+ *
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+public final class ObservableSingleStageObserver<T> extends ObservableStageObserver<T> {
+
+    final boolean hasDefault;
+
+    final T defaultItem;
+
+    public ObservableSingleStageObserver(boolean hasDefault, T defaultItem) {
+        this.hasDefault = hasDefault;
+        this.defaultItem = defaultItem;
+    }
+
+    @Override
+    public void onNext(T t) {
+        if (value != null) {
+            value = null;
+            completeExceptionally(new IllegalArgumentException("Sequence contains more than one element!"));
+        } else {
+            value = t;
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (!isDone()) {
+            T v = value;
+            clear();
+            if (v != null) {
+                complete(v);
+            } else if (hasDefault) {
+                complete(defaultItem);
+            } else {
+                completeExceptionally(new NoSuchElementException());
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableStageObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableStageObserver.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Base class that extends CompletableFuture and provides basic infrastructure
+ * to notify watchers upon upstream signals.
+ * @param <T> the element type
+ * @since 3.0.0
+ */
+abstract class ObservableStageObserver<T> extends CompletableFuture<T> implements Observer<T> {
+
+    final AtomicReference<Disposable> upstream = new AtomicReference<>();
+
+    T value;
+
+    @Override
+    public final void onSubscribe(@NonNull Disposable d) {
+        DisposableHelper.setOnce(upstream, d);
+    }
+
+    @Override
+    public final void onError(Throwable t) {
+        clear();
+        if (!completeExceptionally(t)) {
+            RxJavaPlugins.onError(t);
+        }
+    }
+
+    protected final void disposeUpstream() {
+        DisposableHelper.dispose(upstream);
+    }
+
+    protected final void clear() {
+        value = null;
+        upstream.lazySet(DisposableHelper.DISPOSED);
+    }
+
+    @Override
+    public final boolean cancel(boolean mayInterruptIfRunning) {
+        disposeUpstream();
+        return super.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public final boolean complete(T value) {
+        disposeUpstream();
+        return super.complete(value);
+    }
+
+    @Override
+    public final boolean completeExceptionally(Throwable ex) {
+        disposeUpstream();
+        return super.completeExceptionally(ex);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableBlockingStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableBlockingStreamTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.stream.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.processors.UnicastProcessor;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+public class ObservableBlockingStreamTest extends RxJavaTest {
+
+    @Test
+    public void empty() {
+        try (Stream<Integer> stream = Observable.<Integer>empty().blockingStream()) {
+            assertEquals(0, stream.toArray().length);
+        }
+    }
+
+    @Test
+    public void just() {
+        try (Stream<Integer> stream = Observable.just(1).blockingStream()) {
+            assertArrayEquals(new Integer[] { 1 }, stream.toArray(Integer[]::new));
+        }
+    }
+
+    @Test
+    public void range() {
+        try (Stream<Integer> stream = Observable.range(1, 5).blockingStream()) {
+            assertArrayEquals(new Integer[] { 1, 2, 3, 4, 5 }, stream.toArray(Integer[]::new));
+        }
+    }
+
+    @Test
+    public void rangeBackpressured() {
+        try (Stream<Integer> stream = Observable.range(1, 5).blockingStream(1)) {
+            assertArrayEquals(new Integer[] { 1, 2, 3, 4, 5 }, stream.toArray(Integer[]::new));
+        }
+    }
+
+    @Test
+    public void rangeAsyncBackpressured() {
+        try (Stream<Integer> stream = Observable.range(1, 1000).subscribeOn(Schedulers.computation()).blockingStream()) {
+            List<Integer> list = stream.collect(Collectors.toList());
+
+            assertEquals(1000, list.size());
+            for (int i = 1; i <= 1000; i++) {
+                assertEquals(i, list.get(i - 1).intValue());
+            }
+        }
+    }
+
+    @Test
+    public void rangeAsyncBackpressured1() {
+        try (Stream<Integer> stream = Observable.range(1, 1000).subscribeOn(Schedulers.computation()).blockingStream(1)) {
+            List<Integer> list = stream.collect(Collectors.toList());
+
+            assertEquals(1000, list.size());
+            for (int i = 1; i <= 1000; i++) {
+                assertEquals(i, list.get(i - 1).intValue());
+            }
+        }
+    }
+
+    @Test
+    public void error() {
+        try (Stream<Integer> stream = Observable.<Integer>error(new TestException()).blockingStream()) {
+            stream.toArray(Integer[]::new);
+            fail("Should have thrown!");
+        } catch (TestException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void close() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        up.onNext(1);
+        up.onNext(2);
+        up.onNext(3);
+        up.onNext(4);
+        up.onNext(5);
+
+        try (Stream<Integer> stream = up.blockingStream()) {
+            assertArrayEquals(new Integer[] { 1, 2, 3 }, stream.limit(3).toArray(Integer[]::new));
+        }
+
+        assertFalse(up.hasSubscribers());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableCollectWithCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableCollectWithCollectorTest.java
@@ -1,0 +1,444 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.core.RxJavaTest;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.processors.*;
+import io.reactivex.rxjava3.subjects.PublishSubject;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class ObservableCollectWithCollectorTest extends RxJavaTest {
+
+    @Test
+    public void basic() {
+        Observable.range(1, 5)
+        .collect(Collectors.toList())
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void empty() {
+        Observable.empty()
+        .collect(Collectors.toList())
+        .test()
+        .assertResult(Collections.emptyList());
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .collect(Collectors.toList())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorSupplierCrash() {
+        Observable.range(1, 5)
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                throw new TestException();
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> { };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> a;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorAccumulatorCrash() {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        source
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                return () -> 1;
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> { throw new TestException(); };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> a;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void collectorFinisherCrash() {
+        Observable.range(1, 5)
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                return () -> 1;
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> {  };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> { throw new TestException(); };
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorAccumulatorDropSignals() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Observable<Integer> source = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onNext(2);
+                    observer.onError(new IOException());
+                    observer.onComplete();
+                }
+            };
+
+            source
+            .collect(new Collector<Integer, Integer, Integer>() {
+
+                @Override
+                public Supplier<Integer> supplier() {
+                    return () -> 1;
+                }
+
+                @Override
+                public BiConsumer<Integer, Integer> accumulator() {
+                    return (a, b) -> { throw new TestException(); };
+                }
+
+                @Override
+                public BinaryOperator<Integer> combiner() {
+                    return (a, b) -> a + b;
+                }
+
+                @Override
+                public Function<Integer, Integer> finisher() {
+                    return a -> a;
+                }
+
+                @Override
+                public Set<Characteristics> characteristics() {
+                    return Collections.emptySet();
+                }
+            })
+            .test()
+            .assertFailure(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        });
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.create()
+                .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void onSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(f -> f.collect(Collectors.toList()));
+    }
+
+    @Test
+    public void basicToObservable() {
+        Observable.range(1, 5)
+        .collect(Collectors.toList())
+        .toObservable()
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void emptyToObservable() {
+        Observable.empty()
+        .collect(Collectors.toList())
+        .toObservable()
+        .test()
+        .assertResult(Collections.emptyList());
+    }
+
+    @Test
+    public void errorToObservable() {
+        Observable.error(new TestException())
+        .collect(Collectors.toList())
+        .toObservable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorSupplierCrashToObservable() {
+        Observable.range(1, 5)
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                throw new TestException();
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> { };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> a;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .toObservable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorAccumulatorCrashToObservable() {
+        BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
+
+        source
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                return () -> 1;
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> { throw new TestException(); };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> a;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .toObservable()
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(source.hasSubscribers());
+    }
+
+    @Test
+    public void collectorFinisherCrashToObservable() {
+        Observable.range(1, 5)
+        .collect(new Collector<Integer, Integer, Integer>() {
+
+            @Override
+            public Supplier<Integer> supplier() {
+                return () -> 1;
+            }
+
+            @Override
+            public BiConsumer<Integer, Integer> accumulator() {
+                return (a, b) -> {  };
+            }
+
+            @Override
+            public BinaryOperator<Integer> combiner() {
+                return (a, b) -> a + b;
+            }
+
+            @Override
+            public Function<Integer, Integer> finisher() {
+                return a -> { throw new TestException(); };
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Collections.emptySet();
+            }
+        })
+        .toObservable()
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void collectorAccumulatorDropSignalsToObservable() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Observable<Integer> source = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onNext(2);
+                    observer.onError(new IOException());
+                    observer.onComplete();
+                }
+            };
+
+            source
+            .collect(new Collector<Integer, Integer, Integer>() {
+
+                @Override
+                public Supplier<Integer> supplier() {
+                    return () -> 1;
+                }
+
+                @Override
+                public BiConsumer<Integer, Integer> accumulator() {
+                    return (a, b) -> { throw new TestException(); };
+                }
+
+                @Override
+                public BinaryOperator<Integer> combiner() {
+                    return (a, b) -> a + b;
+                }
+
+                @Override
+                public Function<Integer, Integer> finisher() {
+                    return a -> a;
+                }
+
+                @Override
+                public Set<Characteristics> characteristics() {
+                    return Collections.emptySet();
+                }
+            })
+            .toObservable()
+            .test()
+            .assertFailure(TestException.class);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        });
+    }
+
+    @Test
+    public void disposeToObservable() {
+        TestHelper.checkDisposed(PublishProcessor.create()
+                .collect(Collectors.toList()).toObservable());
+    }
+
+    @Test
+    public void onSubscribeToObservable() {
+        TestHelper.checkDoubleOnSubscribeObservable(f -> f.collect(Collectors.toList()).toObservable());
+    }
+
+    @Test
+    public void toObservableTake() {
+        Observable.range(1, 5)
+        .collect(Collectors.toList())
+        .toObservable()
+        .take(1)
+        .test()
+        .assertResult(Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void disposeBeforeEnd() {
+        TestObserver<List<Integer>> to = Observable.range(1, 5).concatWith(Observable.never())
+        .collect(Collectors.toList())
+        .test();
+
+        to.dispose();
+
+        to.assertEmpty();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableFlatMapStreamTest.java
@@ -1,0 +1,466 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subjects.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class ObservableFlatMapStreamTest extends RxJavaTest {
+
+    @Test
+    public void empty() {
+        Observable.empty()
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void emptyHidden() {
+        Observable.empty()
+        .hide()
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void just() {
+        Observable.just(1)
+        .flatMapStream(v -> Stream.of(v + 1, v + 2, v + 3, v + 4, v + 5))
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void justHidden() {
+        Observable.just(1).hide()
+        .flatMapStream(v -> Stream.of(v + 1, v + 2, v + 3, v + 4, v + 5))
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void error() {
+        Observable.error(new TestException())
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void supplierFusedError() {
+        Observable.fromCallable(() -> { throw new TestException(); })
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void errorHidden() {
+        Observable.error(new TestException())
+        .hide()
+        .flatMapStream(v -> Stream.of(1, 2, 3, 4, 5))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void range() {
+        Observable.range(1, 5)
+        .flatMapStream(v -> IntStream.range(v * 10, v * 10 + 5).boxed())
+        .test()
+        .assertResult(
+                10, 11, 12, 13, 14,
+                20, 21, 22, 23, 24,
+                30, 31, 32, 33, 34,
+                40, 41, 42, 43, 44,
+                50, 51, 52, 53, 54
+        );
+    }
+
+    @Test
+    public void rangeHidden() {
+        Observable.range(1, 5)
+        .hide()
+        .flatMapStream(v -> IntStream.range(v * 10, v * 10 + 5).boxed())
+        .test()
+        .assertResult(
+                10, 11, 12, 13, 14,
+                20, 21, 22, 23, 24,
+                30, 31, 32, 33, 34,
+                40, 41, 42, 43, 44,
+                50, 51, 52, 53, 54
+        );
+    }
+
+    @Test
+    public void rangeToEmpty() {
+        Observable.range(1, 5)
+        .flatMapStream(v -> Stream.of())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void rangeTake() {
+        Observable.range(1, 5)
+        .flatMapStream(v -> IntStream.range(v * 10, v * 10 + 5).boxed())
+        .take(12)
+        .test()
+        .assertResult(
+                10, 11, 12, 13, 14,
+                20, 21, 22, 23, 24,
+                30, 31
+        );
+    }
+
+    @Test
+    public void rangeTakeHidden() {
+        Observable.range(1, 5)
+        .hide()
+        .flatMapStream(v -> IntStream.range(v * 10, v * 10 + 5).boxed())
+        .take(12)
+        .test()
+        .assertResult(
+                10, 11, 12, 13, 14,
+                20, 21, 22, 23, 24,
+                30, 31
+        );
+    }
+
+    @Test
+    public void upstreamCancelled() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        TestObserver<Integer> to = ps
+                .flatMapStream(v -> Stream.of(v + 1, v + 2).onClose(() -> calls.getAndIncrement()))
+                .take(1)
+                .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        to.assertResult(2);
+
+        assertFalse(ps.hasObservers());
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void upstreamCancelledCloseCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            PublishSubject<Integer> ps = PublishSubject.create();
+
+            TestObserver<Integer> to = ps
+                    .flatMapStream(v -> Stream.of(v + 1, v + 2).onClose(() -> { throw new TestException(); }))
+                    .take(1)
+                    .test();
+
+            assertTrue(ps.hasObservers());
+
+            ps.onNext(1);
+
+            to.assertResult(2);
+
+            assertFalse(ps.hasObservers());
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void crossMap() {
+        Observable.range(1, 1000)
+        .flatMapStream(v -> IntStream.range(v * 1000, v * 1000 + 1000).boxed())
+        .test()
+        .assertValueCount(1_000_000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void crossMapHidden() {
+        Observable.range(1, 1000)
+        .hide()
+        .flatMapStream(v -> IntStream.range(v * 1000, v * 1000 + 1000).boxed())
+        .test()
+        .assertValueCount(1_000_000)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void onSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(f -> f.flatMapStream(v -> Stream.of(1, 2)));
+    }
+
+    @Test
+    public void mapperThrows() {
+        Observable.just(1).hide()
+        .concatMapStream(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapperNull() {
+        Observable.just(1).hide()
+        .concatMapStream(v -> null)
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void streamNull() {
+        Observable.just(1).hide()
+        .concatMapStream(v -> Stream.of(1, null))
+        .test()
+        .assertFailure(NullPointerException.class, 1);
+    }
+
+    @Test
+    public void hasNextThrows() {
+        Observable.just(1).hide()
+        .concatMapStream(v -> Stream.generate(() -> { throw new TestException(); }))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void hasNextThrowsLater() {
+        AtomicInteger counter = new AtomicInteger();
+        Observable.just(1).hide()
+        .concatMapStream(v -> Stream.generate(() -> {
+            if (counter.getAndIncrement() == 0) {
+                return 1;
+            }
+            throw new TestException();
+        }))
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void mapperThrowsWhenUpstreamErrors() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            PublishSubject<Integer> ps = PublishSubject.create();
+
+            AtomicInteger counter = new AtomicInteger();
+
+            TestObserver<Integer> to = ps.hide()
+            .concatMapStream(v -> {
+                if (counter.getAndIncrement() == 0) {
+                    return Stream.of(1, 2);
+                }
+                ps.onError(new IOException());
+                throw new TestException();
+            })
+            .test();
+
+            ps.onNext(1);
+            ps.onNext(2);
+
+            to
+            .assertFailure(IOException.class, 1, 2);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void cancelAfterIteratorNext() throws Exception {
+        TestObserver<Integer> to = new TestObserver<>();
+
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                to.dispose();
+                return 1;
+            }
+        });
+
+        Observable.just(1)
+        .hide()
+        .concatMapStream(v -> stream)
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void cancelAfterIteratorHasNext() throws Exception {
+        TestObserver<Integer> to = new TestObserver<>();
+
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                to.dispose();
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Observable.just(1)
+        .hide()
+        .concatMapStream(v -> stream)
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void asyncUpstreamFused() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        TestObserver<Integer> to = us.flatMapStream(v -> Stream.of(1, 2))
+        .test();
+
+        assertTrue(us.hasObservers());
+
+        us.onNext(1);
+
+        to.assertValuesOnly(1, 2);
+
+        us.onComplete();
+
+        to.assertResult(1, 2);
+    }
+
+    @Test
+    public void asyncUpstreamFusionBoundary() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        TestObserver<Integer> to = us
+                .map(v -> v + 1)
+                .flatMapStream(v -> Stream.of(1, 2))
+        .test();
+
+        assertTrue(us.hasObservers());
+
+        us.onNext(1);
+
+        to.assertValuesOnly(1, 2);
+
+        us.onComplete();
+
+        to.assertResult(1, 2);
+    }
+
+    @Test
+    public void fusedPollCrash() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+
+        TestObserver<Integer> to = us
+                .map(v -> { throw new TestException(); })
+                .compose(TestHelper.observableStripBoundary())
+                .flatMapStream(v -> Stream.of(1, 2))
+        .test();
+
+        assertTrue(us.hasObservers());
+
+        us.onNext(1);
+
+        assertFalse(us.hasObservers());
+
+        to.assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(PublishSubject.create().flatMapStream(v -> Stream.of(1)));
+    }
+
+    @Test
+    public void eventsIgnoredAfterCrash() {
+        AtomicInteger calls = new AtomicInteger();
+
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(@NonNull Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposable.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onComplete();
+            }
+        }
+        .flatMapStream(v -> {
+            calls.getAndIncrement();
+            throw new TestException();
+        })
+        .take(1)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void eventsIgnoredAfterDispose() {
+        AtomicInteger calls = new AtomicInteger();
+
+        new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(@NonNull Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposable.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onComplete();
+            }
+        }
+        .flatMapStream(v -> {
+            calls.getAndIncrement();
+            return Stream.of(1);
+        })
+        .take(1)
+        .test()
+        .assertResult(1);
+
+        assertEquals(1, calls.get());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromCompletionStageTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.observers.TestObserver;
+
+public class ObservableFromCompletionStageTest extends RxJavaTest {
+
+    @Test
+    public void syncSuccess() {
+        Observable.fromCompletionStage(CompletableFuture.completedFuture(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void syncFailure() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+        cf.completeExceptionally(new TestException());
+
+        Observable.fromCompletionStage(cf)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void syncNull() {
+        Observable.fromCompletionStage(CompletableFuture.<Integer>completedFuture(null))
+        .test()
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void cancel() {
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+
+        TestObserver<Integer> to = Observable.fromCompletionStage(cf)
+        .test();
+
+        to.assertEmpty();
+
+        to.dispose();
+
+        cf.complete(1);
+
+        to.assertEmpty();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromOptionalTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+
+public class ObservableFromOptionalTest extends RxJavaTest {
+
+    @Test
+    public void hasValue() {
+        Observable.fromOptional(Optional.of(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void empty() {
+        Observable.fromOptional(Optional.empty())
+        .test()
+        .assertResult();
+    }
+
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableFromStreamTest.java
@@ -14,61 +14,48 @@
 package io.reactivex.rxjava3.internal.jdk8;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.Iterator;
 import java.util.concurrent.atomic.*;
 import java.util.stream.*;
 
 import org.junit.Test;
-import org.reactivestreams.Subscription;
 
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.internal.fuseable.*;
-import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.testsupport.*;
 
-public class FlowableFromStreamTest extends RxJavaTest {
+public class ObservableFromStreamTest extends RxJavaTest {
 
     @Test
     public void empty() {
-        Flowable.fromStream(Stream.<Integer>of())
+        Observable.fromStream(Stream.<Integer>of())
         .test()
         .assertResult();
     }
 
     @Test
     public void just() {
-        Flowable.fromStream(Stream.<Integer>of(1))
+        Observable.fromStream(Stream.<Integer>of(1))
         .test()
         .assertResult(1);
     }
 
     @Test
     public void many() {
-        Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
+        Observable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
-    public void manyBackpressured() {
-        Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
-        .test(0L)
-        .assertEmpty()
-        .requestMore(1)
-        .assertValuesOnly(1)
-        .requestMore(2)
-        .assertValuesOnly(1, 2, 3)
-        .requestMore(2)
-        .assertResult(1, 2, 3, 4, 5);
-    }
-
-    @Test
     public void noReuse() {
-        Flowable<Integer> source = Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5));
+        Observable<Integer> source = Observable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5));
 
         source
         .test()
@@ -81,7 +68,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void take() {
-        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        Observable.fromStream(IntStream.rangeClosed(1, 10).boxed())
         .take(5)
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -89,7 +76,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void emptyConditional() {
-        Flowable.fromStream(Stream.<Integer>of())
+        Observable.fromStream(Stream.<Integer>of())
         .filter(v -> true)
         .test()
         .assertResult();
@@ -97,7 +84,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void justConditional() {
-        Flowable.fromStream(Stream.<Integer>of(1))
+        Observable.fromStream(Stream.<Integer>of(1))
         .filter(v -> true)
         .test()
         .assertResult(1);
@@ -105,29 +92,15 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void manyConditional() {
-        Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
+        Observable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
         .filter(v -> true)
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
-    public void manyBackpressuredConditional() {
-        Flowable.fromStream(Stream.<Integer>of(1, 2, 3, 4, 5))
-        .filter(v -> true)
-        .test(0L)
-        .assertEmpty()
-        .requestMore(1)
-        .assertValuesOnly(1)
-        .requestMore(2)
-        .assertValuesOnly(1, 2, 3)
-        .requestMore(2)
-        .assertResult(1, 2, 3, 4, 5);
-    }
-
-    @Test
     public void manyConditionalSkip() {
-        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        Observable.fromStream(IntStream.rangeClosed(1, 10).boxed())
         .filter(v -> v % 2 == 0)
         .test()
         .assertResult(2, 4, 6, 8, 10);
@@ -135,7 +108,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void takeConditional() {
-        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        Observable.fromStream(IntStream.rangeClosed(1, 10).boxed())
         .filter(v -> true)
         .take(5)
         .test()
@@ -146,11 +119,12 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void noOfferNoCrashAfterClear() throws Throwable {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
 
-        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
-        .subscribe(new FlowableSubscriber<Integer>() {
+        Observable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .subscribe(new Observer<Integer>() {
             @Override
-            public void onSubscribe(@NonNull Subscription s) {
-                queue.set((SimpleQueue<?>)s);
+            public void onSubscribe(@NonNull Disposable d) {
+                queue.set((SimpleQueue<?>)d);
+                ((QueueDisposable<?>)d).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -189,12 +163,12 @@ public class FlowableFromStreamTest extends RxJavaTest {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
         AtomicInteger calls = new AtomicInteger();
 
-        Flowable.fromStream(Stream.of(1).onClose(() -> calls.getAndIncrement()))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        Observable.fromStream(Stream.of(1).onClose(() -> calls.getAndIncrement()))
+        .subscribe(new Observer<Integer>() {
             @Override
-            public void onSubscribe(@NonNull Subscription s) {
-                queue.set((SimpleQueue<?>)s);
-                ((QueueSubscription<?>)s).requestFusion(QueueFuseable.ANY);
+            public void onSubscribe(@NonNull Disposable d) {
+                queue.set((SimpleQueue<?>)d);
+                ((QueueDisposable<?>)d).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -222,15 +196,56 @@ public class FlowableFromStreamTest extends RxJavaTest {
     }
 
     @Test
+    public void fusedPoll2() throws Throwable {
+        AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
+        AtomicInteger calls = new AtomicInteger();
+
+        Observable.fromStream(Stream.of(1, 2).onClose(() -> calls.getAndIncrement()))
+        .subscribe(new Observer<Integer>() {
+            @Override
+            public void onSubscribe(@NonNull Disposable d) {
+                queue.set((SimpleQueue<?>)d);
+                ((QueueDisposable<?>)d).requestFusion(QueueFuseable.ANY);
+            }
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+
+        SimpleQueue<?> q = queue.get();
+
+        assertFalse(q.isEmpty());
+
+        assertEquals(1, q.poll());
+
+        assertFalse(q.isEmpty());
+
+        assertEquals(2, q.poll());
+
+        assertTrue(q.isEmpty());
+
+        assertEquals(1, calls.get());
+    }
+
+    @Test
     public void streamOfNull() {
-        Flowable.fromStream(Stream.of((Integer)null))
+        Observable.fromStream(Stream.of((Integer)null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void streamOfNullConditional() {
-        Flowable.fromStream(Stream.of((Integer)null))
+        Observable.fromStream(Stream.of((Integer)null))
         .filter(v -> true)
         .test()
         .assertFailure(NullPointerException.class);
@@ -238,11 +253,11 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void syncFusionSupport() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
-        ts.setInitialFusionMode(QueueFuseable.ANY);
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
 
-        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
-        .subscribeWith(ts)
+        Observable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .subscribeWith(to)
         .assertFuseable()
         .assertFusionMode(QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -250,28 +265,14 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void asyncFusionNotSupported() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
-        ts.setInitialFusionMode(QueueFuseable.ASYNC);
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ASYNC);
 
-        Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
-        .subscribeWith(ts)
+        Observable.fromStream(IntStream.rangeClosed(1, 10).boxed())
+        .subscribeWith(to)
         .assertFuseable()
         .assertFusionMode(QueueFuseable.NONE)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    }
-
-    @Test
-    public void fusedForParallel() {
-        Flowable.fromStream(IntStream.rangeClosed(1, 1000).boxed())
-        .parallel()
-        .runOn(Schedulers.computation(), 1)
-        .map(v -> v + 1)
-        .sequential()
-        .test()
-        .awaitDone(5, TimeUnit.SECONDS)
-        .assertValueCount(1000)
-        .assertNoErrors()
-        .assertComplete();
     }
 
     @Test
@@ -279,7 +280,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
         TestHelper.withErrorTracking(errors -> {
             Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5).onClose(() -> { throw new TestException(); });
 
-            Flowable.fromStream(stream)
+            Observable.fromStream(stream)
             .test()
             .assertResult(1, 2, 3, 4, 5);
 
@@ -292,7 +293,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
         TestHelper.withErrorTracking(errors -> {
             Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5).onClose(() -> { throw new TestException(); });
 
-            Flowable.fromStream(stream)
+            Observable.fromStream(stream)
             .take(3)
             .test()
             .assertResult(1, 2, 3);
@@ -304,7 +305,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     @Test
     public void hasNextCrash() {
         AtomicInteger v = new AtomicInteger();
-        Flowable.fromStream(Stream.<Integer>generate(() -> {
+        Observable.fromStream(Stream.<Integer>generate(() -> {
             int value = v.getAndIncrement();
             if (value == 1) {
                 throw new TestException();
@@ -318,7 +319,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     @Test
     public void hasNextCrashConditional() {
         AtomicInteger counter = new AtomicInteger();
-        Flowable.fromStream(Stream.<Integer>generate(() -> {
+        Observable.fromStream(Stream.<Integer>generate(() -> {
             int value = counter.getAndIncrement();
             if (value == 1) {
                 throw new TestException();
@@ -330,137 +331,11 @@ public class FlowableFromStreamTest extends RxJavaTest {
         .assertFailure(TestException.class, 0);
     }
 
-    void requestOneByOneBase(boolean conditional) {
-        List<Object> list = new ArrayList<>();
-
-        Flowable<Integer> source = Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed());
-        if (conditional) {
-            source = source.filter(v -> true);
-        }
-
-        source.subscribe(new FlowableSubscriber<Integer>() {
-
-            @NonNull Subscription upstream;
-
-            @Override
-            public void onSubscribe(@NonNull Subscription s) {
-                this.upstream = s;
-                s.request(1);
-            }
-
-            @Override
-            public void onNext(Integer t) {
-                list.add(t);
-                upstream.request(1);
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                list.add(t);
-            }
-
-            @Override
-            public void onComplete() {
-                list.add(100);
-            }
-        });
-
-        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100), list);
-    }
-
-    @Test
-    public void requestOneByOne() {
-        requestOneByOneBase(false);
-    }
-
-    @Test
-    public void requestOneByOneConditional() {
-        requestOneByOneBase(true);
-    }
-
-    void requestRaceBase(boolean conditional) throws Exception {
-        ExecutorService exec = Executors.newCachedThreadPool();
-        try {
-            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-
-                AtomicInteger counter = new AtomicInteger();
-
-                int max = 100;
-
-                Flowable<Integer> source = Flowable.fromStream(IntStream.rangeClosed(1, max).boxed());
-                if (conditional) {
-                    source = source.filter(v -> true);
-                }
-
-                CountDownLatch cdl = new CountDownLatch(1);
-
-                source
-                .subscribe(new FlowableSubscriber<Integer>() {
-
-                    @NonNull Subscription upstream;
-
-                    @Override
-                    public void onSubscribe(@NonNull Subscription s) {
-
-                        this.upstream = s;
-                        s.request(1);
-
-                    }
-
-                    @Override
-                    public void onNext(Integer t) {
-                        counter.getAndIncrement();
-
-                        AtomicInteger sync = new AtomicInteger(2);
-                        exec.submit(() -> {
-                            if (sync.decrementAndGet() != 0) {
-                                while (sync.get() != 0) { }
-                            }
-                            upstream.request(1);
-                        });
-
-                        if (sync.decrementAndGet() != 0) {
-                            while (sync.get() != 0) { }
-                        }
-                    }
-
-                    @Override
-                    public void onError(Throwable t) {
-                        t.printStackTrace();
-                        cdl.countDown();
-                    }
-
-                    @Override
-                    public void onComplete() {
-                        counter.getAndIncrement();
-                        cdl.countDown();
-                    }
-                });
-
-                assertTrue(cdl.await(60, TimeUnit.SECONDS));
-
-                assertEquals(max + 1, counter.get());
-            }
-        } finally {
-            exec.shutdown();
-        }
-    }
-
-    @Test
-    public void requestRace() throws Exception {
-        requestRaceBase(false);
-    }
-
-    @Test
-    public void requestRaceConditional() throws Exception {
-        requestRaceBase(true);
-    }
-
     @Test
     public void closeCalledOnEmpty() {
         AtomicInteger calls = new AtomicInteger();
 
-        Flowable.fromStream(Stream.of().onClose(() -> calls.getAndIncrement()))
+        Observable.fromStream(Stream.of().onClose(() -> calls.getAndIncrement()))
         .test()
         .assertResult();
 
@@ -471,7 +346,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void closeCalledAfterItems() {
         AtomicInteger calls = new AtomicInteger();
 
-        Flowable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
+        Observable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
         .test()
         .assertResult(1, 2, 3, 4, 5);
 
@@ -482,7 +357,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void closeCalledOnCancel() {
         AtomicInteger calls = new AtomicInteger();
 
-        Flowable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
+        Observable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
         .take(3)
         .test()
         .assertResult(1, 2, 3);
@@ -494,7 +369,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void closeCalledOnItemCrash() {
         AtomicInteger calls = new AtomicInteger();
         AtomicInteger counter = new AtomicInteger();
-        Flowable.fromStream(Stream.<Integer>generate(() -> {
+        Observable.fromStream(Stream.<Integer>generate(() -> {
             int value = counter.getAndIncrement();
             if (value == 1) {
                 throw new TestException();
@@ -511,7 +386,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void closeCalledAfterItemsConditional() {
         AtomicInteger calls = new AtomicInteger();
 
-        Flowable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
+        Observable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
         .filter(v -> true)
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -523,7 +398,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void closeCalledOnCancelConditional() {
         AtomicInteger calls = new AtomicInteger();
 
-        Flowable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
+        Observable.fromStream(Stream.of(1, 2, 3, 4, 5).onClose(() -> calls.getAndIncrement()))
         .filter(v -> true)
         .take(3)
         .test()
@@ -536,7 +411,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void closeCalledOnItemCrashConditional() {
         AtomicInteger calls = new AtomicInteger();
         AtomicInteger counter = new AtomicInteger();
-        Flowable.fromStream(Stream.<Integer>generate(() -> {
+        Observable.fromStream(Stream.<Integer>generate(() -> {
             int value = counter.getAndIncrement();
             if (value == 1) {
                 throw new TestException();
@@ -551,7 +426,63 @@ public class FlowableFromStreamTest extends RxJavaTest {
     }
 
     @Test
-    public void badRequest() {
-        TestHelper.assertBadRequestReported(Flowable.fromStream(Stream.of(1)));
+    public void dispose() {
+        TestHelper.checkDisposed(Observable.fromStream(Stream.of(1)));
+    }
+
+    @Test
+    public void cancelAfterIteratorNext() throws Exception {
+        TestObserver<Integer> to = new TestObserver<>();
+
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                to.dispose();
+                return 1;
+            }
+        });
+
+        Observable.fromStream(stream)
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
+
+    @Test
+    public void cancelAfterIteratorHasNext() throws Exception {
+        TestObserver<Integer> to = new TestObserver<>();
+
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int calls;
+
+            @Override
+            public boolean hasNext() {
+                if (++calls == 1) {
+                    to.dispose();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Observable.fromStream(stream)
+        .subscribe(to);
+
+        to.assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableMapOptionalTest.java
@@ -1,0 +1,394 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.fuseable.QueueFuseable;
+import io.reactivex.rxjava3.subjects.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class ObservableMapOptionalTest extends RxJavaTest {
+
+    static final Function<? super Integer, Optional<? extends Integer>> MODULO = v -> v % 2 == 0 ? Optional.of(v) : Optional.<Integer>empty();
+
+    @Test
+    public void allPresent() {
+        Observable.range(1, 5)
+        .mapOptional(Optional::of)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void allEmpty() {
+        Observable.range(1, 5)
+        .mapOptional(v -> Optional.<Integer>empty())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void mixed() {
+        Observable.range(1, 10)
+        .mapOptional(MODULO)
+        .test()
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void mapperChash() {
+        BehaviorSubject<Integer> source = BehaviorSubject.createDefault(1);
+
+        source
+        .mapOptional(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void mapperNull() {
+        BehaviorSubject<Integer> source = BehaviorSubject.createDefault(1);
+
+        source
+        .mapOptional(v -> null)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void crashDropsOnNexts() {
+        Observable<Integer> source = new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposable.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+            }
+        };
+
+        source
+        .mapOptional(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void syncFusedAll() {
+        Observable.range(1, 5)
+        .mapOptional(Optional::of)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void asyncFusedAll() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .mapOptional(Optional::of)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void boundaryFusedAll() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .mapOptional(Optional::of)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void syncFusedNone() {
+        Observable.range(1, 5)
+        .mapOptional(v -> Optional.empty())
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void asyncFusedNone() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .mapOptional(v -> Optional.empty())
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void boundaryFusedNone() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .mapOptional(v -> Optional.empty())
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult();
+    }
+
+    @Test
+    public void syncFusedMixed() {
+        Observable.range(1, 10)
+        .mapOptional(MODULO)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void asyncFusedMixed() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        us
+        .mapOptional(MODULO)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void boundaryFusedMixed() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        us
+        .mapOptional(MODULO)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void allPresentConditional() {
+        Observable.range(1, 5)
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void allEmptyConditional() {
+        Observable.range(1, 5)
+        .mapOptional(v -> Optional.<Integer>empty())
+        .filter(v -> true)
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void mixedConditional() {
+        Observable.range(1, 10)
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .test()
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void mapperChashConditional() {
+        BehaviorSubject<Integer> source = BehaviorSubject.createDefault(1);
+
+        source
+        .mapOptional(v -> { throw new TestException(); })
+        .filter(v -> true)
+        .test()
+        .assertFailure(TestException.class);
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void mapperNullConditional() {
+        BehaviorSubject<Integer> source = BehaviorSubject.createDefault(1);
+
+        source
+        .mapOptional(v -> null)
+        .filter(v -> true)
+        .test()
+        .assertFailure(NullPointerException.class);
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void crashDropsOnNextsConditional() {
+        Observable<Integer> source = new Observable<Integer>() {
+            @Override
+            protected void subscribeActual(Observer<? super Integer> observer) {
+                observer.onSubscribe(Disposable.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+            }
+        };
+
+        source
+        .mapOptional(v -> { throw new TestException(); })
+        .filter(v -> true)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void syncFusedAllConditional() {
+        Observable.range(1, 5)
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void asyncFusedAllConditional() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void boundaryFusedAllConditiona() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .mapOptional(Optional::of)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void syncFusedNoneConditional() {
+        Observable.range(1, 5)
+        .mapOptional(v -> Optional.empty())
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void asyncFusedNoneConditional() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .mapOptional(v -> Optional.empty())
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void boundaryFusedNoneConditional() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .mapOptional(v -> Optional.empty())
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult();
+    }
+
+    @Test
+    public void syncFusedMixedConditional() {
+        Observable.range(1, 10)
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.SYNC)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void asyncFusedMixedConditional() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        us
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void boundaryFusedMixedConditional() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        us
+        .mapOptional(MODULO)
+        .filter(v -> true)
+        .to(TestHelper.testConsumer(false, QueueFuseable.ASYNC | QueueFuseable.BOUNDARY))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(2, 4, 6, 8, 10);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java
@@ -1,0 +1,475 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.subjects.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
+
+    @Test
+    public void firstJust() throws Exception {
+        Integer v = Observable.just(1)
+                .firstStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void firstEmpty() throws Exception {
+        Integer v = Observable.<Integer>empty()
+                .firstStage(2)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)2, v);
+    }
+
+    @Test
+    public void firstCancels() throws Exception {
+        BehaviorSubject<Integer> source = BehaviorSubject.createDefault(1);
+
+        Integer v = source
+                .firstStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void firstCompletableFutureCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void firstCompletableManualCompleteCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void firstCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void firstError() throws Exception {
+        CompletableFuture<Integer> cf = Observable.<Integer>error(new TestException())
+                .firstStage(null)
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void firstSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .firstStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void firstDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                }
+            }
+            .firstStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+
+    @Test
+    public void singleJust() throws Exception {
+        Integer v = Observable.just(1)
+                .singleStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void singleEmpty() throws Exception {
+        Integer v = Observable.<Integer>empty()
+                .singleStage(2)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)2, v);
+    }
+
+    @Test
+    public void singleTooManyCancels() throws Exception {
+        ReplaySubject<Integer> source = ReplaySubject.create();
+        source.onNext(1);
+        source.onNext(2);
+
+        TestHelper.assertError(source
+                .singleStage(null)
+                .toCompletableFuture(), IllegalArgumentException.class);
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void singleCompletableFutureCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void singleCompletableManualCompleteCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void singleCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void singleError() throws Exception {
+        CompletableFuture<Integer> cf = Observable.<Integer>error(new TestException())
+                .singleStage(null)
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void singleSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .singleStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void singleDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onComplete();
+                }
+            }
+            .singleStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+
+    @Test
+    public void lastJust() throws Exception {
+        Integer v = Observable.just(1)
+                .lastStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void lastRange() throws Exception {
+        Integer v = Observable.range(1, 5)
+                .lastStage(null)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)5, v);
+    }
+
+    @Test
+    public void lastEmpty() throws Exception {
+        Integer v = Observable.<Integer>empty()
+                .lastStage(2)
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)2, v);
+    }
+
+    @Test
+    public void lastCompletableFutureCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void lastCompletableManualCompleteCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void lastCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastStage(null)
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void lastError() throws Exception {
+        CompletableFuture<Integer> cf = Observable.<Integer>error(new TestException())
+                .lastStage(null)
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void lastSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .lastStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void lastDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onComplete();
+                }
+            }
+            .lastStage(null)
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableStageSubscriberOrErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ObservableStageSubscriberOrErrorTest.java
@@ -1,0 +1,469 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.subjects.*;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
+
+    @Test
+    public void firstJust() throws Exception {
+        Integer v = Observable.just(1)
+                .firstOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void firstEmpty() throws Exception {
+        TestHelper.assertError(
+                Observable.<Integer>empty()
+                .firstOrErrorStage()
+                .toCompletableFuture(), NoSuchElementException.class);
+    }
+
+    @Test
+    public void firstCancels() throws Exception {
+        BehaviorSubject<Integer> source = BehaviorSubject.createDefault(1);
+
+        Integer v = source
+                .firstOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void firstCompletableFutureCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void firstCompletableManualCompleteCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void firstCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .firstOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void firstError() throws Exception {
+        CompletableFuture<Integer> cf = Observable.<Integer>error(new TestException())
+                .firstOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void firstSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .firstOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void firstDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                }
+            }
+            .firstOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+
+    @Test
+    public void singleJust() throws Exception {
+        Integer v = Observable.just(1)
+                .singleOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void singleEmpty() throws Exception {
+        TestHelper.assertError(
+                Observable.<Integer>empty()
+                .singleOrErrorStage()
+                .toCompletableFuture(), NoSuchElementException.class);
+    }
+
+    @Test
+    public void singleTooManyCancels() throws Exception {
+        ReplaySubject<Integer> source = ReplaySubject.create();
+        source.onNext(1);
+        source.onNext(2);
+
+        TestHelper.assertError(source
+            .singleOrErrorStage()
+            .toCompletableFuture(), IllegalArgumentException.class);
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void singleCompletableFutureCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void singleCompletableManualCompleteCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void singleCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .singleOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void singleError() throws Exception {
+        CompletableFuture<Integer> cf = Observable.<Integer>error(new TestException())
+                .singleOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void singleSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .singleOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void singleDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onComplete();
+                }
+            }
+            .singleOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+
+    @Test
+    public void lastJust() throws Exception {
+        Integer v = Observable.just(1)
+                .lastOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)1, v);
+    }
+
+    @Test
+    public void lastRange() throws Exception {
+        Integer v = Observable.range(1, 5)
+                .lastOrErrorStage()
+                .toCompletableFuture()
+                .get();
+
+        assertEquals((Integer)5, v);
+    }
+
+    @Test
+    public void lastEmpty() throws Exception {
+        TestHelper.assertError(Observable.<Integer>empty()
+                .lastOrErrorStage()
+                .toCompletableFuture(), NoSuchElementException.class);
+    }
+
+    @Test
+    public void lastCompletableFutureCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.cancel(true);
+
+        assertTrue(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+    }
+
+    @Test
+    public void lastCompletableManualCompleteCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.complete(1);
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        assertEquals((Integer)1, cf.get());
+    }
+
+    @Test
+    public void lastCompletableManualCompleteExceptionallyCancels() throws Exception {
+        PublishSubject<Integer> source = PublishSubject.create();
+
+        CompletableFuture<Integer> cf = source
+                .lastOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(source.hasObservers());
+
+        cf.completeExceptionally(new TestException());
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        assertFalse(source.hasObservers());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void lastError() throws Exception {
+        CompletableFuture<Integer> cf = Observable.<Integer>error(new TestException())
+                .lastOrErrorStage()
+                .toCompletableFuture();
+
+        assertTrue(cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        TestHelper.assertError(cf, TestException.class);
+    }
+
+    @Test
+    public void lastSourceIgnoresCancel() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onComplete();
+                    observer.onError(new TestException());
+                    observer.onComplete();
+                }
+            }
+            .lastOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void lastDoubleOnSubscribe() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Integer v = new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(1);
+                    observer.onComplete();
+                }
+            }
+            .lastOrErrorStage()
+            .toCompletableFuture()
+            .get();
+
+            assertEquals((Integer)1, v);
+
+            TestHelper.assertError(errors, 0, ProtocolViolationException.class);
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -882,14 +882,14 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void innerErrorAfterPoll() {
-        final UnicastProcessor<Integer> us = UnicastProcessor.create();
-        us.onNext(1);
+        final UnicastProcessor<Integer> up = UnicastProcessor.create();
+        up.onNext(1);
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
-                us.onError(new TestException());
+                up.onError(new TestException());
             }
         };
 
@@ -897,7 +897,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         .concatMapEager(new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
-                return us;
+                return up;
             }
         }, 1, 128)
         .subscribe(ts);
@@ -973,12 +973,12 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void fuseAndTake() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        us.onNext(1);
-        us.onComplete();
+        up.onNext(1);
+        up.onComplete();
 
-        us.concatMapEager(new Function<Integer, Flowable<Integer>>() {
+        up.concatMapEager(new Function<Integer, Flowable<Integer>>() {
             @Override
             public Flowable<Integer> apply(Integer v) throws Exception {
                 return Flowable.just(1);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinctTest.java
@@ -128,13 +128,13 @@ public class FlowableDistinctTest extends RxJavaTest {
     public void fusedAsync() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        us
+        up
         .distinct()
         .subscribe(ts);
 
-        TestHelper.emit(us, 1, 1, 2, 1, 3, 2, 4, 5, 4);
+        TestHelper.emit(up, 1, 1, 2, 1, 3, 2, 4, 5, 4);
 
         ts.assertFusionMode(QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFilterTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFilterTest.java
@@ -557,9 +557,9 @@ public class FlowableFilterTest extends RxJavaTest {
     public void fusedAsync() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        us
+        up
         .filter(new Predicate<Integer>() {
             @Override
             public boolean test(Integer v) throws Exception {
@@ -568,7 +568,7 @@ public class FlowableFilterTest extends RxJavaTest {
         })
         .subscribe(ts);
 
-        TestHelper.emit(us, 1, 2, 3, 4, 5);
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
 
         ts.assertFusionMode(QueueFuseable.ASYNC)
         .assertResult(2, 4);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMapTest.java
@@ -583,13 +583,13 @@ public class FlowableMapTest extends RxJavaTest {
     public void fusedAsync() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        us
+        up
         .map(Functions.<Integer>identity())
         .subscribe(ts);
 
-        TestHelper.emit(us, 1, 2, 3, 4, 5);
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
 
         ts.assertFusionMode(QueueFuseable.ASYNC)
         .assertResult(1, 2, 3, 4, 5);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOnTest.java
@@ -1193,11 +1193,11 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void inputAsyncFused() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        TestSubscriber<Integer> ts = us.observeOn(Schedulers.single()).test();
+        TestSubscriber<Integer> ts = up.observeOn(Schedulers.single()).test();
 
-        TestHelper.emit(us, 1, 2, 3, 4, 5);
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
 
         ts
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1206,11 +1206,11 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void inputAsyncFusedError() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        TestSubscriber<Integer> ts = us.observeOn(Schedulers.single()).test();
+        TestSubscriber<Integer> ts = up.observeOn(Schedulers.single()).test();
 
-        us.onError(new TestException());
+        up.onError(new TestException());
 
         ts
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1219,11 +1219,11 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void inputAsyncFusedErrorDelayed() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        TestSubscriber<Integer> ts = us.observeOn(Schedulers.single(), true).test();
+        TestSubscriber<Integer> ts = up.observeOn(Schedulers.single(), true).test();
 
-        us.onError(new TestException());
+        up.onError(new TestException());
 
         ts
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1260,12 +1260,12 @@ public class FlowableObserveOnTest extends RxJavaTest {
     public void inputOutputAsyncFusedError() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        us.observeOn(Schedulers.single())
+        up.observeOn(Schedulers.single())
         .subscribe(ts);
 
-        us.onError(new TestException());
+        up.onError(new TestException());
 
         ts
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1280,12 +1280,12 @@ public class FlowableObserveOnTest extends RxJavaTest {
     public void inputOutputAsyncFusedErrorDelayed() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        us.observeOn(Schedulers.single(), true)
+        up.observeOn(Schedulers.single(), true)
         .subscribe(ts);
 
-        us.onError(new TestException());
+        up.onError(new TestException());
 
         ts
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1298,11 +1298,11 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void outputFusedCancelReentrant() throws Exception {
-        final UnicastProcessor<Integer> us = UnicastProcessor.create();
+        final UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         final CountDownLatch cdl = new CountDownLatch(1);
 
-        us.observeOn(Schedulers.single())
+        up.observeOn(Schedulers.single())
         .subscribe(new FlowableSubscriber<Integer>() {
             Subscription upstream;
             int count;
@@ -1315,7 +1315,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             @Override
             public void onNext(Integer value) {
                 if (++count == 1) {
-                    us.onNext(2);
+                    up.onNext(2);
                     upstream.cancel();
                     cdl.countDown();
                 }
@@ -1332,7 +1332,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             }
         });
 
-        us.onNext(1);
+        up.onNext(1);
 
         cdl.await();
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -169,9 +169,9 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
     public void fusedAsync() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
+        UnicastSubject<Integer> us = UnicastSubject.create();
 
-        up
+        us
         .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
             @Override
             public boolean test(Integer a, Integer b) throws Exception {
@@ -180,7 +180,7 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
         })
         .subscribe(to);
 
-        TestHelper.emit(up, 1, 2, 2, 3, 3, 4, 5);
+        TestHelper.emit(us, 1, 2, 2, 3, 3, 4, 5);
 
         to.assertFuseable()
         .assertFusionMode(QueueFuseable.ASYNC)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoAfterNextTest.java
@@ -131,11 +131,11 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
     public void asyncFused() {
         TestObserverEx<Integer> to0 = new TestObserverEx<>(QueueFuseable.ASYNC);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
+        UnicastSubject<Integer> us = UnicastSubject.create();
 
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        up
+        us
         .doAfterNext(afterNext)
         .subscribe(to0);
 
@@ -228,11 +228,11 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
     public void asyncFusedConditional() {
         TestObserverEx<Integer> to0 = new TestObserverEx<>(QueueFuseable.ASYNC);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
+        UnicastSubject<Integer> us = UnicastSubject.create();
 
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        up
+        us
         .doAfterNext(afterNext)
         .filter(Functions.alwaysTrue())
         .subscribe(to0);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoFinallyTest.java
@@ -129,10 +129,10 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
     public void asyncFused() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        up
+        us
         .doFinally(this)
         .subscribe(to);
 
@@ -146,10 +146,10 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
     public void asyncFusedBoundary() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        up
+        us
         .doFinally(this)
         .subscribe(to);
 
@@ -267,10 +267,10 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
     public void asyncFusedConditional() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        up
+        us
         .doFinally(this)
         .filter(Functions.alwaysTrue())
         .subscribe(to);
@@ -285,10 +285,10 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
     public void asyncFusedBoundaryConditional() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ASYNC | QueueFuseable.BOUNDARY);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
-        up
+        us
         .doFinally(this)
         .filter(Functions.alwaysTrue())
         .subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnEachTest.java
@@ -596,9 +596,9 @@ public class ObservableDoOnEachTest extends RxJavaTest {
 
         final int[] call = { 0, 0 };
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
+        UnicastSubject<Integer> us = UnicastSubject.create();
 
-        up
+        us
         .doOnNext(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
@@ -613,7 +613,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         })
         .subscribe(to);
 
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
         to.assertFuseable()
         .assertFusionMode(QueueFuseable.ASYNC)
@@ -630,9 +630,9 @@ public class ObservableDoOnEachTest extends RxJavaTest {
 
         final int[] call = { 0, 0 };
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
+        UnicastSubject<Integer> us = UnicastSubject.create();
 
-        up
+        us
         .doOnNext(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
@@ -648,7 +648,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         .filter(Functions.alwaysTrue())
         .subscribe(to);
 
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
         to.assertFuseable()
         .assertFusionMode(QueueFuseable.ASYNC)
@@ -665,9 +665,9 @@ public class ObservableDoOnEachTest extends RxJavaTest {
 
         final int[] call = { 0, 0 };
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
+        UnicastSubject<Integer> us = UnicastSubject.create();
 
-        up.hide()
+        us.hide()
         .doOnNext(new Consumer<Integer>() {
             @Override
             public void accept(Integer v) throws Exception {
@@ -683,7 +683,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         .filter(Functions.alwaysTrue())
         .subscribe(to);
 
-        TestHelper.emit(up, 1, 2, 3, 4, 5);
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
 
         to.assertFuseable()
         .assertFusionMode(QueueFuseable.NONE)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableObserveOnTest.java
@@ -775,12 +775,12 @@ public class ObservableObserveOnTest extends RxJavaTest {
     public void workerNotDisposedPrematurelyAsyncInNormalOut() {
         DisposeTrackingScheduler s = new DisposeTrackingScheduler();
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
-        up.onNext(1);
-        up.onComplete();
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        us.onNext(1);
+        us.onComplete();
 
         Observable.concat(
-                up.observeOn(s),
+                us.observeOn(s),
                 Observable.just(2)
         )
         .test()

--- a/src/test/java/io/reactivex/rxjava3/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/UnicastProcessorTest.java
@@ -131,14 +131,14 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void onTerminateCalledWhenOnError() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastProcessor<Integer> us = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
             @Override public void run() {
                 didRunOnTerminate.set(true);
             }
         });
 
         assertFalse(didRunOnTerminate.get());
-        us.onError(new RuntimeException("some error"));
+        up.onError(new RuntimeException("some error"));
         assertTrue(didRunOnTerminate.get());
     }
 
@@ -146,14 +146,14 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void onTerminateCalledWhenOnComplete() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastProcessor<Integer> us = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
             @Override public void run() {
                 didRunOnTerminate.set(true);
             }
         });
 
         assertFalse(didRunOnTerminate.get());
-        us.onComplete();
+        up.onComplete();
         assertTrue(didRunOnTerminate.get());
     }
 
@@ -161,13 +161,13 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void onTerminateCalledWhenCanceled() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastProcessor<Integer> us = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
             @Override public void run() {
                 didRunOnTerminate.set(true);
             }
         });
 
-        final Disposable subscribe = us.subscribe();
+        final Disposable subscribe = up.subscribe();
 
         assertFalse(didRunOnTerminate.get());
         subscribe.dispose();
@@ -327,7 +327,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void subscribeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final UnicastProcessor<Integer> us = UnicastProcessor.create();
+            final UnicastProcessor<Integer> up = UnicastProcessor.create();
 
             final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
             final TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
@@ -335,14 +335,14 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    us.subscribe(ts1);
+                    up.subscribe(ts1);
                 }
             };
 
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    us.subscribe(ts2);
+                    up.subscribe(ts2);
                 }
             };
 
@@ -361,67 +361,67 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void hasObservers() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create();
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-        assertFalse(us.hasSubscribers());
+        assertFalse(up.hasSubscribers());
 
-        TestSubscriber<Integer> ts = us.test();
+        TestSubscriber<Integer> ts = up.test();
 
-        assertTrue(us.hasSubscribers());
+        assertTrue(up.hasSubscribers());
 
         ts.cancel();
 
-        assertFalse(us.hasSubscribers());
+        assertFalse(up.hasSubscribers());
     }
 
     @Test
     public void drainFusedFailFast() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create(false);
+        UnicastProcessor<Integer> up = UnicastProcessor.create(false);
 
-        TestSubscriberEx<Integer> ts = us.to(TestHelper.<Integer>testSubscriber(1, QueueFuseable.ANY, false));
+        TestSubscriberEx<Integer> ts = up.to(TestHelper.<Integer>testSubscriber(1, QueueFuseable.ANY, false));
 
-        us.done = true;
-        us.drainFused(ts);
+        up.done = true;
+        up.drainFused(ts);
 
         ts.assertResult();
     }
 
     @Test
     public void drainFusedFailFastEmpty() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create(false);
+        UnicastProcessor<Integer> up = UnicastProcessor.create(false);
 
-        TestSubscriberEx<Integer> ts = us.to(TestHelper.<Integer>testSubscriber(1, QueueFuseable.ANY, false));
+        TestSubscriberEx<Integer> ts = up.to(TestHelper.<Integer>testSubscriber(1, QueueFuseable.ANY, false));
 
-        us.drainFused(ts);
+        up.drainFused(ts);
 
         ts.assertEmpty();
     }
 
     @Test
     public void checkTerminatedFailFastEmpty() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create(false);
+        UnicastProcessor<Integer> up = UnicastProcessor.create(false);
 
-        TestSubscriberEx<Integer> ts = us.to(TestHelper.<Integer>testSubscriber(1, QueueFuseable.ANY, false));
+        TestSubscriberEx<Integer> ts = up.to(TestHelper.<Integer>testSubscriber(1, QueueFuseable.ANY, false));
 
-        us.checkTerminated(true, true, false, ts, us.queue);
+        up.checkTerminated(true, true, false, ts, up.queue);
 
         ts.assertEmpty();
     }
 
     @Test
     public void alreadyCancelled() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create(false);
+        UnicastProcessor<Integer> up = UnicastProcessor.create(false);
 
-        us.test().cancel();
+        up.test().cancel();
 
         BooleanSubscription bs = new BooleanSubscription();
-        us.onSubscribe(bs);
+        up.onSubscribe(bs);
 
         assertTrue(bs.isCancelled());
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            us.onError(new TestException());
+            up.onError(new TestException());
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
@@ -431,9 +431,9 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void unicastSubscriptionBadRequest() {
-        UnicastProcessor<Integer> us = UnicastProcessor.create(false);
+        UnicastProcessor<Integer> up = UnicastProcessor.create(false);
 
-        UnicastProcessor<Integer>.UnicastQueueSubscription usc = (UnicastProcessor<Integer>.UnicastQueueSubscription)us.wip;
+        UnicastProcessor<Integer>.UnicastQueueSubscription usc = (UnicastProcessor<Integer>.UnicastQueueSubscription)up.wip;
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -449,17 +449,17 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
         for (int j = 0; j < TestHelper.RACE_LONG_LOOPS; j++) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                final UnicastProcessor<Integer> us = UnicastProcessor.create();
+                final UnicastProcessor<Integer> up = UnicastProcessor.create();
 
-                TestObserver<Integer> to = us
+                TestObserver<Integer> to = up
                 .observeOn(Schedulers.io())
                 .map(Functions.<Integer>identity())
                 .observeOn(Schedulers.single())
                 .firstOrError()
                 .test();
 
-                for (int i = 0; us.hasSubscribers(); i++) {
-                    us.onNext(i);
+                for (int i = 0; up.hasSubscribers(); i++) {
+                    up.onNext(i);
                 }
 
                 to

--- a/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
@@ -228,14 +228,14 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void completeCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final int[] calls = { 0 };
-            final UnicastSubject<Object> up = UnicastSubject.create(100, new Runnable() {
+            final UnicastSubject<Object> us = UnicastSubject.create(100, new Runnable() {
                 @Override
                 public void run() {
                     calls[0]++;
                 }
             });
 
-            final TestObserver<Object> to = up.test();
+            final TestObserver<Object> to = us.test();
 
             Runnable r1 = new Runnable() {
                 @Override
@@ -247,7 +247,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
             Runnable r2 = new Runnable() {
                 @Override
                 public void run() {
-                    up.onComplete();
+                    us.onComplete();
                 }
             };
 

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverExTest.java
@@ -1094,16 +1094,16 @@ public class TestObserverExTest extends RxJavaTest {
         TestObserverEx<Object> to = new TestObserverEx<>();
         to.setInitialFusionMode(QueueFuseable.ANY);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
+        UnicastSubject<Integer> us = UnicastSubject.create();
 
-        up
+        us
         .map(new Function<Integer, Object>() {
             @Override
             public Object apply(Integer v) throws Exception { throw new TestException(); }
         })
         .subscribe(to);
 
-        up.onNext(1);
+        us.onNext(1);
 
         to.assertSubscribed()
         .assertFuseable()
@@ -1132,13 +1132,13 @@ public class TestObserverExTest extends RxJavaTest {
         TestObserverEx<Object> to = new TestObserverEx<>();
         to.setInitialFusionMode(QueueFuseable.ANY);
 
-        UnicastSubject<Integer> up = UnicastSubject.create();
+        UnicastSubject<Integer> us = UnicastSubject.create();
 
-        up
+        us
         .subscribe(to);
 
-        up.onNext(1);
-        up.onComplete();
+        us.onNext(1);
+        us.onComplete();
 
         to.assertSubscribed()
         .assertFuseable()

--- a/src/test/java/io/reactivex/rxjava3/validators/CheckLocalVariablesInTests.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/CheckLocalVariablesInTests.java
@@ -94,7 +94,15 @@ public class CheckLocalVariablesInTests {
                                                 .append(fname)
                                                 .append("#L").append(lineNum)
                                                 .append("    ").append(line)
-                                                .append("\n");
+                                                .append("\n")
+                                                .append(" at ")
+                                                .append(fname.replace(".java", ""))
+                                                .append(".method(")
+                                                .append(fname)
+                                                .append(":")
+                                                .append(lineNum)
+                                                .append(")\n");
+
                                                 total++;
                                             }
                                         }
@@ -111,9 +119,7 @@ public class CheckLocalVariablesInTests {
             }
         }
         if (total != 0) {
-            fail.append("Found ")
-            .append(total)
-            .append(" instances");
+            fail.insert(0, "Found " + total + " instances");
             System.out.println(fail);
             throw new AssertionError(fail.toString());
         }
@@ -147,6 +153,16 @@ public class CheckLocalVariablesInTests {
     @Test
     public void publishProcessorAsPs() throws Exception {
         findPattern("PublishProcessor<.*>\\s+ps");
+    }
+
+    @Test
+    public void unicastSubjectAsUp() throws Exception {
+        findPattern("UnicastSubject<.*>\\s+up");
+    }
+
+    @Test
+    public void unicastProcessorAsUs() throws Exception {
+        findPattern("UnicastProcessor<.*>\\s+us");
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/validators/JavadocWording.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/JavadocWording.java
@@ -57,8 +57,8 @@ public class JavadocWording {
                                 && !m.signature.contains("Flowable")
                                 && !m.signature.contains("Observable")
                                 && !m.signature.contains("ObservableSource")) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Maybe doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -74,8 +74,8 @@ public class JavadocWording {
                                 && !m.signature.contains("Flowable")
                                 && !m.signature.contains("TestSubscriber")
                         ) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Subscriber but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -90,8 +90,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Publisher")
                                 && !m.signature.contains("Flowable")
                         ) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions Subscription but not using Flowable\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Subscription but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -108,8 +108,8 @@ public class JavadocWording {
                                 && !m.signature.contains("TestObserver")) {
 
                             if (idx < 5 || !m.javadoc.substring(idx - 5, idx + 8).equals("MaybeObserver")) {
-                                e.append("java.lang.RuntimeException: Maybe doc mentions Observer but not using Observable\r\n at io.reactivex.")
-                                .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Maybe doc mentions Observer but not using Observable\r\n at io.reactivex.rxjava3.core.")
+                                .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
 
@@ -124,8 +124,8 @@ public class JavadocWording {
                     if (idx >= 0) {
                         if (!m.signature.contains("Publisher")) {
                             if (idx == 0 || !m.javadoc.substring(idx - 1, idx + 9).equals("(Publisher")) {
-                                e.append("java.lang.RuntimeException: Maybe doc mentions Publisher but not in the signature\r\n at io.reactivex.")
-                                .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Maybe doc mentions Publisher but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
 
@@ -139,8 +139,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Flowable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Flowable")) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions Flowable but not in the signature\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Flowable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -154,7 +154,7 @@ public class JavadocWording {
                         int j = m.javadoc.indexOf("#toSingle", jdx);
                         int k = m.javadoc.indexOf("{@code Single", jdx);
                         if (!m.signature.contains("Single") && (j + 3 != idx && k + 7 != idx)) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions Single but not in the signature\r\n at io.reactivex.")
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Single but not in the signature\r\n at io.reactivex.rxjava3.core.")
                             .append("Maybe(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
@@ -167,8 +167,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("SingleSource", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("SingleSource")) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions SingleSource but not in the signature\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Maybe doc mentions SingleSource but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -180,8 +180,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Observable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Observable")) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions Observable but not in the signature\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Maybe doc mentions Observable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -193,8 +193,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("ObservableSource", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("ObservableSource")) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Maybe doc mentions ObservableSource but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -233,8 +233,8 @@ public class JavadocWording {
                                 && !m.signature.contains("MaybeSource")
                                 && !m.signature.contains("Single")
                                 && !m.signature.contains("SingleSource")) {
-                            e.append("java.lang.RuntimeException: Flowable doc mentions onSuccess\r\n at io.reactivex.")
-                            .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Flowable doc mentions onSuccess\r\n at io.reactivex.rxjava3.core.")
+                            .append("Flowable.method(Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -248,8 +248,8 @@ public class JavadocWording {
                     if (idx >= 0) {
                         if (!m.signature.contains("ObservableSource")
                                 && !m.signature.contains("Observable")) {
-                            e.append("java.lang.RuntimeException: Flowable doc mentions Observer but not using Flowable\r\n at io.reactivex.")
-                            .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Flowable doc mentions Observer but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Flowable.method(Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -273,8 +273,8 @@ public class JavadocWording {
                         ) {
                             CharSequence subSequence = m.javadoc.subSequence(idx - 6, idx + 11);
                             if (idx < 6 || !subSequence.equals("{@link Disposable")) {
-                                e.append("java.lang.RuntimeException: Flowable doc mentions Disposable but not using Flowable\r\n at io.reactivex.")
-                                .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Flowable doc mentions Disposable but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                                .append("Flowable.method(Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
 
@@ -288,8 +288,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Observable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Observable")) {
-                            e.append("java.lang.RuntimeException: Flowable doc mentions Observable but not in the signature\r\n at io.reactivex.")
-                            .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Flowable doc mentions Observable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Flowable.method(Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -302,8 +302,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("ObservableSource", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("ObservableSource")) {
-                            e.append("java.lang.RuntimeException: Flowable doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
-                            .append("Flowable (Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Flowable doc mentions ObservableSource but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Flowable.method(Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -342,8 +342,8 @@ public class JavadocWording {
                                 && !m.signature.contains("MaybeSource")
                                 && !m.signature.contains("Single")
                                 && !m.signature.contains("SingleSource")) {
-                            e.append("java.lang.RuntimeException: Observable doc mentions onSuccess\r\n at io.reactivex.")
-                            .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Observable doc mentions onSuccess\r\n at io.reactivex.rxjava3.core.")
+                            .append("Observable.method(Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -358,8 +358,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Flowable")
                                 && !m.signature.contains("Publisher")
                         ) {
-                            e.append("java.lang.RuntimeException: Observable doc mentions Subscription but not using Flowable\r\n at io.reactivex.")
-                            .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Observable doc mentions Subscription but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Observable.method(Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -373,8 +373,8 @@ public class JavadocWording {
                     if (idx >= 0) {
                         if (!m.signature.contains("Flowable")) {
                             if (idx < 6 || !m.javadoc.substring(idx - 6, idx + 8).equals("@link Flowable")) {
-                                e.append("java.lang.RuntimeException: Observable doc mentions Flowable but not in the signature\r\n at io.reactivex.")
-                                .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Observable doc mentions Flowable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Observable.method(Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
 
@@ -388,8 +388,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Publisher", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Publisher")) {
-                            e.append("java.lang.RuntimeException: Observable doc mentions Publisher but not in the signature\r\n at io.reactivex.")
-                            .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Observable doc mentions Publisher but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Observable.method(Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -402,8 +402,8 @@ public class JavadocWording {
                     if (idx >= 0) {
                         if (!m.signature.contains("Publisher")
                                 && !m.signature.contains("Flowable")) {
-                            e.append("java.lang.RuntimeException: Observable doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
-                            .append("Observable (Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Observable doc mentions Subscriber but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Observable.method(Observable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -443,8 +443,8 @@ public class JavadocWording {
                                 && !m.signature.contains("Flowable")
                                 && !m.signature.contains("Observable")
                                 && !m.signature.contains("ObservableSource")) {
-                            e.append("java.lang.RuntimeException: Single doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.")
-                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Single doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -459,8 +459,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Publisher")
                                 && !m.signature.contains("Flowable")
                                 && !m.signature.contains("TestSubscriber")) {
-                            e.append("java.lang.RuntimeException: Single doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
-                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Single doc mentions Subscriber but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -475,8 +475,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Flowable")
                                 && !m.signature.contains("Publisher")
                         ) {
-                            e.append("java.lang.RuntimeException: Single doc mentions Subscription but not using Flowable\r\n at io.reactivex.")
-                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Single doc mentions Subscription but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -493,8 +493,8 @@ public class JavadocWording {
                                 && !m.signature.contains("TestObserver")) {
 
                             if (idx < 6 || !m.javadoc.substring(idx - 6, idx + 8).equals("SingleObserver")) {
-                                e.append("java.lang.RuntimeException: Single doc mentions Observer but not using Observable\r\n at io.reactivex.")
-                                .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Single doc mentions Observer but not using Observable\r\n at io.reactivex.rxjava3.core.")
+                                .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
 
@@ -509,8 +509,8 @@ public class JavadocWording {
                     if (idx >= 0) {
                         if (!m.signature.contains("Publisher")) {
                             if (idx == 0 || !m.javadoc.substring(idx - 1, idx + 9).equals("(Publisher")) {
-                                e.append("java.lang.RuntimeException: Single doc mentions Publisher but not in the signature\r\n at io.reactivex.")
-                                .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Single doc mentions Publisher but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
 
@@ -524,8 +524,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf(" Flowable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Flowable")) {
-                            e.append("java.lang.RuntimeException: Single doc mentions Flowable but not in the signature\r\n at io.reactivex.")
-                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Single doc mentions Flowable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -537,8 +537,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf(" Maybe", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Maybe")) {
-                            e.append("java.lang.RuntimeException: Single doc mentions Maybe but not in the signature\r\n at io.reactivex.")
-                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Single doc mentions Maybe but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -550,8 +550,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf(" MaybeSource", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("MaybeSource")) {
-                            e.append("java.lang.RuntimeException: Single doc mentions SingleSource but not in the signature\r\n at io.reactivex.")
-                            .append("Maybe (Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Single doc mentions SingleSource but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -563,8 +563,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf(" Observable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Observable")) {
-                            e.append("java.lang.RuntimeException: Single doc mentions Observable but not in the signature\r\n at io.reactivex.")
-                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Single doc mentions Observable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -576,8 +576,8 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf(" ObservableSource", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("ObservableSource")) {
-                            e.append("java.lang.RuntimeException: Single doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
-                            .append("Single (Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Single doc mentions ObservableSource but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Single.method(Single.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
                         jdx = idx + 6;
                     } else {
@@ -617,8 +617,8 @@ public class JavadocWording {
                                 && !m.signature.contains("Flowable")
                                 && !m.signature.contains("Observable")
                                 && !m.signature.contains("ObservableSource")) {
-                            e.append("java.lang.RuntimeException: Completable doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.")
-                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Completable doc mentions onNext but no Flowable/Observable in signature\r\n at io.reactivex.rxjava3.core.")
+                            .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -633,8 +633,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Publisher")
                                 && !m.signature.contains("Flowable")
                                 && !m.signature.contains("TestSubscriber")) {
-                            e.append("java.lang.RuntimeException: Completable doc mentions Subscriber but not using Flowable\r\n at io.reactivex.")
-                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Completable doc mentions Subscriber but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -649,8 +649,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Flowable")
                                 && !m.signature.contains("Publisher")
                         ) {
-                            e.append("java.lang.RuntimeException: Completable doc mentions Subscription but not using Flowable\r\n at io.reactivex.")
-                            .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            e.append("java.lang.RuntimeException: Completable doc mentions Subscription but not using Flowable\r\n at io.reactivex.rxjava3.core.")
+                            .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                         }
 
                         jdx = idx + 6;
@@ -667,8 +667,8 @@ public class JavadocWording {
                                 && !m.signature.contains("TestObserver")) {
 
                             if (idx < 11 || !m.javadoc.substring(idx - 11, idx + 8).equals("CompletableObserver")) {
-                                e.append("java.lang.RuntimeException: Completable doc mentions Observer but not using Observable\r\n at io.reactivex.")
-                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Completable doc mentions Observer but not using Observable\r\n at io.reactivex.rxjava3.core.")
+                                .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
 
@@ -683,8 +683,8 @@ public class JavadocWording {
                     if (idx >= 0) {
                         if (!m.signature.contains("Publisher")) {
                             if (idx == 0 || !m.javadoc.substring(idx - 1, idx + 9).equals("(Publisher")) {
-                                e.append("java.lang.RuntimeException: Completable doc mentions Publisher but not in the signature\r\n at io.reactivex.")
-                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Completable doc mentions Publisher but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
 
@@ -700,8 +700,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Flowable")) {
                             Pattern p = Pattern.compile("@see\\s+#[A-Za-z0-9 _.,()]*Flowable");
                             if (!p.matcher(m.javadoc).find()) {
-                                e.append("java.lang.RuntimeException: Completable doc mentions Flowable but not in the signature\r\n at io.reactivex.")
-                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Completable doc mentions Flowable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
                         jdx = idx + 6;
@@ -716,8 +716,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Single")) {
                             Pattern p = Pattern.compile("@see\\s+#[A-Za-z0-9 _.,()]*Single");
                             if (!p.matcher(m.javadoc).find()) {
-                                e.append("java.lang.RuntimeException: Completable doc mentions Single but not in the signature\r\n at io.reactivex.")
-                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Completable doc mentions Single but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
                         jdx = idx + 6;
@@ -732,8 +732,8 @@ public class JavadocWording {
                         if (!m.signature.contains("SingleSource")) {
                             Pattern p = Pattern.compile("@see\\s+#[A-Za-z0-9 _.,()]*SingleSource");
                             if (!p.matcher(m.javadoc).find()) {
-                                e.append("java.lang.RuntimeException: Completable doc mentions SingleSource but not in the signature\r\n at io.reactivex.")
-                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Completable doc mentions SingleSource but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
                         jdx = idx + 6;
@@ -748,8 +748,8 @@ public class JavadocWording {
                         if (!m.signature.contains("Observable")) {
                             Pattern p = Pattern.compile("@see\\s+#[A-Za-z0-9 _.,()]*Observable");
                             if (!p.matcher(m.javadoc).find()) {
-                                e.append("java.lang.RuntimeException: Completable doc mentions Observable but not in the signature\r\n at io.reactivex.")
-                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Completable doc mentions Observable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
                         jdx = idx + 6;
@@ -764,8 +764,8 @@ public class JavadocWording {
                         if (!m.signature.contains("ObservableSource")) {
                             Pattern p = Pattern.compile("@see\\s+#[A-Za-z0-9 _.,()]*ObservableSource");
                             if (!p.matcher(m.javadoc).find()) {
-                                e.append("java.lang.RuntimeException: Completable doc mentions ObservableSource but not in the signature\r\n at io.reactivex.")
-                                .append("Completable (Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                                e.append("java.lang.RuntimeException: Completable doc mentions ObservableSource but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Completable.method(Completable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
                         }
                         jdx = idx + 6;
@@ -807,9 +807,9 @@ public class JavadocWording {
             if (idx >= 0) {
                 e.append("java.lang.RuntimeException: a/an typo ")
                 .append(word)
-                .append("\r\n at io.reactivex.")
+                .append("\r\n at io.reactivex.rxjava3.core.")
                 .append(baseTypeName)
-                .append(" (")
+                .append(".method(")
                 .append(baseTypeName)
                 .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                 jdx = idx + 6;
@@ -824,9 +824,9 @@ public class JavadocWording {
             if (idx >= 0) {
                 e.append("java.lang.RuntimeException: a/an typo ")
                 .append(word)
-                .append("\r\n at io.reactivex.")
+                .append("\r\n at io.reactivex.rxjava3.core.")
                 .append(baseTypeName)
-                .append(" (")
+                .append(".method(")
                 .append(baseTypeName)
                 .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                 jdx = idx + 6;
@@ -841,9 +841,9 @@ public class JavadocWording {
             if (idx >= 0) {
                 e.append("java.lang.RuntimeException: a/an typo ")
                 .append(word)
-                .append("\r\n at io.reactivex.")
+                .append("\r\n at io.reactivex.rxjava3.core.")
                 .append(baseTypeName)
-                .append(" (")
+                .append(".method(")
                 .append(baseTypeName)
                 .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                 jdx = idx + 6;
@@ -858,9 +858,9 @@ public class JavadocWording {
             if (idx >= 0) {
                 e.append("java.lang.RuntimeException: a/an typo ")
                 .append(word)
-                .append("\r\n at io.reactivex.")
+                .append("\r\n at io.reactivex.rxjava3.core.")
                 .append(baseTypeName)
-                .append(" (")
+                .append(".method(")
                 .append(baseTypeName)
                 .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                 jdx = idx + 6;
@@ -895,9 +895,9 @@ public class JavadocWording {
             if (idx >= 0) {
                 e.append("java.lang.RuntimeException: a/an typo ")
                 .append(word)
-                .append("\r\n at io.reactivex.")
+                .append("\r\n at io.reactivex.rxjava3.core.")
                 .append(baseTypeName)
-                .append(" (")
+                .append(".method(")
                 .append(baseTypeName)
                 .append(".java:").append(m.javadocLine).append(")\r\n\r\n");
                 jdx = idx + wrongPre.length() + 1 + word.length();
@@ -923,9 +923,9 @@ public class JavadocWording {
                 jdx = idx2 + 5;
             } else {
                 e.append("java.lang.RuntimeException: unbalanced <dd></dd> ")
-                .append("\r\n at io.reactivex.")
+                .append("\r\n at io.reactivex.rxjava3.core.")
                 .append(baseTypeName)
-                .append(" (")
+                .append(".method(")
                 .append(baseTypeName)
                 .append(".java:").append(m.javadocLine + lineNumber(m.javadoc, idx1) - 1).append(")\r\n\r\n");
                 break;
@@ -936,9 +936,9 @@ public class JavadocWording {
     static void backpressureMentionedWithoutAnnotation(StringBuilder e, RxMethod m, String baseTypeName) {
         if (m.backpressureDocLine > 0 && m.backpressureKind == null) {
             e.append("java.lang.RuntimeException: backpressure documented but not annotated ")
-            .append("\r\n at io.reactivex.")
+            .append("\r\n at io.reactivex.rxjava3.core.")
             .append(baseTypeName)
-            .append(" (")
+            .append(".method(")
             .append(baseTypeName)
             .append(".java:").append(m.backpressureDocLine).append(")\r\n\r\n");
         }

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -509,6 +509,10 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "singleStage", Object.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "lastStage", Object.class));
 
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "firstStage", Object.class));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "singleStage", Object.class));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "lastStage", Object.class));
+
         addOverride(new ParamOverride(Maybe.class, 0, ParamMode.ANY, "toCompletionStage", Object.class));
         addOverride(new ParamOverride(Completable.class, 0, ParamMode.ANY, "toCompletionStage", Object.class));
 


### PR DESCRIPTION
Add the following Java 8 operators to `Observable`:

- `fromOptional`
- `fromCompletionStage`
- `fromStream`
- `firstStage`
- `firstOrErrorStage`
- `singeStage`
- `singleOrErrorStage`
- `lastStage`
- `lastOrErrorStage`
- `blockingStream`
- `mapOptional`
- `collect`
- `concatMapStream` / `flatMapStream`

In addition, some validators received reporting improvements (such as using ` at ` so the IDE can jump to the exact line of the issue). Consequently, all local variable misnaming of `UnicastSubject up` and `UnicastProcessor us` have been fixed as well.

Related #6776