### PR TITLE
3.x: XProcessor.offer to throw NPE immediately

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
@@ -234,11 +234,11 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      */
     BehaviorProcessor(T defaultValue) {
         this();
-        this.value.lazySet(Objects.requireNonNull(defaultValue, "defaultValue is null"));
+        this.value.lazySet(defaultValue);
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> s) {
+    protected void subscribeActual(@NonNull Subscriber<? super T> s) {
         BehaviorSubscription<T> bs = new BehaviorSubscription<>(s, this);
         s.onSubscribe(bs);
         if (add(bs)) {
@@ -258,7 +258,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    public void onSubscribe(Subscription s) {
+    public void onSubscribe(@NonNull Subscription s) {
         if (terminalEvent.get() != null) {
             s.cancel();
             return;
@@ -267,7 +267,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
 
         if (terminalEvent.get() != null) {
@@ -281,7 +281,7 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (!terminalEvent.compareAndSet(null, t)) {
             RxJavaPlugins.onError(t);
@@ -316,14 +316,13 @@ public final class BehaviorProcessor<T> extends FlowableProcessor<T> {
      * <p>History: 2.0.8 - experimental
      * @param t the item to emit, not null
      * @return true if the item was emitted to all Subscribers
+     * @throws NullPointerException if {@code t} is {@code null}
      * @since 2.2
      */
     @CheckReturnValue
-    public boolean offer(T t) {
-        if (t == null) {
-            onError(ExceptionHelper.createNullPointerException("offer called with a null value."));
-            return true;
-        }
+    public boolean offer(@NonNull T t) {
+        ExceptionHelper.nullCheck(t, "offer called with a null value.");
+
         BehaviorSubscription<T>[] array = subscribers.get();
 
         for (BehaviorSubscription<T> s : array) {

--- a/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
@@ -141,7 +141,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    protected void subscribeActual(Subscriber<? super T> t) {
+    protected void subscribeActual(@NonNull Subscriber<? super T> t) {
         PublishSubscription<T> ps = new PublishSubscription<>(t, this);
         t.onSubscribe(ps);
         if (add(ps)) {
@@ -226,7 +226,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    public void onSubscribe(Subscription s) {
+    public void onSubscribe(@NonNull Subscription s) {
         if (subscribers.get() == TERMINATED) {
             s.cancel();
             return;
@@ -236,7 +236,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         for (PublishSubscription<T> s : subscribers.get()) {
             s.onNext(t);
@@ -245,7 +245,7 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (subscribers.get() == TERMINATED) {
             RxJavaPlugins.onError(t);
@@ -281,14 +281,13 @@ public final class PublishProcessor<T> extends FlowableProcessor<T> {
      * <p>History: 2.0.8 - experimental
      * @param t the item to emit, not null
      * @return true if the item was emitted to all Subscribers
+     * @throws NullPointerException if {@code t} is {@code null}
      * @since 2.2
      */
     @CheckReturnValue
-    public boolean offer(T t) {
-        if (t == null) {
-            onError(ExceptionHelper.createNullPointerException("offer called with a null value."));
-            return true;
-        }
+    public boolean offer(@NonNull T t) {
+        ExceptionHelper.nullCheck(t, "offer called with a null value.");
+
         PublishSubscription<T>[] array = subscribers.get();
 
         for (PublishSubscription<T> s : array) {

--- a/src/test/java/io/reactivex/rxjava3/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/BehaviorProcessorTest.java
@@ -673,12 +673,14 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
         ts = pp.test(1);
 
-        assertTrue(pp.offer(null));
+        try {
+            pp.offer(null);
+            fail("Should have thrown NPE!");
+        } catch (NullPointerException expected) {
+            // expected
+        }
 
-        ts.assertFailure(NullPointerException.class, 2);
-
-        assertTrue(pp.hasThrowable());
-        assertTrue(pp.getThrowable().toString(), pp.getThrowable() instanceof NullPointerException);
+        ts.assertValuesOnly(2);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/processors/MulticastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/MulticastProcessorTest.java
@@ -466,7 +466,12 @@ public class MulticastProcessorTest extends RxJavaTest {
             up.onNext(i);
         }
 
-        assertFalse(mp.offer(10));
+        try {
+            mp.offer(10);
+            fail("Should have thrown IllegalStateException");
+        } catch (IllegalStateException expected) {
+            // expected
+        }
 
         up.onComplete();
 

--- a/src/test/java/io/reactivex/rxjava3/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/PublishProcessorTest.java
@@ -597,12 +597,14 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
         ts = pp.test(0);
 
-        assertTrue(pp.offer(null));
+        try {
+            pp.offer(null);
+            fail("Should have thrown NPE!");
+        } catch (NullPointerException expected) {
+            // expected
+        }
 
-        ts.assertFailure(NullPointerException.class);
-
-        assertTrue(pp.hasThrowable());
-        assertTrue(pp.getThrowable().toString(), pp.getThrowable() instanceof NullPointerException);
+        ts.assertEmpty();
     }
 
     @Test


### PR DESCRIPTION
Make `offer` throw a `NullPointerException` immediately instead of turning it into an error signal. In addition, have `MulticastProcessor.offer` throw an `IllegalStateException` if called when the processor is in fusion mode.

Resolves #6794 