### PR TITLE
3.x: Add missing throwIfFatal calls

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/disposables/AutoCloseableDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/disposables/AutoCloseableDisposable.java
@@ -14,7 +14,7 @@
 package io.reactivex.rxjava3.disposables;
 
 import io.reactivex.rxjava3.annotations.NonNull;
-import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 
 /**
  * A disposable container that manages an {@link AutoCloseable} instance.
@@ -33,7 +33,7 @@ final class AutoCloseableDisposable extends ReferenceDisposable<AutoCloseable> {
         try {
             value.close();
         } catch (Throwable ex) {
-            RxJavaPlugins.onError(ex);
+            throw ExceptionHelper.wrapOrThrow(ex);
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStream.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.*;
-import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.fuseable.*;
 import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
@@ -61,6 +61,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
                     stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
                 }
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 EmptySubscription.error(ex, s);
                 return;
             }
@@ -243,6 +244,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
                         try {
                             t = queue.poll();
                         } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
                             trySignalError(downstream, ex);
                             continue;
                         }
@@ -271,6 +273,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
                                     iterator = null;
                                 }
                             } catch (Throwable ex) {
+                                Exceptions.throwIfFatal(ex);
                                 trySignalError(downstream, ex);
                             }
                             continue;
@@ -282,6 +285,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
                         try {
                             item = Objects.requireNonNull(iterator.next(), "The Stream.Iterator returned a null value");
                         } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
                             trySignalError(downstream, ex);
                             continue;
                         }
@@ -297,6 +301,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
                                         clearCurrentRethrowCloseError();
                                     }
                                 } catch (Throwable ex) {
+                                    Exceptions.throwIfFatal(ex);
                                     trySignalError(downstream, ex);
                                 }
                             }
@@ -328,6 +333,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
             try {
                 clearCurrentRethrowCloseError();
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 RxJavaPlugins.onError(ex);
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFlatMapStream.java
@@ -55,6 +55,7 @@ public final class ObservableFlatMapStream<T, R> extends Observable<R> {
                     stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
                 }
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 EmptyDisposable.error(ex, observer);
                 return;
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCollect.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCollect.java
@@ -39,6 +39,7 @@ public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T,
         try {
             u = Objects.requireNonNull(initialSupplier.get(), "The initial value supplied is null");
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptySubscription.error(e, s);
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCollectSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCollectSingle.java
@@ -44,6 +44,7 @@ public final class FlowableCollectSingle<T, U> extends Single<U> implements Fuse
         try {
             u = Objects.requireNonNull(initialSupplier.get(), "The initialSupplier returned a null value");
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, observer);
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnEach.java
@@ -159,6 +159,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
                 try {
                     onError.accept(ex);
                 } catch (Throwable exc) {
+                    Exceptions.throwIfFatal(exc);
                     throw new CompositeException(ex, exc);
                 }
                 throw ExceptionHelper.<Exception>throwIfThrowable(ex);
@@ -173,6 +174,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
                         try {
                             onError.accept(ex);
                         } catch (Throwable exc) {
+                            Exceptions.throwIfFatal(exc);
                             throw new CompositeException(ex, exc);
                         }
                         throw ExceptionHelper.<Exception>throwIfThrowable(ex);
@@ -314,6 +316,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
                 try {
                     onError.accept(ex);
                 } catch (Throwable exc) {
+                    Exceptions.throwIfFatal(exc);
                     throw new CompositeException(ex, exc);
                 }
                 throw ExceptionHelper.<Exception>throwIfThrowable(ex);
@@ -328,6 +331,7 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
                         try {
                             onError.accept(ex);
                         } catch (Throwable exc) {
+                            Exceptions.throwIfFatal(exc);
                             throw new CompositeException(ex, exc);
                         }
                         throw ExceptionHelper.<Exception>throwIfThrowable(ex);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplay.java
@@ -209,6 +209,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         try {
             connection.accept(ps);
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             if (doConnect) {
                 ps.shouldConnect.compareAndSet(true, false);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScalarXMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScalarXMap.java
@@ -136,6 +136,7 @@ public final class FlowableScalarXMap {
             try {
                 other = Objects.requireNonNull(mapper.apply(value), "The mapper returned a null Publisher");
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 EmptySubscription.error(e, s);
                 return;
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -245,6 +245,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                                     try {
                                         endSource = Objects.requireNonNull(closingIndicator.apply(startItem), "The closingIndicator returned a null Publisher");
                                     } catch (Throwable ex) {
+                                        Exceptions.throwIfFatal(ex);
                                         upstream.cancel();
                                         startSubscriber.cancel();
                                         resources.dispose();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipIterable.java
@@ -101,7 +101,7 @@ public final class FlowableZipIterable<T, U, V> extends AbstractFlowableWithUpst
             try {
                 u = Objects.requireNonNull(iterator.next(), "The iterator returned a null value");
             } catch (Throwable e) {
-                error(e);
+                fail(e);
                 return;
             }
 
@@ -109,7 +109,7 @@ public final class FlowableZipIterable<T, U, V> extends AbstractFlowableWithUpst
             try {
                 v = Objects.requireNonNull(zipper.apply(t, u), "The zipper function returned a null value");
             } catch (Throwable e) {
-                error(e);
+                fail(e);
                 return;
             }
 
@@ -120,7 +120,7 @@ public final class FlowableZipIterable<T, U, V> extends AbstractFlowableWithUpst
             try {
                 b = iterator.hasNext();
             } catch (Throwable e) {
-                error(e);
+                fail(e);
                 return;
             }
 
@@ -131,7 +131,7 @@ public final class FlowableZipIterable<T, U, V> extends AbstractFlowableWithUpst
             }
         }
 
-        void error(Throwable e) {
+        void fail(Throwable e) {
             Exceptions.throwIfFatal(e);
             done = true;
             upstream.cancel();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromFuture.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromFuture.java
@@ -52,6 +52,7 @@ public final class MaybeFromFuture<T> extends Maybe<T> {
                     v = future.get(timeout, unit);
                 }
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 if (ex instanceof ExecutionException) {
                     ex = ex.getCause();
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBuffer.java
@@ -186,6 +186,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
                 try {
                     b = ExceptionHelper.nullCheck(bufferSupplier.get(), "The bufferSupplier returned a null Collection.");
                 } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
                     buffers.clear();
                     upstream.dispose();
                     downstream.onError(e);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollect.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollect.java
@@ -14,6 +14,7 @@ package io.reactivex.rxjava3.internal.operators.observable;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.disposables.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
@@ -37,6 +38,7 @@ public final class ObservableCollect<T, U> extends AbstractObservableWithUpstrea
         try {
             u = Objects.requireNonNull(initialSupplier.get(), "The initialSupplier returned a null value");
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
             return;
         }
@@ -86,6 +88,7 @@ public final class ObservableCollect<T, U> extends AbstractObservableWithUpstrea
             try {
                 collector.accept(u, t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 upstream.dispose();
                 onError(e);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollectSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollectSingle.java
@@ -14,6 +14,7 @@ package io.reactivex.rxjava3.internal.operators.observable;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.disposables.*;
 import io.reactivex.rxjava3.internal.fuseable.FuseToObservable;
@@ -41,6 +42,7 @@ public final class ObservableCollectSingle<T, U> extends Single<U> implements Fu
         try {
             u = Objects.requireNonNull(initialSupplier.get(), "The initialSupplier returned a null value");
         } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
             EmptyDisposable.error(e, t);
             return;
         }
@@ -94,6 +96,7 @@ public final class ObservableCollectSingle<T, U> extends Single<U> implements Fu
             try {
                 collector.accept(u, t);
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 upstream.dispose();
                 onError(e);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplay.java
@@ -205,6 +205,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         try {
             connection.accept(ps);
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             if (doConnect) {
                 ps.shouldConnect.compareAndSet(true, false);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScalarXMap.java
@@ -140,6 +140,7 @@ public final class ObservableScalarXMap {
             try {
                 other = Objects.requireNonNull(mapper.apply(value), "The mapper returned a null ObservableSource");
             } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
                 EmptyDisposable.error(e, observer);
                 return;
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -237,6 +237,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                                 try {
                                     endSource = Objects.requireNonNull(closingIndicator.apply(startItem), "The closingIndicator returned a null ObservableSource");
                                 } catch (Throwable ex) {
+                                    Exceptions.throwIfFatal(ex);
                                     upstream.dispose();
                                     startObserver.dispose();
                                     resources.dispose();

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTask.java
@@ -20,6 +20,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
@@ -56,6 +57,7 @@ final class InstantPeriodicTask implements Callable<Void>, Disposable {
             setRest(executor.submit(this));
             runner = null;
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             runner = null;
             RxJavaPlugins.onError(ex);
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -16,6 +16,7 @@
 
 package io.reactivex.rxjava3.internal.schedulers;
 
+import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -38,6 +39,7 @@ public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implem
             runnable.run();
             runner = null;
         } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
             runner = null;
             lazySet(FINISHED);
             RxJavaPlugins.onError(ex);

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;
 
 /**
@@ -108,6 +109,7 @@ public final class SchedulerPoolFactory {
                 }
                 return Integer.parseInt(value);
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 return defaultNotFound;
             }
         }
@@ -123,6 +125,7 @@ public final class SchedulerPoolFactory {
                 }
                 return "true".equals(value);
             } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
                 return defaultNotFound;
             }
         }

--- a/src/test/java/io/reactivex/rxjava3/disposables/DisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/DisposableTest.java
@@ -213,17 +213,20 @@ public class DisposableTest extends RxJavaTest {
 
             assertTrue(errors.isEmpty());
 
+            try {
+                d.dispose();
+                fail("Should have thrown!");
+            } catch (TestException expected) {
+                // expected
+            }
+
+            assertTrue(d.isDisposed());
+
             d.dispose();
 
             assertTrue(d.isDisposed());
-            assertEquals(1, errors.size());
 
-            d.dispose();
-
-            assertTrue(d.isDisposed());
-            assertEquals(1, errors.size());
-
-            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+            assertTrue(errors.isEmpty());
         });
     }
 

--- a/src/test/java/io/reactivex/rxjava3/validators/CatchThrowIfFatalCheck.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/CatchThrowIfFatalCheck.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.validators;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+/**
+ * Check if a {@code catch(Throwable} is followed by a
+ * {@code Exceptions.throwIfFatal}, {@code Exceptions.wrapOrThrow}
+ * or {@code fail} call.
+ * @since 3.0.0
+ */
+public class CatchThrowIfFatalCheck {
+
+    @Test
+    public void check() throws Exception {
+        File f = TestHelper.findSource("Flowable");
+        if (f == null) {
+            System.out.println("Unable to find sources of RxJava");
+            return;
+        }
+
+        Queue<File> dirs = new ArrayDeque<>();
+
+        StringBuilder fail = new StringBuilder();
+        int errors = 0;
+
+        File parent = f.getParentFile().getParentFile();
+
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/')));
+
+        while (!dirs.isEmpty()) {
+            f = dirs.poll();
+
+            File[] list = f.listFiles();
+            if (list != null && list.length != 0) {
+
+                for (File u : list) {
+                    if (u.isDirectory()) {
+                        dirs.offer(u);
+                    } else {
+                        List<String> lines = Files.readAllLines(u.toPath());
+
+                        for (int i = 0; i < lines.size(); i++) {
+                            String line = lines.get(i).trim();
+
+                            if (line.startsWith("} catch (Throwable ")) {
+                                String next = lines.get(i + 1).trim();
+                                boolean throwIfFatal = next.contains("Exceptions.throwIfFatal");
+                                boolean wrapOrThrow = next.contains("ExceptionHelper.wrapOrThrow");
+                                boolean failCall = next.startsWith("fail(");
+
+                                if (!(throwIfFatal || wrapOrThrow || failCall)) {
+                                    errors++;
+                                    fail.append("Missing Exceptions.throwIfFatal\n    ")
+                                    .append(next)
+                                    .append("\n at ")
+                                    .append(u.getName().replace(".java", ""))
+                                    .append(".method(")
+                                    .append(u.getName())
+                                    .append(":")
+                                    .append(i + 1)
+                                    .append(")\n")
+                                    ;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (errors != 0) {
+            fail.insert(0, "Found " + errors + " cases\n");
+            System.out.println(fail);
+            throw new AssertionError(fail.toString());
+        }
+    }
+}


### PR DESCRIPTION
- Add missing `Exceptions.throwIfFatal` calls in `catch (Throwable ` blocks.
- Add validator that checks for the existence of these `throwIfFatal`, `wrapOrThrow` or `fail` calls.
- Fix `AutoCloseableDisposable` to use `wrapOrThrow` like the other `Disposable` wrapper implementations.

Resolves #6796