### PR TITLE
3.x: Fix diamonds, spelling, unnecessary code

### DIFF
--- a/docs/Backpressure.md
+++ b/docs/Backpressure.md
@@ -34,25 +34,25 @@ The following diagrams show how you could use each of these operators on the bur
 The `sample` operator periodically "dips" into the sequence and emits only the most recently emitted item during each dip:
 
 <img src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/bp.sample.png" width="640" height="260" />​
-````groovy
+```java
 Observable<Integer> burstySampled = bursty.sample(500, TimeUnit.MILLISECONDS);
-````
+```
 
 ### throttleFirst
 The `throttleFirst` operator is similar, but emits not the most recently emitted item, but the first item that was emitted after the previous "dip":
 
 <img src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/bp.throttleFirst.png" width="640" height="260" />​
-````groovy
+```java
 Observable<Integer> burstyThrottled = bursty.throttleFirst(500, TimeUnit.MILLISECONDS);
-````
+```
 
 ### debounce (or throttleWithTimeout)
 The `debounce` operator emits only those items from the source Observable that are not followed by another item within a specified duration:
 
 <img src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/bp.debounce.png" width="640" height="240" />​
-````groovy
+```java
 Observable<Integer> burstyDebounced = bursty.debounce(10, TimeUnit.MILLISECONDS);
-````
+```
 
 ## Buffers and windows
 
@@ -65,14 +65,14 @@ The following diagrams show how you could use each of these operators on the bur
 You could, for example, close and emit a buffer of items from the bursty Observable periodically, at a regular interval of time:
 
 <img src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/bp.buffer2.png" width="640" height="270" />​
-````groovy
+```java
 Observable<List<Integer>> burstyBuffered = bursty.buffer(500, TimeUnit.MILLISECONDS);
-````
+```
 
 Or you could get fancy, and collect items in buffers during the bursty periods and emit them at the end of each burst, by using the `debounce` operator to emit a buffer closing indicator to the `buffer` operator:
 
 <img src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/bp.buffer1.png" width="640" height="500" />​
-````groovy
+```java
 // we have to multicast the original bursty Observable so we can use it
 // both as our source and as the source for our buffer closing selector:
 Observable<Integer> burstyMulticast = bursty.publish().refCount();
@@ -87,16 +87,16 @@ Observable<List<Integer>> burstyBuffered = burstyMulticast.buffer(burstyDebounce
 `window` is similar to `buffer`. One variant of `window` allows you to periodically emit Observable windows of items at a regular interval of time:
 
 <img src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/bp.window1.png" width="640" height="325" />​
-````groovy
+```java
 Observable<Observable<Integer>> burstyWindowed = bursty.window(500, TimeUnit.MILLISECONDS);
 ````
 
 You could also choose to emit a new window each time you have collected a particular number of items from the source Observable:
 
 <img src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/bp.window2.png" width="640" height="325" />​
-````groovy
+```java
 Observable<Observable<Integer>> burstyWindowed = bursty.window(5);
-````
+```
 
 # Callstack blocking as a flow-control alternative to backpressure
 
@@ -110,8 +110,8 @@ When you subscribe to an `Observable` with a `Subscriber`, you can request react
 
 Then, after handling this item (or these items) in `onNext()`, you can call `request()` again to instruct the `Observable` to emit another item (or items).  Here is an example of a `Subscriber` that requests one item at a time from `someObservable`:
 
-````java
-someObservable.subscribe(new Subscriber<t>() {
+```java
+someObservable.subscribe(new Subscriber<T>() {
     @Override
     public void onStart() {
       request(1);
@@ -134,7 +134,7 @@ someObservable.subscribe(new Subscriber<t>() {
       request(1);
     }
 });
-````
+```
 
 You can pass a magic number to `request`, `request(Long.MAX_VALUE)`, to disable reactive pull backpressure and to ask the Observable to emit items at its own pace. `request(0)` is a legal call, but has no effect. Passing values less than zero to `request` will cause an exception to be thrown.
 

--- a/docs/Combining-Observables.md
+++ b/docs/Combining-Observables.md
@@ -2,13 +2,13 @@ This section explains operators you can use to combine multiple Observables.
 
 # Outline
 
-- [`combineLatest`](#combineLatest)
+- [`combineLatest`](#combinelatest)
 - [`join` and `groupJoin`](#joins)
 - [`merge`](#merge)
-- [`mergeDelayError`](#mergeDelayError)
+- [`mergeDelayError`](#mergedelayerror)
 - [`rxjava-joins`](#rxjava-joins)
-- [`startWith`](#startWith)
-- [`switchOnNext`](#switchOnNext)
+- [`startWith`](#startwith)
+- [`switchOnNext`](#switchonnext)
 - [`zip`](#zip)
 
 ## startWith

--- a/docs/How-To-Use-RxJava.md
+++ b/docs/How-To-Use-RxJava.md
@@ -96,9 +96,9 @@ You use the Observable [`just( )`](http://reactivex.io/documentation/operators
 Observable<String> o = Observable.from("a", "b", "c");
 
 def list = [5, 6, 7, 8]
-Observable<Integer> o = Observable.from(list);
+Observable<Integer> o2 = Observable.from(list);
 
-Observable<String> o = Observable.just("one object");
+Observable<String> o3 = Observable.just("one object");
 ```
 
 These converted Observables will synchronously invoke the [`onNext( )`](Observable#onnext-oncompleted-and-onerror) method of any subscriber that subscribes to them, for each item to be emitted by the Observable, and will then invoke the subscriber’s [`onCompleted( )`](Observable#onnext-oncompleted-and-onerror) method.

--- a/docs/Writing-operators-for-2.0.md
+++ b/docs/Writing-operators-for-2.0.md
@@ -1,7 +1,7 @@
 ##### Table of contents
 
   - [Introduction](#introduction)
-    - [Warning on internal components](warning-on-internal-components)
+    - [Warning on internal components](#warning-on-internal-components)
   - [Atomics, serialization, deferred actions](#atomics-serialization-deferred-actions)
     - [Field updaters and Android](#field-updaters-and-android)
     - [Request accounting](#request-accounting)

--- a/src/jmh/java/io/reactivex/rxjava3/core/BinaryFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/BinaryFlatMapPerf.java
@@ -86,48 +86,42 @@ public class BinaryFlatMapPerf {
 
         singleFlatMapPublisher = Single.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return arrayFlowable;
             }
         });
 
         singleFlatMapHidePublisher = Single.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return arrayFlowableHide;
             }
         });
 
         singleFlattenAsPublisher = Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<? extends Integer>>() {
             @Override
-            public Iterable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Iterable<? extends Integer> apply(Integer v) {
                 return list;
             }
         });
 
         maybeFlatMapPublisher = Maybe.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return arrayFlowable;
             }
         });
 
         maybeFlatMapHidePublisher = Maybe.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return arrayFlowableHide;
             }
         });
 
         maybeFlattenAsPublisher = Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<? extends Integer>>() {
             @Override
-            public Iterable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Iterable<? extends Integer> apply(Integer v) {
                 return list;
             }
         });
@@ -140,48 +134,42 @@ public class BinaryFlatMapPerf {
 
         singleFlatMapObservable = Single.just(1).flatMapObservable(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return arrayObservable;
             }
         });
 
         singleFlatMapHideObservable = Single.just(1).flatMapObservable(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return arrayObservableHide;
             }
         });
 
         singleFlattenAsObservable = Single.just(1).flattenAsObservable(new Function<Integer, Iterable<? extends Integer>>() {
             @Override
-            public Iterable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Iterable<? extends Integer> apply(Integer v) {
                 return list;
             }
         });
 
         maybeFlatMapObservable = Maybe.just(1).flatMapObservable(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return arrayObservable;
             }
         });
 
         maybeFlatMapHideObservable = Maybe.just(1).flatMapObservable(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return arrayObservableHide;
             }
         });
 
         maybeFlattenAsObservable = Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<? extends Integer>>() {
             @Override
-            public Iterable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Iterable<? extends Integer> apply(Integer v) {
                 return list;
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/core/CallableAsyncPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/CallableAsyncPerf.java
@@ -68,7 +68,7 @@ public class CallableAsyncPerf {
 
         Callable<Integer> c = new Callable<Integer>() {
             @Override
-            public Integer call() throws Exception {
+            public Integer call() {
                 return 1;
             }
         };
@@ -120,71 +120,71 @@ public class CallableAsyncPerf {
     @Benchmark
     public void observeOnFlowable(Blackhole bh) {
         observeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineFlowable(Blackhole bh) {
         pipelineFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void subscribeOnObservable(Blackhole bh) {
         subscribeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void observeOnObservable(Blackhole bh) {
         observeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineObservable(Blackhole bh) {
         pipelineObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void observeOnSingle(Blackhole bh) {
         observeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void subscribeOnSingle(Blackhole bh) {
         subscribeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineSingle(Blackhole bh) {
         pipelineSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void observeOnCompletable(Blackhole bh) {
         observeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void subscribeOnCompletable(Blackhole bh) {
         subscribeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineCompletable(Blackhole bh) {
         pipelineCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void observeOnMaybe(Blackhole bh) {
         observeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void subscribeOnMaybe(Blackhole bh) {
         subscribeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineMaybe(Blackhole bh) {
         pipelineMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
 }

--- a/src/jmh/java/io/reactivex/rxjava3/core/EachTypeFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/EachTypeFlatMapPerf.java
@@ -114,11 +114,11 @@ public class EachTypeFlatMapPerf {
 
     @Benchmark
     public void singleJust(Blackhole bh) {
-        singleJust.subscribe(new LatchedSingleObserver<Integer>(bh));
+        singleJust.subscribe(new LatchedSingleObserver<>(bh));
     }
 
     @Benchmark
     public void singleJustMapJust(Blackhole bh) {
-        singleJustMapJust.subscribe(new LatchedSingleObserver<Integer>(bh));
+        singleJustMapJust.subscribe(new LatchedSingleObserver<>(bh));
     }
 }

--- a/src/jmh/java/io/reactivex/rxjava3/core/FlatMapJustPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/FlatMapJustPerf.java
@@ -41,14 +41,14 @@ public class FlatMapJustPerf {
 
         flowable = Flowable.fromArray(array).flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Flowable.just(v);
             }
         });
 
         observable = Observable.fromArray(array).flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/core/FlattenCrossMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/FlattenCrossMapPerf.java
@@ -47,14 +47,14 @@ public class FlattenCrossMapPerf {
 
         flowable = Flowable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
+            public Iterable<Integer> apply(Integer v) {
                 return list;
             }
         });
 
         observable = Observable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
+            public Iterable<Integer> apply(Integer v) {
                 return list;
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/core/FlattenJustPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/FlattenJustPerf.java
@@ -44,14 +44,14 @@ public class FlattenJustPerf {
 
         flowable = Flowable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
+            public Iterable<Integer> apply(Integer v) {
                 return singletonList;
             }
         });
 
         observable = Observable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
+            public Iterable<Integer> apply(Integer v) {
                 return singletonList;
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/core/FlattenRangePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/FlattenRangePerf.java
@@ -44,14 +44,14 @@ public class FlattenRangePerf {
 
         flowable = Flowable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
+            public Iterable<Integer> apply(Integer v) {
                 return list;
             }
         });
 
         observable = Observable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
+            public Iterable<Integer> apply(Integer v) {
                 return list;
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/core/FlowableFlatMapCompletableAsyncPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/FlowableFlatMapCompletableAsyncPerf.java
@@ -45,7 +45,7 @@ public class FlowableFlatMapCompletableAsyncPerf implements Action {
     Flowable<Object> flatMap;
 
     @Override
-    public void run() throws Exception {
+    public void run() {
         Blackhole.consumeCPU(work);
     }
 

--- a/src/jmh/java/io/reactivex/rxjava3/core/InputWithIncrementingInteger.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/InputWithIncrementingInteger.java
@@ -43,7 +43,7 @@ public abstract class InputWithIncrementingInteger {
         }
     }
 
-    final class IncrementingIterable implements Iterable<Integer> {
+    static final class IncrementingIterable implements Iterable<Integer> {
 
         final class IncrementingIterator implements Iterator<Integer> {
             int i;
@@ -77,7 +77,7 @@ public abstract class InputWithIncrementingInteger {
         }
     }
 
-    final class IncrementingPublisher implements Publisher<Integer> {
+    static final class IncrementingPublisher implements Publisher<Integer> {
 
         final int size;
 

--- a/src/jmh/java/io/reactivex/rxjava3/core/JustAsyncPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/JustAsyncPerf.java
@@ -113,71 +113,71 @@ public class JustAsyncPerf {
     @Benchmark
     public void observeOnFlowable(Blackhole bh) {
         observeOnFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineFlowable(Blackhole bh) {
         pipelineFlowable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void subscribeOnObservable(Blackhole bh) {
         subscribeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void observeOnObservable(Blackhole bh) {
         observeOnObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineObservable(Blackhole bh) {
         pipelineObservable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void observeOnSingle(Blackhole bh) {
         observeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void subscribeOnSingle(Blackhole bh) {
         subscribeOnSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineSingle(Blackhole bh) {
         pipelineSingle.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void observeOnCompletable(Blackhole bh) {
         observeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void subscribeOnCompletable(Blackhole bh) {
         subscribeOnCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineCompletable(Blackhole bh) {
         pipelineCompletable.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void observeOnMaybe(Blackhole bh) {
         observeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void subscribeOnMaybe(Blackhole bh) {
         subscribeOnMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
     @Benchmark
     public void pipelineMaybe(Blackhole bh) {
         pipelineMaybe.subscribeWith(new PerfAsyncConsumer(bh)).await(1);
-    };
+    }
 
 }

--- a/src/jmh/java/io/reactivex/rxjava3/core/MemoryPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/MemoryPerf.java
@@ -143,31 +143,31 @@ public final class MemoryPerf {
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.just(1);
             }
         }, "just", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.range(1, 10);
             }
         }, "range", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.empty();
             }
         }, "empty", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.fromCallable(new Callable<Object>() {
                     @Override
-                    public Object call() throws Exception {
+                    public Object call() {
                         return 1;
                     }
                 });
@@ -176,38 +176,38 @@ public final class MemoryPerf {
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return new MyRx2Observer();
             }
         }, "consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return new io.reactivex.rxjava3.observers.TestObserver<>();
             }
         }, "test-consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.just(1).subscribeWith(new MyRx2Observer());
             }
         }, "just+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.range(1, 10).subscribeWith(new MyRx2Observer());
             }
         }, "range+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.range(1, 10).map(new Function<Integer, Object>() {
                     @Override
-                    public Object apply(Integer v) throws Exception {
+                    public Object apply(Integer v) {
                         return v;
                     }
                 }).subscribeWith(new MyRx2Observer());
@@ -216,15 +216,15 @@ public final class MemoryPerf {
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.range(1, 10).map(new Function<Integer, Object>() {
                     @Override
-                    public Object apply(Integer v) throws Exception {
+                    public Object apply(Integer v) {
                         return v;
                     }
                 }).filter(new Predicate<Object>() {
                     @Override
-                    public boolean test(Object v) throws Exception {
+                    public boolean test(Object v) {
                         return true;
                     }
                 }).subscribeWith(new MyRx2Observer());
@@ -233,91 +233,91 @@ public final class MemoryPerf {
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.range(1, 10).subscribeOn(io.reactivex.rxjava3.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
             }
         }, "range+subscribeOn+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.range(1, 10).observeOn(io.reactivex.rxjava3.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
             }
         }, "range+observeOn+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Observable.range(1, 10).subscribeOn(io.reactivex.rxjava3.schedulers.Schedulers.computation()).observeOn(io.reactivex.rxjava3.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
             }
         }, "range+subscribeOn+observeOn+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.AsyncSubject.create();
             }
         }, "Async", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.PublishSubject.create();
             }
         }, "Publish", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.ReplaySubject.create();
             }
         }, "Replay", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.BehaviorSubject.create();
             }
         }, "Behavior", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.UnicastSubject.create();
             }
         }, "Unicast", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.AsyncSubject.create().subscribeWith(new MyRx2Observer());
             }
         }, "Async+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.PublishSubject.create().subscribeWith(new MyRx2Observer());
             }
         }, "Publish+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.ReplaySubject.create().subscribeWith(new MyRx2Observer());
             }
         }, "Replay+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.BehaviorSubject.create().subscribeWith(new MyRx2Observer());
             }
         }, "Behavior+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.subjects.UnicastSubject.create().subscribeWith(new MyRx2Observer());
             }
         }, "Unicast+consumer", "Rx2Observable");
@@ -326,38 +326,38 @@ public final class MemoryPerf {
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.just(1);
             }
         }, "just", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.range(1, 10);
             }
         }, "range", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.empty();
             }
         }, "empty", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.empty();
             }
         }, "empty", "Rx2Flowable", 10000000);
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.fromCallable(new Callable<Object>() {
                     @Override
-                    public Object call() throws Exception {
+                    public Object call() {
                         return 1;
                     }
                 });
@@ -366,38 +366,38 @@ public final class MemoryPerf {
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return new MyRx2Subscriber();
             }
         }, "consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return new io.reactivex.rxjava3.observers.TestObserver<>();
             }
         }, "test-consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.just(1).subscribeWith(new MyRx2Subscriber());
             }
         }, "just+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.range(1, 10).subscribeWith(new MyRx2Subscriber());
             }
         }, "range+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.range(1, 10).map(new Function<Integer, Object>() {
                     @Override
-                    public Object apply(Integer v) throws Exception {
+                    public Object apply(Integer v) {
                         return v;
                     }
                 }).subscribeWith(new MyRx2Subscriber());
@@ -406,15 +406,15 @@ public final class MemoryPerf {
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.range(1, 10).map(new Function<Integer, Object>() {
                     @Override
-                    public Object apply(Integer v) throws Exception {
+                    public Object apply(Integer v) {
                         return v;
                     }
                 }).filter(new Predicate<Object>() {
                     @Override
-                    public boolean test(Object v) throws Exception {
+                    public boolean test(Object v) {
                         return true;
                     }
                 }).subscribeWith(new MyRx2Subscriber());
@@ -423,91 +423,91 @@ public final class MemoryPerf {
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.range(1, 10).subscribeOn(io.reactivex.rxjava3.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
             }
         }, "range+subscribeOn+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.range(1, 10).observeOn(io.reactivex.rxjava3.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
             }
         }, "range+observeOn+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.core.Flowable.range(1, 10).subscribeOn(io.reactivex.rxjava3.schedulers.Schedulers.computation()).observeOn(io.reactivex.rxjava3.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
             }
         }, "range+subscribeOn+observeOn+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.AsyncProcessor.create();
             }
         }, "Async", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.PublishProcessor.create();
             }
         }, "Publish", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.ReplayProcessor.create();
             }
         }, "Replay", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.BehaviorProcessor.create();
             }
         }, "Behavior", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.UnicastProcessor.create();
             }
         }, "Unicast", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.AsyncProcessor.create().subscribeWith(new MyRx2Subscriber());
             }
         }, "Async+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.PublishProcessor.create().subscribeWith(new MyRx2Subscriber());
             }
         }, "Publish+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.ReplayProcessor.create().subscribeWith(new MyRx2Subscriber());
             }
         }, "Replay+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.BehaviorProcessor.create().subscribeWith(new MyRx2Subscriber());
             }
         }, "Behavior+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 return io.reactivex.rxjava3.processors.UnicastProcessor.create().subscribeWith(new MyRx2Subscriber());
             }
         }, "Unicast+consumer", "Rx2Flowable");

--- a/src/jmh/java/io/reactivex/rxjava3/core/OperatorFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/OperatorFlatMapPerf.java
@@ -40,7 +40,7 @@ public class OperatorFlatMapPerf {
     }
 
     @Benchmark
-    public void flatMapIntPassthruSync(Input input) throws InterruptedException {
+    public void flatMapIntPassthruSync(Input input) {
         input.flowable.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer v) {
@@ -66,7 +66,7 @@ public class OperatorFlatMapPerf {
     }
 
     @Benchmark
-    public void flatMapTwoNestedSync(final Input input) throws InterruptedException {
+    public void flatMapTwoNestedSync(final Input input) {
         Flowable.range(1, 2).flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(Integer i) {

--- a/src/jmh/java/io/reactivex/rxjava3/core/PerfSubscriber.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/PerfSubscriber.java
@@ -20,7 +20,7 @@ import org.reactivestreams.Subscription;
 
 public class PerfSubscriber implements FlowableSubscriber<Object> {
 
-    public CountDownLatch latch = new CountDownLatch(1);
+    public final CountDownLatch latch = new CountDownLatch(1);
     private final Blackhole bh;
 
     public PerfSubscriber(Blackhole bh) {

--- a/src/jmh/java/io/reactivex/rxjava3/core/ReducePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/ReducePerf.java
@@ -40,7 +40,7 @@ public class ReducePerf implements BiFunction<Integer, Integer, Integer> {
     Maybe<Integer> flowMaybe;
 
     @Override
-    public Integer apply(Integer t1, Integer t2) throws Exception {
+    public Integer apply(Integer t1, Integer t2) {
         return t1 + t2;
     }
 

--- a/src/jmh/java/io/reactivex/rxjava3/core/TakeUntilPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/TakeUntilPerf.java
@@ -39,7 +39,7 @@ public class TakeUntilPerf implements Consumer<Integer> {
     Observable<Integer> observable;
 
     @Override
-    public void accept(Integer t) throws Exception {
+    public void accept(Integer t) {
         items++;
     }
 
@@ -48,7 +48,7 @@ public class TakeUntilPerf implements Consumer<Integer> {
 
         flowable = Flowable.range(1, 1000 * 1000).takeUntil(Flowable.fromCallable(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 int c = count;
                 while (items < c) { }
                 return 1;
@@ -57,7 +57,7 @@ public class TakeUntilPerf implements Consumer<Integer> {
 
         observable = Observable.range(1, 1000 * 1000).takeUntil(Observable.fromCallable(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 int c = count;
                 while (items < c) { }
                 return 1;
@@ -71,7 +71,7 @@ public class TakeUntilPerf implements Consumer<Integer> {
 
         flowable.subscribe(this, Functions.emptyConsumer(), new Action() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 cdl.countDown();
             }
         });
@@ -85,7 +85,7 @@ public class TakeUntilPerf implements Consumer<Integer> {
 
         observable.subscribe(this, Functions.emptyConsumer(), new Action() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 cdl.countDown();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/core/ToFlowablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/ToFlowablePerf.java
@@ -48,7 +48,7 @@ public class ToFlowablePerf {
 
         final BiFunction<Integer, Integer, Integer> second = new BiFunction<Integer, Integer, Integer>() {
             @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
+            public Integer apply(Integer a, Integer b) {
                 return b;
             }
         };
@@ -57,7 +57,7 @@ public class ToFlowablePerf {
 
         flowableInner = source.concatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Flowable.range(1, 50).reduce(second).toFlowable();
             }
         });
@@ -68,7 +68,7 @@ public class ToFlowablePerf {
 
         observableInner = sourceObs.concatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.range(1, 50).reduce(second).toObservable();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/core/XMapYPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/XMapYPerf.java
@@ -103,84 +103,84 @@ public class XMapYPerf {
 
         flowFlatMapFlowable1 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Flowable.just(v);
             }
         });
 
         flowFlatMapFlowable0 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Flowable.empty();
             }
         });
 
         flowFlatMapSingle1 = fsource.flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
             @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
+            public SingleSource<Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });
 
         flowFlatMapMaybe1 = fsource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
+            public MaybeSource<Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });
 
         flowFlatMapMaybe0 = fsource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
+            public MaybeSource<Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });
 
         flowFlatMapCompletable0 = fsource.flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
-            public CompletableSource apply(Integer v) throws Exception {
+            public CompletableSource apply(Integer v) {
                 return Completable.complete();
             }
         });
 
         flowFlatMapIterable1 = fsource.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
+            public Iterable<Integer> apply(Integer v) {
                 return Collections.singletonList(v);
             }
         });
 
         flowFlatMapIterable0 = fsource.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Collections.<Integer>emptyList();
+            public Iterable<Integer> apply(Integer v) {
+                return Collections.emptyList();
             }
         });
 
         flowFlatMapSingle1 = fsource.flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
             @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
+            public SingleSource<Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });
 
         flowFlatMapMaybe1 = fsource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
+            public MaybeSource<Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });
 
         flowFlatMapMaybe0 = fsource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
+            public MaybeSource<Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });
 
         flowFlatMapCompletable0 = fsource.flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
-            public CompletableSource apply(Integer v) throws Exception {
+            public CompletableSource apply(Integer v) {
                 return Completable.complete();
             }
         });
@@ -189,43 +189,43 @@ public class XMapYPerf {
 
         flowFlatMapSingleAsFlow1 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Single.just(v).toFlowable();
             }
         });
 
         flowFlatMapMaybeAsFlow1 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Maybe.just(v).toFlowable();
             }
         });
 
         flowFlatMapMaybeAsFlow0 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Maybe.<Integer>empty().toFlowable();
             }
         });
 
         flowFlatMapCompletableAsFlow0 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Completable.complete().<Integer>toFlowable();
+            public Publisher<Integer> apply(Integer v) {
+                return Completable.complete().toFlowable();
             }
         });
 
         flowFlatMapIterableAsFlow1 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Flowable.fromIterable(Collections.singletonList(v));
             }
         });
 
         flowFlatMapIterableAsFlow0 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.fromIterable(Collections.<Integer>emptyList());
+            public Publisher<Integer> apply(Integer v) {
+                return Flowable.fromIterable(Collections.emptyList());
             }
         });
 
@@ -235,57 +235,57 @@ public class XMapYPerf {
 
         obsFlatMapObservable1 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });
 
         obsFlatMapObservable0 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });
 
         obsFlatMapSingle1 = osource.flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
             @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
+            public SingleSource<Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });
 
         obsFlatMapMaybe1 = osource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
+            public MaybeSource<Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });
 
         obsFlatMapMaybe0 = osource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
             @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
+            public MaybeSource<Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });
 
         obsFlatMapCompletable0 = osource.flatMapCompletable(new Function<Integer, CompletableSource>() {
             @Override
-            public CompletableSource apply(Integer v) throws Exception {
+            public CompletableSource apply(Integer v) {
                 return Completable.complete();
             }
         });
 
         obsFlatMapIterable1 = osource.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
+            public Iterable<Integer> apply(Integer v) {
                 return Collections.singletonList(v);
             }
         });
 
         obsFlatMapIterable0 = osource.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Collections.<Integer>emptyList();
+            public Iterable<Integer> apply(Integer v) {
+                return Collections.emptyList();
             }
         });
 
@@ -293,43 +293,43 @@ public class XMapYPerf {
 
         obsFlatMapSingleAsObs1 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
+            public Observable<Integer> apply(Integer v) {
                 return Single.just(v).toObservable();
             }
         });
 
         obsFlatMapMaybeAsObs1 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
+            public Observable<Integer> apply(Integer v) {
                 return Maybe.just(v).toObservable();
             }
         });
 
         obsFlatMapMaybeAsObs0 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
+            public Observable<Integer> apply(Integer v) {
                 return Maybe.<Integer>empty().toObservable();
             }
         });
 
         obsFlatMapCompletableAsObs0 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
-                return Completable.complete().<Integer>toObservable();
+            public Observable<Integer> apply(Integer v) {
+                return Completable.complete().toObservable();
             }
         });
 
         obsFlatMapIterableAsObs1 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.fromIterable(Collections.singletonList(v));
             }
         });
 
         obsFlatMapIterableAsObs0 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
-                return Observable.fromIterable(Collections.<Integer>emptyList());
+            public Observable<Integer> apply(Integer v) {
+                return Observable.fromIterable(Collections.emptyList());
             }
         });
     }

--- a/src/jmh/java/io/reactivex/rxjava3/parallel/ParallelPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/parallel/ParallelPerf.java
@@ -49,7 +49,7 @@ public class ParallelPerf implements Function<Integer, Integer> {
     Flowable<Integer> parallel;
 
     @Override
-    public Integer apply(Integer t) throws Exception {
+    public Integer apply(Integer t) {
         Blackhole.consumeCPU(compute);
         return t;
     }
@@ -66,7 +66,7 @@ public class ParallelPerf implements Function<Integer, Integer> {
 
         flatMap = source.flatMap(new Function<Integer, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
+            public Publisher<Integer> apply(Integer v) {
                 return Flowable.just(v).subscribeOn(Schedulers.computation())
                         .map(ParallelPerf.this);
             }
@@ -75,13 +75,13 @@ public class ParallelPerf implements Function<Integer, Integer> {
         groupBy = source.groupBy(new Function<Integer, Integer>() {
             int i;
             @Override
-            public Integer apply(Integer v) throws Exception {
+            public Integer apply(Integer v) {
                 return (i++) % cpu;
             }
         })
         .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
             @Override
-            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
+            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) {
                 return g.observeOn(Schedulers.computation()).map(ParallelPerf.this);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapCompletablePerf.java
@@ -48,24 +48,21 @@ public class FlowableConcatMapCompletablePerf {
 
         flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.empty();
             }
         });
 
         flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Completable.complete().toFlowable();
             }
         });
 
         flowableDedicated = source.concatMapCompletable(new Function<Integer, Completable>() {
             @Override
-            public Completable apply(Integer v)
-                    throws Exception {
+            public Completable apply(Integer v) {
                 return Completable.complete();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapMaybeEmptyPerf.java
@@ -48,24 +48,21 @@ public class FlowableConcatMapMaybeEmptyPerf {
 
         flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.empty();
             }
         });
 
         concatMapToFlowableEmpty = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Maybe.<Integer>empty().toFlowable();
             }
         });
 
         flowableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapMaybePerf.java
@@ -48,24 +48,21 @@ public class FlowableConcatMapMaybePerf {
 
         flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.just(v);
             }
         });
 
         flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Maybe.just(v).toFlowable();
             }
         });
 
         flowableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapSinglePerf.java
@@ -48,24 +48,21 @@ public class FlowableConcatMapSinglePerf {
 
         flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.just(v);
             }
         });
 
         flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Single.just(v).toFlowable();
             }
         });
 
         flowableDedicated = source.concatMapSingle(new Function<Integer, Single<? extends Integer>>() {
             @Override
-            public Single<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Single<? extends Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapCompletablePerf.java
@@ -48,24 +48,21 @@ public class FlowableFlatMapCompletablePerf {
 
         flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.empty();
             }
         });
 
         flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Completable.complete().toFlowable();
             }
         });
 
         flowableDedicated = source.flatMapCompletable(new Function<Integer, Completable>() {
             @Override
-            public Completable apply(Integer v)
-                    throws Exception {
+            public Completable apply(Integer v) {
                 return Completable.complete();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapMaybeEmptyPerf.java
@@ -48,24 +48,21 @@ public class FlowableFlatMapMaybeEmptyPerf {
 
         flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.empty();
             }
         });
 
         flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Maybe.<Integer>empty().toFlowable();
             }
         });
 
         flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapMaybePerf.java
@@ -48,24 +48,21 @@ public class FlowableFlatMapMaybePerf {
 
         flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.just(v);
             }
         });
 
         flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Maybe.just(v).toFlowable();
             }
         });
 
         flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapSinglePerf.java
@@ -48,24 +48,21 @@ public class FlowableFlatMapSinglePerf {
 
         flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.just(v);
             }
         });
 
         flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Single.just(v).toFlowable();
             }
         });
 
         flowableDedicated = source.flatMapSingle(new Function<Integer, Single<? extends Integer>>() {
             @Override
-            public Single<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Single<? extends Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapCompletablePerf.java
@@ -48,24 +48,21 @@ public class FlowableSwitchMapCompletablePerf {
 
         flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.empty();
             }
         });
 
         flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Completable.complete().toFlowable();
             }
         });
 
         flowableDedicated = source.switchMapCompletable(new Function<Integer, Completable>() {
             @Override
-            public Completable apply(Integer v)
-                    throws Exception {
+            public Completable apply(Integer v) {
                 return Completable.complete();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapMaybeEmptyPerf.java
@@ -48,24 +48,21 @@ public class FlowableSwitchMapMaybeEmptyPerf {
 
         flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.empty();
             }
         });
 
         flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Maybe.<Integer>empty().toFlowable();
             }
         });
 
         flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapMaybePerf.java
@@ -48,24 +48,21 @@ public class FlowableSwitchMapMaybePerf {
 
         flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.just(v);
             }
         });
 
         flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Maybe.just(v).toFlowable();
             }
         });
 
         flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapSinglePerf.java
@@ -48,24 +48,21 @@ public class FlowableSwitchMapSinglePerf {
 
         flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Flowable.just(v);
             }
         });
 
         flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
             @Override
-            public Publisher<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Publisher<? extends Integer> apply(Integer v) {
                 return Single.just(v).toFlowable();
             }
         });
 
         flowableDedicated = source.switchMapSingle(new Function<Integer, Single<? extends Integer>>() {
             @Override
-            public Single<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Single<? extends Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapCompletablePerf.java
@@ -47,24 +47,21 @@ public class ObservableConcatMapCompletablePerf {
 
         observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });
 
         observableConvert = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Completable.complete().toObservable();
             }
         });
 
         observableDedicated = source.concatMapCompletable(new Function<Integer, Completable>() {
             @Override
-            public Completable apply(Integer v)
-                    throws Exception {
+            public Completable apply(Integer v) {
                 return Completable.complete();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapMaybeEmptyPerf.java
@@ -47,24 +47,21 @@ public class ObservableConcatMapMaybeEmptyPerf {
 
         observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });
 
         concatMapToObservableEmpty = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Maybe.<Integer>empty().toObservable();
             }
         });
 
         observableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapMaybePerf.java
@@ -47,24 +47,21 @@ public class ObservableConcatMapMaybePerf {
 
         observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });
 
         observableConvert = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Maybe.just(v).toObservable();
             }
         });
 
         observableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapSinglePerf.java
@@ -47,24 +47,21 @@ public class ObservableConcatMapSinglePerf {
 
         observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });
 
         observableConvert = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Single.just(v).toObservable();
             }
         });
 
         observableDedicated = source.concatMapSingle(new Function<Integer, Single<? extends Integer>>() {
             @Override
-            public Single<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Single<? extends Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapCompletablePerf.java
@@ -47,24 +47,21 @@ public class ObservableFlatMapCompletablePerf {
 
         observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });
 
         observableConvert = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Completable.complete().toObservable();
             }
         });
 
         observableDedicated = source.flatMapCompletable(new Function<Integer, Completable>() {
             @Override
-            public Completable apply(Integer v)
-                    throws Exception {
+            public Completable apply(Integer v) {
                 return Completable.complete();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapMaybeEmptyPerf.java
@@ -47,24 +47,21 @@ public class ObservableFlatMapMaybeEmptyPerf {
 
         observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });
 
         observableConvert = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Maybe.<Integer>empty().toObservable();
             }
         });
 
         observableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapMaybePerf.java
@@ -47,24 +47,21 @@ public class ObservableFlatMapMaybePerf {
 
         observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });
 
         observableConvert = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Maybe.just(v).toObservable();
             }
         });
 
         observableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapSinglePerf.java
@@ -47,24 +47,21 @@ public class ObservableFlatMapSinglePerf {
 
         observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });
 
         observableConvert = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Single.just(v).toObservable();
             }
         });
 
         observableDedicated = source.flatMapSingle(new Function<Integer, Single<? extends Integer>>() {
             @Override
-            public Single<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Single<? extends Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapCompletablePerf.java
@@ -47,24 +47,21 @@ public class ObservableSwitchMapCompletablePerf {
 
         observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });
 
         observableConvert = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Completable.complete().toObservable();
             }
         });
 
         observableDedicated = source.switchMapCompletable(new Function<Integer, Completable>() {
             @Override
-            public Completable apply(Integer v)
-                    throws Exception {
+            public Completable apply(Integer v) {
                 return Completable.complete();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapMaybeEmptyPerf.java
@@ -47,24 +47,21 @@ public class ObservableSwitchMapMaybeEmptyPerf {
 
         observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });
 
         observableConvert = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Maybe.<Integer>empty().toObservable();
             }
         });
 
         observableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapMaybePerf.java
@@ -47,24 +47,21 @@ public class ObservableSwitchMapMaybePerf {
 
         observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });
 
         observableConvert = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Maybe.just(v).toObservable();
             }
         });
 
         observableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Maybe<? extends Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapSinglePerf.java
@@ -47,24 +47,21 @@ public class ObservableSwitchMapSinglePerf {
 
         observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });
 
         observableConvert = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Observable<? extends Integer> apply(Integer v) {
                 return Single.just(v).toObservable();
             }
         });
 
         observableDedicated = source.switchMapSingle(new Function<Integer, Single<? extends Integer>>() {
             @Override
-            public Single<? extends Integer> apply(Integer v)
-                    throws Exception {
+            public Single<? extends Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });

--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -1844,7 +1844,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <T> Single<Notification<T>> materialize() {
-        return RxJavaPlugins.onAssembly(new CompletableMaterialize<T>(this));
+        return RxJavaPlugins.onAssembly(new CompletableMaterialize<>(this));
     }
 
     /**
@@ -2239,7 +2239,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <T> Observable<T> startWith(@NonNull ObservableSource<T> other) {
         Objects.requireNonNull(other, "other is null");
-        return Observable.wrap(other).concatWith(this.<T>toObservable());
+        return Observable.wrap(other).concatWith(this.toObservable());
     }
     /**
      * Returns a Flowable which first delivers the events
@@ -2637,7 +2637,7 @@ public abstract class Completable implements CompletableSource {
         if (this instanceof FuseToFlowable) {
             return ((FuseToFlowable<T>)this).fuseToFlowable();
         }
-        return RxJavaPlugins.onAssembly(new CompletableToFlowable<T>(this));
+        return RxJavaPlugins.onAssembly(new CompletableToFlowable<>(this));
     }
 
     /**
@@ -2661,7 +2661,7 @@ public abstract class Completable implements CompletableSource {
         if (this instanceof FuseToMaybe) {
             return ((FuseToMaybe<T>)this).fuseToMaybe();
         }
-        return RxJavaPlugins.onAssembly(new MaybeFromCompletable<T>(this));
+        return RxJavaPlugins.onAssembly(new MaybeFromCompletable<>(this));
     }
 
     /**
@@ -2684,7 +2684,7 @@ public abstract class Completable implements CompletableSource {
         if (this instanceof FuseToObservable) {
             return ((FuseToObservable<T>)this).fuseToObservable();
         }
-        return RxJavaPlugins.onAssembly(new CompletableToObservable<T>(this));
+        return RxJavaPlugins.onAssembly(new CompletableToObservable<>(this));
     }
 
     /**
@@ -2706,7 +2706,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <@NonNull T> Single<T> toSingle(@NonNull Supplier<? extends T> completionValueSupplier) {
         Objects.requireNonNull(completionValueSupplier, "completionValueSupplier is null");
-        return RxJavaPlugins.onAssembly(new CompletableToSingle<T>(this, completionValueSupplier, null));
+        return RxJavaPlugins.onAssembly(new CompletableToSingle<>(this, completionValueSupplier, null));
     }
 
     /**
@@ -2848,7 +2848,7 @@ public abstract class Completable implements CompletableSource {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
      * a {@code defaultItem} of {@code null} or turn the flow into a sequence of {@link Optional}s and default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).toCompletionStage(Optional.empty());

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -332,7 +332,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         }
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false));
+        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<>(sources, combiner, bufferSize, false));
     }
 
     /**
@@ -429,7 +429,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, false));
+        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<>(sources, combiner, bufferSize, false));
     }
 
     /**
@@ -530,7 +530,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (sources.length == 0) {
             return empty();
         }
-        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true));
+        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<>(sources, combiner, bufferSize, true));
     }
 
     /**
@@ -629,7 +629,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<T, R>(sources, combiner, bufferSize, true));
+        return RxJavaPlugins.onAssembly(new FlowableCombineLatest<>(sources, combiner, bufferSize, true));
     }
 
     /**
@@ -1892,7 +1892,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> error(@NonNull Supplier<? extends Throwable> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableError<T>(supplier));
+        return RxJavaPlugins.onAssembly(new FlowableError<>(supplier));
     }
 
     /**
@@ -1997,7 +1997,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> fromCallable(@NonNull Callable<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableFromCallable<T>(supplier));
+        return RxJavaPlugins.onAssembly(new FlowableFromCallable<>(supplier));
     }
 
     /**
@@ -2039,7 +2039,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> fromFuture(@NonNull Future<? extends T> future) {
         Objects.requireNonNull(future, "future is null");
-        return RxJavaPlugins.onAssembly(new FlowableFromFuture<T>(future, 0L, null));
+        return RxJavaPlugins.onAssembly(new FlowableFromFuture<>(future, 0L, null));
     }
 
     /**
@@ -2086,7 +2086,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <@NonNull T> Flowable<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit) {
         Objects.requireNonNull(future, "future is null");
         Objects.requireNonNull(unit, "unit is null");
-        return RxJavaPlugins.onAssembly(new FlowableFromFuture<T>(future, timeout, unit));
+        return RxJavaPlugins.onAssembly(new FlowableFromFuture<>(future, timeout, unit));
     }
 
     /**
@@ -2205,7 +2205,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> fromIterable(@NonNull Iterable<? extends T> source) {
         Objects.requireNonNull(source, "source is null");
-        return RxJavaPlugins.onAssembly(new FlowableFromIterable<T>(source));
+        return RxJavaPlugins.onAssembly(new FlowableFromIterable<>(source));
     }
 
     /**
@@ -2246,7 +2246,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         }
         Objects.requireNonNull(source, "source is null");
 
-        return RxJavaPlugins.onAssembly(new FlowableFromPublisher<T>(source));
+        return RxJavaPlugins.onAssembly(new FlowableFromPublisher<>(source));
     }
 
     /**
@@ -2287,7 +2287,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new FlowableFromSupplier<T>(supplier));
+        return RxJavaPlugins.onAssembly(new FlowableFromSupplier<>(supplier));
     }
 
     /**
@@ -2318,7 +2318,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T> Flowable<T> generate(@NonNull Consumer<@NonNull Emitter<T>> generator) {
         Objects.requireNonNull(generator, "generator is null");
         return generate(Functions.nullSupplier(),
-                FlowableInternalHelper.<T, Object>simpleGenerator(generator),
+                FlowableInternalHelper.simpleGenerator(generator),
                 Functions.emptyConsumer());
     }
 
@@ -2351,7 +2351,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, S> Flowable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiConsumer<S, @NonNull Emitter<T>> generator) {
         Objects.requireNonNull(generator, "generator is null");
-        return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator),
+        return generate(initialState, FlowableInternalHelper.simpleBiGenerator(generator),
                 Functions.emptyConsumer());
     }
 
@@ -2387,7 +2387,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T, S> Flowable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiConsumer<S, @NonNull Emitter<T>> generator,
             @NonNull Consumer<? super S> disposeState) {
         Objects.requireNonNull(generator, "generator is null");
-        return generate(initialState, FlowableInternalHelper.<T, S>simpleBiGenerator(generator), disposeState);
+        return generate(initialState, FlowableInternalHelper.simpleBiGenerator(generator), disposeState);
     }
 
     /**
@@ -4622,7 +4622,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public static <T, R> Flowable<R> zip(@NonNull Iterable<? extends Publisher<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new FlowableZip<T, R>(null, sources, zipper, bufferSize(), false));
+        return RxJavaPlugins.onAssembly(new FlowableZip<>(null, sources, zipper, bufferSize(), false));
     }
 
     /**
@@ -4684,7 +4684,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableZip<T, R>(null, sources, zipper, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new FlowableZip<>(null, sources, zipper, bufferSize, delayError));
     }
 
     /**
@@ -5486,7 +5486,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         }
         Objects.requireNonNull(zipper, "zipper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new FlowableZip<T, R>(sources, null, zipper, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new FlowableZip<>(sources, null, zipper, bufferSize, delayError));
     }
 
     // ***************************************************************************************************
@@ -6025,7 +6025,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Future<T> toFuture() {
-        return subscribeWith(new FutureSubscriber<T>());
+        return subscribeWith(new FutureSubscriber<>());
     }
 
     /**
@@ -6303,7 +6303,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Flowable<List<T>> buffer(int count, int skip) {
-        return buffer(count, skip, ArrayListSupplier.<T>asSupplier());
+        return buffer(count, skip, ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -6415,7 +6415,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
     public final Flowable<List<T>> buffer(long timespan, long timeskip, @NonNull TimeUnit unit) {
-        return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.<T>asSupplier());
+        return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -6453,7 +6453,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public final Flowable<List<T>> buffer(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.<T>asSupplier());
+        return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -6610,7 +6610,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public final Flowable<List<T>> buffer(long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int count) {
-        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asSupplier(), false);
+        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.asSupplier(), false);
     }
 
     /**
@@ -6700,7 +6700,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public final Flowable<List<T>> buffer(long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asSupplier(), false);
+        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.asSupplier(), false);
     }
 
     /**
@@ -6737,7 +6737,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <TOpening, TClosing> Flowable<List<T>> buffer(
             @NonNull Flowable<? extends TOpening> openingIndicator,
             @NonNull Function<? super TOpening, ? extends Publisher<? extends TClosing>> closingIndicator) {
-        return buffer(openingIndicator, closingIndicator, ArrayListSupplier.<T>asSupplier());
+        return buffer(openingIndicator, closingIndicator, ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -6817,7 +6817,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <B> Flowable<List<T>> buffer(@NonNull Publisher<B> boundaryIndicator) {
-        return buffer(boundaryIndicator, ArrayListSupplier.<T>asSupplier());
+        return buffer(boundaryIndicator, ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -6855,7 +6855,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     public final <B> Flowable<List<T>> buffer(@NonNull Publisher<B> boundaryIndicator, int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
-        return buffer(boundaryIndicator, Functions.<T>createArrayList(initialCapacity));
+        return buffer(boundaryIndicator, Functions.createArrayList(initialCapacity));
     }
 
     /**
@@ -7089,7 +7089,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <U> Single<U> collect(@NonNull Supplier<? extends U> initialItemSupplier, @NonNull BiConsumer<? super U, ? super T> collector) {
         Objects.requireNonNull(initialItemSupplier, "initialItemSupplier is null");
         Objects.requireNonNull(collector, "collector is null");
-        return RxJavaPlugins.onAssembly(new FlowableCollectSingle<T, U>(this, initialItemSupplier, collector));
+        return RxJavaPlugins.onAssembly(new FlowableCollectSingle<>(this, initialItemSupplier, collector));
     }
 
     /**
@@ -8896,7 +8896,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <K> Flowable<T> distinct(@NonNull Function<? super T, K> keySelector) {
-        return distinct(keySelector, Functions.<K>createHashSet());
+        return distinct(keySelector, Functions.createHashSet());
     }
 
     /**
@@ -9063,7 +9063,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     public final Flowable<T> distinctUntilChanged(@NonNull BiPredicate<? super T, ? super T> comparer) {
         Objects.requireNonNull(comparer, "comparer is null");
-        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<>(this, Functions.<T>identity(), comparer));
+        return RxJavaPlugins.onAssembly(new FlowableDistinctUntilChanged<>(this, Functions.identity(), comparer));
     }
 
     /**
@@ -10632,7 +10632,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10664,7 +10664,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <K> Flowable<GroupedFlowable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector) {
-        return groupBy(keySelector, Functions.<T>identity(), false, bufferSize());
+        return groupBy(keySelector, Functions.identity(), false, bufferSize());
     }
 
     /**
@@ -10691,7 +10691,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10724,7 +10724,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <K> Flowable<GroupedFlowable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector, boolean delayError) {
-        return groupBy(keySelector, Functions.<T>identity(), delayError, bufferSize());
+        return groupBy(keySelector, Functions.identity(), delayError, bufferSize());
     }
 
     /**
@@ -10751,7 +10751,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10816,7 +10816,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10882,7 +10882,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -10927,7 +10927,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
 
-        return RxJavaPlugins.onAssembly(new FlowableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError, null));
+        return RxJavaPlugins.onAssembly(new FlowableGroupBy<>(this, keySelector, valueSelector, bufferSize, delayError, null));
     }
 
     /**
@@ -10995,7 +10995,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -11050,7 +11050,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(evictingMapFactory, "evictingMapFactory is null");
 
-        return RxJavaPlugins.onAssembly(new FlowableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError, evictingMapFactory));
+        return RxJavaPlugins.onAssembly(new FlowableGroupBy<>(this, keySelector, valueSelector, bufferSize, delayError, evictingMapFactory));
     }
 
     /**
@@ -11100,7 +11100,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         Objects.requireNonNull(leftEnd, "leftEnd is null");
         Objects.requireNonNull(rightEnd, "rightEnd is null");
         Objects.requireNonNull(resultSelector, "resultSelector is null");
-        return RxJavaPlugins.onAssembly(new FlowableGroupJoin<T, TRight, TLeftEnd, TRightEnd, R>(
+        return RxJavaPlugins.onAssembly(new FlowableGroupJoin<>(
                 this, other, leftEnd, rightEnd, resultSelector));
     }
 
@@ -11456,7 +11456,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Flowable<R> lift(@NonNull FlowableOperator<? extends R, ? super T> lifter) {
         Objects.requireNonNull(lifter, "lifter is null");
-        return RxJavaPlugins.onAssembly(new FlowableLift<R, T>(this, lifter));
+        return RxJavaPlugins.onAssembly(new FlowableLift<>(this, lifter));
     }
 
     /**
@@ -11486,7 +11486,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <@NonNull R> Flowable<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new FlowableMap<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new FlowableMap<>(this, mapper));
     }
 
     /**
@@ -13894,7 +13894,7 @@ public abstract class Flowable<T> implements Publisher<T> {
         if (s instanceof SafeSubscriber) {
             subscribe((SafeSubscriber<? super T>)s);
         } else {
-            subscribe(new SafeSubscriber<T>(s));
+            subscribe(new SafeSubscriber<>(s));
         }
     }
 
@@ -14768,7 +14768,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Flowable<T> sorted() {
-        return toList().toFlowable().map(Functions.listSorter(Functions.<T>naturalComparator())).flatMapIterable(Functions.<List<T>>identity());
+        return toList().toFlowable().map(Functions.listSorter(Functions.naturalComparator())).flatMapIterable(Functions.identity());
     }
 
     /**
@@ -14797,7 +14797,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> sorted(@NonNull Comparator<@NonNull ? super T> sortFunction) {
         Objects.requireNonNull(sortFunction, "sortFunction");
-        return toList().toFlowable().map(Functions.listSorter(sortFunction)).flatMapIterable(Functions.<List<T>>identity());
+        return toList().toFlowable().map(Functions.listSorter(sortFunction)).flatMapIterable(Functions.identity());
     }
 
     /**
@@ -15065,7 +15065,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             subscribe((FlowableSubscriber<? super T>)s);
         } else {
             Objects.requireNonNull(s, "s is null");
-            subscribe(new StrictSubscriber<T>(s));
+            subscribe(new StrictSubscriber<>(s));
         }
     }
 
@@ -17119,7 +17119,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Flowable<Timed<T>> timestamp(@NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return map(Functions.<T>timestampWith(unit, scheduler));
+        return map(Functions.timestampWith(unit, scheduler));
     }
 
     /**
@@ -17178,7 +17178,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Single<List<T>> toList() {
-        return RxJavaPlugins.onAssembly(new FlowableToListSingle<T, List<T>>(this));
+        return RxJavaPlugins.onAssembly(new FlowableToListSingle<>(this));
     }
 
     /**
@@ -17216,7 +17216,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @NonNull
     public final Single<List<T>> toList(int capacityHint) {
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
-        return RxJavaPlugins.onAssembly(new FlowableToListSingle<>(this, Functions.<T>createArrayList(capacityHint)));
+        return RxJavaPlugins.onAssembly(new FlowableToListSingle<>(this, Functions.createArrayList(capacityHint)));
     }
 
     /**
@@ -17290,7 +17290,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <K> Single<Map<K, T>> toMap(@NonNull Function<? super T, ? extends K> keySelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
-        return collect(HashMapSupplier.<K, T>asSupplier(), Functions.toMapKeySelector(keySelector));
+        return collect(HashMapSupplier.asSupplier(), Functions.toMapKeySelector(keySelector));
     }
 
     /**
@@ -17330,7 +17330,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <K, V> Single<Map<K, V>> toMap(@NonNull Function<? super T, ? extends K> keySelector, @NonNull Function<? super T, ? extends V> valueSelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
-        return collect(HashMapSupplier.<K, V>asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
+        return collect(HashMapSupplier.asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
     }
 
     /**
@@ -17533,7 +17533,7 @@ public abstract class Flowable<T> implements Publisher<T> {
             @NonNull Function<? super T, ? extends V> valueSelector,
             @NonNull Supplier<Map<K, Collection<V>>> mapSupplier
             ) {
-        return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.<V, K>asFunction());
+        return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.asFunction());
     }
 
     /**
@@ -17731,7 +17731,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * <p>
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window will only contain one element. The behavior is
-     * a tradeoff between no-dataloss and ensuring upstream cancellation can happen.
+     * a trade-off between no-dataloss and ensuring upstream cancellation can happen.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure of its inner and outer subscribers, however, the inner Publisher uses an
@@ -17766,7 +17766,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff between no-dataloss and ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off between no-dataloss and ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure of its inner and outer subscribers, however, the inner Publisher uses an
@@ -17804,7 +17804,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff between no-dataloss and ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off between no-dataloss and ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure of its inner and outer subscribers, however, the inner Publisher uses an
@@ -17848,7 +17848,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -17889,7 +17889,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -17932,7 +17932,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -17981,7 +17981,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -18021,7 +18021,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -18065,7 +18065,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -18110,7 +18110,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -18154,7 +18154,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -18200,7 +18200,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -18248,7 +18248,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator consumes the source {@code Publisher} in an unbounded manner.
@@ -18301,7 +18301,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The outer Publisher of this operator does not support backpressure as it uses a {@code boundary} Publisher to control data
@@ -18337,7 +18337,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The outer Publisher of this operator does not support backpressure as it uses a {@code boundary} Publisher to control data
@@ -18378,7 +18378,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The outer Publisher of this operator doesn't support backpressure because the emission of new
@@ -18421,7 +18421,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The outer Publisher of this operator doesn't support backpressure because the emission of new
@@ -18731,7 +18731,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final <U, R> Flowable<R> zipWith(@NonNull Iterable<U> other,  @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return RxJavaPlugins.onAssembly(new FlowableZipIterable<T, U, R>(this, other, zipper));
+        return RxJavaPlugins.onAssembly(new FlowableZipIterable<>(this, other, zipper));
     }
 
     /**
@@ -19154,7 +19154,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
      * a {@code defaultItem} of {@code null} or turn the flow into a sequence of {@link Optional}s and default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).firstStage(Optional.empty());
@@ -19191,7 +19191,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
      * a {@code defaultItem} of {@code null} or turn the flow into a sequence of {@link Optional}s and default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).singleStage(Optional.empty());
@@ -19227,7 +19227,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
      * a {@code defaultItem} of {@code null} or turn the flow into a sequence of {@link Optional}s and default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).lastStage(Optional.empty());
@@ -19409,7 +19409,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     public final Stream<T> blockingStream(int prefetch) {
         Iterator<T> iterator = blockingIterable(prefetch).iterator();
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false)
-                .onClose(() -> ((Disposable)iterator).dispose());
+                .onClose(((Disposable) iterator)::dispose);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -653,7 +653,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> error(@NonNull Throwable exception) {
         Objects.requireNonNull(exception, "exception is null");
-        return RxJavaPlugins.onAssembly(new MaybeError<T>(exception));
+        return RxJavaPlugins.onAssembly(new MaybeError<>(exception));
     }
 
     /**
@@ -679,7 +679,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> error(@NonNull Supplier<? extends Throwable> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new MaybeErrorCallable<T>(supplier));
+        return RxJavaPlugins.onAssembly(new MaybeErrorCallable<>(supplier));
     }
 
     /**
@@ -706,7 +706,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> fromAction(@NonNull Action run) {
         Objects.requireNonNull(run, "run is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromAction<T>(run));
+        return RxJavaPlugins.onAssembly(new MaybeFromAction<>(run));
     }
 
     /**
@@ -726,7 +726,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> fromCompletable(@NonNull CompletableSource completableSource) {
         Objects.requireNonNull(completableSource, "completableSource is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromCompletable<T>(completableSource));
+        return RxJavaPlugins.onAssembly(new MaybeFromCompletable<>(completableSource));
     }
 
     /**
@@ -790,7 +790,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Maybe<T> fromCallable(@NonNull Callable<? extends T> callable) {
         Objects.requireNonNull(callable, "callable is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromCallable<T>(callable));
+        return RxJavaPlugins.onAssembly(new MaybeFromCallable<>(callable));
     }
 
     /**
@@ -824,7 +824,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Maybe<T> fromFuture(@NonNull Future<? extends T> future) {
         Objects.requireNonNull(future, "future is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromFuture<T>(future, 0L, null));
+        return RxJavaPlugins.onAssembly(new MaybeFromFuture<>(future, 0L, null));
     }
 
     /**
@@ -863,7 +863,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     public static <@NonNull T> Maybe<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit) {
         Objects.requireNonNull(future, "future is null");
         Objects.requireNonNull(unit, "unit is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromFuture<T>(future, timeout, unit));
+        return RxJavaPlugins.onAssembly(new MaybeFromFuture<>(future, timeout, unit));
     }
 
     /**
@@ -883,7 +883,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Maybe<T> fromRunnable(@NonNull Runnable run) {
         Objects.requireNonNull(run, "run is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromRunnable<T>(run));
+        return RxJavaPlugins.onAssembly(new MaybeFromRunnable<>(run));
     }
 
     /**
@@ -930,7 +930,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Maybe<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromSupplier<T>(supplier));
+        return RxJavaPlugins.onAssembly(new MaybeFromSupplier<>(supplier));
     }
 
     /**
@@ -1865,7 +1865,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     public static <T, R> Maybe<R> zip(@NonNull Iterable<? extends MaybeSource<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new MaybeZipIterable<T, R>(sources, zipper));
+        return RxJavaPlugins.onAssembly(new MaybeZipIterable<>(sources, zipper));
     }
 
     /**
@@ -2331,7 +2331,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
             return empty();
         }
         Objects.requireNonNull(zipper, "zipper is null");
-        return RxJavaPlugins.onAssembly(new MaybeZipArray<T, R>(sources, zipper));
+        return RxJavaPlugins.onAssembly(new MaybeZipArray<>(sources, zipper));
     }
 
     // ------------------------------------------------------------------
@@ -3530,7 +3530,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> lift(@NonNull MaybeOperator<? extends R, ? super T> lift) {
         Objects.requireNonNull(lift, "lift is null");
-        return RxJavaPlugins.onAssembly(new MaybeLift<T, R>(this, lift));
+        return RxJavaPlugins.onAssembly(new MaybeLift<>(this, lift));
     }
 
     /**
@@ -3554,7 +3554,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Maybe<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new MaybeMap<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new MaybeMap<>(this, mapper));
     }
 
     /**
@@ -4349,7 +4349,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
         Objects.requireNonNull(onSuccess, "onSuccess is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
-        return subscribeWith(new MaybeCallbackObserver<T>(onSuccess, onError, onComplete));
+        return subscribeWith(new MaybeCallbackObserver<>(onSuccess, onError, onComplete));
     }
 
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4925,7 +4925,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code mapOptional} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <R> the non-null output type
-     * @param mapper the function that receives the upstream success iteem and should return a <em>non-empty</em> {@code Optional}
+     * @param mapper the function that receives the upstream success item and should return a <em>non-empty</em> {@code Optional}
      * to emit as the success output or an <em>empty</em> {@code Optional} to complete the {@code Maybe}
      * @return the new Maybe instance
      * @since 3.0.0
@@ -4952,8 +4952,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
-     * {@link #toCompletionStage(Object)} with {@code null} or turn the upstrea into a sequence of {@link Optional}s and
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
+     * {@link #toCompletionStage(Object)} with {@code null} or turn the upstream into a sequence of {@link Optional}s and
      * default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).toCompletionStage(Optional.empty());
@@ -4985,7 +4985,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
      * a {@code defaultItem} of {@code null} or turn the flow into a sequence of {@link Optional}s and default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).toCompletionStage(Optional.empty());

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -265,7 +265,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
         // the queue holds a pair of values so we need to double the capacity
         int s = bufferSize << 1;
-        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<T, R>(null, sources, combiner, s, false));
+        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<>(null, sources, combiner, s, false));
     }
 
     /**
@@ -364,7 +364,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
         // the queue holds a pair of values so we need to double the capacity
         int s = bufferSize << 1;
-        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<T, R>(sources, null, combiner, s, false));
+        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<>(sources, null, combiner, s, false));
     }
 
     /**
@@ -917,7 +917,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         }
         // the queue holds a pair of values so we need to double the capacity
         int s = bufferSize << 1;
-        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<T, R>(sources, null, combiner, s, true));
+        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<>(sources, null, combiner, s, true));
     }
 
     /**
@@ -1013,7 +1013,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
 
         // the queue holds a pair of values so we need to double the capacity
         int s = bufferSize << 1;
-        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<T, R>(null, sources, combiner, s, true));
+        return RxJavaPlugins.onAssembly(new ObservableCombineLatest<>(null, sources, combiner, s, true));
     }
 
     /**
@@ -1669,7 +1669,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> error(@NonNull Supplier<? extends Throwable> errorSupplier) {
         Objects.requireNonNull(errorSupplier, "errorSupplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableError<T>(errorSupplier));
+        return RxJavaPlugins.onAssembly(new ObservableError<>(errorSupplier));
     }
 
     /**
@@ -1763,7 +1763,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromCallable(@NonNull Callable<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableFromCallable<T>(supplier));
+        return RxJavaPlugins.onAssembly(new ObservableFromCallable<>(supplier));
     }
 
     /**
@@ -1797,7 +1797,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromFuture(@NonNull Future<? extends T> future) {
         Objects.requireNonNull(future, "future is null");
-        return RxJavaPlugins.onAssembly(new ObservableFromFuture<T>(future, 0L, null));
+        return RxJavaPlugins.onAssembly(new ObservableFromFuture<>(future, 0L, null));
     }
 
     /**
@@ -1836,7 +1836,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T> Observable<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit) {
         Objects.requireNonNull(future, "future is null");
         Objects.requireNonNull(unit, "unit is null");
-        return RxJavaPlugins.onAssembly(new ObservableFromFuture<T>(future, timeout, unit));
+        return RxJavaPlugins.onAssembly(new ObservableFromFuture<>(future, timeout, unit));
     }
 
     /**
@@ -1940,7 +1940,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromIterable(@NonNull Iterable<? extends T> source) {
         Objects.requireNonNull(source, "source is null");
-        return RxJavaPlugins.onAssembly(new ObservableFromIterable<T>(source));
+        return RxJavaPlugins.onAssembly(new ObservableFromIterable<>(source));
     }
 
     /**
@@ -1977,7 +1977,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromPublisher(@NonNull Publisher<? extends T> publisher) {
         Objects.requireNonNull(publisher, "publisher is null");
-        return RxJavaPlugins.onAssembly(new ObservableFromPublisher<T>(publisher));
+        return RxJavaPlugins.onAssembly(new ObservableFromPublisher<>(publisher));
     }
 
     /**
@@ -2014,7 +2014,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new ObservableFromSupplier<T>(supplier));
+        return RxJavaPlugins.onAssembly(new ObservableFromSupplier<>(supplier));
     }
 
     /**
@@ -2043,8 +2043,8 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Observable<T> generate(@NonNull Consumer<Emitter<T>> generator) {
         Objects.requireNonNull(generator, "generator is null");
-        return generate(Functions.<Object>nullSupplier(),
-                ObservableInternalHelper.simpleGenerator(generator), Functions.<Object>emptyConsumer());
+        return generate(Functions.nullSupplier(),
+                ObservableInternalHelper.simpleGenerator(generator), Functions.emptyConsumer());
     }
 
     /**
@@ -4188,7 +4188,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public static <T, R> Observable<R> zip(@NonNull Iterable<? extends ObservableSource<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(null, sources, zipper, bufferSize(), false));
+        return RxJavaPlugins.onAssembly(new ObservableZip<>(null, sources, zipper, bufferSize(), false));
     }
 
     /**
@@ -4250,7 +4250,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(null, sources, zipper, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new ObservableZip<>(null, sources, zipper, bufferSize, delayError));
     }
 
     /**
@@ -5004,7 +5004,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         }
         Objects.requireNonNull(zipper, "zipper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableZip<T, R>(sources, null, zipper, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new ObservableZip<>(sources, null, zipper, bufferSize, delayError));
     }
 
     // ***************************************************************************************************
@@ -5477,7 +5477,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Future<T> toFuture() {
-        return subscribeWith(new FutureObserver<T>());
+        return subscribeWith(new FutureObserver<>());
     }
 
     /**
@@ -5648,7 +5648,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Observable<@NonNull List<T>> buffer(int count, int skip) {
-        return buffer(count, skip, ArrayListSupplier.<T>asSupplier());
+        return buffer(count, skip, ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -5746,7 +5746,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
     public final Observable<@NonNull List<T>> buffer(long timespan, long timeskip, @NonNull TimeUnit unit) {
-        return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.<T>asSupplier());
+        return buffer(timespan, timeskip, unit, Schedulers.computation(), ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -5780,7 +5780,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public final Observable<@NonNull List<T>> buffer(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.<T>asSupplier());
+        return buffer(timespan, timeskip, unit, scheduler, ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -5921,7 +5921,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public final Observable<@NonNull List<T>> buffer(long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int count) {
-        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.<T>asSupplier(), false);
+        return buffer(timespan, unit, scheduler, count, ArrayListSupplier.asSupplier(), false);
     }
 
     /**
@@ -6003,7 +6003,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public final Observable<@NonNull List<T>> buffer(long timespan, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.<T>asSupplier(), false);
+        return buffer(timespan, unit, scheduler, Integer.MAX_VALUE, ArrayListSupplier.asSupplier(), false);
     }
 
     /**
@@ -6036,7 +6036,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <TOpening, TClosing> Observable<@NonNull List<T>> buffer(
             @NonNull ObservableSource<? extends TOpening> openingIndicator,
             @NonNull Function<? super TOpening, ? extends ObservableSource<? extends TClosing>> closingIndicator) {
-        return buffer(openingIndicator, closingIndicator, ArrayListSupplier.<T>asSupplier());
+        return buffer(openingIndicator, closingIndicator, ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -6108,7 +6108,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <B> Observable<@NonNull List<T>> buffer(@NonNull ObservableSource<B> boundary) {
-        return buffer(boundary, ArrayListSupplier.<T>asSupplier());
+        return buffer(boundary, ArrayListSupplier.asSupplier());
     }
 
     /**
@@ -6142,7 +6142,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final <B> Observable<@NonNull List<T>> buffer(@NonNull ObservableSource<B> boundary, int initialCapacity) {
         ObjectHelper.verifyPositive(initialCapacity, "initialCapacity");
-        return buffer(boundary, Functions.<T>createArrayList(initialCapacity));
+        return buffer(boundary, Functions.createArrayList(initialCapacity));
     }
 
     /**
@@ -6355,7 +6355,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <U> Single<U> collect(@NonNull Supplier<? extends U> initialValueSupplier, @NonNull BiConsumer<? super U, ? super T> collector) {
         Objects.requireNonNull(initialValueSupplier, "initialValueSupplier is null");
         Objects.requireNonNull(collector, "collector is null");
-        return RxJavaPlugins.onAssembly(new ObservableCollectSingle<T, U>(this, initialValueSupplier, collector));
+        return RxJavaPlugins.onAssembly(new ObservableCollectSingle<>(this, initialValueSupplier, collector));
     }
 
     /**
@@ -8088,7 +8088,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final Observable<T> distinctUntilChanged(@NonNull BiPredicate<? super T, ? super T> comparer) {
         Objects.requireNonNull(comparer, "comparer is null");
-        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<>(this, Functions.<T>identity(), comparer));
+        return RxJavaPlugins.onAssembly(new ObservableDistinctUntilChanged<>(this, Functions.identity(), comparer));
     }
 
     /**
@@ -9351,7 +9351,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -9392,7 +9392,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -9436,7 +9436,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -9481,7 +9481,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -9529,7 +9529,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
      * so-called group abandonment where a group will only contain one element and the group will be
      * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a tradeoff between no-dataloss, upstream cancellation and excessive group creation.
+     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -9564,7 +9564,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
 
-        return RxJavaPlugins.onAssembly(new ObservableGroupBy<T, K, V>(this, keySelector, valueSelector, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new ObservableGroupBy<>(this, keySelector, valueSelector, bufferSize, delayError));
     }
 
     /**
@@ -9611,7 +9611,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         Objects.requireNonNull(leftEnd, "leftEnd is null");
         Objects.requireNonNull(rightEnd, "rightEnd is null");
         Objects.requireNonNull(resultSelector, "resultSelector is null");
-        return RxJavaPlugins.onAssembly(new ObservableGroupJoin<T, TRight, TLeftEnd, TRightEnd, R>(
+        return RxJavaPlugins.onAssembly(new ObservableGroupJoin<>(
                 this, other, leftEnd, rightEnd, resultSelector));
     }
 
@@ -9939,7 +9939,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final <R> Observable<R> lift(@NonNull ObservableOperator<? extends R, ? super T> lifter) {
         Objects.requireNonNull(lifter, "lifter is null");
-        return RxJavaPlugins.onAssembly(new ObservableLift<R, T>(this, lifter));
+        return RxJavaPlugins.onAssembly(new ObservableLift<>(this, lifter));
     }
 
     /**
@@ -9964,7 +9964,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final <R> Observable<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableMap<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new ObservableMap<>(this, mapper));
     }
 
     /**
@@ -11584,7 +11584,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
         if (observer instanceof SafeObserver) {
             subscribe(observer);
         } else {
-            subscribe(new SafeObserver<T>(observer));
+            subscribe(new SafeObserver<>(observer));
         }
     }
 
@@ -12352,7 +12352,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Observable<T> sorted() {
-        return toList().toObservable().map(Functions.listSorter(Functions.<T>naturalComparator())).flatMapIterable(Functions.<List<T>>identity());
+        return toList().toObservable().map(Functions.listSorter(Functions.naturalComparator())).flatMapIterable(Functions.identity());
     }
 
     /**
@@ -12377,7 +12377,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final Observable<T> sorted(@NonNull Comparator<? super T> sortFunction) {
         Objects.requireNonNull(sortFunction, "sortFunction is null");
-        return toList().toObservable().map(Functions.listSorter(sortFunction)).flatMapIterable(Functions.<List<T>>identity());
+        return toList().toObservable().map(Functions.listSorter(sortFunction)).flatMapIterable(Functions.identity());
     }
 
     /**
@@ -14309,7 +14309,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Observable<Timed<T>> timestamp(@NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return map(Functions.<T>timestampWith(unit, scheduler));
+        return map(Functions.timestampWith(unit, scheduler));
     }
 
     /**
@@ -14396,7 +14396,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final Single<@NonNull List<T>> toList(int capacityHint) {
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
-        return RxJavaPlugins.onAssembly(new ObservableToListSingle<T, List<T>>(this, capacityHint));
+        return RxJavaPlugins.onAssembly(new ObservableToListSingle<>(this, capacityHint));
     }
 
     /**
@@ -14463,7 +14463,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @NonNull
     public final <K> Single<@NonNull Map<K, T>> toMap(@NonNull Function<? super T, ? extends K> keySelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
-        return collect(HashMapSupplier.<K, T>asSupplier(), Functions.toMapKeySelector(keySelector));
+        return collect(HashMapSupplier.asSupplier(), Functions.toMapKeySelector(keySelector));
     }
 
     /**
@@ -14501,7 +14501,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             @NonNull Function<? super T, ? extends V> valueSelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
-        return collect(HashMapSupplier.<K, V>asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
+        return collect(HashMapSupplier.asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
     }
 
     /**
@@ -14568,8 +14568,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <K> Single<@NonNull Map<K, Collection<T>>> toMultimap(@NonNull Function<? super T, ? extends K> keySelector) {
-        @SuppressWarnings({ "rawtypes", "unchecked" })
-        Function<? super T, ? extends T> valueSelector = (Function)Functions.identity();
+        Function<? super T, ? extends T> valueSelector = Functions.identity();
         Supplier<Map<K, Collection<T>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<T>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
@@ -14684,7 +14683,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
             @NonNull Function<? super T, ? extends V> valueSelector,
             @NonNull Supplier<Map<K, Collection<V>>> mapSupplier
     ) {
-        return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.<V, K>asFunction());
+        return toMultimap(keySelector, valueSelector, mapSupplier, ArrayListSupplier.asFunction());
     }
 
     /**
@@ -14864,7 +14863,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Single<@NonNull List<T>> toSortedList(int capacityHint) {
-        return toSortedList(Functions.<T>naturalOrder(), capacityHint);
+        return toSortedList(Functions.naturalOrder(), capacityHint);
     }
 
     /**
@@ -14992,7 +14991,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -15026,7 +15025,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -15062,7 +15061,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -15104,7 +15103,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -15138,7 +15137,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -15176,7 +15175,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} operates by default on the {@code computation} {@link Scheduler}.</dd>
@@ -15215,7 +15214,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -15252,7 +15251,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -15292,7 +15291,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -15334,7 +15333,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
@@ -15381,7 +15380,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -15413,7 +15412,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -15450,7 +15449,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -15487,7 +15486,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * Note that ignoring windows or subscribing later (i.e., on another thread) will result in
      * so-called window abandonment where a window may not contain any elements. In this case, subsequent
      * elements will be dropped until the condition for the next window boundary is satisfied. The behavior is
-     * a tradeoff for ensuring upstream cancellation can happen under some race conditions.
+     * a trade-off for ensuring upstream cancellation can happen under some race conditions.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This version of {@code window} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -15766,7 +15765,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final <U, R> Observable<R> zipWith(@NonNull Iterable<U> other, @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return RxJavaPlugins.onAssembly(new ObservableZipIterable<T, U, R>(this, other, zipper));
+        return RxJavaPlugins.onAssembly(new ObservableZipIterable<>(this, other, zipper));
     }
 
     /**
@@ -16127,7 +16126,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
      * a {@code defaultItem} of {@code null} or turn the flow into a sequence of {@link Optional}s and default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).firstStage(Optional.empty());
@@ -16161,7 +16160,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
      * a {@code defaultItem} of {@code null} or turn the flow into a sequence of {@link Optional}s and default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).singleStage(Optional.empty());
@@ -16194,7 +16193,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
-     * {@code CompletionStage}s don't have a notion of emptyness and allow {@code null}s, therefore, one can either use
+     * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use
      * a {@code defaultItem} of {@code null} or turn the flow into a sequence of {@link Optional}s and default to {@link Optional#empty()}:
      * <pre><code>
      * CompletionStage&lt;Optional&lt;T&gt;&gt; stage = source.map(Optional::of).lastStage(Optional.empty());
@@ -16356,7 +16355,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     public final Stream<T> blockingStream(int capacityHint) {
         Iterator<T> iterator = blockingIterable(capacityHint).iterator();
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false)
-                .onClose(() -> ((Disposable)iterator).dispose());
+                .onClose(((Disposable) iterator)::dispose);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -158,7 +158,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     public static <T> Single<T> ambArray(@NonNull SingleSource<? extends T>... sources) {
         if (sources.length == 0) {
-            return error(SingleInternalHelper.<T>emptyThrower());
+            return error(SingleInternalHelper.emptyThrower());
         }
         if (sources.length == 1) {
             @SuppressWarnings("unchecked")
@@ -423,7 +423,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
     public static <T> Flowable<T> concatArrayEager(@NonNull SingleSource<? extends T>... sources) {
-        return Flowable.fromArray(sources).concatMapEager(SingleInternalHelper.<T>toFlowable());
+        return Flowable.fromArray(sources).concatMapEager(SingleInternalHelper.toFlowable());
     }
 
     /**
@@ -451,7 +451,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concatEager(@NonNull Publisher<? extends SingleSource<? extends T>> sources) {
-        return Flowable.fromPublisher(sources).concatMapEager(SingleInternalHelper.<T>toFlowable());
+        return Flowable.fromPublisher(sources).concatMapEager(SingleInternalHelper.toFlowable());
     }
 
     /**
@@ -477,7 +477,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Flowable<T> concatEager(@NonNull Iterable<? extends SingleSource<? extends T>> sources) {
-        return Flowable.fromIterable(sources).concatMapEager(SingleInternalHelper.<T>toFlowable());
+        return Flowable.fromIterable(sources).concatMapEager(SingleInternalHelper.toFlowable());
     }
 
     /**
@@ -570,7 +570,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> error(@NonNull Supplier<? extends Throwable> errorSupplier) {
         Objects.requireNonNull(errorSupplier, "errorSupplier is null");
-        return RxJavaPlugins.onAssembly(new SingleError<T>(errorSupplier));
+        return RxJavaPlugins.onAssembly(new SingleError<>(errorSupplier));
     }
 
     /**
@@ -632,7 +632,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Single<T> fromCallable(@NonNull Callable<? extends T> callable) {
         Objects.requireNonNull(callable, "callable is null");
-        return RxJavaPlugins.onAssembly(new SingleFromCallable<T>(callable));
+        return RxJavaPlugins.onAssembly(new SingleFromCallable<>(callable));
     }
 
     /**
@@ -662,7 +662,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T> Single<T> fromFuture(@NonNull Future<? extends T> future) {
-        return toSingle(Flowable.<T>fromFuture(future));
+        return toSingle(Flowable.fromFuture(future));
     }
 
     /**
@@ -696,7 +696,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T> Single<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit) {
-        return toSingle(Flowable.<T>fromFuture(future, timeout, unit));
+        return toSingle(Flowable.fromFuture(future, timeout, unit));
     }
 
     /**
@@ -732,7 +732,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public static <@NonNull T> Single<T> fromFuture(@NonNull Future<? extends T> future, long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return toSingle(Flowable.<T>fromFuture(future, timeout, unit, scheduler));
+        return toSingle(Flowable.fromFuture(future, timeout, unit, scheduler));
     }
 
     /**
@@ -763,7 +763,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public static <@NonNull T> Single<T> fromFuture(@NonNull Future<? extends T> future, @NonNull Scheduler scheduler) {
-        return toSingle(Flowable.<T>fromFuture(future, scheduler));
+        return toSingle(Flowable.fromFuture(future, scheduler));
     }
 
     /**
@@ -801,7 +801,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromPublisher(@NonNull Publisher<? extends T> publisher) {
         Objects.requireNonNull(publisher, "publisher is null");
-        return RxJavaPlugins.onAssembly(new SingleFromPublisher<T>(publisher));
+        return RxJavaPlugins.onAssembly(new SingleFromPublisher<>(publisher));
     }
 
     /**
@@ -825,11 +825,11 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T> Single<T> fromObservable(@NonNull ObservableSource<? extends T> observableSource) {
         Objects.requireNonNull(observableSource, "observableSource is null");
-        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<T>(observableSource, null));
+        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<>(observableSource, null));
     }
 
     /**
-     * Returns a {@link Single} that invokes passed supplierfunction and emits its result
+     * Returns a {@link Single} that invokes passed supplier and emits its result
      * for each new SingleObserver that subscribes.
      * <p>
      * Allows you to defer execution of passed function until SingleObserver subscribes to the {@link Single}.
@@ -863,7 +863,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Single<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
-        return RxJavaPlugins.onAssembly(new SingleFromSupplier<T>(supplier));
+        return RxJavaPlugins.onAssembly(new SingleFromSupplier<>(supplier));
     }
 
     /**
@@ -996,10 +996,9 @@ public abstract class Single<T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> Single<T> merge(@NonNull SingleSource<? extends SingleSource<? extends T>> source) {
         Objects.requireNonNull(source, "source is null");
-        return RxJavaPlugins.onAssembly(new SingleFlatMap<SingleSource<? extends T>, T>(source, (Function)Functions.identity()));
+        return RxJavaPlugins.onAssembly(new SingleFlatMap<SingleSource<? extends T>, T>(source, Functions.identity()));
     }
 
     /**
@@ -1580,7 +1579,7 @@ public abstract class Single<T> implements SingleSource<T> {
     public static <T, R> Single<R> zip(@NonNull Iterable<? extends SingleSource<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new SingleZipIterable<T, R>(sources, zipper));
+        return RxJavaPlugins.onAssembly(new SingleZipIterable<>(sources, zipper));
     }
 
     /**
@@ -2037,7 +2036,7 @@ public abstract class Single<T> implements SingleSource<T> {
         if (sources.length == 0) {
             return error(new NoSuchElementException());
         }
-        return RxJavaPlugins.onAssembly(new SingleZipArray<T, R>(sources, zipper));
+        return RxJavaPlugins.onAssembly(new SingleZipArray<>(sources, zipper));
     }
 
     /**
@@ -3057,7 +3056,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <R> Single<R> lift(@NonNull SingleOperator<? extends R, ? super T> lift) {
         Objects.requireNonNull(lift, "lift is null");
-        return RxJavaPlugins.onAssembly(new SingleLift<T, R>(this, lift));
+        return RxJavaPlugins.onAssembly(new SingleLift<>(this, lift));
     }
 
     /**
@@ -3081,7 +3080,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <@NonNull R> Single<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new SingleMap<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new SingleMap<>(this, mapper));
     }
 
     /**
@@ -4068,7 +4067,7 @@ public abstract class Single<T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Future<T> toFuture() {
-        return subscribeWith(new FutureSingleObserver<T>());
+        return subscribeWith(new FutureSingleObserver<>());
     }
 
     /**
@@ -4271,7 +4270,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *  <dd>{@code mapOptional} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <R> the non-null output type
-     * @param mapper the function that receives the upstream success iteem and should return a <em>non-empty</em> {@code Optional}
+     * @param mapper the function that receives the upstream success item and should return a <em>non-empty</em> {@code Optional}
      * to emit as the success output or an <em>empty</em> {@code Optional} to complete the {@code Maybe}
      * @return the new Maybe instance
      * @since 3.0.0

--- a/src/main/java/io/reactivex/rxjava3/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/CompositeException.java
@@ -63,7 +63,6 @@ public final class CompositeException extends RuntimeException {
      */
     public CompositeException(@NonNull Iterable<? extends Throwable> errors) {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<>();
-        List<Throwable> localExceptions = new ArrayList<>();
         if (errors != null) {
             for (Throwable ex : errors) {
                 if (ex instanceof CompositeException) {
@@ -81,7 +80,7 @@ public final class CompositeException extends RuntimeException {
         if (deDupedExceptions.isEmpty()) {
             throw new IllegalArgumentException("errors is empty");
         }
-        localExceptions.addAll(deDupedExceptions);
+        List<Throwable> localExceptions = new ArrayList<>(deDupedExceptions);
         this.exceptions = Collections.unmodifiableList(localExceptions);
         this.message = exceptions.size() + " exceptions occurred. ";
     }

--- a/src/main/java/io/reactivex/rxjava3/exceptions/package-info.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/package-info.java
@@ -17,7 +17,7 @@
 /**
  * Exception handling utilities ({@link io.reactivex.rxjava3.exceptions.Exceptions Exceptions}),
  * composite exception container ({@link io.reactivex.rxjava3.exceptions.CompositeException CompositeException}) and
- * various lifecycle-reladed ({@link io.reactivex.rxjava3.exceptions.MissingBackpressureException UndeliverableException})
+ * various lifecycle-related ({@link io.reactivex.rxjava3.exceptions.MissingBackpressureException UndeliverableException})
  * and behavior-violation exception types ({@link io.reactivex.rxjava3.exceptions.OnErrorNotImplementedException OnErrorNotImplementedException},
  * {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException MissingBackpressureException}).
  */

--- a/src/main/java/io/reactivex/rxjava3/internal/disposables/EmptyDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/disposables/EmptyDisposable.java
@@ -95,7 +95,7 @@ public enum EmptyDisposable implements QueueDisposable<Object> {
 
     @Nullable
     @Override
-    public Object poll() throws Exception {
+    public Object poll() {
         return null; // always empty
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/disposables/ListCompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/disposables/ListCompositeDisposable.java
@@ -32,7 +32,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
 
     public ListCompositeDisposable(Disposable... resources) {
         Objects.requireNonNull(resources, "resources is null");
-        this.resources = new LinkedList<Disposable>();
+        this.resources = new LinkedList<>();
         for (Disposable d : resources) {
             Objects.requireNonNull(d, "Disposable item is null");
             this.resources.add(d);
@@ -41,7 +41,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
 
     public ListCompositeDisposable(Iterable<? extends Disposable> resources) {
         Objects.requireNonNull(resources, "resources is null");
-        this.resources = new LinkedList<Disposable>();
+        this.resources = new LinkedList<>();
         for (Disposable d : resources) {
             Objects.requireNonNull(d, "Disposable item is null");
             this.resources.add(d);
@@ -79,7 +79,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
                 if (!disposed) {
                     List<Disposable> set = resources;
                     if (set == null) {
-                        set = new LinkedList<Disposable>();
+                        set = new LinkedList<>();
                         resources = set;
                     }
                     set.add(d);
@@ -98,7 +98,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
                 if (!disposed) {
                     List<Disposable> set = resources;
                     if (set == null) {
-                        set = new LinkedList<Disposable>();
+                        set = new LinkedList<>();
                         resources = set;
                     }
                     for (Disposable d : ds) {
@@ -171,7 +171,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
                 if (errors == null) {
-                    errors = new ArrayList<Throwable>();
+                    errors = new ArrayList<>();
                 }
                 errors.add(ex);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/functions/Functions.java
@@ -36,46 +36,46 @@ public final class Functions {
 
     @NonNull
     public static <T1, T2, R> Function<Object[], R> toFunction(@NonNull BiFunction<? super T1, ? super T2, ? extends R> f) {
-        return new Array2Func<T1, T2, R>(f);
+        return new Array2Func<>(f);
     }
 
     @NonNull
     public static <T1, T2, T3, R> Function<Object[], R> toFunction(@NonNull Function3<T1, T2, T3, R> f) {
-        return new Array3Func<T1, T2, T3, R>(f);
+        return new Array3Func<>(f);
     }
 
     @NonNull
     public static <T1, T2, T3, T4, R> Function<Object[], R> toFunction(@NonNull Function4<T1, T2, T3, T4, R> f) {
-        return new Array4Func<T1, T2, T3, T4, R>(f);
+        return new Array4Func<>(f);
     }
 
     @NonNull
     public static <T1, T2, T3, T4, T5, R> Function<Object[], R> toFunction(@NonNull Function5<T1, T2, T3, T4, T5, R> f) {
-        return new Array5Func<T1, T2, T3, T4, T5, R>(f);
+        return new Array5Func<>(f);
     }
 
     @NonNull
     public static <T1, T2, T3, T4, T5, T6, R> Function<Object[], R> toFunction(
             @NonNull Function6<T1, T2, T3, T4, T5, T6, R> f) {
-        return new Array6Func<T1, T2, T3, T4, T5, T6, R>(f);
+        return new Array6Func<>(f);
     }
 
     @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, R> Function<Object[], R> toFunction(
             @NonNull Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-        return new Array7Func<T1, T2, T3, T4, T5, T6, T7, R>(f);
+        return new Array7Func<>(f);
     }
 
     @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function<Object[], R> toFunction(
             @NonNull Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-        return new Array8Func<T1, T2, T3, T4, T5, T6, T7, T8, R>(f);
+        return new Array8Func<>(f);
     }
 
     @NonNull
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Function<Object[], R> toFunction(
             @NonNull Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> f) {
-        return new Array9Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, R>(f);
+        return new Array9Func<>(f);
     }
 
     /** A singleton identity function. */
@@ -186,17 +186,17 @@ public final class Functions {
         }
 
         @Override
-        public U call() throws Exception {
+        public U call() {
             return value;
         }
 
         @Override
-        public U apply(T t) throws Exception {
+        public U apply(T t) {
             return value;
         }
 
         @Override
-        public U get() throws Throwable {
+        public U get() {
             return value;
         }
     }
@@ -209,7 +209,7 @@ public final class Functions {
      */
     @NonNull
     public static <T> Callable<T> justCallable(@NonNull T value) {
-        return new JustValue<Object, T>(value);
+        return new JustValue<>(value);
     }
 
     /**
@@ -220,7 +220,7 @@ public final class Functions {
      */
     @NonNull
     public static <T> Supplier<T> justSupplier(@NonNull T value) {
-        return new JustValue<Object, T>(value);
+        return new JustValue<>(value);
     }
 
     /**
@@ -232,7 +232,7 @@ public final class Functions {
      */
     @NonNull
     public static <T, U> Function<T, U> justFunction(@NonNull U value) {
-        return new JustValue<T, U>(value);
+        return new JustValue<>(value);
     }
 
     static final class CastToClass<T, U> implements Function<T, U> {
@@ -243,7 +243,7 @@ public final class Functions {
         }
 
         @Override
-        public U apply(T t) throws Exception {
+        public U apply(T t) {
             return clazz.cast(t);
         }
     }
@@ -257,7 +257,7 @@ public final class Functions {
      */
     @NonNull
     public static <T, U> Function<T, U> castFunction(@NonNull Class<U> target) {
-        return new CastToClass<T, U>(target);
+        return new CastToClass<>(target);
     }
 
     static final class ArrayListCapacityCallable<T> implements Supplier<List<T>> {
@@ -268,13 +268,13 @@ public final class Functions {
         }
 
         @Override
-        public List<T> get() throws Exception {
-            return new ArrayList<T>(capacity);
+        public List<T> get() {
+            return new ArrayList<>(capacity);
         }
     }
 
     public static <T> Supplier<List<T>> createArrayList(int capacity) {
-        return new ArrayListCapacityCallable<T>(capacity);
+        return new ArrayListCapacityCallable<>(capacity);
     }
 
     static final class EqualsPredicate<T> implements Predicate<T> {
@@ -285,25 +285,25 @@ public final class Functions {
         }
 
         @Override
-        public boolean test(T t) throws Exception {
+        public boolean test(T t) {
             return Objects.equals(t, value);
         }
     }
 
     public static <T> Predicate<T> equalsWith(T value) {
-        return new EqualsPredicate<T>(value);
+        return new EqualsPredicate<>(value);
     }
 
     enum HashSetCallable implements Supplier<Set<Object>>, Callable<Set<Object>> {
         INSTANCE;
         @Override
-        public Set<Object> call() throws Exception {
-            return new HashSet<Object>();
+        public Set<Object> call() {
+            return new HashSet<>();
         }
 
         @Override
-        public Set<Object> get() throws Throwable {
-            return new HashSet<Object>();
+        public Set<Object> get() {
+            return new HashSet<>();
         }
     }
 
@@ -334,7 +334,7 @@ public final class Functions {
 
         @Override
         public void accept(Throwable v) throws Throwable {
-            onNotification.accept(Notification.<T>createOnError(v));
+            onNotification.accept(Notification.createOnError(v));
         }
     }
 
@@ -347,20 +347,20 @@ public final class Functions {
 
         @Override
         public void run() throws Throwable {
-            onNotification.accept(Notification.<T>createOnComplete());
+            onNotification.accept(Notification.createOnComplete());
         }
     }
 
     public static <T> Consumer<T> notificationOnNext(Consumer<? super Notification<T>> onNotification) {
-        return new NotificationOnNext<T>(onNotification);
+        return new NotificationOnNext<>(onNotification);
     }
 
     public static <T> Consumer<Throwable> notificationOnError(Consumer<? super Notification<T>> onNotification) {
-        return new NotificationOnError<T>(onNotification);
+        return new NotificationOnError<>(onNotification);
     }
 
     public static <T> Action notificationOnComplete(Consumer<? super Notification<T>> onNotification) {
-        return new NotificationOnComplete<T>(onNotification);
+        return new NotificationOnComplete<>(onNotification);
     }
 
     static final class ActionConsumer<T> implements Consumer<T> {
@@ -377,7 +377,7 @@ public final class Functions {
     }
 
     public static <T> Consumer<T> actionConsumer(Action action) {
-        return new ActionConsumer<T>(action);
+        return new ActionConsumer<>(action);
     }
 
     static final class ClassFilter<T, U> implements Predicate<T> {
@@ -388,13 +388,13 @@ public final class Functions {
         }
 
         @Override
-        public boolean test(T t) throws Exception {
+        public boolean test(T t) {
             return clazz.isInstance(t);
         }
     }
 
     public static <T, U> Predicate<T> isInstanceOf(Class<U> clazz) {
-        return new ClassFilter<T, U>(clazz);
+        return new ClassFilter<>(clazz);
     }
 
     static final class BooleanSupplierPredicateReverse<T> implements Predicate<T> {
@@ -411,7 +411,7 @@ public final class Functions {
     }
 
     public static <T> Predicate<T> predicateReverseFor(BooleanSupplier supplier) {
-        return new BooleanSupplierPredicateReverse<T>(supplier);
+        return new BooleanSupplierPredicateReverse<>(supplier);
     }
 
     static final class TimestampFunction<T> implements Function<T, Timed<T>> {
@@ -425,13 +425,13 @@ public final class Functions {
         }
 
         @Override
-        public Timed<T> apply(T t) throws Exception {
-            return new Timed<T>(t, scheduler.now(unit), unit);
+        public Timed<T> apply(T t) {
+            return new Timed<>(t, scheduler.now(unit), unit);
         }
     }
 
     public static <T> Function<T, Timed<T>> timestampWith(TimeUnit unit, Scheduler scheduler) {
-        return new TimestampFunction<T>(unit, scheduler);
+        return new TimestampFunction<>(unit, scheduler);
     }
 
     static final class ToMapKeySelector<K, T> implements BiConsumer<Map<K, T>, T> {
@@ -449,7 +449,7 @@ public final class Functions {
     }
 
     public static <T, K> BiConsumer<Map<K, T>, T> toMapKeySelector(final Function<? super T, ? extends K> keySelector) {
-        return new ToMapKeySelector<K, T>(keySelector);
+        return new ToMapKeySelector<>(keySelector);
     }
 
     static final class ToMapKeyValueSelector<K, V, T> implements BiConsumer<Map<K, V>, T> {
@@ -471,7 +471,7 @@ public final class Functions {
     }
 
     public static <T, K, V> BiConsumer<Map<K, V>, T> toMapKeyValueSelector(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector) {
-        return new ToMapKeyValueSelector<K, V, T>(valueSelector, keySelector);
+        return new ToMapKeyValueSelector<>(valueSelector, keySelector);
     }
 
     static final class ToMultimapKeyValueSelector<K, V, T> implements BiConsumer<Map<K, Collection<V>>, T> {
@@ -506,7 +506,7 @@ public final class Functions {
     public static <T, K, V> BiConsumer<Map<K, Collection<V>>, T> toMultimapKeyValueSelector(
             final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector,
             final Function<? super K, ? extends Collection<? super V>> collectionFactory) {
-        return new ToMultimapKeyValueSelector<K, V, T>(collectionFactory, valueSelector, keySelector);
+        return new ToMultimapKeyValueSelector<>(collectionFactory, valueSelector, keySelector);
     }
 
     enum NaturalComparator implements Comparator<Object> {
@@ -539,7 +539,7 @@ public final class Functions {
     }
 
     public static <T> Function<List<T>, List<T>> listSorter(final Comparator<? super T> comparator) {
-        return new ListSorter<T>(comparator);
+        return new ListSorter<>(comparator);
     }
 
     public static final Consumer<Subscription> REQUEST_MAX = new MaxRequestSubscription();
@@ -762,7 +762,7 @@ public final class Functions {
         }
 
         @Override
-        public Object get() throws Throwable {
+        public Object get() {
             return null;
         }
     }
@@ -777,7 +777,7 @@ public final class Functions {
 
     static final class MaxRequestSubscription implements Consumer<Subscription> {
         @Override
-        public void accept(Subscription t) throws Exception {
+        public void accept(Subscription t) {
             t.request(Long.MAX_VALUE);
         }
     }
@@ -796,7 +796,7 @@ public final class Functions {
         }
 
         @Override
-        public void accept(Subscription s) throws Exception {
+        public void accept(Subscription s) {
             s.request(bufferSize);
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ObservableFlatMapStream.java
@@ -112,7 +112,7 @@ public final class ObservableFlatMapStream<T, R> extends Observable<R> {
                             done = true;
                             break;
                         }
-                        R value = Objects.requireNonNull(it.next(), "The Stream's Iterator.next retuned a null value");
+                        R value = Objects.requireNonNull(it.next(), "The Stream's Iterator.next returned a null value");
                         if (disposed) {
                             done = true;
                             break;

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/ParallelCollector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/ParallelCollector.java
@@ -209,7 +209,6 @@ public final class ParallelCollector<T, A, R> extends Flowable<R> {
                     Exceptions.throwIfFatal(ex);
                     get().cancel();
                     onError(ex);
-                    return;
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/observers/DeferredScalarDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/observers/DeferredScalarDisposable.java
@@ -114,7 +114,7 @@ public class DeferredScalarDisposable<T> extends BasicIntQueueDisposable<T> {
 
     @Nullable
     @Override
-    public final T poll() throws Exception {
+    public final T poll() {
         if (get() == FUSED_READY) {
             T v = value;
             value = null;

--- a/src/main/java/io/reactivex/rxjava3/internal/observers/FutureObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/observers/FutureObserver.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
@@ -41,7 +42,7 @@ implements Observer<T>, Future<T>, Disposable {
 
     public FutureObserver() {
         super(1);
-        this.upstream = new AtomicReference<Disposable>();
+        this.upstream = new AtomicReference<>();
     }
 
     @Override
@@ -90,7 +91,7 @@ implements Observer<T>, Future<T>, Disposable {
     }
 
     @Override
-    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    public T get(long timeout, @NonNull TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {

--- a/src/main/java/io/reactivex/rxjava3/internal/observers/FutureSingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/observers/FutureSingleObserver.java
@@ -18,6 +18,7 @@ import static io.reactivex.rxjava3.internal.util.ExceptionHelper.timeoutMessage;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.SingleObserver;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
@@ -40,7 +41,7 @@ implements SingleObserver<T>, Future<T>, Disposable {
 
     public FutureSingleObserver() {
         super(1);
-        this.upstream = new AtomicReference<Disposable>();
+        this.upstream = new AtomicReference<>();
     }
 
     @Override
@@ -89,7 +90,7 @@ implements SingleObserver<T>, Future<T>, Disposable {
     }
 
     @Override
-    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    public T get(long timeout, @NonNull TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableCache.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableCache.java
@@ -39,7 +39,7 @@ public final class CompletableCache extends Completable implements CompletableOb
 
     public CompletableCache(CompletableSource source) {
         this.source = source;
-        this.observers = new AtomicReference<InnerCompletableCache[]>(EMPTY);
+        this.observers = new AtomicReference<>(EMPTY);
         this.once = new AtomicBoolean();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcat.java
@@ -106,9 +106,9 @@ public final class CompletableConcat extends Completable {
                 }
 
                 if (prefetch == Integer.MAX_VALUE) {
-                    queue = new SpscLinkedArrayQueue<CompletableSource>(Flowable.bufferSize());
+                    queue = new SpscLinkedArrayQueue<>(Flowable.bufferSize());
                 } else {
-                    queue = new SpscArrayQueue<CompletableSource>(prefetch);
+                    queue = new SpscArrayQueue<>(prefetch);
                 }
 
                 downstream.onSubscribe(this);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromObservable.java
@@ -26,7 +26,7 @@ public final class CompletableFromObservable<T> extends Completable {
 
     @Override
     protected void subscribeActual(final CompletableObserver observer) {
-        observable.subscribe(new CompletableFromObservableObserver<T>(observer));
+        observable.subscribe(new CompletableFromObservableObserver<>(observer));
     }
 
     static final class CompletableFromObservableObserver<T> implements Observer<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromPublisher.java
@@ -29,7 +29,7 @@ public final class CompletableFromPublisher<T> extends Completable {
 
     @Override
     protected void subscribeActual(final CompletableObserver downstream) {
-        flowable.subscribe(new FromPublisherSubscriber<T>(downstream));
+        flowable.subscribe(new FromPublisherSubscriber<>(downstream));
     }
 
     static final class FromPublisherSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromSingle.java
@@ -26,7 +26,7 @@ public final class CompletableFromSingle<T> extends Completable {
 
     @Override
     protected void subscribeActual(final CompletableObserver observer) {
-        single.subscribe(new CompletableFromSingleObserver<T>(observer));
+        single.subscribe(new CompletableFromSingleObserver<>(observer));
     }
 
     static final class CompletableFromSingleObserver<T> implements SingleObserver<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableMaterialize.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableMaterialize.java
@@ -34,6 +34,6 @@ public final class CompletableMaterialize<T> extends Single<Notification<T>> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super Notification<T>> observer) {
-        source.subscribe(new MaterializeSingleObserver<T>(observer));
+        source.subscribe(new MaterializeSingleObserver<>(observer));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableToFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableToFlowable.java
@@ -28,7 +28,7 @@ public final class CompletableToFlowable<T> extends Flowable<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        SubscriberCompletableObserver<T> os = new SubscriberCompletableObserver<T>(s);
+        SubscriberCompletableObserver<T> os = new SubscriberCompletableObserver<>(s);
         source.subscribe(os);
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableToObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableToObservable.java
@@ -71,7 +71,7 @@ public final class CompletableToObservable<T> extends Observable<T> {
         }
 
         @Override
-        public Void poll() throws Exception {
+        public Void poll() {
             return null; // always empty
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableUsing.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableUsing.java
@@ -80,7 +80,7 @@ public final class CompletableUsing<R> extends Completable {
             return;
         }
 
-        source.subscribe(new UsingObserver<R>(observer, resource, disposer, eager));
+        source.subscribe(new UsingObserver<>(observer, resource, disposer, eager));
     }
 
     static final class UsingObserver<R>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
@@ -38,7 +38,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
 
     @Override
     public Iterator<T> iterator() {
-        BlockingFlowableIterator<T> it = new BlockingFlowableIterator<T>(bufferSize);
+        BlockingFlowableIterator<T> it = new BlockingFlowableIterator<>(bufferSize);
         source.subscribe(it);
         return it;
     }
@@ -65,7 +65,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
         volatile Throwable error;
 
         BlockingFlowableIterator(int batchSize) {
-            this.queue = new SpscArrayQueue<T>(batchSize);
+            this.queue = new SpscArrayQueue<>(batchSize);
             this.batchSize = batchSize;
             this.limit = batchSize - (batchSize >> 2);
             this.lock = new ReentrantLock();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableLatest.java
@@ -39,7 +39,7 @@ public final class BlockingFlowableLatest<T> implements Iterable<T> {
 
     @Override
     public Iterator<T> iterator() {
-        LatestSubscriberIterator<T> lio = new LatestSubscriberIterator<T>();
+        LatestSubscriberIterator<T> lio = new LatestSubscriberIterator<>();
         Flowable.<T>fromPublisher(source).materialize().subscribe(lio);
         return lio;
     }
@@ -48,7 +48,7 @@ public final class BlockingFlowableLatest<T> implements Iterable<T> {
     static final class LatestSubscriberIterator<T> extends DisposableSubscriber<Notification<T>> implements Iterator<T> {
         final Semaphore notify = new Semaphore(0);
         // observer's notification
-        final AtomicReference<Notification<T>> value = new AtomicReference<Notification<T>>();
+        final AtomicReference<Notification<T>> value = new AtomicReference<>();
 
         // iterator's notification
         Notification<T> iteratorNotification;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableMostRecent.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableMostRecent.java
@@ -40,7 +40,7 @@ public final class BlockingFlowableMostRecent<T> implements Iterable<T> {
 
     @Override
     public Iterator<T> iterator() {
-        MostRecentSubscriber<T> mostRecentSubscriber = new MostRecentSubscriber<T>(initialValue);
+        MostRecentSubscriber<T> mostRecentSubscriber = new MostRecentSubscriber<>(initialValue);
 
         source.subscribe(mostRecentSubscriber);
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableNext.java
@@ -41,8 +41,8 @@ public final class BlockingFlowableNext<T> implements Iterable<T> {
 
     @Override
     public Iterator<T> iterator() {
-        NextSubscriber<T> nextSubscriber = new NextSubscriber<T>();
-        return new NextIterator<T>(source, nextSubscriber);
+        NextSubscriber<T> nextSubscriber = new NextSubscriber<>();
+        return new NextIterator<>(source, nextSubscriber);
     }
 
     // test needs to access the observer.waiting flag
@@ -133,7 +133,7 @@ public final class BlockingFlowableNext<T> implements Iterable<T> {
     }
 
     static final class NextSubscriber<T> extends DisposableSubscriber<Notification<T>> {
-        private final BlockingQueue<Notification<T>> buf = new ArrayBlockingQueue<Notification<T>>(1);
+        private final BlockingQueue<Notification<T>> buf = new ArrayBlockingQueue<>(1);
         final AtomicInteger waiting = new AtomicInteger();
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAll.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAll.java
@@ -31,7 +31,7 @@ public final class FlowableAll<T> extends AbstractFlowableWithUpstream<T, Boolea
 
     @Override
     protected void subscribeActual(Subscriber<? super Boolean> s) {
-        source.subscribe(new AllSubscriber<T>(s, predicate));
+        source.subscribe(new AllSubscriber<>(s, predicate));
     }
 
     static final class AllSubscriber<T> extends DeferredScalarSubscription<Boolean> implements FlowableSubscriber<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAllSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAllSingle.java
@@ -35,12 +35,12 @@ public final class FlowableAllSingle<T> extends Single<Boolean> implements FuseT
 
     @Override
     protected void subscribeActual(SingleObserver<? super Boolean> observer) {
-        source.subscribe(new AllSubscriber<T>(observer, predicate));
+        source.subscribe(new AllSubscriber<>(observer, predicate));
     }
 
     @Override
     public Flowable<Boolean> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableAll<T>(source, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableAll<>(source, predicate));
     }
 
     static final class AllSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmb.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmb.java
@@ -69,7 +69,7 @@ public final class FlowableAmb<T> extends Flowable<T> {
             return;
         }
 
-        AmbCoordinator<T> ac = new AmbCoordinator<T>(s, count);
+        AmbCoordinator<T> ac = new AmbCoordinator<>(s, count);
         ac.subscribe(sources);
     }
 
@@ -89,7 +89,7 @@ public final class FlowableAmb<T> extends Flowable<T> {
             AmbInnerSubscriber<T>[] as = subscribers;
             int len = as.length;
             for (int i = 0; i < len; i++) {
-                as[i] = new AmbInnerSubscriber<T>(this, i + 1, downstream);
+                as[i] = new AmbInnerSubscriber<>(this, i + 1, downstream);
             }
             winner.lazySet(0); // release the contents of 'as'
             downstream.onSubscribe(this);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAny.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAny.java
@@ -29,7 +29,7 @@ public final class FlowableAny<T> extends AbstractFlowableWithUpstream<T, Boolea
 
     @Override
     protected void subscribeActual(Subscriber<? super Boolean> s) {
-        source.subscribe(new AnySubscriber<T>(s, predicate));
+        source.subscribe(new AnySubscriber<>(s, predicate));
     }
 
     static final class AnySubscriber<T> extends DeferredScalarSubscription<Boolean> implements FlowableSubscriber<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAnySingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAnySingle.java
@@ -34,12 +34,12 @@ public final class FlowableAnySingle<T> extends Single<Boolean> implements FuseT
 
     @Override
     protected void subscribeActual(SingleObserver<? super Boolean> observer) {
-        source.subscribe(new AnySubscriber<T>(observer, predicate));
+        source.subscribe(new AnySubscriber<>(observer, predicate));
     }
 
     @Override
     public Flowable<Boolean> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableAny<T>(source, predicate));
+        return RxJavaPlugins.onAssembly(new FlowableAny<>(source, predicate));
     }
 
     static final class AnySubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBlockingSubscribe.java
@@ -42,9 +42,9 @@ public final class FlowableBlockingSubscribe {
      * @param <T> the value type
      */
     public static <T> void subscribe(Publisher<? extends T> o, Subscriber<? super T> subscriber) {
-        final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
+        final BlockingQueue<Object> queue = new LinkedBlockingQueue<>();
 
-        BlockingSubscriber<T> bs = new BlockingSubscriber<T>(queue);
+        BlockingSubscriber<T> bs = new BlockingSubscriber<>(queue);
 
         o.subscribe(bs);
 
@@ -82,7 +82,7 @@ public final class FlowableBlockingSubscribe {
      */
     public static <T> void subscribe(Publisher<? extends T> o) {
         BlockingIgnoringReceiver callback = new BlockingIgnoringReceiver();
-        LambdaSubscriber<T> ls = new LambdaSubscriber<T>(Functions.emptyConsumer(),
+        LambdaSubscriber<T> ls = new LambdaSubscriber<>(Functions.emptyConsumer(),
         callback, callback, Functions.REQUEST_MAX);
 
         o.subscribe(ls);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBuffer.java
@@ -42,11 +42,11 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
     @Override
     public void subscribeActual(Subscriber<? super C> s) {
         if (size == skip) {
-            source.subscribe(new PublisherBufferExactSubscriber<T, C>(s, size, bufferSupplier));
+            source.subscribe(new PublisherBufferExactSubscriber<>(s, size, bufferSupplier));
         } else if (skip > size) {
-            source.subscribe(new PublisherBufferSkipSubscriber<T, C>(s, size, skip, bufferSupplier));
+            source.subscribe(new PublisherBufferSkipSubscriber<>(s, size, skip, bufferSupplier));
         } else {
-            source.subscribe(new PublisherBufferOverlappingSubscriber<T, C>(s, size, skip, bufferSupplier));
+            source.subscribe(new PublisherBufferOverlappingSubscriber<>(s, size, skip, bufferSupplier));
         }
     }
 
@@ -318,7 +318,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
             this.skip = skip;
             this.bufferSupplier = bufferSupplier;
             this.once = new AtomicBoolean();
-            this.buffers = new ArrayDeque<C>();
+            this.buffers = new ArrayDeque<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferBoundary.java
@@ -44,7 +44,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     @Override
     protected void subscribeActual(Subscriber<? super U> s) {
         BufferBoundarySubscriber<T, U, Open, Close> parent =
-            new BufferBoundarySubscriber<T, U, Open, Close>(
+            new BufferBoundarySubscriber<>(
                 s, bufferOpen, bufferClose, bufferSupplier
             );
         s.onSubscribe(parent);
@@ -93,11 +93,11 @@ extends AbstractFlowableWithUpstream<T, U> {
             this.bufferSupplier = bufferSupplier;
             this.bufferOpen = bufferOpen;
             this.bufferClose = bufferClose;
-            this.queue = new SpscLinkedArrayQueue<C>(bufferSize());
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize());
             this.subscribers = new CompositeDisposable();
             this.requested = new AtomicLong();
-            this.upstream = new AtomicReference<Subscription>();
-            this.buffers = new LinkedHashMap<Long, C>();
+            this.upstream = new AtomicReference<>();
+            this.buffers = new LinkedHashMap<>();
             this.errors = new AtomicThrowable();
         }
 
@@ -105,7 +105,7 @@ extends AbstractFlowableWithUpstream<T, U> {
         public void onSubscribe(Subscription s) {
             if (SubscriptionHelper.setOnce(this.upstream, s)) {
 
-                BufferOpenSubscriber<Open> open = new BufferOpenSubscriber<Open>(this);
+                BufferOpenSubscriber<Open> open = new BufferOpenSubscriber<>(this);
                 subscribers.add(open);
 
                 bufferOpen.subscribe(open);
@@ -199,7 +199,7 @@ extends AbstractFlowableWithUpstream<T, U> {
                 bufs.put(idx, buf);
             }
 
-            BufferCloseSubscriber<T, C> bc = new BufferCloseSubscriber<T, C>(this, idx);
+            BufferCloseSubscriber<T, C> bc = new BufferCloseSubscriber<>(this, idx);
             subscribers.add(bc);
             p.subscribe(bc);
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferExactBoundary.java
@@ -41,7 +41,7 @@ extends AbstractFlowableWithUpstream<T, U> {
 
     @Override
     protected void subscribeActual(Subscriber<? super U> s) {
-        source.subscribe(new BufferExactBoundarySubscriber<T, U, B>(new SerializedSubscriber<U>(s), bufferSupplier, boundary));
+        source.subscribe(new BufferExactBoundarySubscriber<>(new SerializedSubscriber<>(s), bufferSupplier, boundary));
     }
 
     static final class BufferExactBoundarySubscriber<T, U extends Collection<? super T>, B>
@@ -58,7 +58,7 @@ extends AbstractFlowableWithUpstream<T, U> {
 
         BufferExactBoundarySubscriber(Subscriber<? super U> actual, Supplier<U> bufferSupplier,
                                              Publisher<B> boundary) {
-            super(actual, new MpscLinkedQueue<U>());
+            super(actual, new MpscLinkedQueue<>());
             this.bufferSupplier = bufferSupplier;
             this.boundary = boundary;
         }
@@ -84,7 +84,7 @@ extends AbstractFlowableWithUpstream<T, U> {
 
             buffer = b;
 
-            BufferBoundarySubscriber<T, U, B> bs = new BufferBoundarySubscriber<T, U, B>(this);
+            BufferBoundarySubscriber<T, U, B> bs = new BufferBoundarySubscriber<>(this);
             other = bs;
 
             downstream.onSubscribe(this);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferTimed.java
@@ -56,16 +56,16 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
     @Override
     protected void subscribeActual(Subscriber<? super U> s) {
         if (timespan == timeskip && maxSize == Integer.MAX_VALUE) {
-            source.subscribe(new BufferExactUnboundedSubscriber<T, U>(
-                    new SerializedSubscriber<U>(s),
+            source.subscribe(new BufferExactUnboundedSubscriber<>(
+                    new SerializedSubscriber<>(s),
                     bufferSupplier, timespan, unit, scheduler));
             return;
         }
         Scheduler.Worker w = scheduler.createWorker();
 
         if (timespan == timeskip) {
-            source.subscribe(new BufferExactBoundedSubscriber<T, U>(
-                    new SerializedSubscriber<U>(s),
+            source.subscribe(new BufferExactBoundedSubscriber<>(
+                    new SerializedSubscriber<>(s),
                     bufferSupplier,
                     timespan, unit, maxSize, restartTimerOnMaxSize, w
             ));
@@ -73,8 +73,8 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
         }
         // Can't use maxSize because what to do if a buffer is full but its
         // timespan hasn't been elapsed?
-        source.subscribe(new BufferSkipBoundedSubscriber<T, U>(
-                new SerializedSubscriber<U>(s),
+        source.subscribe(new BufferSkipBoundedSubscriber<>(
+                new SerializedSubscriber<>(s),
                 bufferSupplier, timespan, timeskip, unit, w));
     }
 
@@ -89,12 +89,12 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
 
         U buffer;
 
-        final AtomicReference<Disposable> timer = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> timer = new AtomicReference<>();
 
         BufferExactUnboundedSubscriber(
                 Subscriber<? super U> actual, Supplier<U> bufferSupplier,
                 long timespan, TimeUnit unit, Scheduler scheduler) {
-            super(actual, new MpscLinkedQueue<U>());
+            super(actual, new MpscLinkedQueue<>());
             this.bufferSupplier = bufferSupplier;
             this.timespan = timespan;
             this.unit = unit;
@@ -238,13 +238,13 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
         BufferSkipBoundedSubscriber(Subscriber<? super U> actual,
                 Supplier<U> bufferSupplier, long timespan,
                 long timeskip, TimeUnit unit, Worker w) {
-            super(actual, new MpscLinkedQueue<U>());
+            super(actual, new MpscLinkedQueue<>());
             this.bufferSupplier = bufferSupplier;
             this.timespan = timespan;
             this.timeskip = timeskip;
             this.unit = unit;
             this.w = w;
-            this.buffers = new LinkedList<U>();
+            this.buffers = new LinkedList<>();
         }
 
         @Override
@@ -298,7 +298,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
         public void onComplete() {
             List<U> bs;
             synchronized (this) {
-                bs = new ArrayList<U>(buffers);
+                bs = new ArrayList<>(buffers);
                 buffers.clear();
             }
 
@@ -404,7 +404,7 @@ public final class FlowableBufferTimed<T, U extends Collection<? super T>> exten
                 Supplier<U> bufferSupplier,
                 long timespan, TimeUnit unit, int maxSize,
                 boolean restartOnMaxSize, Worker w) {
-            super(actual, new MpscLinkedQueue<U>());
+            super(actual, new MpscLinkedQueue<>());
             this.bufferSupplier = bufferSupplier;
             this.timespan = timespan;
             this.unit = unit;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCache.java
@@ -99,15 +99,15 @@ implements FlowableSubscriber<T> {
         super(source);
         this.capacityHint = capacityHint;
         this.once = new AtomicBoolean();
-        Node<T> n = new Node<T>(capacityHint);
+        Node<T> n = new Node<>(capacityHint);
         this.head = n;
         this.tail = n;
-        this.subscribers = new AtomicReference<CacheSubscription<T>[]>(EMPTY);
+        this.subscribers = new AtomicReference<>(EMPTY);
     }
 
     @Override
     protected void subscribeActual(Subscriber<? super T> t) {
-        CacheSubscription<T> consumer = new CacheSubscription<T>(t, this);
+        CacheSubscription<T> consumer = new CacheSubscription<>(t, this);
         t.onSubscribe(consumer);
         add(consumer);
 
@@ -303,7 +303,7 @@ implements FlowableSubscriber<T> {
         int tailOffset = this.tailOffset;
         // if the current tail node is full, create a fresh node
         if (tailOffset == capacityHint) {
-            Node<T> n = new Node<T>(tailOffset);
+            Node<T> n = new Node<>(tailOffset);
             n.values[0] = t;
             this.tailOffset = 1;
             tail.next = n;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCollect.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCollect.java
@@ -44,7 +44,7 @@ public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T,
             return;
         }
 
-        source.subscribe(new CollectSubscriber<T, U>(s, u, collector));
+        source.subscribe(new CollectSubscriber<>(s, u, collector));
     }
 
     static final class CollectSubscriber<T, U> extends DeferredScalarSubscription<U> implements FlowableSubscriber<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCollectSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCollectSingle.java
@@ -49,12 +49,12 @@ public final class FlowableCollectSingle<T, U> extends Single<U> implements Fuse
             return;
         }
 
-        source.subscribe(new CollectSubscriber<T, U>(observer, u, collector));
+        source.subscribe(new CollectSubscriber<>(observer, u, collector));
     }
 
     @Override
     public Flowable<U> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableCollect<T, U>(source, initialSupplier, collector));
+        return RxJavaPlugins.onAssembly(new FlowableCollect<>(source, initialSupplier, collector));
     }
 
     static final class CollectSubscriber<T, U> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatest.java
@@ -132,12 +132,12 @@ extends Flowable<R> {
             return;
         }
         if (n == 1) {
-            ((Publisher<T>)a[0]).subscribe(new MapSubscriber<T, R>(s, new SingletonArrayFunc()));
+            a[0].subscribe(new MapSubscriber<>(s, new SingletonArrayFunc()));
             return;
         }
 
         CombineLatestCoordinator<T, R> coordinator =
-                new CombineLatestCoordinator<T, R>(s, combiner, n, bufferSize, delayErrors);
+                new CombineLatestCoordinator<>(s, combiner, n, bufferSize, delayErrors);
 
         s.onSubscribe(coordinator);
 
@@ -183,13 +183,13 @@ extends Flowable<R> {
             @SuppressWarnings("unchecked")
             CombineLatestInnerSubscriber<T>[] a = new CombineLatestInnerSubscriber[n];
             for (int i = 0; i < n; i++) {
-                a[i] = new CombineLatestInnerSubscriber<T>(this, i, bufferSize);
+                a[i] = new CombineLatestInnerSubscriber<>(this, i, bufferSize);
             }
             this.subscribers = a;
             this.latest = new Object[n];
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
             this.requested = new AtomicLong();
-            this.error = new  AtomicReference<Throwable>();
+            this.error = new  AtomicReference<>();
             this.delayErrors = delayErrors;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatArray.java
@@ -34,7 +34,7 @@ public final class FlowableConcatArray<T> extends Flowable<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        ConcatArraySubscriber<T> parent = new ConcatArraySubscriber<T>(sources, delayError, s);
+        ConcatArraySubscriber<T> parent = new ConcatArraySubscriber<>(sources, delayError, s);
         s.onSubscribe(parent);
 
         parent.onComplete();
@@ -82,7 +82,7 @@ public final class FlowableConcatArray<T> extends Flowable<T> {
             if (delayError) {
                 List<Throwable> list = errors;
                 if (list == null) {
-                    list = new ArrayList<Throwable>(sources.length - index + 1);
+                    list = new ArrayList<>(sources.length - index + 1);
                     errors = list;
                 }
                 list.add(t);
@@ -121,7 +121,7 @@ public final class FlowableConcatArray<T> extends Flowable<T> {
                         if (delayError) {
                             List<Throwable> list = errors;
                             if (list == null) {
-                                list = new ArrayList<Throwable>(n - i + 1);
+                                list = new ArrayList<>(n - i + 1);
                                 errors = list;
                             }
                             list.add(ex);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMap.java
@@ -46,11 +46,11 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
             int prefetch, ErrorMode errorMode) {
         switch (errorMode) {
         case BOUNDARY:
-            return new ConcatMapDelayed<T, R>(s, mapper, prefetch, false);
+            return new ConcatMapDelayed<>(s, mapper, prefetch, false);
         case END:
-            return new ConcatMapDelayed<T, R>(s, mapper, prefetch, true);
+            return new ConcatMapDelayed<>(s, mapper, prefetch, true);
         default:
-            return new ConcatMapImmediate<T, R>(s, mapper, prefetch);
+            return new ConcatMapImmediate<>(s, mapper, prefetch);
         }
     }
 
@@ -100,7 +100,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
             this.mapper = mapper;
             this.prefetch = prefetch;
             this.limit = prefetch - (prefetch >> 2);
-            this.inner = new ConcatMapInner<R>(this);
+            this.inner = new ConcatMapInner<>(this);
             this.errors = new AtomicThrowable();
         }
 
@@ -133,7 +133,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                     }
                 }
 
-                queue = new SpscArrayQueue<T>(prefetch);
+                queue = new SpscArrayQueue<>(prefetch);
 
                 subscribeActual();
 
@@ -328,7 +328,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                     continue;
                                 } else {
                                     active = true;
-                                    inner.setSubscription(new WeakScalarSubscription<R>(vr, inner));
+                                    inner.setSubscription(new WeakScalarSubscription<>(vr, inner));
                                 }
 
                             } else {
@@ -527,7 +527,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
                                     continue;
                                 } else {
                                     active = true;
-                                    inner.setSubscription(new WeakScalarSubscription<R>(vr, inner));
+                                    inner.setSubscription(new WeakScalarSubscription<>(vr, inner));
                                 }
                             } else {
                                 active = true;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEager.java
@@ -51,7 +51,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new ConcatMapEagerDelayErrorSubscriber<T, R>(
+        source.subscribe(new ConcatMapEagerDelayErrorSubscriber<>(
                 s, mapper, maxConcurrency, prefetch, errorMode));
     }
 
@@ -93,7 +93,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
             this.maxConcurrency = maxConcurrency;
             this.prefetch = prefetch;
             this.errorMode = errorMode;
-            this.subscribers = new SpscLinkedArrayQueue<InnerQueuedSubscriber<R>>(Math.min(prefetch, maxConcurrency));
+            this.subscribers = new SpscLinkedArrayQueue<>(Math.min(prefetch, maxConcurrency));
             this.errors = new AtomicThrowable();
             this.requested = new AtomicLong();
         }
@@ -123,7 +123,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                 return;
             }
 
-            InnerQueuedSubscriber<R> inner = new InnerQueuedSubscriber<R>(this, prefetch);
+            InnerQueuedSubscriber<R> inner = new InnerQueuedSubscriber<>(this, prefetch);
 
             if (cancelled) {
                 return;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEagerPublisher.java
@@ -53,7 +53,7 @@ public final class FlowableConcatMapEagerPublisher<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new ConcatMapEagerDelayErrorSubscriber<T, R>(
+        source.subscribe(new ConcatMapEagerDelayErrorSubscriber<>(
                 s, mapper, maxConcurrency, prefetch, errorMode));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
@@ -50,13 +50,13 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
     protected void subscribeActual(Subscriber<? super R> s) {
         switch (errorMode) {
         case BOUNDARY:
-            source.subscribe(new ConcatMapDelayed<T, R>(s, mapper, prefetch, false, scheduler.createWorker()));
+            source.subscribe(new ConcatMapDelayed<>(s, mapper, prefetch, false, scheduler.createWorker()));
             break;
         case END:
-            source.subscribe(new ConcatMapDelayed<T, R>(s, mapper, prefetch, true, scheduler.createWorker()));
+            source.subscribe(new ConcatMapDelayed<>(s, mapper, prefetch, true, scheduler.createWorker()));
             break;
         default:
-            source.subscribe(new ConcatMapImmediate<T, R>(s, mapper, prefetch, scheduler.createWorker()));
+            source.subscribe(new ConcatMapImmediate<>(s, mapper, prefetch, scheduler.createWorker()));
         }
     }
 
@@ -98,7 +98,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
             this.mapper = mapper;
             this.prefetch = prefetch;
             this.limit = prefetch - (prefetch >> 2);
-            this.inner = new ConcatMapInner<R>(this);
+            this.inner = new ConcatMapInner<>(this);
             this.errors = new AtomicThrowable();
             this.worker = worker;
         }
@@ -132,7 +132,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                     }
                 }
 
-                queue = new SpscArrayQueue<T>(prefetch);
+                queue = new SpscArrayQueue<>(prefetch);
 
                 subscribeActual();
 
@@ -341,7 +341,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                                 continue;
                             } else {
                                 active = true;
-                                inner.setSubscription(new WeakScalarSubscription<R>(vr, inner));
+                                inner.setSubscription(new WeakScalarSubscription<>(vr, inner));
                             }
 
                         } else {
@@ -524,7 +524,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                                 continue;
                             } else {
                                 active = true;
-                                inner.setSubscription(new WeakScalarSubscription<R>(vr, inner));
+                                inner.setSubscription(new WeakScalarSubscription<>(vr, inner));
                             }
                         } else {
                             active = true;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithCompletable.java
@@ -40,7 +40,7 @@ public final class FlowableConcatWithCompletable<T> extends AbstractFlowableWith
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new ConcatWithSubscriber<T>(s, other));
+        source.subscribe(new ConcatWithSubscriber<>(s, other));
     }
 
     static final class ConcatWithSubscriber<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithMaybe.java
@@ -41,7 +41,7 @@ public final class FlowableConcatWithMaybe<T> extends AbstractFlowableWithUpstre
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new ConcatWithSubscriber<T>(s, other));
+        source.subscribe(new ConcatWithSubscriber<>(s, other));
     }
 
     static final class ConcatWithSubscriber<T>
@@ -59,7 +59,7 @@ public final class FlowableConcatWithMaybe<T> extends AbstractFlowableWithUpstre
         ConcatWithSubscriber(Subscriber<? super T> actual, MaybeSource<? extends T> other) {
             super(actual);
             this.other = other;
-            this.otherDisposable = new AtomicReference<Disposable>();
+            this.otherDisposable = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatWithSingle.java
@@ -41,7 +41,7 @@ public final class FlowableConcatWithSingle<T> extends AbstractFlowableWithUpstr
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new ConcatWithSubscriber<T>(s, other));
+        source.subscribe(new ConcatWithSubscriber<>(s, other));
     }
 
     static final class ConcatWithSubscriber<T>
@@ -57,7 +57,7 @@ public final class FlowableConcatWithSingle<T> extends AbstractFlowableWithUpstr
         ConcatWithSubscriber(Subscriber<? super T> actual, SingleSource<? extends T> other) {
             super(actual);
             this.other = other;
-            this.otherDisposable = new AtomicReference<Disposable>();
+            this.otherDisposable = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCountSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCountSingle.java
@@ -36,7 +36,7 @@ public final class FlowableCountSingle<T> extends Single<Long> implements FuseTo
 
     @Override
     public Flowable<Long> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableCount<T>(source));
+        return RxJavaPlugins.onAssembly(new FlowableCount<>(source));
     }
 
     static final class CountSubscriber implements FlowableSubscriber<Object>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCreate.java
@@ -45,23 +45,23 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         switch (backpressure) {
         case MISSING: {
-            emitter = new MissingEmitter<T>(t);
+            emitter = new MissingEmitter<>(t);
             break;
         }
         case ERROR: {
-            emitter = new ErrorAsyncEmitter<T>(t);
+            emitter = new ErrorAsyncEmitter<>(t);
             break;
         }
         case DROP: {
-            emitter = new DropAsyncEmitter<T>(t);
+            emitter = new DropAsyncEmitter<>(t);
             break;
         }
         case LATEST: {
-            emitter = new LatestAsyncEmitter<T>(t);
+            emitter = new LatestAsyncEmitter<>(t);
             break;
         }
         default: {
-            emitter = new BufferAsyncEmitter<T>(t, bufferSize());
+            emitter = new BufferAsyncEmitter<>(t, bufferSize());
             break;
         }
         }
@@ -97,7 +97,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
         SerializedEmitter(BaseEmitter<T> emitter) {
             this.emitter = emitter;
             this.errors = new AtomicThrowable();
-            this.queue = new SpscLinkedArrayQueue<T>(16);
+            this.queue = new SpscLinkedArrayQueue<>(16);
         }
 
         @Override
@@ -347,7 +347,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         @Override
         public final FlowableEmitter<T> serialize() {
-            return new SerializedEmitter<T>(this);
+            return new SerializedEmitter<>(this);
         }
 
         @Override
@@ -460,7 +460,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         BufferAsyncEmitter(Subscriber<? super T> actual, int capacityHint) {
             super(actual);
-            this.queue = new SpscLinkedArrayQueue<T>(capacityHint);
+            this.queue = new SpscLinkedArrayQueue<>(capacityHint);
             this.wip = new AtomicInteger();
         }
 
@@ -598,7 +598,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         LatestAsyncEmitter(Subscriber<? super T> downstream) {
             super(downstream);
-            this.queue = new AtomicReference<T>();
+            this.queue = new AtomicReference<>();
             this.wip = new AtomicInteger();
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounce.java
@@ -38,7 +38,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new DebounceSubscriber<T, U>(new SerializedSubscriber<T>(s), debounceSelector));
+        source.subscribe(new DebounceSubscriber<>(new SerializedSubscriber<>(s), debounceSelector));
     }
 
     static final class DebounceSubscriber<T, U> extends AtomicLong
@@ -50,7 +50,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
 
         Subscription upstream;
 
-        final AtomicReference<Disposable> debouncer = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> debouncer = new AtomicReference<>();
 
         volatile long index;
 
@@ -96,7 +96,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
                 return;
             }
 
-            DebounceInnerSubscriber<T, U> dis = new DebounceInnerSubscriber<T, U>(this, idx, t);
+            DebounceInnerSubscriber<T, U> dis = new DebounceInnerSubscriber<>(this, idx, t);
 
             if (debouncer.compareAndSet(d, dis)) {
                 p.subscribe(dis);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounceTimed.java
@@ -42,8 +42,8 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new DebounceTimedSubscriber<T>(
-                new SerializedSubscriber<T>(s),
+        source.subscribe(new DebounceTimedSubscriber<>(
+                new SerializedSubscriber<>(s),
                 timeout, unit, scheduler.createWorker()));
     }
 
@@ -93,7 +93,7 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
                 d.dispose();
             }
 
-            DebounceEmitter<T> de = new DebounceEmitter<T>(t, idx, this);
+            DebounceEmitter<T> de = new DebounceEmitter<>(t, idx, this);
             timer = de;
             d = worker.schedule(de, timeout, unit);
             de.setResource(d);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelay.java
@@ -42,12 +42,12 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
         if (delayError) {
             downstream = t;
         } else {
-            downstream = new SerializedSubscriber<T>(t);
+            downstream = new SerializedSubscriber<>(t);
         }
 
         Scheduler.Worker w = scheduler.createWorker();
 
-        source.subscribe(new DelaySubscriber<T>(downstream, delay, unit, w, delayError));
+        source.subscribe(new DelaySubscriber<>(downstream, delay, unit, w, delayError));
     }
 
     static final class DelaySubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -37,7 +37,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
 
     @Override
     public void subscribeActual(final Subscriber<? super T> child) {
-        MainSubscriber<T> parent = new MainSubscriber<T>(child, main);
+        MainSubscriber<T> parent = new MainSubscriber<>(child, main);
         child.onSubscribe(parent);
         other.subscribe(parent.other);
     }
@@ -58,7 +58,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
             this.downstream = downstream;
             this.main = main;
             this.other = new OtherSubscriber();
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
         }
 
         void next() {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDematerialize.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDematerialize.java
@@ -34,7 +34,7 @@ public final class FlowableDematerialize<T, R> extends AbstractFlowableWithUpstr
 
     @Override
     protected void subscribeActual(Subscriber<? super R> subscriber) {
-        source.subscribe(new DematerializeSubscriber<T, R>(subscriber, selector));
+        source.subscribe(new DematerializeSubscriber<>(subscriber, selector));
     }
 
     static final class DematerializeSubscriber<T, R> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDetach.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDetach.java
@@ -27,7 +27,7 @@ public final class FlowableDetach<T> extends AbstractFlowableWithUpstream<T, T> 
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new DetachSubscriber<T>(s));
+        source.subscribe(new DetachSubscriber<>(s));
     }
 
     static final class DetachSubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinct.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinct.java
@@ -52,7 +52,7 @@ public final class FlowableDistinct<T, K> extends AbstractFlowableWithUpstream<T
             return;
         }
 
-        source.subscribe(new DistinctSubscriber<T, K>(subscriber, keySelector, collection));
+        source.subscribe(new DistinctSubscriber<>(subscriber, keySelector, collection));
     }
 
     static final class DistinctSubscriber<T, K> extends BasicFuseableSubscriber<T, T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -37,9 +37,9 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
     protected void subscribeActual(Subscriber<? super T> s) {
         if (s instanceof ConditionalSubscriber) {
             ConditionalSubscriber<? super T> cs = (ConditionalSubscriber<? super T>) s;
-            source.subscribe(new DistinctUntilChangedConditionalSubscriber<T, K>(cs, keySelector, comparer));
+            source.subscribe(new DistinctUntilChangedConditionalSubscriber<>(cs, keySelector, comparer));
         } else {
-            source.subscribe(new DistinctUntilChangedSubscriber<T, K>(s, keySelector, comparer));
+            source.subscribe(new DistinctUntilChangedSubscriber<>(s, keySelector, comparer));
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoAfterNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoAfterNext.java
@@ -39,9 +39,9 @@ public final class FlowableDoAfterNext<T> extends AbstractFlowableWithUpstream<T
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         if (s instanceof ConditionalSubscriber) {
-            source.subscribe(new DoAfterConditionalSubscriber<T>((ConditionalSubscriber<? super T>)s, onAfterNext));
+            source.subscribe(new DoAfterConditionalSubscriber<>((ConditionalSubscriber<? super T>) s, onAfterNext));
         } else {
-            source.subscribe(new DoAfterSubscriber<T>(s, onAfterNext));
+            source.subscribe(new DoAfterSubscriber<>(s, onAfterNext));
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoFinally.java
@@ -41,9 +41,9 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         if (s instanceof ConditionalSubscriber) {
-            source.subscribe(new DoFinallyConditionalSubscriber<T>((ConditionalSubscriber<? super T>)s, onFinally));
+            source.subscribe(new DoFinallyConditionalSubscriber<>((ConditionalSubscriber<? super T>) s, onFinally));
         } else {
-            source.subscribe(new DoFinallySubscriber<T>(s, onFinally));
+            source.subscribe(new DoFinallySubscriber<>(s, onFinally));
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnEach.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnEach.java
@@ -44,10 +44,10 @@ public final class FlowableDoOnEach<T> extends AbstractFlowableWithUpstream<T, T
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         if (s instanceof ConditionalSubscriber) {
-            source.subscribe(new DoOnEachConditionalSubscriber<T>(
-                    (ConditionalSubscriber<? super T>)s, onNext, onError, onComplete, onAfterTerminate));
+            source.subscribe(new DoOnEachConditionalSubscriber<>(
+                    (ConditionalSubscriber<? super T>) s, onNext, onError, onComplete, onAfterTerminate));
         } else {
-            source.subscribe(new DoOnEachSubscriber<T>(
+            source.subscribe(new DoOnEachSubscriber<>(
                     s, onNext, onError, onComplete, onAfterTerminate));
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDoOnLifecycle.java
@@ -35,7 +35,7 @@ public final class FlowableDoOnLifecycle<T> extends AbstractFlowableWithUpstream
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new SubscriptionLambdaSubscriber<T>(s, onSubscribe, onRequest, onCancel));
+        source.subscribe(new SubscriptionLambdaSubscriber<>(s, onSubscribe, onRequest, onCancel));
     }
 
     static final class SubscriptionLambdaSubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableElementAt.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableElementAt.java
@@ -35,7 +35,7 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new ElementAtSubscriber<T>(s, index, defaultValue, errorOnFewer));
+        source.subscribe(new ElementAtSubscriber<>(s, index, defaultValue, errorOnFewer));
     }
 
     static final class ElementAtSubscriber<T> extends DeferredScalarSubscription<T> implements FlowableSubscriber<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableElementAtMaybe.java
@@ -33,12 +33,12 @@ public final class FlowableElementAtMaybe<T> extends Maybe<T> implements FuseToF
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new ElementAtSubscriber<T>(observer, index));
+        source.subscribe(new ElementAtSubscriber<>(observer, index));
     }
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableElementAt<T>(source, index, null, false));
+        return RxJavaPlugins.onAssembly(new FlowableElementAt<>(source, index, null, false));
     }
 
     static final class ElementAtSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableElementAtSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableElementAtSingle.java
@@ -38,12 +38,12 @@ public final class FlowableElementAtSingle<T> extends Single<T> implements FuseT
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new ElementAtSubscriber<T>(observer, index, defaultValue));
+        source.subscribe(new ElementAtSubscriber<>(observer, index, defaultValue));
     }
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableElementAt<T>(source, index, defaultValue, true));
+        return RxJavaPlugins.onAssembly(new FlowableElementAt<>(source, index, defaultValue, true));
     }
 
     static final class ElementAtSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFilter.java
@@ -31,10 +31,10 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         if (s instanceof ConditionalSubscriber) {
-            source.subscribe(new FilterConditionalSubscriber<T>(
-                    (ConditionalSubscriber<? super T>)s, predicate));
+            source.subscribe(new FilterConditionalSubscriber<>(
+                    (ConditionalSubscriber<? super T>) s, predicate));
         } else {
-            source.subscribe(new FilterSubscriber<T>(s, predicate));
+            source.subscribe(new FilterSubscriber<>(s, predicate));
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMap.java
@@ -55,7 +55,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
     public static <T, U> FlowableSubscriber<T> subscribe(Subscriber<? super U> s,
             Function<? super T, ? extends Publisher<? extends U>> mapper,
             boolean delayErrors, int maxConcurrency, int bufferSize) {
-        return new MergeSubscriber<T, U>(s, mapper, delayErrors, maxConcurrency, bufferSize);
+        return new MergeSubscriber<>(s, mapper, delayErrors, maxConcurrency, bufferSize);
     }
 
     static final class MergeSubscriber<T, U> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
@@ -76,7 +76,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
 
         volatile boolean cancelled;
 
-        final AtomicReference<InnerSubscriber<?, ?>[]> subscribers = new AtomicReference<InnerSubscriber<?, ?>[]>();
+        final AtomicReference<InnerSubscriber<?, ?>[]> subscribers = new AtomicReference<>();
 
         static final InnerSubscriber<?, ?>[] EMPTY = new InnerSubscriber<?, ?>[0];
 
@@ -157,7 +157,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                     }
                 }
             } else {
-                InnerSubscriber<T, U> inner = new InnerSubscriber<T, U>(this, uniqueId++);
+                InnerSubscriber<T, U> inner = new InnerSubscriber<>(this, uniqueId++);
                 if (addInner(inner)) {
                     p.subscribe(inner);
                 }
@@ -216,9 +216,9 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
             SimplePlainQueue<U> q = queue;
             if (q == null) {
                 if (maxConcurrency == Integer.MAX_VALUE) {
-                    q = new SpscLinkedArrayQueue<U>(bufferSize);
+                    q = new SpscLinkedArrayQueue<>(bufferSize);
                 } else {
-                    q = new SpscArrayQueue<U>(maxConcurrency);
+                    q = new SpscArrayQueue<>(maxConcurrency);
                 }
                 queue = q;
             }
@@ -267,7 +267,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
         SimpleQueue<U> getInnerQueue(InnerSubscriber<T, U> inner) {
             SimpleQueue<U> q = inner.queue;
             if (q == null) {
-                q = new SpscArrayQueue<U>(bufferSize);
+                q = new SpscArrayQueue<>(bufferSize);
                 inner.queue = q;
             }
             return q;
@@ -298,7 +298,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
             } else {
                 SimpleQueue<U> q = inner.queue;
                 if (q == null) {
-                    q = new SpscArrayQueue<U>(bufferSize);
+                    q = new SpscArrayQueue<>(bufferSize);
                     inner.queue = q;
                 }
                 if (!q.offer(value)) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -50,7 +50,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
     @Override
     protected void subscribeActual(Subscriber<? super T> subscriber) {
-        source.subscribe(new FlatMapCompletableMainSubscriber<T>(subscriber, mapper, delayErrors, maxConcurrency));
+        source.subscribe(new FlatMapCompletableMainSubscriber<>(subscriber, mapper, delayErrors, maxConcurrency));
     }
 
     static final class FlatMapCompletableMainSubscriber<T> extends BasicIntQueueSubscription<T>
@@ -171,7 +171,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() {
             return null; // always empty
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -53,12 +53,12 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
 
     @Override
     protected void subscribeActual(CompletableObserver observer) {
-        source.subscribe(new FlatMapCompletableMainSubscriber<T>(observer, mapper, delayErrors, maxConcurrency));
+        source.subscribe(new FlatMapCompletableMainSubscriber<>(observer, mapper, delayErrors, maxConcurrency));
     }
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableFlatMapCompletable<T>(source, mapper, delayErrors, maxConcurrency));
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapCompletable<>(source, mapper, delayErrors, maxConcurrency));
     }
 
     static final class FlatMapCompletableMainSubscriber<T> extends AtomicInteger

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -50,7 +50,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new FlatMapMaybeSubscriber<T, R>(s, mapper, delayErrors, maxConcurrency));
+        source.subscribe(new FlatMapMaybeSubscriber<>(s, mapper, delayErrors, maxConcurrency));
     }
 
     static final class FlatMapMaybeSubscriber<T, R>
@@ -91,7 +91,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
             this.set = new CompositeDisposable();
             this.errors = new AtomicThrowable();
             this.active = new AtomicInteger(1);
-            this.queue = new AtomicReference<SpscLinkedArrayQueue<R>>();
+            this.queue = new AtomicReference<>();
         }
 
         @Override
@@ -210,7 +210,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
                 if (current != null) {
                     return current;
                 }
-                current = new SpscLinkedArrayQueue<R>(Flowable.bufferSize());
+                current = new SpscLinkedArrayQueue<>(Flowable.bufferSize());
                 if (queue.compareAndSet(null, current)) {
                     return current;
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -50,7 +50,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new FlatMapSingleSubscriber<T, R>(s, mapper, delayErrors, maxConcurrency));
+        source.subscribe(new FlatMapSingleSubscriber<>(s, mapper, delayErrors, maxConcurrency));
     }
 
     static final class FlatMapSingleSubscriber<T, R>
@@ -91,7 +91,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
             this.set = new CompositeDisposable();
             this.errors = new AtomicThrowable();
             this.active = new AtomicInteger(1);
-            this.queue = new AtomicReference<SpscLinkedArrayQueue<R>>();
+            this.queue = new AtomicReference<>();
         }
 
         @Override
@@ -210,7 +210,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
                 if (current != null) {
                     return current;
                 }
-                current = new SpscLinkedArrayQueue<R>(Flowable.bufferSize());
+                current = new SpscLinkedArrayQueue<>(Flowable.bufferSize());
                 if (queue.compareAndSet(null, current)) {
                     return current;
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterable.java
@@ -76,7 +76,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
 
             return;
         }
-        source.subscribe(new FlattenIterableSubscriber<T, R>(s, mapper, prefetch));
+        source.subscribe(new FlattenIterableSubscriber<>(s, mapper, prefetch));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromArray.java
@@ -33,10 +33,10 @@ public final class FlowableFromArray<T> extends Flowable<T> {
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
         if (s instanceof ConditionalSubscriber) {
-            s.onSubscribe(new ArrayConditionalSubscription<T>(
+            s.onSubscribe(new ArrayConditionalSubscription<>(
                     (ConditionalSubscriber<? super T>)s, array));
         } else {
-            s.onSubscribe(new ArraySubscription<T>(s, array));
+            s.onSubscribe(new ArraySubscription<>(s, array));
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromCallable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromCallable.java
@@ -32,7 +32,7 @@ public final class FlowableFromCallable<T> extends Flowable<T> implements Suppli
 
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
-        DeferredScalarSubscription<T> deferred = new DeferredScalarSubscription<T>(s);
+        DeferredScalarSubscription<T> deferred = new DeferredScalarSubscription<>(s);
         s.onSubscribe(deferred);
 
         T t;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromFuture.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromFuture.java
@@ -35,7 +35,7 @@ public final class FlowableFromFuture<T> extends Flowable<T> {
 
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
-        DeferredScalarSubscription<T> deferred = new DeferredScalarSubscription<T>(s);
+        DeferredScalarSubscription<T> deferred = new DeferredScalarSubscription<>(s);
         s.onSubscribe(deferred);
 
         T v;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromObservable.java
@@ -26,7 +26,7 @@ public final class FlowableFromObservable<T> extends Flowable<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        upstream.subscribe(new SubscriberObserver<T>(s));
+        upstream.subscribe(new SubscriberObserver<>(s));
     }
 
     static final class SubscriberObserver<T> implements Observer<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSupplier.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSupplier.java
@@ -38,7 +38,7 @@ public final class FlowableFromSupplier<T> extends Flowable<T> implements Suppli
 
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
-        DeferredScalarSubscription<T> deferred = new DeferredScalarSubscription<T>(s);
+        DeferredScalarSubscription<T> deferred = new DeferredScalarSubscription<>(s);
         s.onSubscribe(deferred);
 
         T t;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGenerate.java
@@ -48,7 +48,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
             return;
         }
 
-        s.onSubscribe(new GeneratorSubscription<T, S>(s, generator, disposeState, state));
+        s.onSubscribe(new GeneratorSubscription<>(s, generator, disposeState, state));
     }
 
     static final class GeneratorSubscription<T, S>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -56,10 +56,10 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         try {
             if (mapFactory == null) {
                 evictedGroups = null;
-                groups = new ConcurrentHashMap<Object, GroupedUnicast<K, V>>();
+                groups = new ConcurrentHashMap<>();
             } else {
-                evictedGroups = new ConcurrentLinkedQueue<GroupedUnicast<K, V>>();
-                Consumer<Object> evictionAction = (Consumer) new EvictionAction<K, V>(evictedGroups);
+                evictedGroups = new ConcurrentLinkedQueue<>();
+                Consumer<Object> evictionAction = (Consumer) new EvictionAction<>(evictedGroups);
                 groups = (Map) mapFactory.apply(evictionAction);
             }
         } catch (Throwable e) {
@@ -69,7 +69,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             return;
         }
         GroupBySubscriber<T, K, V> subscriber =
-                new GroupBySubscriber<T, K, V>(s, keySelector, valueSelector, bufferSize, delayError, groups, evictedGroups);
+                new GroupBySubscriber<>(s, keySelector, valueSelector, bufferSize, delayError, groups, evictedGroups);
         source.subscribe(subscriber);
     }
 
@@ -327,8 +327,8 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         final State<T, K> state;
 
         public static <T, K> GroupedUnicast<K, T> createWith(K key, int bufferSize, GroupBySubscriber<?, K, T> parent, boolean delayError) {
-            State<T, K> state = new State<T, K>(bufferSize, parent, key, delayError);
-            return new GroupedUnicast<K, T>(key, state);
+            State<T, K> state = new State<>(bufferSize, parent, key, delayError);
+            return new GroupedUnicast<>(key, state);
         }
 
         protected GroupedUnicast(K key, State<T, K> state) {
@@ -370,7 +370,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
         final AtomicBoolean cancelled = new AtomicBoolean();
 
-        final AtomicReference<Subscriber<? super T>> actual = new AtomicReference<Subscriber<? super T>>();
+        final AtomicReference<Subscriber<? super T>> actual = new AtomicReference<>();
 
         boolean outputFused;
         int produced;
@@ -383,7 +383,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         static final int ABANDONED_HAS_SUBSCRIBER = ABANDONED | HAS_SUBSCRIBER;
 
         State(int bufferSize, GroupBySubscriber<?, K, T> parent, K key, boolean delayError) {
-            this.queue = new SpscLinkedArrayQueue<T>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
             this.parent = parent;
             this.key = key;
             this.delayError = delayError;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupJoin.java
@@ -59,7 +59,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
     protected void subscribeActual(Subscriber<? super R> s) {
 
         GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
-                new GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
+                new GroupJoinSubscription<>(s, leftEnd, rightEnd, resultSelector);
 
         s.onSubscribe(parent);
 
@@ -132,10 +132,10 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
             this.downstream = actual;
             this.requested = new AtomicLong();
             this.disposables = new CompositeDisposable();
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize());
-            this.lefts = new LinkedHashMap<Integer, UnicastProcessor<TRight>>();
-            this.rights = new LinkedHashMap<Integer, TRight>();
-            this.error = new AtomicReference<Throwable>();
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize());
+            this.lefts = new LinkedHashMap<>();
+            this.rights = new LinkedHashMap<>();
+            this.error = new AtomicReference<>();
             this.leftEnd = leftEnd;
             this.rightEnd = rightEnd;
             this.resultSelector = resultSelector;
@@ -239,7 +239,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
                         @SuppressWarnings("unchecked")
                         TLeft left = (TLeft)val;
 
-                        UnicastProcessor<TRight> up = UnicastProcessor.<TRight>create();
+                        UnicastProcessor<TRight> up = UnicastProcessor.create();
                         int idx = leftIndex++;
                         lefts.put(idx, up);
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableHide.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableHide.java
@@ -32,7 +32,7 @@ public final class FlowableHide<T> extends AbstractFlowableWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new HideSubscriber<T>(s));
+        source.subscribe(new HideSubscriber<>(s));
     }
 
     static final class HideSubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIgnoreElements.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIgnoreElements.java
@@ -28,7 +28,7 @@ public final class FlowableIgnoreElements<T> extends AbstractFlowableWithUpstrea
 
     @Override
     protected void subscribeActual(final Subscriber<? super T> t) {
-        source.subscribe(new IgnoreElementsSubscriber<T>(t));
+        source.subscribe(new IgnoreElementsSubscriber<>(t));
     }
 
     static final class IgnoreElementsSubscriber<T> implements FlowableSubscriber<T>, QueueSubscription<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIgnoreElementsCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIgnoreElementsCompletable.java
@@ -31,12 +31,12 @@ public final class FlowableIgnoreElementsCompletable<T> extends Completable impl
 
     @Override
     protected void subscribeActual(final CompletableObserver t) {
-        source.subscribe(new IgnoreElementsSubscriber<T>(t));
+        source.subscribe(new IgnoreElementsSubscriber<>(t));
     }
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableIgnoreElements<T>(source));
+        return RxJavaPlugins.onAssembly(new FlowableIgnoreElements<>(source));
     }
 
     static final class IgnoreElementsSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableInternalHelper.java
@@ -47,7 +47,7 @@ public final class FlowableInternalHelper {
     }
 
     public static <T, S> BiFunction<S, Emitter<T>, S> simpleGenerator(Consumer<Emitter<T>> consumer) {
-        return new SimpleGenerator<T, S>(consumer);
+        return new SimpleGenerator<>(consumer);
     }
 
     static final class SimpleBiGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
@@ -65,7 +65,7 @@ public final class FlowableInternalHelper {
     }
 
     public static <T, S> BiFunction<S, Emitter<T>, S> simpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
-        return new SimpleBiGenerator<T, S>(consumer);
+        return new SimpleBiGenerator<>(consumer);
     }
 
     static final class ItemDelayFunction<T, U> implements Function<T, Publisher<T>> {
@@ -78,12 +78,12 @@ public final class FlowableInternalHelper {
         @Override
         public Publisher<T> apply(final T v) throws Throwable {
             Publisher<U> p = Objects.requireNonNull(itemDelay.apply(v), "The itemDelay returned a null Publisher");
-            return new FlowableTakePublisher<U>(p, 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+            return new FlowableTakePublisher<>(p, 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
         }
     }
 
     public static <T, U> Function<T, Publisher<T>> itemDelay(final Function<? super T, ? extends Publisher<U>> itemDelay) {
-        return new ItemDelayFunction<T, U>(itemDelay);
+        return new ItemDelayFunction<>(itemDelay);
     }
 
     static final class SubscriberOnNext<T> implements Consumer<T> {
@@ -94,7 +94,7 @@ public final class FlowableInternalHelper {
         }
 
         @Override
-        public void accept(T v) throws Exception {
+        public void accept(T v) {
             subscriber.onNext(v);
         }
     }
@@ -107,7 +107,7 @@ public final class FlowableInternalHelper {
         }
 
         @Override
-        public void accept(Throwable v) throws Exception {
+        public void accept(Throwable v) {
             subscriber.onError(v);
         }
     }
@@ -120,21 +120,21 @@ public final class FlowableInternalHelper {
         }
 
         @Override
-        public void run() throws Exception {
+        public void run() {
             subscriber.onComplete();
         }
     }
 
     public static <T> Consumer<T> subscriberOnNext(Subscriber<T> subscriber) {
-        return new SubscriberOnNext<T>(subscriber);
+        return new SubscriberOnNext<>(subscriber);
     }
 
     public static <T> Consumer<Throwable> subscriberOnError(Subscriber<T> subscriber) {
-        return new SubscriberOnError<T>(subscriber);
+        return new SubscriberOnError<>(subscriber);
     }
 
     public static <T> Action subscriberOnComplete(Subscriber<T> subscriber) {
-        return new SubscriberOnComplete<T>(subscriber);
+        return new SubscriberOnComplete<>(subscriber);
     }
 
     static final class FlatMapWithCombinerInner<U, R, T> implements Function<U, R> {
@@ -166,14 +166,14 @@ public final class FlowableInternalHelper {
         public Publisher<R> apply(final T t) throws Throwable {
             @SuppressWarnings("unchecked")
             Publisher<U> u = (Publisher<U>)Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Publisher");
-            return new FlowableMapPublisher<U, R>(u, new FlatMapWithCombinerInner<U, R, T>(combiner, t));
+            return new FlowableMapPublisher<>(u, new FlatMapWithCombinerInner<U, R, T>(combiner, t));
         }
     }
 
     public static <T, U, R> Function<T, Publisher<R>> flatMapWithCombiner(
             final Function<? super T, ? extends Publisher<? extends U>> mapper,
                     final BiFunction<? super T, ? super U, ? extends R> combiner) {
-        return new FlatMapWithCombinerOuter<T, R, U>(combiner, mapper);
+        return new FlatMapWithCombinerOuter<>(combiner, mapper);
     }
 
     static final class FlatMapIntoIterable<T, U> implements Function<T, Publisher<U>> {
@@ -185,34 +185,34 @@ public final class FlowableInternalHelper {
 
         @Override
         public Publisher<U> apply(T t) throws Throwable {
-            return new FlowableFromIterable<U>(Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Iterable"));
+            return new FlowableFromIterable<>(Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Iterable"));
         }
     }
 
     public static <T, U> Function<T, Publisher<U>> flatMapIntoIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        return new FlatMapIntoIterable<T, U>(mapper);
+        return new FlatMapIntoIterable<>(mapper);
     }
 
     public static <T> Supplier<ConnectableFlowable<T>> replaySupplier(final Flowable<T> parent) {
-        return new ReplaySupplier<T>(parent);
+        return new ReplaySupplier<>(parent);
     }
 
     public static <T> Supplier<ConnectableFlowable<T>> replaySupplier(final Flowable<T> parent, final int bufferSize, boolean eagerTruncate) {
-        return new BufferedReplaySupplier<T>(parent, bufferSize, eagerTruncate);
+        return new BufferedReplaySupplier<>(parent, bufferSize, eagerTruncate);
     }
 
     public static <T> Supplier<ConnectableFlowable<T>> replaySupplier(final Flowable<T> parent, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
-        return new BufferedTimedReplay<T>(parent, bufferSize, time, unit, scheduler, eagerTruncate);
+        return new BufferedTimedReplay<>(parent, bufferSize, time, unit, scheduler, eagerTruncate);
     }
 
     public static <T> Supplier<ConnectableFlowable<T>> replaySupplier(final Flowable<T> parent, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
-        return new TimedReplay<T>(parent, time, unit, scheduler, eagerTruncate);
+        return new TimedReplay<>(parent, time, unit, scheduler, eagerTruncate);
     }
 
     public enum RequestMax implements Consumer<Subscription> {
         INSTANCE;
         @Override
-        public void accept(Subscription t) throws Exception {
+        public void accept(Subscription t) {
             t.request(Long.MAX_VALUE);
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableInterval.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableInterval.java
@@ -66,7 +66,7 @@ public final class FlowableInterval extends Flowable<Long> {
 
         long count;
 
-        final AtomicReference<Disposable> resource = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> resource = new AtomicReference<>();
 
         IntervalSubscriber(Subscriber<? super Long> downstream) {
             this.downstream = downstream;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIntervalRange.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIntervalRange.java
@@ -71,7 +71,7 @@ public final class FlowableIntervalRange extends Flowable<Long> {
 
         long count;
 
-        final AtomicReference<Disposable> resource = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> resource = new AtomicReference<>();
 
         IntervalRangeSubscriber(Subscriber<? super Long> actual, long start, long end) {
             this.downstream = actual;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableJoin.java
@@ -56,7 +56,7 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
     protected void subscribeActual(Subscriber<? super R> s) {
 
         JoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
-                new JoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>(s, leftEnd, rightEnd, resultSelector);
+                new JoinSubscription<>(s, leftEnd, rightEnd, resultSelector);
 
         s.onSubscribe(parent);
 
@@ -116,10 +116,10 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
             this.downstream = actual;
             this.requested = new AtomicLong();
             this.disposables = new CompositeDisposable();
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize());
-            this.lefts = new LinkedHashMap<Integer, TLeft>();
-            this.rights = new LinkedHashMap<Integer, TRight>();
-            this.error = new AtomicReference<Throwable>();
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize());
+            this.lefts = new LinkedHashMap<>();
+            this.rights = new LinkedHashMap<>();
+            this.error = new AtomicReference<>();
             this.leftEnd = leftEnd;
             this.rightEnd = rightEnd;
             this.resultSelector = resultSelector;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableJust.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableJust.java
@@ -31,7 +31,7 @@ public final class FlowableJust<T> extends Flowable<T> implements ScalarSupplier
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        s.onSubscribe(new ScalarSubscription<T>(s, value));
+        s.onSubscribe(new ScalarSubscription<>(s, value));
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableLastMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableLastMaybe.java
@@ -36,7 +36,7 @@ public final class FlowableLastMaybe<T> extends Maybe<T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new LastSubscriber<T>(observer));
+        source.subscribe(new LastSubscriber<>(observer));
     }
 
     static final class LastSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableLastSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableLastSingle.java
@@ -42,7 +42,7 @@ public final class FlowableLastSingle<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new LastSubscriber<T>(observer, defaultItem));
+        source.subscribe(new LastSubscriber<>(observer, defaultItem));
     }
 
     static final class LastSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMapNotification.java
@@ -41,7 +41,7 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new MapNotificationSubscriber<T, R>(s, onNextMapper, onErrorMapper, onCompleteSupplier));
+        source.subscribe(new MapNotificationSubscriber<>(s, onNextMapper, onErrorMapper, onCompleteSupplier));
     }
 
     static final class MapNotificationSubscriber<T, R>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMaterialize.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMaterialize.java
@@ -27,7 +27,7 @@ public final class FlowableMaterialize<T> extends AbstractFlowableWithUpstream<T
 
     @Override
     protected void subscribeActual(Subscriber<? super Notification<T>> s) {
-        source.subscribe(new MaterializeSubscriber<T>(s));
+        source.subscribe(new MaterializeSubscriber<>(s));
     }
 
     static final class MaterializeSubscriber<T> extends SinglePostCompleteSubscriber<T, Notification<T>> {
@@ -46,12 +46,12 @@ public final class FlowableMaterialize<T> extends AbstractFlowableWithUpstream<T
 
         @Override
         public void onError(Throwable t) {
-            complete(Notification.<T>createOnError(t));
+            complete(Notification.createOnError(t));
         }
 
         @Override
         public void onComplete() {
-            complete(Notification.<T>createOnComplete());
+            complete(Notification.createOnComplete());
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithCompletable.java
@@ -41,7 +41,7 @@ public final class FlowableMergeWithCompletable<T> extends AbstractFlowableWithU
 
     @Override
     protected void subscribeActual(Subscriber<? super T> subscriber) {
-        MergeWithSubscriber<T> parent = new MergeWithSubscriber<T>(subscriber);
+        MergeWithSubscriber<T> parent = new MergeWithSubscriber<>(subscriber);
         subscriber.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
@@ -68,7 +68,7 @@ public final class FlowableMergeWithCompletable<T> extends AbstractFlowableWithU
 
         MergeWithSubscriber(Subscriber<? super T> downstream) {
             this.downstream = downstream;
-            this.mainSubscription = new AtomicReference<Subscription>();
+            this.mainSubscription = new AtomicReference<>();
             this.otherObserver = new OtherObserver(this);
             this.errors = new AtomicThrowable();
             this.requested = new AtomicLong();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -43,7 +43,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
 
     @Override
     protected void subscribeActual(Subscriber<? super T> subscriber) {
-        MergeWithObserver<T> parent = new MergeWithObserver<T>(subscriber);
+        MergeWithObserver<T> parent = new MergeWithObserver<>(subscriber);
         subscriber.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
@@ -88,8 +88,8 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
 
         MergeWithObserver(Subscriber<? super T> downstream) {
             this.downstream = downstream;
-            this.mainSubscription = new AtomicReference<Subscription>();
-            this.otherObserver = new OtherObserver<T>(this);
+            this.mainSubscription = new AtomicReference<>();
+            this.otherObserver = new OtherObserver<>(this);
             this.errors = new AtomicThrowable();
             this.requested = new AtomicLong();
             this.prefetch = bufferSize();
@@ -211,7 +211,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
         SimplePlainQueue<T> getOrCreateQueue() {
             SimplePlainQueue<T> q = queue;
             if (q == null) {
-                q = new SpscArrayQueue<T>(bufferSize());
+                q = new SpscArrayQueue<>(bufferSize());
                 queue = q;
             }
             return q;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableMergeWithSingle.java
@@ -43,7 +43,7 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
 
     @Override
     protected void subscribeActual(Subscriber<? super T> subscriber) {
-        MergeWithObserver<T> parent = new MergeWithObserver<T>(subscriber);
+        MergeWithObserver<T> parent = new MergeWithObserver<>(subscriber);
         subscriber.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
@@ -88,8 +88,8 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
 
         MergeWithObserver(Subscriber<? super T> downstream) {
             this.downstream = downstream;
-            this.mainSubscription = new AtomicReference<Subscription>();
-            this.otherObserver = new OtherObserver<T>(this);
+            this.mainSubscription = new AtomicReference<>();
+            this.otherObserver = new OtherObserver<>(this);
             this.errors = new AtomicThrowable();
             this.requested = new AtomicLong();
             this.prefetch = bufferSize();
@@ -206,7 +206,7 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
         SimplePlainQueue<T> getOrCreateQueue() {
             SimplePlainQueue<T> q = queue;
             if (q == null) {
-                q = new SpscArrayQueue<T>(bufferSize());
+                q = new SpscArrayQueue<>(bufferSize());
                 queue = q;
             }
             return q;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
@@ -50,10 +50,10 @@ final Scheduler scheduler;
         Worker worker = scheduler.createWorker();
 
         if (s instanceof ConditionalSubscriber) {
-            source.subscribe(new ObserveOnConditionalSubscriber<T>(
+            source.subscribe(new ObserveOnConditionalSubscriber<>(
                     (ConditionalSubscriber<? super T>) s, worker, delayError, prefetch));
         } else {
-            source.subscribe(new ObserveOnSubscriber<T>(s, worker, delayError, prefetch));
+            source.subscribe(new ObserveOnSubscriber<>(s, worker, delayError, prefetch));
         }
     }
 
@@ -289,7 +289,7 @@ final Scheduler scheduler;
                     }
                 }
 
-                queue = new SpscArrayQueue<T>(prefetch);
+                queue = new SpscArrayQueue<>(prefetch);
 
                 downstream.onSubscribe(this);
 
@@ -533,7 +533,7 @@ final Scheduler scheduler;
                     }
                 }
 
-                queue = new SpscArrayQueue<T>(prefetch);
+                queue = new SpscArrayQueue<>(prefetch);
 
                 downstream.onSubscribe(this);
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -43,7 +43,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new BackpressureBufferSubscriber<T>(s, bufferSize, unbounded, delayError, onOverflow));
+        source.subscribe(new BackpressureBufferSubscriber<>(s, bufferSize, unbounded, delayError, onOverflow));
     }
 
     static final class BackpressureBufferSubscriber<T> extends BasicIntQueueSubscription<T> implements FlowableSubscriber<T> {
@@ -75,9 +75,9 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
             SimplePlainQueue<T> q;
 
             if (unbounded) {
-                q = new SpscLinkedArrayQueue<T>(bufferSize);
+                q = new SpscLinkedArrayQueue<>(bufferSize);
             } else {
-                q = new SpscArrayQueue<T>(bufferSize);
+                q = new SpscArrayQueue<>(bufferSize);
             }
 
             this.queue = q;
@@ -255,7 +255,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() {
             return queue.poll();
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
@@ -48,7 +48,7 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new OnBackpressureBufferStrategySubscriber<T>(s, onOverflow, strategy, bufferSize));
+        source.subscribe(new OnBackpressureBufferStrategySubscriber<>(s, onOverflow, strategy, bufferSize));
     }
 
     static final class OnBackpressureBufferStrategySubscriber<T>
@@ -83,7 +83,7 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
             this.strategy = strategy;
             this.bufferSize = bufferSize;
             this.requested = new AtomicLong();
-            this.deque = new ArrayDeque<T>();
+            this.deque = new ArrayDeque<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureDrop.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureDrop.java
@@ -45,7 +45,7 @@ public final class FlowableOnBackpressureDrop<T> extends AbstractFlowableWithUps
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        this.source.subscribe(new BackpressureDropSubscriber<T>(s, onDrop));
+        this.source.subscribe(new BackpressureDropSubscriber<>(s, onDrop));
     }
 
     static final class BackpressureDropSubscriber<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureError.java
@@ -31,7 +31,7 @@ public final class FlowableOnBackpressureError<T> extends AbstractFlowableWithUp
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        this.source.subscribe(new BackpressureErrorSubscriber<T>(s));
+        this.source.subscribe(new BackpressureErrorSubscriber<>(s));
     }
 
     static final class BackpressureErrorSubscriber<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureLatest.java
@@ -29,7 +29,7 @@ public final class FlowableOnBackpressureLatest<T> extends AbstractFlowableWithU
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new BackpressureLatestSubscriber<T>(s));
+        source.subscribe(new BackpressureLatestSubscriber<>(s));
     }
 
     static final class BackpressureLatestSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
@@ -47,7 +47,7 @@ public final class FlowableOnBackpressureLatest<T> extends AbstractFlowableWithU
 
         final AtomicLong requested = new AtomicLong();
 
-        final AtomicReference<T> current = new AtomicReference<T>();
+        final AtomicReference<T> current = new AtomicReference<>();
 
         BackpressureLatestSubscriber(Subscriber<? super T> downstream) {
             this.downstream = downstream;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorNext.java
@@ -34,7 +34,7 @@ public final class FlowableOnErrorNext<T> extends AbstractFlowableWithUpstream<T
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        OnErrorNextSubscriber<T> parent = new OnErrorNextSubscriber<T>(s, nextSupplier);
+        OnErrorNextSubscriber<T> parent = new OnErrorNextSubscriber<>(s, nextSupplier);
         s.onSubscribe(parent);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorReturn.java
@@ -31,7 +31,7 @@ public final class FlowableOnErrorReturn<T> extends AbstractFlowableWithUpstream
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new OnErrorReturnSubscriber<T>(s, valueSupplier));
+        source.subscribe(new OnErrorReturnSubscriber<>(s, valueSupplier));
     }
 
     static final class OnErrorReturnSubscriber<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublish.java
@@ -34,7 +34,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  * completes or the connection is disposed.
  * <p>
  * The difference to FlowablePublish is that when the upstream terminates,
- * late subscriberss will receive that terminal event until the connection is
+ * late subscribers will receive that terminal event until the connection is
  * disposed and the ConnectableFlowable is reset to its fresh state.
  *
  * @param <T> the element type
@@ -52,7 +52,7 @@ implements HasUpstreamPublisher<T> {
     public FlowablePublish(Publisher<T> source, int bufferSize) {
         this.source = source;
         this.bufferSize = bufferSize;
-        this.current = new AtomicReference<PublishConnection<T>>();
+        this.current = new AtomicReference<>();
     }
 
     @Override
@@ -61,8 +61,8 @@ implements HasUpstreamPublisher<T> {
     }
 
     /**
-     * The internal buffer size of this FloawblePublishAlt operator.
-     * @return The internal buffer size of this FloawblePublishAlt operator.
+     * The internal buffer size of this FlowablePublishAlt operator.
+     * @return The internal buffer size of this FlowablePublishAlt operator.
      */
     public int publishBufferSize() {
         return bufferSize;
@@ -77,7 +77,7 @@ implements HasUpstreamPublisher<T> {
             conn = current.get();
 
             if (conn == null || conn.isDisposed()) {
-                PublishConnection<T> fresh = new PublishConnection<T>(current, bufferSize);
+                PublishConnection<T> fresh = new PublishConnection<>(current, bufferSize);
                 if (!current.compareAndSet(conn, fresh)) {
                     continue;
                 }
@@ -109,7 +109,7 @@ implements HasUpstreamPublisher<T> {
 
             // don't create a fresh connection if the current is disposed
             if (conn == null) {
-                PublishConnection<T> fresh = new PublishConnection<T>(current, bufferSize);
+                PublishConnection<T> fresh = new PublishConnection<>(current, bufferSize);
                 if (!current.compareAndSet(conn, fresh)) {
                     continue;
                 }
@@ -119,7 +119,7 @@ implements HasUpstreamPublisher<T> {
             break;
         }
 
-        InnerSubscription<T> inner = new InnerSubscription<T>(s, conn);
+        InnerSubscription<T> inner = new InnerSubscription<>(s, conn);
         s.onSubscribe(inner);
 
         if (conn.add(inner)) {
@@ -180,10 +180,10 @@ implements HasUpstreamPublisher<T> {
         @SuppressWarnings("unchecked")
         PublishConnection(AtomicReference<PublishConnection<T>> current, int bufferSize) {
             this.current = current;
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.connect = new AtomicBoolean();
             this.bufferSize = bufferSize;
-            this.subscribers = new AtomicReference<InnerSubscription<T>[]>(EMPTY);
+            this.subscribers = new AtomicReference<>(EMPTY);
         }
 
         @SuppressWarnings("unchecked")
@@ -222,7 +222,7 @@ implements HasUpstreamPublisher<T> {
                     }
                 }
 
-                queue = new SpscArrayQueue<T>(bufferSize);
+                queue = new SpscArrayQueue<>(bufferSize);
 
                 s.request(bufferSize);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticast.java
@@ -55,7 +55,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        MulticastProcessor<T> mp = new MulticastProcessor<T>(prefetch, delayError);
+        MulticastProcessor<T> mp = new MulticastProcessor<>(prefetch, delayError);
 
         Publisher<? extends R> other;
 
@@ -67,7 +67,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             return;
         }
 
-        OutputCanceller<R> out = new OutputCanceller<R>(s, mp);
+        OutputCanceller<R> out = new OutputCanceller<>(s, mp);
 
         other.subscribe(out);
 
@@ -159,8 +159,8 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             this.limit = prefetch - (prefetch >> 2); // request after 75% consumption
             this.delayError = delayError;
             this.wip = new AtomicInteger();
-            this.upstream = new AtomicReference<Subscription>();
-            this.subscribers = new AtomicReference<MulticastSubscription<T>[]>(EMPTY);
+            this.upstream = new AtomicReference<>();
+            this.subscribers = new AtomicReference<>(EMPTY);
         }
 
         @Override
@@ -293,7 +293,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
 
         @Override
         protected void subscribeActual(Subscriber<? super T> s) {
-            MulticastSubscription<T> ms = new MulticastSubscription<T>(s, this);
+            MulticastSubscription<T> ms = new MulticastSubscription<>(s, this);
             s.onSubscribe(ms);
             if (add(ms)) {
                 if (ms.isCancelled()) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReduce.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReduce.java
@@ -40,7 +40,7 @@ public final class FlowableReduce<T> extends AbstractFlowableWithUpstream<T, T> 
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new ReduceSubscriber<T>(s, reducer));
+        source.subscribe(new ReduceSubscriber<>(s, reducer));
     }
 
     static final class ReduceSubscriber<T> extends DeferredScalarSubscription<T> implements FlowableSubscriber<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReduceMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReduceMaybe.java
@@ -50,12 +50,12 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableReduce<T>(source, reducer));
+        return RxJavaPlugins.onAssembly(new FlowableReduce<>(source, reducer));
     }
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new ReduceSubscriber<T>(observer, reducer));
+        source.subscribe(new ReduceSubscriber<>(observer, reducer));
     }
 
     static final class ReduceSubscriber<T> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReduceSeedSingle.java
@@ -47,7 +47,7 @@ public final class FlowableReduceSeedSingle<T, R> extends Single<R> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super R> observer) {
-        source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
+        source.subscribe(new ReduceSeedObserver<>(observer, reducer, seed));
     }
 
     static final class ReduceSeedObserver<T, R> implements FlowableSubscriber<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReduceWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReduceWithSingle.java
@@ -55,6 +55,6 @@ public final class FlowableReduceWithSingle<T, R> extends Single<R> {
             EmptyDisposable.error(ex, observer);
             return;
         }
-        source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
+        source.subscribe(new ReduceSeedObserver<>(observer, reducer, seed));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRefCount.java
@@ -84,7 +84,7 @@ public final class FlowableRefCount<T> extends Flowable<T> {
             }
         }
 
-        source.subscribe(new RefCountSubscriber<T>(s, this, conn));
+        source.subscribe(new RefCountSubscriber<>(s, this, conn));
 
         if (connect) {
             source.connect(conn);
@@ -168,7 +168,7 @@ public final class FlowableRefCount<T> extends Flowable<T> {
         }
 
         @Override
-        public void accept(Disposable t) throws Exception {
+        public void accept(Disposable t) {
             DisposableHelper.replace(this, t);
             synchronized (parent) {
                 if (disconnectedEarly) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRepeat.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRepeat.java
@@ -32,7 +32,7 @@ public final class FlowableRepeat<T> extends AbstractFlowableWithUpstream<T, T> 
         SubscriptionArbiter sa = new SubscriptionArbiter(false);
         s.onSubscribe(sa);
 
-        RepeatSubscriber<T> rs = new RepeatSubscriber<T>(s, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sa, source);
+        RepeatSubscriber<T> rs = new RepeatSubscriber<>(s, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sa, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRepeatUntil.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRepeatUntil.java
@@ -34,7 +34,7 @@ public final class FlowableRepeatUntil<T> extends AbstractFlowableWithUpstream<T
         SubscriptionArbiter sa = new SubscriptionArbiter(false);
         s.onSubscribe(sa);
 
-        RepeatSubscriber<T> rs = new RepeatSubscriber<T>(s, until, sa, source);
+        RepeatSubscriber<T> rs = new RepeatSubscriber<>(s, until, sa, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRepeatWhen.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRepeatWhen.java
@@ -37,9 +37,9 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
 
-        SerializedSubscriber<T> z = new SerializedSubscriber<T>(s);
+        SerializedSubscriber<T> z = new SerializedSubscriber<>(s);
 
-        FlowableProcessor<Object> processor = UnicastProcessor.<Object>create(8).toSerialized();
+        FlowableProcessor<Object> processor = UnicastProcessor.create(8).toSerialized();
 
         Publisher<?> when;
 
@@ -51,9 +51,9 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
             return;
         }
 
-        WhenReceiver<T, Object> receiver = new WhenReceiver<T, Object>(source);
+        WhenReceiver<T, Object> receiver = new WhenReceiver<>(source);
 
-        RepeatWhenSubscriber<T> subscriber = new RepeatWhenSubscriber<T>(z, processor, receiver);
+        RepeatWhenSubscriber<T> subscriber = new RepeatWhenSubscriber<>(z, processor, receiver);
 
         receiver.subscriber = subscriber;
 
@@ -80,7 +80,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
 
         WhenReceiver(Publisher<T> source) {
             this.source = source;
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.requested = new AtomicLong();
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableReplay.java
@@ -56,7 +56,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     public static <U, R> Flowable<R> multicastSelector(
             final Supplier<? extends ConnectableFlowable<U>> connectableFactory,
             final Function<? super Flowable<U>, ? extends Publisher<R>> selector) {
-        return new MulticastFlowable<R, U>(connectableFactory, selector);
+        return new MulticastFlowable<>(connectableFactory, selector);
     }
 
     /**
@@ -83,7 +83,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         if (bufferSize == Integer.MAX_VALUE) {
             return createFrom(source);
         }
-        return create(source, new ReplayBufferSupplier<T>(bufferSize, eagerTruncate));
+        return create(source, new ReplayBufferSupplier<>(bufferSize, eagerTruncate));
     }
 
     /**
@@ -114,7 +114,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     public static <T> ConnectableFlowable<T> create(Flowable<T> source,
             final long maxAge, final TimeUnit unit, final Scheduler scheduler, final int bufferSize, boolean eagerTruncate) {
-        return create(source, new ScheduledReplayBufferSupplier<T>(bufferSize, maxAge, unit, scheduler, eagerTruncate));
+        return create(source, new ScheduledReplayBufferSupplier<>(bufferSize, maxAge, unit, scheduler, eagerTruncate));
     }
 
     /**
@@ -126,9 +126,9 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     static <T> ConnectableFlowable<T> create(Flowable<T> source,
             final Supplier<? extends ReplayBuffer<T>> bufferFactory) {
         // the current connection to source needs to be shared between the operator and its onSubscribe call
-        final AtomicReference<ReplaySubscriber<T>> curr = new AtomicReference<ReplaySubscriber<T>>();
-        Publisher<T> onSubscribe = new ReplayPublisher<T>(curr, bufferFactory);
-        return RxJavaPlugins.onAssembly(new FlowableReplay<T>(onSubscribe, source, curr, bufferFactory));
+        final AtomicReference<ReplaySubscriber<T>> curr = new AtomicReference<>();
+        Publisher<T> onSubscribe = new ReplayPublisher<>(curr, bufferFactory);
+        return RxJavaPlugins.onAssembly(new FlowableReplay<>(onSubscribe, source, curr, bufferFactory));
     }
 
     private FlowableReplay(Publisher<T> onSubscribe, Flowable<T> source,
@@ -179,7 +179,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
                 }
 
                 // create a new subscriber-to-source
-                ReplaySubscriber<T> u = new ReplaySubscriber<T>(buf);
+                ReplaySubscriber<T> u = new ReplaySubscriber<>(buf);
                 // try setting it as the current subscriber-to-source
                 if (!current.compareAndSet(ps, u)) {
                     // did not work, perhaps a new subscriber arrived
@@ -255,7 +255,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         ReplaySubscriber(ReplayBuffer<T> buffer) {
             this.buffer = buffer;
             this.management = new AtomicInteger();
-            this.subscribers = new AtomicReference<InnerSubscription<T>[]>(EMPTY);
+            this.subscribers = new AtomicReference<>(EMPTY);
             this.shouldConnect = new AtomicBoolean();
         }
 
@@ -1004,7 +1004,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
         @Override
         Object enterTransform(Object value, boolean terminal) {
-            return new Timed<Object>(value, terminal ? Long.MAX_VALUE : scheduler.now(unit), unit);
+            return new Timed<>(value, terminal ? Long.MAX_VALUE : scheduler.now(unit), unit);
         }
 
         @Override
@@ -1128,7 +1128,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
                 return;
             }
 
-            final SubscriberResourceWrapper<R> srw = new SubscriberResourceWrapper<R>(child);
+            final SubscriberResourceWrapper<R> srw = new SubscriberResourceWrapper<>(child);
 
             observable.subscribe(srw);
 
@@ -1187,7 +1187,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
         @Override
         public ReplayBuffer<T> get() {
-            return new SizeBoundReplayBuffer<T>(bufferSize, eagerTruncate);
+            return new SizeBoundReplayBuffer<>(bufferSize, eagerTruncate);
         }
     }
 
@@ -1209,7 +1209,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
 
         @Override
         public ReplayBuffer<T> get() {
-            return new SizeAndTimeBoundReplayBuffer<T>(bufferSize, maxAge, unit, scheduler, eagerTruncate);
+            return new SizeAndTimeBoundReplayBuffer<>(bufferSize, maxAge, unit, scheduler, eagerTruncate);
         }
     }
 
@@ -1241,7 +1241,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
                         return;
                     }
                     // create a new subscriber to source
-                    ReplaySubscriber<T> u = new ReplaySubscriber<T>(buf);
+                    ReplaySubscriber<T> u = new ReplaySubscriber<>(buf);
                     // let's try setting it as the current subscriber-to-source
                     if (!curr.compareAndSet(null, u)) {
                         // didn't work, maybe someone else did it or the current subscriber
@@ -1253,7 +1253,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
                 }
 
                 // create the backpressure-managing producer for this child
-                InnerSubscription<T> inner = new InnerSubscription<T>(r, child);
+                InnerSubscription<T> inner = new InnerSubscription<>(r, child);
                 // the producer has been registered with the current subscriber-to-source so
                 // at least it will receive the next terminal event
                 // setting the producer will trigger the first request to be considered by
@@ -1282,7 +1282,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     static final class DefaultUnboundedFactory implements Supplier<Object> {
         @Override
         public Object get() {
-            return new UnboundedReplayBuffer<Object>(16);
+            return new UnboundedReplayBuffer<>(16);
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryBiPredicate.java
@@ -36,7 +36,7 @@ public final class FlowableRetryBiPredicate<T> extends AbstractFlowableWithUpstr
         SubscriptionArbiter sa = new SubscriptionArbiter(false);
         s.onSubscribe(sa);
 
-        RetryBiSubscriber<T> rs = new RetryBiSubscriber<T>(s, predicate, sa, source);
+        RetryBiSubscriber<T> rs = new RetryBiSubscriber<>(s, predicate, sa, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryPredicate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryPredicate.java
@@ -38,7 +38,7 @@ public final class FlowableRetryPredicate<T> extends AbstractFlowableWithUpstrea
         SubscriptionArbiter sa = new SubscriptionArbiter(false);
         s.onSubscribe(sa);
 
-        RetrySubscriber<T> rs = new RetrySubscriber<T>(s, count, predicate, sa, source);
+        RetrySubscriber<T> rs = new RetrySubscriber<>(s, count, predicate, sa, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryWhen.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRetryWhen.java
@@ -36,7 +36,7 @@ public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, 
 
     @Override
     public void subscribeActual(Subscriber<? super T> s) {
-        SerializedSubscriber<T> z = new SerializedSubscriber<T>(s);
+        SerializedSubscriber<T> z = new SerializedSubscriber<>(s);
 
         FlowableProcessor<Throwable> processor = UnicastProcessor.<Throwable>create(8).toSerialized();
 
@@ -50,9 +50,9 @@ public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, 
             return;
         }
 
-        WhenReceiver<T, Throwable> receiver = new WhenReceiver<T, Throwable>(source);
+        WhenReceiver<T, Throwable> receiver = new WhenReceiver<>(source);
 
-        RetryWhenSubscriber<T> subscriber = new RetryWhenSubscriber<T>(z, processor, receiver);
+        RetryWhenSubscriber<T> subscriber = new RetryWhenSubscriber<>(z, processor, receiver);
 
         receiver.subscriber = subscriber;
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSamplePublisher.java
@@ -37,11 +37,11 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        SerializedSubscriber<T> serial = new SerializedSubscriber<T>(s);
+        SerializedSubscriber<T> serial = new SerializedSubscriber<>(s);
         if (emitLast) {
-            source.subscribe(new SampleMainEmitLast<T>(serial, other));
+            source.subscribe(new SampleMainEmitLast<>(serial, other));
         } else {
-            source.subscribe(new SampleMainNoLast<T>(serial, other));
+            source.subscribe(new SampleMainNoLast<>(serial, other));
         }
     }
 
@@ -54,7 +54,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
 
         final AtomicLong requested = new AtomicLong();
 
-        final AtomicReference<Subscription> other = new AtomicReference<Subscription>();
+        final AtomicReference<Subscription> other = new AtomicReference<>();
 
         Subscription upstream;
 
@@ -69,7 +69,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
                 this.upstream = s;
                 downstream.onSubscribe(this);
                 if (other.get() == null) {
-                    sampler.subscribe(new SamplerSubscriber<T>(this));
+                    sampler.subscribe(new SamplerSubscriber<>(this));
                     s.request(Long.MAX_VALUE);
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSampleTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSampleTimed.java
@@ -42,11 +42,11 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        SerializedSubscriber<T> serial = new SerializedSubscriber<T>(s);
+        SerializedSubscriber<T> serial = new SerializedSubscriber<>(s);
         if (emitLast) {
-            source.subscribe(new SampleTimedEmitLast<T>(serial, period, unit, scheduler));
+            source.subscribe(new SampleTimedEmitLast<>(serial, period, unit, scheduler));
         } else {
-            source.subscribe(new SampleTimedNoLast<T>(serial, period, unit, scheduler));
+            source.subscribe(new SampleTimedNoLast<>(serial, period, unit, scheduler));
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScalarXMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScalarXMap.java
@@ -87,7 +87,7 @@ public final class FlowableScalarXMap {
                     EmptySubscription.complete(subscriber);
                     return true;
                 }
-                subscriber.onSubscribe(new ScalarSubscription<R>(subscriber, u));
+                subscriber.onSubscribe(new ScalarSubscription<>(subscriber, u));
             } else {
                 r.subscribe(subscriber);
             }
@@ -108,7 +108,7 @@ public final class FlowableScalarXMap {
      * @return the new Flowable instance
      */
     public static <T, U> Flowable<U> scalarXMap(final T value, final Function<? super T, ? extends Publisher<? extends U>> mapper) {
-        return RxJavaPlugins.onAssembly(new ScalarXMapFlowable<T, U>(value, mapper));
+        return RxJavaPlugins.onAssembly(new ScalarXMapFlowable<>(value, mapper));
     }
 
     /**
@@ -155,7 +155,7 @@ public final class FlowableScalarXMap {
                     EmptySubscription.complete(s);
                     return;
                 }
-                s.onSubscribe(new ScalarSubscription<R>(s, u));
+                s.onSubscribe(new ScalarSubscription<>(s, u));
             } else {
                 other.subscribe(s);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScan.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScan.java
@@ -32,7 +32,7 @@ public final class FlowableScan<T> extends AbstractFlowableWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new ScanSubscriber<T>(s, accumulator));
+        source.subscribe(new ScanSubscriber<>(s, accumulator));
     }
 
     static final class ScanSubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScanSeed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableScanSeed.java
@@ -48,7 +48,7 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
             return;
         }
 
-        source.subscribe(new ScanSeedSubscriber<T, R>(s, accumulator, r, bufferSize()));
+        source.subscribe(new ScanSeedSubscriber<>(s, accumulator, r, bufferSize()));
     }
 
     static final class ScanSeedSubscriber<T, R>
@@ -85,7 +85,7 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
             this.value = value;
             this.prefetch = prefetch;
             this.limit = prefetch - (prefetch >> 2);
-            this.queue = new SpscArrayQueue<R>(prefetch);
+            this.queue = new SpscArrayQueue<>(prefetch);
             this.queue.offer(value);
             this.requested = new AtomicLong();
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqual.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqual.java
@@ -41,7 +41,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
 
     @Override
     public void subscribeActual(Subscriber<? super Boolean> s) {
-        EqualCoordinator<T> parent = new EqualCoordinator<T>(s, prefetch, comparer);
+        EqualCoordinator<T> parent = new EqualCoordinator<>(s, prefetch, comparer);
         s.onSubscribe(parent);
         parent.subscribe(first, second);
     }
@@ -79,8 +79,8 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
             super(actual);
             this.comparer = comparer;
             this.wip = new AtomicInteger();
-            this.first = new EqualSubscriber<T>(this, prefetch);
-            this.second = new EqualSubscriber<T>(this, prefetch);
+            this.first = new EqualSubscriber<>(this, prefetch);
+            this.second = new EqualSubscriber<>(this, prefetch);
             this.errors = new AtomicThrowable();
         }
 
@@ -289,7 +289,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
                     }
                 }
 
-                queue = new SpscArrayQueue<T>(prefetch);
+                queue = new SpscArrayQueue<>(prefetch);
 
                 s.request(prefetch);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqualSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqualSingle.java
@@ -43,14 +43,14 @@ public final class FlowableSequenceEqualSingle<T> extends Single<Boolean> implem
 
     @Override
     public void subscribeActual(SingleObserver<? super Boolean> observer) {
-        EqualCoordinator<T> parent = new EqualCoordinator<T>(observer, prefetch, comparer);
+        EqualCoordinator<T> parent = new EqualCoordinator<>(observer, prefetch, comparer);
         observer.onSubscribe(parent);
         parent.subscribe(first, second);
     }
 
     @Override
     public Flowable<Boolean> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableSequenceEqual<T>(first, second, comparer, prefetch));
+        return RxJavaPlugins.onAssembly(new FlowableSequenceEqual<>(first, second, comparer, prefetch));
     }
 
     static final class EqualCoordinator<T>
@@ -76,8 +76,8 @@ public final class FlowableSequenceEqualSingle<T> extends Single<Boolean> implem
         EqualCoordinator(SingleObserver<? super Boolean> actual, int prefetch, BiPredicate<? super T, ? super T> comparer) {
             this.downstream = actual;
             this.comparer = comparer;
-            this.first = new EqualSubscriber<T>(this, prefetch);
-            this.second = new EqualSubscriber<T>(this, prefetch);
+            this.first = new EqualSubscriber<>(this, prefetch);
+            this.second = new EqualSubscriber<>(this, prefetch);
             this.errors = new AtomicThrowable();
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSerialized.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSerialized.java
@@ -24,6 +24,6 @@ public final class FlowableSerialized<T> extends AbstractFlowableWithUpstream<T,
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new SerializedSubscriber<T>(s));
+        source.subscribe(new SerializedSubscriber<>(s));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSingle.java
@@ -35,7 +35,7 @@ public final class FlowableSingle<T> extends AbstractFlowableWithUpstream<T, T> 
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new SingleElementSubscriber<T>(s, defaultValue, failOnEmpty));
+        source.subscribe(new SingleElementSubscriber<>(s, defaultValue, failOnEmpty));
     }
 
     static final class SingleElementSubscriber<T> extends DeferredScalarSubscription<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSingleMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSingleMaybe.java
@@ -31,12 +31,12 @@ public final class FlowableSingleMaybe<T> extends Maybe<T> implements FuseToFlow
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new SingleElementSubscriber<T>(observer));
+        source.subscribe(new SingleElementSubscriber<>(observer));
     }
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableSingle<T>(source, null, false));
+        return RxJavaPlugins.onAssembly(new FlowableSingle<>(source, null, false));
     }
 
     static final class SingleElementSubscriber<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSingleSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSingleSingle.java
@@ -36,12 +36,12 @@ public final class FlowableSingleSingle<T> extends Single<T> implements FuseToFl
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new SingleElementSubscriber<T>(observer, defaultValue));
+        source.subscribe(new SingleElementSubscriber<>(observer, defaultValue));
     }
 
     @Override
     public Flowable<T> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableSingle<T>(source, defaultValue, true));
+        return RxJavaPlugins.onAssembly(new FlowableSingle<>(source, defaultValue, true));
     }
 
     static final class SingleElementSubscriber<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkip.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkip.java
@@ -27,7 +27,7 @@ public final class FlowableSkip<T> extends AbstractFlowableWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new SkipSubscriber<T>(s, n));
+        source.subscribe(new SkipSubscriber<>(s, n));
     }
 
     static final class SkipSubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipLast.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipLast.java
@@ -30,7 +30,7 @@ public final class FlowableSkipLast<T> extends AbstractFlowableWithUpstream<T, T
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new SkipLastSubscriber<T>(s, skip));
+        source.subscribe(new SkipLastSubscriber<>(s, skip));
     }
 
     static final class SkipLastSubscriber<T> extends ArrayDeque<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipLastTimed.java
@@ -41,7 +41,7 @@ public final class FlowableSkipLastTimed<T> extends AbstractFlowableWithUpstream
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new SkipLastTimedSubscriber<T>(s, time, unit, scheduler, bufferSize, delayError));
+        source.subscribe(new SkipLastTimedSubscriber<>(s, time, unit, scheduler, bufferSize, delayError));
     }
 
     static final class SkipLastTimedSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
@@ -68,7 +68,7 @@ public final class FlowableSkipLastTimed<T> extends AbstractFlowableWithUpstream
             this.time = time;
             this.unit = unit;
             this.scheduler = scheduler;
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
             this.delayError = delayError;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipUntil.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipUntil.java
@@ -31,7 +31,7 @@ public final class FlowableSkipUntil<T, U> extends AbstractFlowableWithUpstream<
 
     @Override
     protected void subscribeActual(Subscriber<? super T> child) {
-        SkipUntilMainSubscriber<T> parent = new SkipUntilMainSubscriber<T>(child);
+        SkipUntilMainSubscriber<T> parent = new SkipUntilMainSubscriber<>(child);
         child.onSubscribe(parent);
 
         other.subscribe(parent.other);
@@ -57,7 +57,7 @@ public final class FlowableSkipUntil<T, U> extends AbstractFlowableWithUpstream<
 
         SkipUntilMainSubscriber(Subscriber<? super T> downstream) {
             this.downstream = downstream;
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.requested = new AtomicLong();
             this.other = new OtherSubscriber();
             this.error = new AtomicThrowable();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipWhile.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSkipWhile.java
@@ -29,7 +29,7 @@ public final class FlowableSkipWhile<T> extends AbstractFlowableWithUpstream<T, 
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new SkipWhileSubscriber<T>(s, predicate));
+        source.subscribe(new SkipWhileSubscriber<>(s, predicate));
     }
 
     static final class SkipWhileSubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSubscribeOn.java
@@ -42,7 +42,7 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
     @Override
     public void subscribeActual(final Subscriber<? super T> s) {
         Scheduler.Worker w = scheduler.createWorker();
-        final SubscribeOnSubscriber<T> sos = new SubscribeOnSubscriber<T>(s, w, source, nonScheduledRequests);
+        final SubscribeOnSubscriber<T> sos = new SubscribeOnSubscriber<>(s, w, source, nonScheduledRequests);
         s.onSubscribe(sos);
 
         w.schedule(sos);
@@ -69,7 +69,7 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
             this.downstream = actual;
             this.worker = worker;
             this.source = source;
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.requested = new AtomicLong();
             this.nonScheduledRequests = !requestOn;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchIfEmpty.java
@@ -27,7 +27,7 @@ public final class FlowableSwitchIfEmpty<T> extends AbstractFlowableWithUpstream
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        SwitchIfEmptySubscriber<T> parent = new SwitchIfEmptySubscriber<T>(s, other);
+        SwitchIfEmptySubscriber<T> parent = new SwitchIfEmptySubscriber<>(s, other);
         s.onSubscribe(parent.arbiter);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
@@ -46,7 +46,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
         if (FlowableScalarXMap.tryScalarXMapSubscribe(source, s, mapper)) {
             return;
         }
-        source.subscribe(new SwitchMapSubscriber<T, R>(s, mapper, bufferSize, delayErrors));
+        source.subscribe(new SwitchMapSubscriber<>(s, mapper, bufferSize, delayErrors));
     }
 
     static final class SwitchMapSubscriber<T, R> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
@@ -64,13 +64,13 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
 
         Subscription upstream;
 
-        final AtomicReference<SwitchMapInnerSubscriber<T, R>> active = new AtomicReference<SwitchMapInnerSubscriber<T, R>>();
+        final AtomicReference<SwitchMapInnerSubscriber<T, R>> active = new AtomicReference<>();
 
         final AtomicLong requested = new AtomicLong();
 
         static final SwitchMapInnerSubscriber<Object, Object> CANCELLED;
         static {
-            CANCELLED = new SwitchMapInnerSubscriber<Object, Object>(null, -1L, 1);
+            CANCELLED = new SwitchMapInnerSubscriber<>(null, -1L, 1);
             CANCELLED.cancel();
         }
 
@@ -118,7 +118,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
                 return;
             }
 
-            SwitchMapInnerSubscriber<T, R> nextInner = new SwitchMapInnerSubscriber<T, R>(this, c, bufferSize);
+            SwitchMapInnerSubscriber<T, R> nextInner = new SwitchMapInnerSubscriber<>(this, c, bufferSize);
 
             for (;;) {
                 inner = active.get();
@@ -371,7 +371,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
                     }
                 }
 
-                queue = new SpscArrayQueue<R>(bufferSize);
+                queue = new SpscArrayQueue<>(bufferSize);
 
                 s.request(bufferSize);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTake.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTake.java
@@ -32,7 +32,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new TakeSubscriber<T>(s, n));
+        source.subscribe(new TakeSubscriber<>(s, n));
     }
 
     static final class TakeSubscriber<T>
@@ -105,12 +105,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
                     if (r == 0L) {
                         break;
                     }
-                    long toRequest;
-                    if (r <= n) {
-                        toRequest = r;
-                    } else {
-                        toRequest = n;
-                    }
+                    long toRequest = Math.min(r, n);
                     long u = r - toRequest;
                     if (compareAndSet(r, u)) {
                         upstream.request(toRequest);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLast.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLast.java
@@ -32,7 +32,7 @@ public final class FlowableTakeLast<T> extends AbstractFlowableWithUpstream<T, T
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new TakeLastSubscriber<T>(s, count));
+        source.subscribe(new TakeLastSubscriber<>(s, count));
     }
 
     static final class TakeLastSubscriber<T> extends ArrayDeque<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastOne.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastOne.java
@@ -25,7 +25,7 @@ public final class FlowableTakeLastOne<T> extends AbstractFlowableWithUpstream<T
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new TakeLastOneSubscriber<T>(s));
+        source.subscribe(new TakeLastOneSubscriber<>(s));
     }
 
     static final class TakeLastOneSubscriber<T> extends DeferredScalarSubscription<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeLastTimed.java
@@ -45,7 +45,7 @@ public final class FlowableTakeLastTimed<T> extends AbstractFlowableWithUpstream
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new TakeLastTimedSubscriber<T>(s, count, time, unit, scheduler, bufferSize, delayError));
+        source.subscribe(new TakeLastTimedSubscriber<>(s, count, time, unit, scheduler, bufferSize, delayError));
     }
 
     static final class TakeLastTimedSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
@@ -74,7 +74,7 @@ public final class FlowableTakeLastTimed<T> extends AbstractFlowableWithUpstream
             this.time = time;
             this.unit = unit;
             this.scheduler = scheduler;
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
             this.delayError = delayError;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakePublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakePublisher.java
@@ -35,6 +35,6 @@ public final class FlowableTakePublisher<T> extends Flowable<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new TakeSubscriber<T>(s, limit));
+        source.subscribe(new TakeSubscriber<>(s, limit));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeUntil.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeUntil.java
@@ -30,7 +30,7 @@ public final class FlowableTakeUntil<T, U> extends AbstractFlowableWithUpstream<
 
     @Override
     protected void subscribeActual(Subscriber<? super T> child) {
-        TakeUntilMainSubscriber<T> parent = new TakeUntilMainSubscriber<T>(child);
+        TakeUntilMainSubscriber<T> parent = new TakeUntilMainSubscriber<>(child);
         child.onSubscribe(parent);
 
         other.subscribe(parent.other);
@@ -55,7 +55,7 @@ public final class FlowableTakeUntil<T, U> extends AbstractFlowableWithUpstream<
         TakeUntilMainSubscriber(Subscriber<? super T> downstream) {
             this.downstream = downstream;
             this.requested = new AtomicLong();
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.other = new OtherSubscriber();
             this.error = new AtomicThrowable();
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeUntilPredicate.java
@@ -30,7 +30,7 @@ public final class FlowableTakeUntilPredicate<T> extends AbstractFlowableWithUps
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new InnerSubscriber<T>(s, predicate));
+        source.subscribe(new InnerSubscriber<>(s, predicate));
     }
 
     static final class InnerSubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeWhile.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTakeWhile.java
@@ -30,7 +30,7 @@ public final class FlowableTakeWhile<T> extends AbstractFlowableWithUpstream<T, 
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new TakeWhileSubscriber<T>(s, predicate));
+        source.subscribe(new TakeWhileSubscriber<>(s, predicate));
     }
 
     static final class TakeWhileSubscriber<T> implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -42,8 +42,8 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new DebounceTimedSubscriber<T>(
-                new SerializedSubscriber<T>(s),
+        source.subscribe(new DebounceTimedSubscriber<>(
+                new SerializedSubscriber<>(s),
                 timeout, unit, scheduler.createWorker()));
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleLatest.java
@@ -56,7 +56,7 @@ public final class FlowableThrottleLatest<T> extends AbstractFlowableWithUpstrea
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new ThrottleLatestSubscriber<T>(s, timeout, unit, scheduler.createWorker(), emitLast));
+        source.subscribe(new ThrottleLatestSubscriber<>(s, timeout, unit, scheduler.createWorker(), emitLast));
     }
 
     static final class ThrottleLatestSubscriber<T>
@@ -100,7 +100,7 @@ public final class FlowableThrottleLatest<T> extends AbstractFlowableWithUpstrea
             this.unit = unit;
             this.worker = worker;
             this.emitLast = emitLast;
-            this.latest = new AtomicReference<T>();
+            this.latest = new AtomicReference<>();
             this.requested = new AtomicLong();
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeInterval.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeInterval.java
@@ -33,7 +33,7 @@ public final class FlowableTimeInterval<T> extends AbstractFlowableWithUpstream<
 
     @Override
     protected void subscribeActual(Subscriber<? super Timed<T>> s) {
-        source.subscribe(new TimeIntervalSubscriber<T>(s, unit, scheduler));
+        source.subscribe(new TimeIntervalSubscriber<>(s, unit, scheduler));
     }
 
     static final class TimeIntervalSubscriber<T> implements FlowableSubscriber<T>, Subscription {
@@ -66,7 +66,7 @@ public final class FlowableTimeInterval<T> extends AbstractFlowableWithUpstream<
             long last = lastTime;
             lastTime = now;
             long delta = now - last;
-            downstream.onNext(new Timed<T>(t, delta, unit));
+            downstream.onNext(new Timed<>(t, delta, unit));
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeout.java
@@ -47,12 +47,12 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         if (other == null) {
-            TimeoutSubscriber<T> parent = new TimeoutSubscriber<T>(s, itemTimeoutIndicator);
+            TimeoutSubscriber<T> parent = new TimeoutSubscriber<>(s, itemTimeoutIndicator);
             s.onSubscribe(parent);
             parent.startFirstTimeout(firstTimeoutIndicator);
             source.subscribe(parent);
         } else {
-            TimeoutFallbackSubscriber<T> parent = new TimeoutFallbackSubscriber<T>(s, itemTimeoutIndicator, other);
+            TimeoutFallbackSubscriber<T> parent = new TimeoutFallbackSubscriber<>(s, itemTimeoutIndicator, other);
             s.onSubscribe(parent);
             parent.startFirstTimeout(firstTimeoutIndicator);
             source.subscribe(parent);
@@ -82,7 +82,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
             this.downstream = actual;
             this.itemTimeoutIndicator = itemTimeoutIndicator;
             this.task = new SequentialDisposable();
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.requested = new AtomicLong();
         }
 
@@ -212,7 +212,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
             this.downstream = actual;
             this.itemTimeoutIndicator = itemTimeoutIndicator;
             this.task = new SequentialDisposable();
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.fallback = fallback;
             this.index = new AtomicLong();
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -43,12 +43,12 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         if (other == null) {
-            TimeoutSubscriber<T> parent = new TimeoutSubscriber<T>(s, timeout, unit, scheduler.createWorker());
+            TimeoutSubscriber<T> parent = new TimeoutSubscriber<>(s, timeout, unit, scheduler.createWorker());
             s.onSubscribe(parent);
             parent.startTimeout(0L);
             source.subscribe(parent);
         } else {
-            TimeoutFallbackSubscriber<T> parent = new TimeoutFallbackSubscriber<T>(s, timeout, unit, scheduler.createWorker(), other);
+            TimeoutFallbackSubscriber<T> parent = new TimeoutFallbackSubscriber<>(s, timeout, unit, scheduler.createWorker(), other);
             s.onSubscribe(parent);
             parent.startTimeout(0L);
             source.subscribe(parent);
@@ -80,7 +80,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
             this.unit = unit;
             this.worker = worker;
             this.task = new SequentialDisposable();
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.requested = new AtomicLong();
         }
 
@@ -203,7 +203,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
             this.worker = worker;
             this.fallback = fallback;
             this.task = new SequentialDisposable();
-            this.upstream = new AtomicReference<Subscription>();
+            this.upstream = new AtomicReference<>();
             this.index = new AtomicLong();
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToList.java
@@ -41,7 +41,7 @@ public final class FlowableToList<T, U extends Collection<? super T>> extends Ab
             EmptySubscription.error(e, s);
             return;
         }
-        source.subscribe(new ToListSubscriber<T, U>(s, coll));
+        source.subscribe(new ToListSubscriber<>(s, coll));
     }
 
     static final class ToListSubscriber<T, U extends Collection<? super T>>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToListSingle.java
@@ -53,12 +53,12 @@ public final class FlowableToListSingle<T, U extends Collection<? super T>> exte
             EmptyDisposable.error(e, observer);
             return;
         }
-        source.subscribe(new ToListSubscriber<T, U>(observer, coll));
+        source.subscribe(new ToListSubscriber<>(observer, coll));
     }
 
     @Override
     public Flowable<U> fuseToFlowable() {
-        return RxJavaPlugins.onAssembly(new FlowableToList<T, U>(source, collectionSupplier));
+        return RxJavaPlugins.onAssembly(new FlowableToList<>(source, collectionSupplier));
     }
 
     static final class ToListSubscriber<T, U extends Collection<? super T>>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUnsubscribeOn.java
@@ -30,7 +30,7 @@ public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new UnsubscribeSubscriber<T>(s, scheduler));
+        source.subscribe(new UnsubscribeSubscriber<>(s, scheduler));
     }
 
     static final class UnsubscribeSubscriber<T> extends AtomicBoolean implements FlowableSubscriber<T>, Subscription {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUsing.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUsing.java
@@ -68,7 +68,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
             return;
         }
 
-        UsingSubscriber<T, D> us = new UsingSubscriber<T, D>(s, resource, disposer, eager);
+        UsingSubscriber<T, D> us = new UsingSubscriber<>(s, resource, disposer, eager);
 
         source.subscribe(us);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindow.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindow.java
@@ -42,12 +42,12 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
     @Override
     public void subscribeActual(Subscriber<? super Flowable<T>> s) {
         if (skip == size) {
-            source.subscribe(new WindowExactSubscriber<T>(s, size, bufferSize));
+            source.subscribe(new WindowExactSubscriber<>(s, size, bufferSize));
         } else
         if (skip > size) {
-            source.subscribe(new WindowSkipSubscriber<T>(s, size, skip, bufferSize));
+            source.subscribe(new WindowSkipSubscriber<>(s, size, skip, bufferSize));
         } else {
-            source.subscribe(new WindowOverlapSubscriber<T>(s, size, skip, bufferSize));
+            source.subscribe(new WindowOverlapSubscriber<>(s, size, skip, bufferSize));
         }
     }
 
@@ -96,10 +96,10 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
             if (i == 0) {
                 getAndIncrement();
 
-                w = UnicastProcessor.<T>create(bufferSize, this);
+                w = UnicastProcessor.create(bufferSize, this);
                 window = w;
 
-                intercept = new FlowableWindowSubscribeIntercept<T>(w);
+                intercept = new FlowableWindowSubscribeIntercept<>(w);
                 downstream.onNext(intercept);
             }
 
@@ -216,10 +216,10 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
             if (i == 0) {
                 getAndIncrement();
 
-                w = UnicastProcessor.<T>create(bufferSize, this);
+                w = UnicastProcessor.create(bufferSize, this);
                 window = w;
 
-                intercept = new FlowableWindowSubscribeIntercept<T>(w);
+                intercept = new FlowableWindowSubscribeIntercept<>(w);
                 downstream.onNext(intercept);
             }
 
@@ -339,8 +339,8 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
             this.downstream = actual;
             this.size = size;
             this.skip = skip;
-            this.queue = new SpscLinkedArrayQueue<UnicastProcessor<T>>(bufferSize);
-            this.windows = new ArrayDeque<UnicastProcessor<T>>();
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
+            this.windows = new ArrayDeque<>();
             this.once = new AtomicBoolean();
             this.firstRequest = new AtomicBoolean();
             this.requested = new AtomicLong();
@@ -369,7 +369,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
                 if (!cancelled) {
                     getAndIncrement();
 
-                    newWindow = UnicastProcessor.<T>create(bufferSize, this);
+                    newWindow = UnicastProcessor.create(bufferSize, this);
 
                     windows.offer(newWindow);
                 }
@@ -477,7 +477,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
                             break;
                         }
 
-                        FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(t);
+                        FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<>(t);
                         a.onNext(intercept);
 
                         if (intercept.tryAbandon()) {
@@ -488,7 +488,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
 
                     if (e == r) {
                         if (cancelled) {
-                            continue outer;
+                            continue;
                         }
 
                         if (checkTerminated(done, q.isEmpty(), a, q)) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundary.java
@@ -38,7 +38,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
 
     @Override
     protected void subscribeActual(Subscriber<? super Flowable<T>> subscriber) {
-        WindowBoundaryMainSubscriber<T, B> parent = new WindowBoundaryMainSubscriber<T, B>(subscriber, capacityHint);
+        WindowBoundaryMainSubscriber<T, B> parent = new WindowBoundaryMainSubscriber<>(subscriber, capacityHint);
 
         subscriber.onSubscribe(parent);
 
@@ -84,10 +84,10 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
         WindowBoundaryMainSubscriber(Subscriber<? super Flowable<T>> downstream, int capacityHint) {
             this.downstream = downstream;
             this.capacityHint = capacityHint;
-            this.boundarySubscriber = new WindowBoundaryInnerSubscriber<T, B>(this);
-            this.upstream = new AtomicReference<Subscription>();
+            this.boundarySubscriber = new WindowBoundaryInnerSubscriber<>(this);
+            this.upstream = new AtomicReference<>();
             this.windows = new AtomicInteger(1);
-            this.queue = new MpscLinkedQueue<Object>();
+            this.queue = new MpscLinkedQueue<>();
             this.errors = new AtomicThrowable();
             this.stopWindows = new AtomicBoolean();
             this.requested = new AtomicLong();
@@ -240,7 +240,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
 
                         if (emitted != requested.get()) {
                             emitted++;
-                            FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(w);
+                            FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<>(w);
                             downstream.onNext(intercept);
                             if (intercept.tryAbandon()) {
                                 w.onComplete();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -46,7 +46,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
 
     @Override
     protected void subscribeActual(Subscriber<? super Flowable<T>> s) {
-        source.subscribe(new WindowBoundaryMainSubscriber<T, B, V>(
+        source.subscribe(new WindowBoundaryMainSubscriber<>(
                 s, open, closingIndicator, bufferSize));
     }
 
@@ -85,16 +85,16 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
         WindowBoundaryMainSubscriber(Subscriber<? super Flowable<T>> actual,
                 Publisher<B> open, Function<? super B, ? extends Publisher<V>> closingIndicator, int bufferSize) {
             this.downstream = actual;
-            this.queue = new MpscLinkedQueue<Object>();
+            this.queue = new MpscLinkedQueue<>();
             this.open = open;
             this.closingIndicator = closingIndicator;
             this.bufferSize = bufferSize;
             this.resources = new CompositeDisposable();
-            this.windows = new ArrayList<UnicastProcessor<T>>();
+            this.windows = new ArrayList<>();
             this.windowCount = new AtomicLong(1L);
             this.downstreamCancelled = new AtomicBoolean();
             this.error = new AtomicThrowable();
-            this.startSubscriber = new WindowStartSubscriber<B>(this);
+            this.startSubscriber = new WindowStartSubscriber<>(this);
             this.requested = new AtomicLong();
         }
 
@@ -171,7 +171,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
         }
 
         void open(B startValue) {
-            queue.offer(new WindowStartItem<B>(startValue));
+            queue.offer(new WindowStartItem<>(startValue));
             drain();
         }
 
@@ -257,7 +257,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
 
                                     windowCount.getAndIncrement();
                                     UnicastProcessor<T> newWindow = UnicastProcessor.create(bufferSize, this);
-                                    WindowEndSubscriberIntercept<T, V> endSubscriber = new WindowEndSubscriberIntercept<T, V>(this, newWindow);
+                                    WindowEndSubscriberIntercept<T, V> endSubscriber = new WindowEndSubscriberIntercept<>(this, newWindow);
 
                                     downstream.onNext(endSubscriber);
 
@@ -388,7 +388,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
             WindowEndSubscriberIntercept(WindowBoundaryMainSubscriber<T, ?, V> parent, UnicastProcessor<T> window) {
                 this.parent = parent;
                 this.window = window;
-                this.upstream = new AtomicReference<Subscription>();
+                this.upstream = new AtomicReference<>();
                 this.once = new AtomicBoolean();
             }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowTimed.java
@@ -55,18 +55,18 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
     protected void subscribeActual(Subscriber<? super Flowable<T>> downstream) {
         if (timespan == timeskip) {
             if (maxSize == Long.MAX_VALUE) {
-                source.subscribe(new WindowExactUnboundedSubscriber<T>(
+                source.subscribe(new WindowExactUnboundedSubscriber<>(
                         downstream,
                         timespan, unit, scheduler, bufferSize));
                 return;
             }
-            source.subscribe(new WindowExactBoundedSubscriber<T>(
+            source.subscribe(new WindowExactBoundedSubscriber<>(
                         downstream,
                         timespan, unit, scheduler,
                         bufferSize, maxSize, restartTimerOnMaxSize));
             return;
         }
-        source.subscribe(new WindowSkipSubscriber<T>(downstream,
+        source.subscribe(new WindowSkipSubscriber<>(downstream,
                 timespan, timeskip, unit, scheduler.createWorker(), bufferSize));
     }
 
@@ -99,7 +99,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
         AbstractWindowSubscriber(Subscriber<? super Flowable<T>> downstream, long timespan, TimeUnit unit, int bufferSize) {
             this.downstream = downstream;
-            this.queue = new MpscLinkedQueue<Object>();
+            this.queue = new MpscLinkedQueue<>();
             this.timespan = timespan;
             this.unit = unit;
             this.bufferSize = bufferSize;
@@ -201,7 +201,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
 
                     emitted = 1;
 
-                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(window);
+                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<>(window);
                     downstream.onNext(intercept);
 
                     timer.replace(scheduler.schedulePeriodicallyDirect(this, timespan, timespan, unit));
@@ -290,7 +290,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                     window = UnicastProcessor.create(bufferSize, windowRunnable);
                                     this.window = window;
 
-                                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(window);
+                                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<>(window);
                                     downstream.onNext(intercept);
 
                                     if (intercept.tryAbandon()) {
@@ -369,7 +369,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     windowCount.getAndIncrement();
                     window = UnicastProcessor.create(bufferSize, this);
 
-                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(window);
+                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<>(window);
                     downstream.onNext(intercept);
 
                     Runnable boundaryTask = new WindowBoundaryRunnable(this, 1L);
@@ -507,7 +507,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     window = UnicastProcessor.create(bufferSize, this);
                     this.window = window;
 
-                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(window);
+                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<>(window);
                     downstream.onNext(intercept);
 
                     if (restartTimerOnMaxSize) {
@@ -557,7 +557,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             super(actual, timespan, unit, bufferSize);
             this.timeskip = timeskip;
             this.worker = worker;
-            this.windows = new LinkedList<UnicastProcessor<T>>();
+            this.windows = new LinkedList<>();
         }
 
         @Override
@@ -570,7 +570,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     UnicastProcessor<T> window = UnicastProcessor.create(bufferSize, this);
                     windows.add(window);
 
-                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(window);
+                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<>(window);
                     downstream.onNext(intercept);
 
                     worker.schedule(new WindowBoundaryRunnable(this, false), timespan, unit);
@@ -644,7 +644,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                     UnicastProcessor<T> window = UnicastProcessor.create(bufferSize, this);
                                     windows.add(window);
 
-                                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<T>(window);
+                                    FlowableWindowSubscribeIntercept<T> intercept = new FlowableWindowSubscribeIntercept<>(window);
                                     downstream.onNext(intercept);
 
                                     worker.schedule(new WindowBoundaryRunnable(this, false), timespan, unit);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWithLatestFrom.java
@@ -36,8 +36,8 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        final SerializedSubscriber<R> serial = new SerializedSubscriber<R>(s);
-        final WithLatestFromSubscriber<T, U, R> wlf = new WithLatestFromSubscriber<T, U, R>(serial, combiner);
+        final SerializedSubscriber<R> serial = new SerializedSubscriber<>(s);
+        final WithLatestFromSubscriber<T, U, R> wlf = new WithLatestFromSubscriber<>(serial, combiner);
 
         serial.onSubscribe(wlf);
 
@@ -55,11 +55,11 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
 
         final BiFunction<? super T, ? super U, ? extends R> combiner;
 
-        final AtomicReference<Subscription> upstream = new AtomicReference<Subscription>();
+        final AtomicReference<Subscription> upstream = new AtomicReference<>();
 
         final AtomicLong requested = new AtomicLong();
 
-        final AtomicReference<Subscription> other = new AtomicReference<Subscription>();
+        final AtomicReference<Subscription> other = new AtomicReference<>();
 
         WithLatestFromSubscriber(Subscriber<? super R> actual, BiFunction<? super T, ? super U, ? extends R> combiner) {
             this.downstream = actual;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -82,11 +82,11 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
         }
 
         if (n == 0) {
-            new FlowableMap<T, R>(source, new SingletonArrayFunc()).subscribeActual(s);
+            new FlowableMap<>(source, new SingletonArrayFunc()).subscribeActual(s);
             return;
         }
 
-        WithLatestFromSubscriber<T, R> parent = new WithLatestFromSubscriber<T, R>(s, combiner, n);
+        WithLatestFromSubscriber<T, R> parent = new WithLatestFromSubscriber<>(s, combiner, n);
         s.onSubscribe(parent);
         parent.subscribe(others, n);
 
@@ -123,8 +123,8 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
                 s[i] = new WithLatestInnerSubscriber(this, i);
             }
             this.subscribers = s;
-            this.values = new AtomicReferenceArray<Object>(n);
-            this.upstream = new AtomicReference<Subscription>();
+            this.values = new AtomicReferenceArray<>(n);
+            this.upstream = new AtomicReference<>();
             this.requested = new AtomicLong();
             this.error = new AtomicThrowable();
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZip.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZip.java
@@ -71,7 +71,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
             return;
         }
 
-        ZipCoordinator<T, R> coordinator = new ZipCoordinator<T, R>(s, zipper, count, bufferSize, delayError);
+        ZipCoordinator<T, R> coordinator = new ZipCoordinator<>(s, zipper, count, bufferSize, delayError);
 
         s.onSubscribe(coordinator);
 
@@ -108,7 +108,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
             @SuppressWarnings("unchecked")
             ZipSubscriber<T, R>[] a = new ZipSubscriber[n];
             for (int i = 0; i < n; i++) {
-                a[i] = new ZipSubscriber<T, R>(this, prefetch);
+                a[i] = new ZipSubscriber<>(this, prefetch);
             }
             this.current = new Object[n];
             this.subscribers = a;
@@ -354,7 +354,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
                     }
                 }
 
-                queue = new SpscArrayQueue<T>(prefetch);
+                queue = new SpscArrayQueue<>(prefetch);
 
                 s.request(prefetch);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCache.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCache.java
@@ -41,13 +41,13 @@ public final class MaybeCache<T> extends Maybe<T> implements MaybeObserver<T> {
 
     @SuppressWarnings("unchecked")
     public MaybeCache(MaybeSource<T> source) {
-        this.source = new AtomicReference<MaybeSource<T>>(source);
-        this.observers = new AtomicReference<CacheDisposable<T>[]>(EMPTY);
+        this.source = new AtomicReference<>(source);
+        this.observers = new AtomicReference<>(EMPTY);
     }
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        CacheDisposable<T> parent = new CacheDisposable<T>(observer, this);
+        CacheDisposable<T> parent = new CacheDisposable<>(observer, this);
         observer.onSubscribe(parent);
 
         if (add(parent)) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArray.java
@@ -38,7 +38,7 @@ public final class MaybeConcatArray<T> extends Flowable<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        ConcatMaybeObserver<T> parent = new ConcatMaybeObserver<T>(s, sources);
+        ConcatMaybeObserver<T> parent = new ConcatMaybeObserver<>(s, sources);
         s.onSubscribe(parent);
         parent.drain();
     }
@@ -68,7 +68,7 @@ public final class MaybeConcatArray<T> extends Flowable<T> {
             this.sources = sources;
             this.requested = new AtomicLong();
             this.disposables = new SequentialDisposable();
-            this.current = new AtomicReference<Object>(NotificationLite.COMPLETE); // as if a previous completed
+            this.current = new AtomicReference<>(NotificationLite.COMPLETE); // as if a previous completed
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArrayDelayError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArrayDelayError.java
@@ -39,7 +39,7 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        ConcatMaybeObserver<T> parent = new ConcatMaybeObserver<T>(s, sources);
+        ConcatMaybeObserver<T> parent = new ConcatMaybeObserver<>(s, sources);
         s.onSubscribe(parent);
         parent.drain();
     }
@@ -71,7 +71,7 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
             this.sources = sources;
             this.requested = new AtomicLong();
             this.disposables = new SequentialDisposable();
-            this.current = new AtomicReference<Object>(NotificationLite.COMPLETE); // as if a previous completed
+            this.current = new AtomicReference<>(NotificationLite.COMPLETE); // as if a previous completed
             this.errors = new AtomicThrowable();
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatIterable.java
@@ -52,7 +52,7 @@ public final class MaybeConcatIterable<T> extends Flowable<T> {
             return;
         }
 
-        ConcatMaybeObserver<T> parent = new ConcatMaybeObserver<T>(s, it);
+        ConcatMaybeObserver<T> parent = new ConcatMaybeObserver<>(s, it);
         s.onSubscribe(parent);
         parent.drain();
     }
@@ -80,7 +80,7 @@ public final class MaybeConcatIterable<T> extends Flowable<T> {
             this.sources = sources;
             this.requested = new AtomicLong();
             this.disposables = new SequentialDisposable();
-            this.current = new AtomicReference<Object>(NotificationLite.COMPLETE); // as if a previous completed
+            this.current = new AtomicReference<>(NotificationLite.COMPLETE); // as if a previous completed
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeCreate.java
@@ -39,7 +39,7 @@ public final class MaybeCreate<T> extends Maybe<T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        Emitter<T> parent = new Emitter<T>(observer);
+        Emitter<T> parent = new Emitter<>(observer);
         observer.onSubscribe(parent);
 
         try {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDelay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDelay.java
@@ -42,7 +42,7 @@ public final class MaybeDelay<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new DelayMaybeObserver<T>(observer, delay, unit, scheduler));
+        source.subscribe(new DelayMaybeObserver<>(observer, delay, unit, scheduler));
     }
 
     static final class DelayMaybeObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDelayOtherPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDelayOtherPublisher.java
@@ -40,7 +40,7 @@ public final class MaybeDelayOtherPublisher<T, U> extends AbstractMaybeWithUpstr
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new DelayMaybeObserver<T, U>(observer, other));
+        source.subscribe(new DelayMaybeObserver<>(observer, other));
     }
 
     static final class DelayMaybeObserver<T, U>
@@ -52,7 +52,7 @@ public final class MaybeDelayOtherPublisher<T, U> extends AbstractMaybeWithUpstr
         Disposable upstream;
 
         DelayMaybeObserver(MaybeObserver<? super T> actual, Publisher<U> otherSource) {
-            this.other = new OtherSubscriber<T>(actual);
+            this.other = new OtherSubscriber<>(actual);
             this.otherSource = otherSource;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDelaySubscriptionOtherPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDelaySubscriptionOtherPublisher.java
@@ -40,7 +40,7 @@ public final class MaybeDelaySubscriptionOtherPublisher<T, U> extends AbstractMa
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        other.subscribe(new OtherSubscriber<T>(observer, source));
+        other.subscribe(new OtherSubscriber<>(observer, source));
     }
 
     static final class OtherSubscriber<T> implements FlowableSubscriber<Object>, Disposable {
@@ -51,7 +51,7 @@ public final class MaybeDelaySubscriptionOtherPublisher<T, U> extends AbstractMa
         Subscription upstream;
 
         OtherSubscriber(MaybeObserver<? super T> actual, MaybeSource<T> source) {
-            this.main = new DelayMaybeObserver<T>(actual);
+            this.main = new DelayMaybeObserver<>(actual);
             this.source = source;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDelayWithCompletable.java
@@ -32,7 +32,7 @@ public final class MaybeDelayWithCompletable<T> extends Maybe<T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        other.subscribe(new OtherObserver<T>(observer, source));
+        other.subscribe(new OtherObserver<>(observer, source));
     }
 
     static final class OtherObserver<T>
@@ -64,7 +64,7 @@ public final class MaybeDelayWithCompletable<T> extends Maybe<T> {
 
         @Override
         public void onComplete() {
-            source.subscribe(new DelayWithMainObserver<T>(this, downstream));
+            source.subscribe(new DelayWithMainObserver<>(this, downstream));
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDetach.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDetach.java
@@ -30,7 +30,7 @@ public final class MaybeDetach<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new DetachMaybeObserver<T>(observer));
+        source.subscribe(new DetachMaybeObserver<>(observer));
     }
 
     static final class DetachMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDoAfterSuccess.java
@@ -37,7 +37,7 @@ public final class MaybeDoAfterSuccess<T> extends AbstractMaybeWithUpstream<T, T
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new DoAfterObserver<T>(observer, onAfterSuccess));
+        source.subscribe(new DoAfterObserver<>(observer, onAfterSuccess));
     }
 
     static final class DoAfterObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDoFinally.java
@@ -39,7 +39,7 @@ public final class MaybeDoFinally<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new DoFinallyObserver<T>(observer, onFinally));
+        source.subscribe(new DoFinallyObserver<>(observer, onFinally));
     }
 
     static final class DoFinallyObserver<T> extends AtomicInteger implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDoOnEvent.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeDoOnEvent.java
@@ -36,7 +36,7 @@ public final class MaybeDoOnEvent<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new DoOnEventMaybeObserver<T>(observer, onEvent));
+        source.subscribe(new DoOnEventMaybeObserver<>(observer, onEvent));
     }
 
     static final class DoOnEventMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeEqualSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeEqualSingle.java
@@ -44,7 +44,7 @@ public final class MaybeEqualSingle<T> extends Single<Boolean> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super Boolean> observer) {
-        EqualCoordinator<T> parent = new EqualCoordinator<T>(observer, isEqual);
+        EqualCoordinator<T> parent = new EqualCoordinator<>(observer, isEqual);
         observer.onSubscribe(parent);
         parent.subscribe(source1, source2);
     }
@@ -65,8 +65,8 @@ public final class MaybeEqualSingle<T> extends Single<Boolean> {
             super(2);
             this.downstream = actual;
             this.isEqual = isEqual;
-            this.observer1 = new EqualObserver<T>(this);
-            this.observer2 = new EqualObserver<T>(this);
+            this.observer1 = new EqualObserver<>(this);
+            this.observer2 = new EqualObserver<>(this);
         }
 
         void subscribe(MaybeSource<? extends T> source1, MaybeSource<? extends T> source2) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFilter.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFilter.java
@@ -36,7 +36,7 @@ public final class MaybeFilter<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new FilterMaybeObserver<T>(observer, predicate));
+        source.subscribe(new FilterMaybeObserver<>(observer, predicate));
     }
 
     static final class FilterMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFilterSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFilterSingle.java
@@ -37,7 +37,7 @@ public final class MaybeFilterSingle<T> extends Maybe<T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new FilterMaybeObserver<T>(observer, predicate));
+        source.subscribe(new FilterMaybeObserver<>(observer, predicate));
     }
 
     static final class FilterMaybeObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapBiSelector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapBiSelector.java
@@ -59,7 +59,7 @@ public final class MaybeFlatMapBiSelector<T, U, R> extends AbstractMaybeWithUpst
         FlatMapBiMainObserver(MaybeObserver<? super R> actual,
                 Function<? super T, ? extends MaybeSource<? extends U>> mapper,
                 BiFunction<? super T, ? super U, ? extends R> resultSelector) {
-            this.inner = new InnerObserver<T, U, R>(actual, resultSelector);
+            this.inner = new InnerObserver<>(actual, resultSelector);
             this.mapper = mapper;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapCompletable.java
@@ -39,7 +39,7 @@ public final class MaybeFlatMapCompletable<T> extends Completable {
 
     @Override
     protected void subscribeActual(CompletableObserver observer) {
-        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<T>(observer, mapper);
+        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<>(observer, mapper);
         observer.onSubscribe(parent);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
@@ -48,7 +48,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new FlatMapIterableObserver<T, R>(s, mapper));
+        source.subscribe(new FlatMapIterableObserver<>(s, mapper));
     }
 
     static final class FlatMapIterableObserver<T, R>
@@ -279,7 +279,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
         @Nullable
         @Override
-        public R poll() throws Exception {
+        public R poll() {
             Iterator<? extends R> iterator = it;
 
             if (iterator != null) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapIterableObservable.java
@@ -44,7 +44,7 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new FlatMapIterableObserver<T, R>(observer, mapper));
+        source.subscribe(new FlatMapIterableObserver<>(observer, mapper));
     }
 
     static final class FlatMapIterableObserver<T, R>
@@ -189,7 +189,7 @@ public final class MaybeFlatMapIterableObservable<T, R> extends Observable<R> {
 
         @Nullable
         @Override
-        public R poll() throws Exception {
+        public R poll() {
             Iterator<? extends R> iterator = it;
 
             if (iterator != null) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapNotification.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapNotification.java
@@ -48,7 +48,7 @@ public final class MaybeFlatMapNotification<T, R> extends AbstractMaybeWithUpstr
 
     @Override
     protected void subscribeActual(MaybeObserver<? super R> observer) {
-        source.subscribe(new FlatMapMaybeObserver<T, R>(observer, onSuccessMapper, onErrorMapper, onCompleteSupplier));
+        source.subscribe(new FlatMapMaybeObserver<>(observer, onSuccessMapper, onErrorMapper, onCompleteSupplier));
     }
 
     static final class FlatMapMaybeObserver<T, R>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapSingle.java
@@ -41,7 +41,7 @@ public final class MaybeFlatMapSingle<T, R> extends Single<R> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super R> downstream) {
-        source.subscribe(new FlatMapMaybeObserver<T, R>(downstream, mapper));
+        source.subscribe(new FlatMapMaybeObserver<>(downstream, mapper));
     }
 
     static final class FlatMapMaybeObserver<T, R>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapSingleElement.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatMapSingleElement.java
@@ -42,7 +42,7 @@ public final class MaybeFlatMapSingleElement<T, R> extends Maybe<R> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super R> downstream) {
-        source.subscribe(new FlatMapMaybeObserver<T, R>(downstream, mapper));
+        source.subscribe(new FlatMapMaybeObserver<>(downstream, mapper));
     }
 
     static final class FlatMapMaybeObserver<T, R>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatten.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFlatten.java
@@ -39,7 +39,7 @@ public final class MaybeFlatten<T, R> extends AbstractMaybeWithUpstream<T, R> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super R> observer) {
-        source.subscribe(new FlatMapMaybeObserver<T, R>(observer, mapper));
+        source.subscribe(new FlatMapMaybeObserver<>(observer, mapper));
     }
 
     static final class FlatMapMaybeObserver<T, R>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromRunnable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromRunnable.java
@@ -58,7 +58,7 @@ public final class MaybeFromRunnable<T> extends Maybe<T> implements Supplier<T> 
     }
 
     @Override
-    public T get() throws Throwable {
+    public T get() {
         runnable.run();
         return null;
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeFromSingle.java
@@ -38,7 +38,7 @@ public final class MaybeFromSingle<T> extends Maybe<T> implements HasUpstreamSin
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new FromSingleObserver<T>(observer));
+        source.subscribe(new FromSingleObserver<>(observer));
     }
 
     static final class FromSingleObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeHide.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeHide.java
@@ -30,7 +30,7 @@ public final class MaybeHide<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new HideMaybeObserver<T>(observer));
+        source.subscribe(new HideMaybeObserver<>(observer));
     }
 
     static final class HideMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeIgnoreElement.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeIgnoreElement.java
@@ -30,7 +30,7 @@ public final class MaybeIgnoreElement<T> extends AbstractMaybeWithUpstream<T, T>
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new IgnoreMaybeObserver<T>(observer));
+        source.subscribe(new IgnoreMaybeObserver<>(observer));
     }
 
     static final class IgnoreMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeIgnoreElementCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeIgnoreElementCompletable.java
@@ -34,12 +34,12 @@ public final class MaybeIgnoreElementCompletable<T> extends Completable implemen
 
     @Override
     protected void subscribeActual(CompletableObserver observer) {
-        source.subscribe(new IgnoreMaybeObserver<T>(observer));
+        source.subscribe(new IgnoreMaybeObserver<>(observer));
     }
 
     @Override
     public Maybe<T> fuseToMaybe() {
-        return RxJavaPlugins.onAssembly(new MaybeIgnoreElement<T>(source));
+        return RxJavaPlugins.onAssembly(new MaybeIgnoreElement<>(source));
     }
 
     static final class IgnoreMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeIsEmpty.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeIsEmpty.java
@@ -31,7 +31,7 @@ public final class MaybeIsEmpty<T> extends AbstractMaybeWithUpstream<T, Boolean>
 
     @Override
     protected void subscribeActual(MaybeObserver<? super Boolean> observer) {
-        source.subscribe(new IsEmptyMaybeObserver<T>(observer));
+        source.subscribe(new IsEmptyMaybeObserver<>(observer));
     }
 
     static final class IsEmptyMaybeObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeIsEmptySingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeIsEmptySingle.java
@@ -41,12 +41,12 @@ implements HasUpstreamMaybeSource<T>, FuseToMaybe<Boolean> {
 
     @Override
     public Maybe<Boolean> fuseToMaybe() {
-        return RxJavaPlugins.onAssembly(new MaybeIsEmpty<T>(source));
+        return RxJavaPlugins.onAssembly(new MaybeIsEmpty<>(source));
     }
 
     @Override
     protected void subscribeActual(SingleObserver<? super Boolean> observer) {
-        source.subscribe(new IsEmptyMaybeObserver<T>(observer));
+        source.subscribe(new IsEmptyMaybeObserver<>(observer));
     }
 
     static final class IsEmptyMaybeObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMaterialize.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMaterialize.java
@@ -34,6 +34,6 @@ public final class MaybeMaterialize<T> extends Single<Notification<T>> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super Notification<T>> observer) {
-        source.subscribe(new MaterializeSingleObserver<T>(observer));
+        source.subscribe(new MaterializeSingleObserver<>(observer));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMergeArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMergeArray.java
@@ -47,11 +47,11 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
         SimpleQueueWithConsumerIndex<Object> queue;
 
         if (n <= bufferSize()) {
-            queue = new MpscFillOnceSimpleQueue<Object>(n);
+            queue = new MpscFillOnceSimpleQueue<>(n);
         } else {
-            queue = new ClqSimpleQueue<Object>();
+            queue = new ClqSimpleQueue<>();
         }
-        MergeMaybeObserver<T> parent = new MergeMaybeObserver<T>(s, n, queue);
+        MergeMaybeObserver<T> parent = new MergeMaybeObserver<>(s, n, queue);
 
         s.onSubscribe(parent);
 
@@ -110,7 +110,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
         @Nullable
         @SuppressWarnings("unchecked")
         @Override
-        public T poll() throws Exception {
+        public T poll() {
             for (;;) {
                 Object o = queue.poll();
                 if (o != NotificationLite.COMPLETE) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeObserveOn.java
@@ -35,7 +35,7 @@ public final class MaybeObserveOn<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new ObserveOnMaybeObserver<T>(observer, scheduler));
+        source.subscribe(new ObserveOnMaybeObserver<>(observer, scheduler));
     }
 
     static final class ObserveOnMaybeObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorComplete.java
@@ -37,7 +37,7 @@ public final class MaybeOnErrorComplete<T> extends AbstractMaybeWithUpstream<T, 
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new OnErrorCompleteMaybeObserver<T>(observer, predicate));
+        source.subscribe(new OnErrorCompleteMaybeObserver<>(observer, predicate));
     }
 
     static final class OnErrorCompleteMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorNext.java
@@ -43,7 +43,7 @@ public final class MaybeOnErrorNext<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new OnErrorNextMaybeObserver<T>(observer, resumeFunction, allowFatal));
+        source.subscribe(new OnErrorNextMaybeObserver<>(observer, resumeFunction, allowFatal));
     }
 
     static final class OnErrorNextMaybeObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorReturn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorReturn.java
@@ -37,7 +37,7 @@ public final class MaybeOnErrorReturn<T> extends AbstractMaybeWithUpstream<T, T>
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new OnErrorReturnMaybeObserver<T>(observer, valueSupplier));
+        source.subscribe(new OnErrorReturnMaybeObserver<>(observer, valueSupplier));
     }
 
     static final class OnErrorReturnMaybeObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybePeek.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybePeek.java
@@ -53,7 +53,7 @@ public final class MaybePeek<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new MaybePeekObserver<T>(observer, this));
+        source.subscribe(new MaybePeekObserver<>(observer, this));
     }
 
     static final class MaybePeekObserver<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeSubscribeOn.java
@@ -34,10 +34,10 @@ public final class MaybeSubscribeOn<T> extends AbstractMaybeWithUpstream<T, T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        SubscribeOnMaybeObserver<T> parent = new SubscribeOnMaybeObserver<T>(observer);
+        SubscribeOnMaybeObserver<T> parent = new SubscribeOnMaybeObserver<>(observer);
         observer.onSubscribe(parent);
 
-        parent.task.replace(scheduler.scheduleDirect(new SubscribeTask<T>(parent, source)));
+        parent.task.replace(scheduler.scheduleDirect(new SubscribeTask<>(parent, source)));
     }
 
     static final class SubscribeTask<T> implements Runnable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeSwitchIfEmpty.java
@@ -35,7 +35,7 @@ public final class MaybeSwitchIfEmpty<T> extends AbstractMaybeWithUpstream<T, T>
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new SwitchIfEmptyMaybeObserver<T>(observer, other));
+        source.subscribe(new SwitchIfEmptyMaybeObserver<>(observer, other));
     }
 
     static final class SwitchIfEmptyMaybeObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeSwitchIfEmptySingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeSwitchIfEmptySingle.java
@@ -42,7 +42,7 @@ public final class MaybeSwitchIfEmptySingle<T> extends Single<T> implements HasU
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new SwitchIfEmptyMaybeObserver<T>(observer, other));
+        source.subscribe(new SwitchIfEmptyMaybeObserver<>(observer, other));
     }
 
     static final class SwitchIfEmptyMaybeObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTakeUntilMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTakeUntilMaybe.java
@@ -38,7 +38,7 @@ public final class MaybeTakeUntilMaybe<T, U> extends AbstractMaybeWithUpstream<T
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        TakeUntilMainMaybeObserver<T, U> parent = new TakeUntilMainMaybeObserver<T, U>(observer);
+        TakeUntilMainMaybeObserver<T, U> parent = new TakeUntilMainMaybeObserver<>(observer);
         observer.onSubscribe(parent);
 
         other.subscribe(parent.other);
@@ -57,7 +57,7 @@ public final class MaybeTakeUntilMaybe<T, U> extends AbstractMaybeWithUpstream<T
 
         TakeUntilMainMaybeObserver(MaybeObserver<? super T> downstream) {
             this.downstream = downstream;
-            this.other = new TakeUntilOtherMaybeObserver<U>(this);
+            this.other = new TakeUntilOtherMaybeObserver<>(this);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTakeUntilPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTakeUntilPublisher.java
@@ -41,7 +41,7 @@ public final class MaybeTakeUntilPublisher<T, U> extends AbstractMaybeWithUpstre
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        TakeUntilMainMaybeObserver<T, U> parent = new TakeUntilMainMaybeObserver<T, U>(observer);
+        TakeUntilMainMaybeObserver<T, U> parent = new TakeUntilMainMaybeObserver<>(observer);
         observer.onSubscribe(parent);
 
         other.subscribe(parent.other);
@@ -60,7 +60,7 @@ public final class MaybeTakeUntilPublisher<T, U> extends AbstractMaybeWithUpstre
 
         TakeUntilMainMaybeObserver(MaybeObserver<? super T> downstream) {
             this.downstream = downstream;
-            this.other = new TakeUntilOtherMaybeObserver<U>(this);
+            this.other = new TakeUntilOtherMaybeObserver<>(this);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTimeoutMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTimeoutMaybe.java
@@ -42,7 +42,7 @@ public final class MaybeTimeoutMaybe<T, U> extends AbstractMaybeWithUpstream<T, 
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        TimeoutMainMaybeObserver<T, U> parent = new TimeoutMainMaybeObserver<T, U>(observer, fallback);
+        TimeoutMainMaybeObserver<T, U> parent = new TimeoutMainMaybeObserver<>(observer, fallback);
         observer.onSubscribe(parent);
 
         other.subscribe(parent.other);
@@ -66,9 +66,9 @@ public final class MaybeTimeoutMaybe<T, U> extends AbstractMaybeWithUpstream<T, 
 
         TimeoutMainMaybeObserver(MaybeObserver<? super T> actual, MaybeSource<? extends T> fallback) {
             this.downstream = actual;
-            this.other = new TimeoutOtherMaybeObserver<T, U>(this);
+            this.other = new TimeoutOtherMaybeObserver<>(this);
             this.fallback = fallback;
-            this.otherObserver = fallback != null ? new TimeoutFallbackMaybeObserver<T>(actual) : null;
+            this.otherObserver = fallback != null ? new TimeoutFallbackMaybeObserver<>(actual) : null;
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTimeoutPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTimeoutPublisher.java
@@ -45,7 +45,7 @@ public final class MaybeTimeoutPublisher<T, U> extends AbstractMaybeWithUpstream
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        TimeoutMainMaybeObserver<T, U> parent = new TimeoutMainMaybeObserver<T, U>(observer, fallback);
+        TimeoutMainMaybeObserver<T, U> parent = new TimeoutMainMaybeObserver<>(observer, fallback);
         observer.onSubscribe(parent);
 
         other.subscribe(parent.other);
@@ -69,9 +69,9 @@ public final class MaybeTimeoutPublisher<T, U> extends AbstractMaybeWithUpstream
 
         TimeoutMainMaybeObserver(MaybeObserver<? super T> actual, MaybeSource<? extends T> fallback) {
             this.downstream = actual;
-            this.other = new TimeoutOtherMaybeObserver<T, U>(this);
+            this.other = new TimeoutOtherMaybeObserver<>(this);
             this.fallback = fallback;
-            this.otherObserver = fallback != null ? new TimeoutFallbackMaybeObserver<T>(actual) : null;
+            this.otherObserver = fallback != null ? new TimeoutFallbackMaybeObserver<>(actual) : null;
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToFlowable.java
@@ -42,7 +42,7 @@ public final class MaybeToFlowable<T> extends Flowable<T> implements HasUpstream
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        source.subscribe(new MaybeToFlowableSubscriber<T>(s));
+        source.subscribe(new MaybeToFlowableSubscriber<>(s));
     }
 
     static final class MaybeToFlowableSubscriber<T> extends DeferredScalarSubscription<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToObservable.java
@@ -52,7 +52,7 @@ public final class MaybeToObservable<T> extends Observable<T> implements HasUpst
      * @since 2.2
      */
     public static <T> MaybeObserver<T> create(Observer<? super T> downstream) {
-        return new MaybeToObservableObserver<T>(downstream);
+        return new MaybeToObservableObserver<>(downstream);
     }
 
     static final class MaybeToObservableObserver<T> extends DeferredScalarDisposable<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToPublisher.java
@@ -30,7 +30,7 @@ public enum MaybeToPublisher implements Function<MaybeSource<Object>, Publisher<
     }
 
     @Override
-    public Publisher<Object> apply(MaybeSource<Object> t) throws Exception {
-        return new MaybeToFlowable<Object>(t);
+    public Publisher<Object> apply(MaybeSource<Object> t) {
+        return new MaybeToFlowable<>(t);
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToSingle.java
@@ -43,7 +43,7 @@ public final class MaybeToSingle<T> extends Single<T> implements HasUpstreamMayb
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new ToSingleMaybeSubscriber<T>(observer, defaultValue));
+        source.subscribe(new ToSingleMaybeSubscriber<>(observer, defaultValue));
     }
 
     static final class ToSingleMaybeSubscriber<T> implements MaybeObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeUnsubscribeOn.java
@@ -35,7 +35,7 @@ public final class MaybeUnsubscribeOn<T> extends AbstractMaybeWithUpstream<T, T>
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new UnsubscribeOnMaybeObserver<T>(observer, scheduler));
+        source.subscribe(new UnsubscribeOnMaybeObserver<>(observer, scheduler));
     }
 
     static final class UnsubscribeOnMaybeObserver<T> extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipArray.java
@@ -40,11 +40,11 @@ public final class MaybeZipArray<T, R> extends Maybe<R> {
         int n = sources.length;
 
         if (n == 1) {
-            sources[0].subscribe(new MaybeMap.MapMaybeObserver<T, R>(observer, new SingletonArrayFunc()));
+            sources[0].subscribe(new MaybeMap.MapMaybeObserver<>(observer, new SingletonArrayFunc()));
             return;
         }
 
-        ZipCoordinator<T, R> parent = new ZipCoordinator<T, R>(observer, n, zipper);
+        ZipCoordinator<T, R> parent = new ZipCoordinator<>(observer, n, zipper);
 
         observer.onSubscribe(parent);
 
@@ -82,7 +82,7 @@ public final class MaybeZipArray<T, R> extends Maybe<R> {
             this.zipper = zipper;
             ZipMaybeObserver<T>[] o = new ZipMaybeObserver[n];
             for (int i = 0; i < n; i++) {
-                o[i] = new ZipMaybeObserver<T>(this, i);
+                o[i] = new ZipMaybeObserver<>(this, i);
             }
             this.observers = o;
             this.values = new Object[n];

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeZipIterable.java
@@ -62,11 +62,11 @@ public final class MaybeZipIterable<T, R> extends Maybe<R> {
         }
 
         if (n == 1) {
-            a[0].subscribe(new MaybeMap.MapMaybeObserver<T, R>(observer, new SingletonArrayFunc()));
+            a[0].subscribe(new MaybeMap.MapMaybeObserver<>(observer, new SingletonArrayFunc()));
             return;
         }
 
-        ZipCoordinator<T, R> parent = new ZipCoordinator<T, R>(observer, n, zipper);
+        ZipCoordinator<T, R> parent = new ZipCoordinator<>(observer, n, zipper);
 
         observer.onSubscribe(parent);
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/CompletableAndThenObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/CompletableAndThenObservable.java
@@ -40,7 +40,7 @@ public final class CompletableAndThenObservable<R> extends Observable<R> {
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        AndThenObservableObserver<R> parent = new AndThenObservableObserver<R>(observer, other);
+        AndThenObservableObserver<R> parent = new AndThenObservableObserver<>(observer, other);
         observer.onSubscribe(parent);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapCompletable.java
@@ -57,7 +57,7 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
 
     @Override
     protected void subscribeActual(CompletableObserver observer) {
-        source.subscribe(new ConcatMapCompletableObserver<T>(observer, mapper, errorMode, prefetch));
+        source.subscribe(new ConcatMapCompletableObserver<>(observer, mapper, errorMode, prefetch));
     }
 
     static final class ConcatMapCompletableObserver<T>
@@ -99,7 +99,7 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
             this.prefetch = prefetch;
             this.errors = new AtomicThrowable();
             this.inner = new ConcatMapInnerObserver(this);
-            this.queue = new SpscArrayQueue<T>(prefetch);
+            this.queue = new SpscArrayQueue<>(prefetch);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybe.java
@@ -58,7 +58,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new ConcatMapMaybeSubscriber<T, R>(s, mapper, prefetch, errorMode));
+        source.subscribe(new ConcatMapMaybeSubscriber<>(s, mapper, prefetch, errorMode));
     }
 
     static final class ConcatMapMaybeSubscriber<T, R>
@@ -113,8 +113,8 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
             this.errorMode = errorMode;
             this.requested = new AtomicLong();
             this.errors = new AtomicThrowable();
-            this.inner = new ConcatMapMaybeObserver<R>(this);
-            this.queue = new SpscArrayQueue<T>(prefetch);
+            this.inner = new ConcatMapMaybeObserver<>(this);
+            this.queue = new SpscArrayQueue<>(prefetch);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -58,7 +58,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new ConcatMapSingleSubscriber<T, R>(s, mapper, prefetch, errorMode));
+        source.subscribe(new ConcatMapSingleSubscriber<>(s, mapper, prefetch, errorMode));
     }
 
     static final class ConcatMapSingleSubscriber<T, R>
@@ -113,8 +113,8 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
             this.errorMode = errorMode;
             this.requested = new AtomicLong();
             this.errors = new AtomicThrowable();
-            this.inner = new ConcatMapSingleObserver<R>(this);
-            this.queue = new SpscArrayQueue<T>(prefetch);
+            this.inner = new ConcatMapSingleObserver<>(this);
+            this.queue = new SpscArrayQueue<>(prefetch);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapCompletable.java
@@ -52,7 +52,7 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
 
     @Override
     protected void subscribeActual(CompletableObserver observer) {
-        source.subscribe(new SwitchMapCompletableObserver<T>(observer, mapper, delayErrors));
+        source.subscribe(new SwitchMapCompletableObserver<>(observer, mapper, delayErrors));
     }
 
     static final class SwitchMapCompletableObserver<T> implements FlowableSubscriber<T>, Disposable {
@@ -79,7 +79,7 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
             this.mapper = mapper;
             this.delayErrors = delayErrors;
             this.errors = new AtomicThrowable();
-            this.inner = new AtomicReference<SwitchMapInnerObserver>();
+            this.inner = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapMaybe.java
@@ -54,7 +54,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new SwitchMapMaybeSubscriber<T, R>(s, mapper, delayErrors));
+        source.subscribe(new SwitchMapMaybeSubscriber<>(s, mapper, delayErrors));
     }
 
     static final class SwitchMapMaybeSubscriber<T, R> extends AtomicInteger
@@ -75,7 +75,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
         final AtomicReference<SwitchMapMaybeObserver<R>> inner;
 
         static final SwitchMapMaybeObserver<Object> INNER_DISPOSED =
-                new SwitchMapMaybeObserver<Object>(null);
+                new SwitchMapMaybeObserver<>(null);
 
         Subscription upstream;
 
@@ -93,7 +93,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
             this.delayErrors = delayErrors;
             this.errors = new AtomicThrowable();
             this.requested = new AtomicLong();
-            this.inner = new AtomicReference<SwitchMapMaybeObserver<R>>();
+            this.inner = new AtomicReference<>();
         }
 
         @Override
@@ -125,7 +125,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
                 return;
             }
 
-            SwitchMapMaybeObserver<R> observer = new SwitchMapMaybeObserver<R>(this);
+            SwitchMapMaybeObserver<R> observer = new SwitchMapMaybeObserver<>(this);
 
             for (;;) {
                 current = inner.get();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapSingle.java
@@ -54,7 +54,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new SwitchMapSingleSubscriber<T, R>(s, mapper, delayErrors));
+        source.subscribe(new SwitchMapSingleSubscriber<>(s, mapper, delayErrors));
     }
 
     static final class SwitchMapSingleSubscriber<T, R> extends AtomicInteger
@@ -75,7 +75,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
         final AtomicReference<SwitchMapSingleObserver<R>> inner;
 
         static final SwitchMapSingleObserver<Object> INNER_DISPOSED =
-                new SwitchMapSingleObserver<Object>(null);
+                new SwitchMapSingleObserver<>(null);
 
         Subscription upstream;
 
@@ -93,7 +93,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
             this.delayErrors = delayErrors;
             this.errors = new AtomicThrowable();
             this.requested = new AtomicLong();
-            this.inner = new AtomicReference<SwitchMapSingleObserver<R>>();
+            this.inner = new AtomicReference<>();
         }
 
         @Override
@@ -125,7 +125,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
                 return;
             }
 
-            SwitchMapSingleObserver<R> observer = new SwitchMapSingleObserver<R>(this);
+            SwitchMapSingleObserver<R> observer = new SwitchMapSingleObserver<>(this);
 
             for (;;) {
                 current = inner.get();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/MaterializeSingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/MaterializeSingleObserver.java
@@ -45,17 +45,17 @@ implements SingleObserver<T>, MaybeObserver<T>, CompletableObserver, Disposable 
 
     @Override
     public void onComplete() {
-        downstream.onSuccess(Notification.<T>createOnComplete());
+        downstream.onSuccess(Notification.createOnComplete());
     }
 
     @Override
     public void onSuccess(T t) {
-        downstream.onSuccess(Notification.<T>createOnNext(t));
+        downstream.onSuccess(Notification.createOnNext(t));
     }
 
     @Override
     public void onError(Throwable e) {
-        downstream.onSuccess(Notification.<T>createOnError(e));
+        downstream.onSuccess(Notification.createOnError(e));
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/MaybeFlatMapObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/MaybeFlatMapObservable.java
@@ -44,7 +44,7 @@ public final class MaybeFlatMapObservable<T, R> extends Observable<R> {
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        FlatMapObserver<T, R> parent = new FlatMapObserver<T, R>(observer, mapper);
+        FlatMapObserver<T, R> parent = new FlatMapObserver<>(observer, mapper);
         observer.onSubscribe(parent);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/MaybeFlatMapPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/MaybeFlatMapPublisher.java
@@ -47,7 +47,7 @@ public final class MaybeFlatMapPublisher<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new FlatMapPublisherSubscriber<T, R>(s, mapper));
+        source.subscribe(new FlatMapPublisherSubscriber<>(s, mapper));
     }
 
     static final class FlatMapPublisherSubscriber<T, R>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapCompletable.java
@@ -55,7 +55,7 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
     @Override
     protected void subscribeActual(CompletableObserver observer) {
         if (!ScalarXMapZHelper.tryAsCompletable(source, mapper, observer)) {
-            source.subscribe(new ConcatMapCompletableObserver<T>(observer, mapper, errorMode, prefetch));
+            source.subscribe(new ConcatMapCompletableObserver<>(observer, mapper, errorMode, prefetch));
         }
     }
 
@@ -120,7 +120,7 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
                         return;
                     }
                 }
-                queue = new SpscLinkedArrayQueue<T>(prefetch);
+                queue = new SpscLinkedArrayQueue<>(prefetch);
                 downstream.onSubscribe(this);
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybe.java
@@ -56,7 +56,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
         if (!ScalarXMapZHelper.tryAsMaybe(source, mapper, observer)) {
-            source.subscribe(new ConcatMapMaybeMainObserver<T, R>(observer, mapper, prefetch, errorMode));
+            source.subscribe(new ConcatMapMaybeMainObserver<>(observer, mapper, prefetch, errorMode));
         }
     }
 
@@ -102,8 +102,8 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
             this.mapper = mapper;
             this.errorMode = errorMode;
             this.errors = new AtomicThrowable();
-            this.inner = new ConcatMapMaybeObserver<R>(this);
-            this.queue = new SpscLinkedArrayQueue<T>(prefetch);
+            this.inner = new ConcatMapMaybeObserver<>(this);
+            this.queue = new SpscLinkedArrayQueue<>(prefetch);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -56,7 +56,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
         if (!ScalarXMapZHelper.tryAsSingle(source, mapper, observer)) {
-            source.subscribe(new ConcatMapSingleMainObserver<T, R>(observer, mapper, prefetch, errorMode));
+            source.subscribe(new ConcatMapSingleMainObserver<>(observer, mapper, prefetch, errorMode));
         }
     }
 
@@ -102,8 +102,8 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
             this.mapper = mapper;
             this.errorMode = errorMode;
             this.errors = new AtomicThrowable();
-            this.inner = new ConcatMapSingleObserver<R>(this);
-            this.queue = new SpscLinkedArrayQueue<T>(prefetch);
+            this.inner = new ConcatMapSingleObserver<>(this);
+            this.queue = new SpscLinkedArrayQueue<>(prefetch);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapCompletable.java
@@ -50,7 +50,7 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
     @Override
     protected void subscribeActual(CompletableObserver observer) {
         if (!ScalarXMapZHelper.tryAsCompletable(source, mapper, observer)) {
-            source.subscribe(new SwitchMapCompletableObserver<T>(observer, mapper, delayErrors));
+            source.subscribe(new SwitchMapCompletableObserver<>(observer, mapper, delayErrors));
         }
     }
 
@@ -78,7 +78,7 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
             this.mapper = mapper;
             this.delayErrors = delayErrors;
             this.errors = new AtomicThrowable();
-            this.inner = new AtomicReference<SwitchMapInnerObserver>();
+            this.inner = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapMaybe.java
@@ -52,7 +52,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
         if (!ScalarXMapZHelper.tryAsMaybe(source, mapper, observer)) {
-            source.subscribe(new SwitchMapMaybeMainObserver<T, R>(observer, mapper, delayErrors));
+            source.subscribe(new SwitchMapMaybeMainObserver<>(observer, mapper, delayErrors));
         }
     }
 
@@ -72,7 +72,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
         final AtomicReference<SwitchMapMaybeObserver<R>> inner;
 
         static final SwitchMapMaybeObserver<Object> INNER_DISPOSED =
-                new SwitchMapMaybeObserver<Object>(null);
+                new SwitchMapMaybeObserver<>(null);
 
         Disposable upstream;
 
@@ -87,7 +87,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
             this.mapper = mapper;
             this.delayErrors = delayErrors;
             this.errors = new AtomicThrowable();
-            this.inner = new AtomicReference<SwitchMapMaybeObserver<R>>();
+            this.inner = new AtomicReference<>();
         }
 
         @Override
@@ -118,7 +118,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
                 return;
             }
 
-            SwitchMapMaybeObserver<R> observer = new SwitchMapMaybeObserver<R>(this);
+            SwitchMapMaybeObserver<R> observer = new SwitchMapMaybeObserver<>(this);
 
             for (;;) {
                 current = inner.get();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableSwitchMapSingle.java
@@ -52,7 +52,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
         if (!ScalarXMapZHelper.tryAsSingle(source, mapper, observer)) {
-            source.subscribe(new SwitchMapSingleMainObserver<T, R>(observer, mapper, delayErrors));
+            source.subscribe(new SwitchMapSingleMainObserver<>(observer, mapper, delayErrors));
         }
     }
 
@@ -72,7 +72,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
         final AtomicReference<SwitchMapSingleObserver<R>> inner;
 
         static final SwitchMapSingleObserver<Object> INNER_DISPOSED =
-                new SwitchMapSingleObserver<Object>(null);
+                new SwitchMapSingleObserver<>(null);
 
         Disposable upstream;
 
@@ -87,7 +87,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
             this.mapper = mapper;
             this.delayErrors = delayErrors;
             this.errors = new AtomicThrowable();
-            this.inner = new AtomicReference<SwitchMapSingleObserver<R>>();
+            this.inner = new AtomicReference<>();
         }
 
         @Override
@@ -118,7 +118,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
                 return;
             }
 
-            SwitchMapSingleObserver<R> observer = new SwitchMapSingleObserver<R>(this);
+            SwitchMapSingleObserver<R> observer = new SwitchMapSingleObserver<>(this);
 
             for (;;) {
                 current = inner.get();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/SingleFlatMapObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/SingleFlatMapObservable.java
@@ -44,7 +44,7 @@ public final class SingleFlatMapObservable<T, R> extends Observable<R> {
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        FlatMapObserver<T, R> parent = new FlatMapObserver<T, R>(observer, mapper);
+        FlatMapObserver<T, R> parent = new FlatMapObserver<>(observer, mapper);
         observer.onSubscribe(parent);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableIterable.java
@@ -35,7 +35,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
 
     @Override
     public Iterator<T> iterator() {
-        BlockingObservableIterator<T> it = new BlockingObservableIterator<T>(bufferSize);
+        BlockingObservableIterator<T> it = new BlockingObservableIterator<>(bufferSize);
         source.subscribe(it);
         return it;
     }
@@ -56,7 +56,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
         volatile Throwable error;
 
         BlockingObservableIterator(int batchSize) {
-            this.queue = new SpscLinkedArrayQueue<T>(batchSize);
+            this.queue = new SpscLinkedArrayQueue<>(batchSize);
             this.lock = new ReentrantLock();
             this.condition = lock.newCondition();
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableLatest.java
@@ -38,7 +38,7 @@ public final class BlockingObservableLatest<T> implements Iterable<T> {
 
     @Override
     public Iterator<T> iterator() {
-        BlockingObservableLatestIterator<T> lio = new BlockingObservableLatestIterator<T>();
+        BlockingObservableLatestIterator<T> lio = new BlockingObservableLatestIterator<>();
 
         Observable<Notification<T>> materialized = Observable.wrap(source).materialize();
 
@@ -52,7 +52,7 @@ public final class BlockingObservableLatest<T> implements Iterable<T> {
 
         final Semaphore notify = new Semaphore(0);
         // observer's notification
-        final AtomicReference<Notification<T>> value = new AtomicReference<Notification<T>>();
+        final AtomicReference<Notification<T>> value = new AtomicReference<>();
 
         @Override
         public void onNext(Notification<T> args) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableMostRecent.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableMostRecent.java
@@ -40,7 +40,7 @@ public final class BlockingObservableMostRecent<T> implements Iterable<T> {
 
     @Override
     public Iterator<T> iterator() {
-        MostRecentObserver<T> mostRecentObserver = new MostRecentObserver<T>(initialValue);
+        MostRecentObserver<T> mostRecentObserver = new MostRecentObserver<>(initialValue);
 
         source.subscribe(mostRecentObserver);
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNext.java
@@ -39,8 +39,8 @@ public final class BlockingObservableNext<T> implements Iterable<T> {
 
     @Override
     public Iterator<T> iterator() {
-        NextObserver<T> nextObserver = new NextObserver<T>();
-        return new NextIterator<T>(source, nextObserver);
+        NextObserver<T> nextObserver = new NextObserver<>();
+        return new NextIterator<>(source, nextObserver);
     }
 
     // test needs to access the observer.waiting flag
@@ -80,7 +80,7 @@ public final class BlockingObservableNext<T> implements Iterable<T> {
                 started = true;
                 // if not started, start now
                 observer.setWaiting();
-                new ObservableMaterialize<T>(items).subscribe(observer);
+                new ObservableMaterialize<>(items).subscribe(observer);
             }
 
             Notification<T> nextNotification;
@@ -130,7 +130,7 @@ public final class BlockingObservableNext<T> implements Iterable<T> {
     }
 
     static final class NextObserver<T> extends DisposableObserver<Notification<T>> {
-        private final BlockingQueue<Notification<T>> buf = new ArrayBlockingQueue<Notification<T>>(1);
+        private final BlockingQueue<Notification<T>> buf = new ArrayBlockingQueue<>(1);
         final AtomicInteger waiting = new AtomicInteger();
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAll.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAll.java
@@ -28,7 +28,7 @@ public final class ObservableAll<T> extends AbstractObservableWithUpstream<T, Bo
 
     @Override
     protected void subscribeActual(Observer<? super Boolean> t) {
-        source.subscribe(new AllObserver<T>(t, predicate));
+        source.subscribe(new AllObserver<>(t, predicate));
     }
 
     static final class AllObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAllSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAllSingle.java
@@ -31,12 +31,12 @@ public final class ObservableAllSingle<T> extends Single<Boolean> implements Fus
 
     @Override
     protected void subscribeActual(SingleObserver<? super Boolean> t) {
-        source.subscribe(new AllObserver<T>(t, predicate));
+        source.subscribe(new AllObserver<>(t, predicate));
     }
 
     @Override
     public Observable<Boolean> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableAll<T>(source, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableAll<>(source, predicate));
     }
 
     static final class AllObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmb.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmb.java
@@ -68,7 +68,7 @@ public final class ObservableAmb<T> extends Observable<T> {
             return;
         }
 
-        AmbCoordinator<T> ac = new AmbCoordinator<T>(observer, count);
+        AmbCoordinator<T> ac = new AmbCoordinator<>(observer, count);
         ac.subscribe(sources);
     }
 
@@ -88,7 +88,7 @@ public final class ObservableAmb<T> extends Observable<T> {
             AmbInnerObserver<T>[] as = observers;
             int len = as.length;
             for (int i = 0; i < len; i++) {
-                as[i] = new AmbInnerObserver<T>(this, i + 1, downstream);
+                as[i] = new AmbInnerObserver<>(this, i + 1, downstream);
             }
             winner.lazySet(0); // release the contents of 'as'
             downstream.onSubscribe(this);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAny.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAny.java
@@ -28,7 +28,7 @@ public final class ObservableAny<T> extends AbstractObservableWithUpstream<T, Bo
 
     @Override
     protected void subscribeActual(Observer<? super Boolean> t) {
-        source.subscribe(new AnyObserver<T>(t, predicate));
+        source.subscribe(new AnyObserver<>(t, predicate));
     }
 
     static final class AnyObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAnySingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAnySingle.java
@@ -32,12 +32,12 @@ public final class ObservableAnySingle<T> extends Single<Boolean> implements Fus
 
     @Override
     protected void subscribeActual(SingleObserver<? super Boolean> t) {
-        source.subscribe(new AnyObserver<T>(t, predicate));
+        source.subscribe(new AnyObserver<>(t, predicate));
     }
 
     @Override
     public Observable<Boolean> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableAny<T>(source, predicate));
+        return RxJavaPlugins.onAssembly(new ObservableAny<>(source, predicate));
     }
 
     static final class AnyObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBlockingSubscribe.java
@@ -41,9 +41,9 @@ public final class ObservableBlockingSubscribe {
      * @param <T> the value type
      */
     public static <T> void subscribe(ObservableSource<? extends T> o, Observer<? super T> observer) {
-        final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
+        final BlockingQueue<Object> queue = new LinkedBlockingQueue<>();
 
-        BlockingObserver<T> bs = new BlockingObserver<T>(queue);
+        BlockingObserver<T> bs = new BlockingObserver<>(queue);
         observer.onSubscribe(bs);
 
         o.subscribe(bs);
@@ -76,7 +76,7 @@ public final class ObservableBlockingSubscribe {
      */
     public static <T> void subscribe(ObservableSource<? extends T> o) {
         BlockingIgnoringReceiver callback = new BlockingIgnoringReceiver();
-        LambdaObserver<T> ls = new LambdaObserver<T>(Functions.emptyConsumer(),
+        LambdaObserver<T> ls = new LambdaObserver<>(Functions.emptyConsumer(),
         callback, callback, Functions.emptyConsumer());
 
         o.subscribe(ls);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBuffer.java
@@ -39,12 +39,12 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
     @Override
     protected void subscribeActual(Observer<? super U> t) {
         if (skip == count) {
-            BufferExactObserver<T, U> bes = new BufferExactObserver<T, U>(t, count, bufferSupplier);
+            BufferExactObserver<T, U> bes = new BufferExactObserver<>(t, count, bufferSupplier);
             if (bes.createBuffer()) {
                 source.subscribe(bes);
             }
         } else {
-            source.subscribe(new BufferSkipObserver<T, U>(t, count, skip, bufferSupplier));
+            source.subscribe(new BufferSkipObserver<>(t, count, skip, bufferSupplier));
         }
     }
 
@@ -157,7 +157,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
             this.count = count;
             this.skip = skip;
             this.bufferSupplier = bufferSupplier;
-            this.buffers = new ArrayDeque<U>();
+            this.buffers = new ArrayDeque<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferBoundary.java
@@ -43,7 +43,7 @@ extends AbstractObservableWithUpstream<T, U> {
     @Override
     protected void subscribeActual(Observer<? super U> t) {
         BufferBoundaryObserver<T, U, Open, Close> parent =
-            new BufferBoundaryObserver<T, U, Open, Close>(
+            new BufferBoundaryObserver<>(
                 t, bufferOpen, bufferClose, bufferSupplier
             );
         t.onSubscribe(parent);
@@ -88,10 +88,10 @@ extends AbstractObservableWithUpstream<T, U> {
             this.bufferSupplier = bufferSupplier;
             this.bufferOpen = bufferOpen;
             this.bufferClose = bufferClose;
-            this.queue = new SpscLinkedArrayQueue<C>(bufferSize());
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize());
             this.observers = new CompositeDisposable();
-            this.upstream = new AtomicReference<Disposable>();
-            this.buffers = new LinkedHashMap<Long, C>();
+            this.upstream = new AtomicReference<>();
+            this.buffers = new LinkedHashMap<>();
             this.errors = new AtomicThrowable();
         }
 
@@ -99,7 +99,7 @@ extends AbstractObservableWithUpstream<T, U> {
         public void onSubscribe(Disposable d) {
             if (DisposableHelper.setOnce(this.upstream, d)) {
 
-                BufferOpenObserver<Open> open = new BufferOpenObserver<Open>(this);
+                BufferOpenObserver<Open> open = new BufferOpenObserver<>(this);
                 observers.add(open);
 
                 bufferOpen.subscribe(open);
@@ -190,7 +190,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 bufs.put(idx, buf);
             }
 
-            BufferCloseObserver<T, C> bc = new BufferCloseObserver<T, C>(this, idx);
+            BufferCloseObserver<T, C> bc = new BufferCloseObserver<>(this, idx);
             observers.add(bc);
             p.subscribe(bc);
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferExactBoundary.java
@@ -39,7 +39,7 @@ extends AbstractObservableWithUpstream<T, U> {
 
     @Override
     protected void subscribeActual(Observer<? super U> t) {
-        source.subscribe(new BufferExactBoundaryObserver<T, U, B>(new SerializedObserver<U>(t), bufferSupplier, boundary));
+        source.subscribe(new BufferExactBoundaryObserver<>(new SerializedObserver<>(t), bufferSupplier, boundary));
     }
 
     static final class BufferExactBoundaryObserver<T, U extends Collection<? super T>, B>
@@ -56,7 +56,7 @@ extends AbstractObservableWithUpstream<T, U> {
 
         BufferExactBoundaryObserver(Observer<? super U> actual, Supplier<U> bufferSupplier,
                                              ObservableSource<B> boundary) {
-            super(actual, new MpscLinkedQueue<U>());
+            super(actual, new MpscLinkedQueue<>());
             this.bufferSupplier = bufferSupplier;
             this.boundary = boundary;
         }
@@ -80,7 +80,7 @@ extends AbstractObservableWithUpstream<T, U> {
 
                 buffer = b;
 
-                BufferBoundaryObserver<T, U, B> bs = new BufferBoundaryObserver<T, U, B>(this);
+                BufferBoundaryObserver<T, U, B> bs = new BufferBoundaryObserver<>(this);
                 other = bs;
 
                 downstream.onSubscribe(this);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferTimed.java
@@ -55,16 +55,16 @@ extends AbstractObservableWithUpstream<T, U> {
     @Override
     protected void subscribeActual(Observer<? super U> t) {
         if (timespan == timeskip && maxSize == Integer.MAX_VALUE) {
-            source.subscribe(new BufferExactUnboundedObserver<T, U>(
-                    new SerializedObserver<U>(t),
+            source.subscribe(new BufferExactUnboundedObserver<>(
+                    new SerializedObserver<>(t),
                     bufferSupplier, timespan, unit, scheduler));
             return;
         }
         Scheduler.Worker w = scheduler.createWorker();
 
         if (timespan == timeskip) {
-            source.subscribe(new BufferExactBoundedObserver<T, U>(
-                    new SerializedObserver<U>(t),
+            source.subscribe(new BufferExactBoundedObserver<>(
+                    new SerializedObserver<>(t),
                     bufferSupplier,
                     timespan, unit, maxSize, restartTimerOnMaxSize, w
             ));
@@ -72,8 +72,8 @@ extends AbstractObservableWithUpstream<T, U> {
         }
         // Can't use maxSize because what to do if a buffer is full but its
         // timespan hasn't been elapsed?
-        source.subscribe(new BufferSkipBoundedObserver<T, U>(
-                new SerializedObserver<U>(t),
+        source.subscribe(new BufferSkipBoundedObserver<>(
+                new SerializedObserver<>(t),
                 bufferSupplier, timespan, timeskip, unit, w));
 
     }
@@ -89,12 +89,12 @@ extends AbstractObservableWithUpstream<T, U> {
 
         U buffer;
 
-        final AtomicReference<Disposable> timer = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> timer = new AtomicReference<>();
 
         BufferExactUnboundedObserver(
                 Observer<? super U> actual, Supplier<U> bufferSupplier,
                 long timespan, TimeUnit unit, Scheduler scheduler) {
-            super(actual, new MpscLinkedQueue<U>());
+            super(actual, new MpscLinkedQueue<>());
             this.bufferSupplier = bufferSupplier;
             this.timespan = timespan;
             this.unit = unit;
@@ -228,13 +228,13 @@ extends AbstractObservableWithUpstream<T, U> {
         BufferSkipBoundedObserver(Observer<? super U> actual,
                 Supplier<U> bufferSupplier, long timespan,
                 long timeskip, TimeUnit unit, Worker w) {
-            super(actual, new MpscLinkedQueue<U>());
+            super(actual, new MpscLinkedQueue<>());
             this.bufferSupplier = bufferSupplier;
             this.timespan = timespan;
             this.timeskip = timeskip;
             this.unit = unit;
             this.w = w;
-            this.buffers = new LinkedList<U>();
+            this.buffers = new LinkedList<>();
         }
 
         @Override
@@ -285,7 +285,7 @@ extends AbstractObservableWithUpstream<T, U> {
         public void onComplete() {
             List<U> bs;
             synchronized (this) {
-                bs = new ArrayList<U>(buffers);
+                bs = new ArrayList<>(buffers);
                 buffers.clear();
             }
 
@@ -409,7 +409,7 @@ extends AbstractObservableWithUpstream<T, U> {
                 Supplier<U> bufferSupplier,
                 long timespan, TimeUnit unit, int maxSize,
                 boolean restartOnMaxSize, Worker w) {
-            super(actual, new MpscLinkedQueue<U>());
+            super(actual, new MpscLinkedQueue<>());
             this.bufferSupplier = bufferSupplier;
             this.timespan = timespan;
             this.unit = unit;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCache.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCache.java
@@ -95,15 +95,15 @@ implements Observer<T> {
         super(source);
         this.capacityHint = capacityHint;
         this.once = new AtomicBoolean();
-        Node<T> n = new Node<T>(capacityHint);
+        Node<T> n = new Node<>(capacityHint);
         this.head = n;
         this.tail = n;
-        this.observers = new AtomicReference<CacheDisposable<T>[]>(EMPTY);
+        this.observers = new AtomicReference<>(EMPTY);
     }
 
     @Override
     protected void subscribeActual(Observer<? super T> t) {
-        CacheDisposable<T> consumer = new CacheDisposable<T>(t, this);
+        CacheDisposable<T> consumer = new CacheDisposable<>(t, this);
         t.onSubscribe(consumer);
         add(consumer);
 
@@ -292,7 +292,7 @@ implements Observer<T> {
         int tailOffset = this.tailOffset;
         // if the current tail node is full, create a fresh node
         if (tailOffset == capacityHint) {
-            Node<T> n = new Node<T>(tailOffset);
+            Node<T> n = new Node<>(tailOffset);
             n.values[0] = t;
             this.tailOffset = 1;
             tail.next = n;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollect.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollect.java
@@ -43,7 +43,7 @@ public final class ObservableCollect<T, U> extends AbstractObservableWithUpstrea
             return;
         }
 
-        source.subscribe(new CollectObserver<T, U>(t, u, collector));
+        source.subscribe(new CollectObserver<>(t, u, collector));
 
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollectSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCollectSingle.java
@@ -47,12 +47,12 @@ public final class ObservableCollectSingle<T, U> extends Single<U> implements Fu
             return;
         }
 
-        source.subscribe(new CollectObserver<T, U>(t, u, collector));
+        source.subscribe(new CollectObserver<>(t, u, collector));
     }
 
     @Override
     public Observable<U> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableCollect<T, U>(source, initialSupplier, collector));
+        return RxJavaPlugins.onAssembly(new ObservableCollect<>(source, initialSupplier, collector));
     }
 
     static final class CollectObserver<T, U> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatest.java
@@ -66,7 +66,7 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
             return;
         }
 
-        LatestCoordinator<T, R> lc = new LatestCoordinator<T, R>(observer, combiner, count, bufferSize, delayError);
+        LatestCoordinator<T, R> lc = new LatestCoordinator<>(observer, combiner, count, bufferSize, delayError);
         lc.subscribe(sources);
     }
 
@@ -99,10 +99,10 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
             this.latest = new Object[count];
             CombinerObserver<T, R>[] as = new CombinerObserver[count];
             for (int i = 0; i < count; i++) {
-                as[i] = new CombinerObserver<T, R>(this, i);
+                as[i] = new CombinerObserver<>(this, i);
             }
             this.observers = as;
-            this.queue = new SpscLinkedArrayQueue<Object[]>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
         }
 
         public void subscribe(ObservableSource<? extends T>[] sources) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMap.java
@@ -48,10 +48,10 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
         }
 
         if (delayErrors == ErrorMode.IMMEDIATE) {
-            SerializedObserver<U> serial = new SerializedObserver<U>(observer);
-            source.subscribe(new SourceObserver<T, U>(serial, mapper, bufferSize));
+            SerializedObserver<U> serial = new SerializedObserver<>(observer);
+            source.subscribe(new SourceObserver<>(serial, mapper, bufferSize));
         } else {
-            source.subscribe(new ConcatMapDelayErrorObserver<T, U>(observer, mapper, bufferSize, delayErrors == ErrorMode.END));
+            source.subscribe(new ConcatMapDelayErrorObserver<>(observer, mapper, bufferSize, delayErrors == ErrorMode.END));
         }
     }
 
@@ -80,7 +80,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
             this.downstream = actual;
             this.mapper = mapper;
             this.bufferSize = bufferSize;
-            this.inner = new InnerObserver<U>(actual, this);
+            this.inner = new InnerObserver<>(actual, this);
         }
 
         @Override
@@ -113,7 +113,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
                     }
                 }
 
-                queue = new SpscLinkedArrayQueue<T>(bufferSize);
+                queue = new SpscLinkedArrayQueue<>(bufferSize);
 
                 downstream.onSubscribe(this);
             }
@@ -305,7 +305,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
             this.bufferSize = bufferSize;
             this.tillTheEnd = tillTheEnd;
             this.errors = new AtomicThrowable();
-            this.observer = new DelayErrorInnerObserver<R>(actual, this);
+            this.observer = new DelayErrorInnerObserver<>(actual, this);
         }
 
         @Override
@@ -338,7 +338,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
                     }
                 }
 
-                queue = new SpscLinkedArrayQueue<T>(bufferSize);
+                queue = new SpscLinkedArrayQueue<>(bufferSize);
 
                 downstream.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEager.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapEager.java
@@ -50,7 +50,7 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new ConcatMapEagerMainObserver<T, R>(observer, mapper, maxConcurrency, prefetch, errorMode));
+        source.subscribe(new ConcatMapEagerMainObserver<>(observer, mapper, maxConcurrency, prefetch, errorMode));
     }
 
     static final class ConcatMapEagerMainObserver<T, R>
@@ -96,7 +96,7 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
             this.prefetch = prefetch;
             this.errorMode = errorMode;
             this.errors = new AtomicThrowable();
-            this.observers = new ArrayDeque<InnerQueuedObserver<R>>();
+            this.observers = new ArrayDeque<>();
         }
 
         @SuppressWarnings("unchecked")
@@ -129,7 +129,7 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
                     }
                 }
 
-                queue = new SpscLinkedArrayQueue<T>(prefetch);
+                queue = new SpscLinkedArrayQueue<>(prefetch);
 
                 downstream.onSubscribe(this);
             }
@@ -282,7 +282,7 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
                         return;
                     }
 
-                    InnerQueuedObserver<R> inner = new InnerQueuedObserver<R>(this, prefetch);
+                    InnerQueuedObserver<R> inner = new InnerQueuedObserver<>(this, prefetch);
 
                     observers.offer(inner);
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapScheduler.java
@@ -48,10 +48,10 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
     @Override
     public void subscribeActual(Observer<? super U> observer) {
         if (delayErrors == ErrorMode.IMMEDIATE) {
-            SerializedObserver<U> serial = new SerializedObserver<U>(observer);
-            source.subscribe(new ConcatMapObserver<T, U>(serial, mapper, bufferSize, scheduler.createWorker()));
+            SerializedObserver<U> serial = new SerializedObserver<>(observer);
+            source.subscribe(new ConcatMapObserver<>(serial, mapper, bufferSize, scheduler.createWorker()));
         } else {
-            source.subscribe(new ConcatMapDelayErrorObserver<T, U>(observer, mapper, bufferSize, delayErrors == ErrorMode.END, scheduler.createWorker()));
+            source.subscribe(new ConcatMapDelayErrorObserver<>(observer, mapper, bufferSize, delayErrors == ErrorMode.END, scheduler.createWorker()));
         }
     }
 
@@ -81,7 +81,7 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
             this.downstream = actual;
             this.mapper = mapper;
             this.bufferSize = bufferSize;
-            this.inner = new InnerObserver<U>(actual, this);
+            this.inner = new InnerObserver<>(actual, this);
             this.worker = worker;
         }
 
@@ -115,7 +115,7 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
                     }
                 }
 
-                queue = new SpscLinkedArrayQueue<T>(bufferSize);
+                queue = new SpscLinkedArrayQueue<>(bufferSize);
 
                 downstream.onSubscribe(this);
             }
@@ -318,7 +318,7 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
             this.bufferSize = bufferSize;
             this.tillTheEnd = tillTheEnd;
             this.errors = new AtomicThrowable();
-            this.observer = new DelayErrorInnerObserver<R>(actual, this);
+            this.observer = new DelayErrorInnerObserver<>(actual, this);
             this.worker = worker;
         }
 
@@ -352,7 +352,7 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
                     }
                 }
 
-                queue = new SpscLinkedArrayQueue<T>(bufferSize);
+                queue = new SpscLinkedArrayQueue<>(bufferSize);
 
                 downstream.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithCompletable.java
@@ -37,7 +37,7 @@ public final class ObservableConcatWithCompletable<T> extends AbstractObservable
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new ConcatWithObserver<T>(observer, other));
+        source.subscribe(new ConcatWithObserver<>(observer, other));
     }
 
     static final class ConcatWithObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithMaybe.java
@@ -37,7 +37,7 @@ public final class ObservableConcatWithMaybe<T> extends AbstractObservableWithUp
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new ConcatWithObserver<T>(observer, other));
+        source.subscribe(new ConcatWithObserver<>(observer, other));
     }
 
     static final class ConcatWithObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatWithSingle.java
@@ -37,7 +37,7 @@ public final class ObservableConcatWithSingle<T> extends AbstractObservableWithU
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new ConcatWithObserver<T>(observer, other));
+        source.subscribe(new ConcatWithObserver<>(observer, other));
     }
 
     static final class ConcatWithObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCountSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCountSingle.java
@@ -32,7 +32,7 @@ public final class ObservableCountSingle<T> extends Single<Long> implements Fuse
 
     @Override
     public Observable<Long> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableCount<T>(source));
+        return RxJavaPlugins.onAssembly(new ObservableCount<>(source));
     }
 
     static final class CountObserver implements Observer<Object>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCreate.java
@@ -33,7 +33,7 @@ public final class ObservableCreate<T> extends Observable<T> {
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        CreateEmitter<T> parent = new CreateEmitter<T>(observer);
+        CreateEmitter<T> parent = new CreateEmitter<>(observer);
         observer.onSubscribe(parent);
 
         try {
@@ -113,7 +113,7 @@ public final class ObservableCreate<T> extends Observable<T> {
 
         @Override
         public ObservableEmitter<T> serialize() {
-            return new SerializedEmitter<T>(this);
+            return new SerializedEmitter<>(this);
         }
 
         @Override
@@ -154,7 +154,7 @@ public final class ObservableCreate<T> extends Observable<T> {
         SerializedEmitter(ObservableEmitter<T> emitter) {
             this.emitter = emitter;
             this.errors = new AtomicThrowable();
-            this.queue = new SpscLinkedArrayQueue<T>(16);
+            this.queue = new SpscLinkedArrayQueue<>(16);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDebounce.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDebounce.java
@@ -34,7 +34,7 @@ public final class ObservableDebounce<T, U> extends AbstractObservableWithUpstre
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new DebounceObserver<T, U>(new SerializedObserver<T>(t), debounceSelector));
+        source.subscribe(new DebounceObserver<>(new SerializedObserver<>(t), debounceSelector));
     }
 
     static final class DebounceObserver<T, U>
@@ -44,7 +44,7 @@ public final class ObservableDebounce<T, U> extends AbstractObservableWithUpstre
 
         Disposable upstream;
 
-        final AtomicReference<Disposable> debouncer = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> debouncer = new AtomicReference<>();
 
         volatile long index;
 
@@ -89,7 +89,7 @@ public final class ObservableDebounce<T, U> extends AbstractObservableWithUpstre
                 return;
             }
 
-            DebounceInnerObserver<T, U> dis = new DebounceInnerObserver<T, U>(this, idx, t);
+            DebounceInnerObserver<T, U> dis = new DebounceInnerObserver<>(this, idx, t);
 
             if (debouncer.compareAndSet(d, dis)) {
                 p.subscribe(dis);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDebounceTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDebounceTimed.java
@@ -37,8 +37,8 @@ public final class ObservableDebounceTimed<T> extends AbstractObservableWithUpst
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new DebounceTimedObserver<T>(
-                new SerializedObserver<T>(t),
+        source.subscribe(new DebounceTimedObserver<>(
+                new SerializedObserver<>(t),
                 timeout, unit, scheduler.createWorker()));
     }
 
@@ -85,7 +85,7 @@ public final class ObservableDebounceTimed<T> extends AbstractObservableWithUpst
                 d.dispose();
             }
 
-            DebounceEmitter<T> de = new DebounceEmitter<T>(t, idx, this);
+            DebounceEmitter<T> de = new DebounceEmitter<>(t, idx, this);
             timer = de;
             d = worker.schedule(de, timeout, unit);
             de.setResource(d);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDelay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDelay.java
@@ -42,12 +42,12 @@ public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, 
         if (delayError) {
             observer = (Observer<T>)t;
         } else {
-            observer = new SerializedObserver<T>(t);
+            observer = new SerializedObserver<>(t);
         }
 
         Scheduler.Worker w = scheduler.createWorker();
 
-        source.subscribe(new DelayObserver<T>(observer, delay, unit, w, delayError));
+        source.subscribe(new DelayObserver<>(observer, delay, unit, w, delayError));
     }
 
     static final class DelayObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDematerialize.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDematerialize.java
@@ -33,7 +33,7 @@ public final class ObservableDematerialize<T, R> extends AbstractObservableWithU
 
     @Override
     public void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new DematerializeObserver<T, R>(observer, selector));
+        source.subscribe(new DematerializeObserver<>(observer, selector));
     }
 
     static final class DematerializeObserver<T, R> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDetach.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDetach.java
@@ -32,7 +32,7 @@ public final class ObservableDetach<T> extends AbstractObservableWithUpstream<T,
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new DetachObserver<T>(observer));
+        source.subscribe(new DetachObserver<>(observer));
     }
 
     static final class DetachObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinct.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinct.java
@@ -49,7 +49,7 @@ public final class ObservableDistinct<T, K> extends AbstractObservableWithUpstre
             return;
         }
 
-        source.subscribe(new DistinctObserver<T, K>(observer, keySelector, collection));
+        source.subscribe(new DistinctObserver<>(observer, keySelector, collection));
     }
 
     static final class DistinctObserver<T, K> extends BasicFuseableObserver<T, T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -32,7 +32,7 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new DistinctUntilChangedObserver<T, K>(observer, keySelector, comparer));
+        source.subscribe(new DistinctUntilChangedObserver<>(observer, keySelector, comparer));
     }
 
     static final class DistinctUntilChangedObserver<T, K> extends BasicFuseableObserver<T, T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoAfterNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoAfterNext.java
@@ -35,7 +35,7 @@ public final class ObservableDoAfterNext<T> extends AbstractObservableWithUpstre
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new DoAfterObserver<T>(observer, onAfterNext));
+        source.subscribe(new DoAfterObserver<>(observer, onAfterNext));
     }
 
     static final class DoAfterObserver<T> extends BasicFuseableObserver<T, T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoFinally.java
@@ -40,7 +40,7 @@ public final class ObservableDoFinally<T> extends AbstractObservableWithUpstream
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new DoFinallyObserver<T>(observer, onFinally));
+        source.subscribe(new DoFinallyObserver<>(observer, onFinally));
     }
 
     static final class DoFinallyObserver<T> extends BasicIntQueueDisposable<T> implements Observer<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnEach.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnEach.java
@@ -39,7 +39,7 @@ public final class ObservableDoOnEach<T> extends AbstractObservableWithUpstream<
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new DoOnEachObserver<T>(t, onNext, onError, onComplete, onAfterTerminate));
+        source.subscribe(new DoOnEachObserver<>(t, onNext, onError, onComplete, onAfterTerminate));
     }
 
     static final class DoOnEachObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnLifecycle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDoOnLifecycle.java
@@ -30,6 +30,6 @@ public final class ObservableDoOnLifecycle<T> extends AbstractObservableWithUpst
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new DisposableLambdaObserver<T>(observer, onSubscribe, onDispose));
+        source.subscribe(new DisposableLambdaObserver<>(observer, onSubscribe, onDispose));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableElementAt.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableElementAt.java
@@ -34,7 +34,7 @@ public final class ObservableElementAt<T> extends AbstractObservableWithUpstream
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new ElementAtObserver<T>(t, index, defaultValue, errorOnFewer));
+        source.subscribe(new ElementAtObserver<>(t, index, defaultValue, errorOnFewer));
     }
 
     static final class ElementAtObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableElementAtMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableElementAtMaybe.java
@@ -29,12 +29,12 @@ public final class ObservableElementAtMaybe<T> extends Maybe<T> implements FuseT
 
     @Override
     public void subscribeActual(MaybeObserver<? super T> t) {
-        source.subscribe(new ElementAtObserver<T>(t, index));
+        source.subscribe(new ElementAtObserver<>(t, index));
     }
 
     @Override
     public Observable<T> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableElementAt<T>(source, index, null, false));
+        return RxJavaPlugins.onAssembly(new ObservableElementAt<>(source, index, null, false));
     }
 
     static final class ElementAtObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableElementAtSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableElementAtSingle.java
@@ -34,12 +34,12 @@ public final class ObservableElementAtSingle<T> extends Single<T> implements Fus
 
     @Override
     public void subscribeActual(SingleObserver<? super T> t) {
-        source.subscribe(new ElementAtObserver<T>(t, index, defaultValue));
+        source.subscribe(new ElementAtObserver<>(t, index, defaultValue));
     }
 
     @Override
     public Observable<T> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableElementAt<T>(source, index, defaultValue, true));
+        return RxJavaPlugins.onAssembly(new ObservableElementAt<>(source, index, defaultValue, true));
     }
 
     static final class ElementAtObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFilter.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFilter.java
@@ -27,7 +27,7 @@ public final class ObservableFilter<T> extends AbstractObservableWithUpstream<T,
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new FilterObserver<T>(observer, predicate));
+        source.subscribe(new FilterObserver<>(observer, predicate));
     }
 
     static final class FilterObserver<T> extends BasicFuseableObserver<T, T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMap.java
@@ -50,7 +50,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             return;
         }
 
-        source.subscribe(new MergeObserver<T, U>(t, mapper, delayErrors, maxConcurrency, bufferSize));
+        source.subscribe(new MergeObserver<>(t, mapper, delayErrors, maxConcurrency, bufferSize));
     }
 
     static final class MergeObserver<T, U> extends AtomicInteger implements Disposable, Observer<T> {
@@ -95,9 +95,9 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             this.maxConcurrency = maxConcurrency;
             this.bufferSize = bufferSize;
             if (maxConcurrency != Integer.MAX_VALUE) {
-                sources = new ArrayDeque<ObservableSource<? extends U>>(maxConcurrency);
+                sources = new ArrayDeque<>(maxConcurrency);
             }
-            this.observers = new AtomicReference<InnerObserver<?, ?>[]>(EMPTY);
+            this.observers = new AtomicReference<>(EMPTY);
         }
 
         @Override
@@ -158,7 +158,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                         break;
                     }
                 } else {
-                    InnerObserver<T, U> inner = new InnerObserver<T, U>(this, uniqueId++);
+                    InnerObserver<T, U> inner = new InnerObserver<>(this, uniqueId++);
                     if (addInner(inner)) {
                         p.subscribe(inner);
                     }
@@ -239,9 +239,9 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 SimplePlainQueue<U> q = queue;
                 if (q == null) {
                     if (maxConcurrency == Integer.MAX_VALUE) {
-                        q = new SpscLinkedArrayQueue<U>(bufferSize);
+                        q = new SpscLinkedArrayQueue<>(bufferSize);
                     } else {
-                        q = new SpscArrayQueue<U>(maxConcurrency);
+                        q = new SpscArrayQueue<>(maxConcurrency);
                     }
                     queue = q;
                 }
@@ -267,7 +267,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
             } else {
                 SimpleQueue<U> q = inner.queue;
                 if (q == null) {
-                    q = new SpscLinkedArrayQueue<U>(bufferSize);
+                    q = new SpscLinkedArrayQueue<>(bufferSize);
                     inner.queue = q;
                 }
                 q.offer(value);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -44,7 +44,7 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new FlatMapCompletableMainObserver<T>(observer, mapper, delayErrors));
+        source.subscribe(new FlatMapCompletableMainObserver<>(observer, mapper, delayErrors));
     }
 
     static final class FlatMapCompletableMainObserver<T> extends BasicIntQueueDisposable<T>
@@ -145,7 +145,7 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() {
             return null; // always empty
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
@@ -46,12 +46,12 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
 
     @Override
     protected void subscribeActual(CompletableObserver observer) {
-        source.subscribe(new FlatMapCompletableMainObserver<T>(observer, mapper, delayErrors));
+        source.subscribe(new FlatMapCompletableMainObserver<>(observer, mapper, delayErrors));
     }
 
     @Override
     public Observable<T> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableFlatMapCompletable<T>(source, mapper, delayErrors));
+        return RxJavaPlugins.onAssembly(new ObservableFlatMapCompletable<>(source, mapper, delayErrors));
     }
 
     static final class FlatMapCompletableMainObserver<T> extends AtomicInteger implements Disposable, Observer<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -44,7 +44,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new FlatMapMaybeObserver<T, R>(observer, mapper, delayErrors));
+        source.subscribe(new FlatMapMaybeObserver<>(observer, mapper, delayErrors));
     }
 
     static final class FlatMapMaybeObserver<T, R>
@@ -79,7 +79,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
             this.set = new CompositeDisposable();
             this.errors = new AtomicThrowable();
             this.active = new AtomicInteger(1);
-            this.queue = new AtomicReference<SpscLinkedArrayQueue<R>>();
+            this.queue = new AtomicReference<>();
         }
 
         @Override
@@ -177,7 +177,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
                 if (current != null) {
                     return current;
                 }
-                current = new SpscLinkedArrayQueue<R>(Observable.bufferSize());
+                current = new SpscLinkedArrayQueue<>(Observable.bufferSize());
                 if (queue.compareAndSet(null, current)) {
                     return current;
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapSingle.java
@@ -44,7 +44,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new FlatMapSingleObserver<T, R>(observer, mapper, delayErrors));
+        source.subscribe(new FlatMapSingleObserver<>(observer, mapper, delayErrors));
     }
 
     static final class FlatMapSingleObserver<T, R>
@@ -79,7 +79,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
             this.set = new CompositeDisposable();
             this.errors = new AtomicThrowable();
             this.active = new AtomicInteger(1);
-            this.queue = new AtomicReference<SpscLinkedArrayQueue<R>>();
+            this.queue = new AtomicReference<>();
         }
 
         @Override
@@ -177,7 +177,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
                 if (current != null) {
                     return current;
                 }
-                current = new SpscLinkedArrayQueue<R>(Observable.bufferSize());
+                current = new SpscLinkedArrayQueue<>(Observable.bufferSize());
                 if (queue.compareAndSet(null, current)) {
                     return current;
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlattenIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlattenIterable.java
@@ -41,7 +41,7 @@ public final class ObservableFlattenIterable<T, R> extends AbstractObservableWit
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new FlattenIterableObserver<T, R>(observer, mapper));
+        source.subscribe(new FlattenIterableObserver<>(observer, mapper));
     }
 
     static final class FlattenIterableObserver<T, R> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromArray.java
@@ -27,7 +27,7 @@ public final class ObservableFromArray<T> extends Observable<T> {
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        FromArrayDisposable<T> d = new FromArrayDisposable<T>(observer, array);
+        FromArrayDisposable<T> d = new FromArrayDisposable<>(observer, array);
 
         observer.onSubscribe(d);
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromCallable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromCallable.java
@@ -36,7 +36,7 @@ public final class ObservableFromCallable<T> extends Observable<T> implements Su
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<T>(observer);
+        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<>(observer);
         observer.onSubscribe(d);
         if (d.isDisposed()) {
             return;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromFuture.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromFuture.java
@@ -33,7 +33,7 @@ public final class ObservableFromFuture<T> extends Observable<T> {
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<T>(observer);
+        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<>(observer);
         observer.onSubscribe(d);
         if (!d.isDisposed()) {
             T v;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromIterable.java
@@ -51,7 +51,7 @@ public final class ObservableFromIterable<T> extends Observable<T> {
             return;
         }
 
-        FromIterableDisposable<T> d = new FromIterableDisposable<T>(observer, it);
+        FromIterableDisposable<T> d = new FromIterableDisposable<>(observer, it);
         observer.onSubscribe(d);
 
         if (!d.fusionMode) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromSupplier.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFromSupplier.java
@@ -35,7 +35,7 @@ public final class ObservableFromSupplier<T> extends Observable<T> implements Su
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<T>(observer);
+        DeferredScalarDisposable<T> d = new DeferredScalarDisposable<>(observer);
         observer.onSubscribe(d);
         if (d.isDisposed()) {
             return;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGenerate.java
@@ -45,7 +45,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
             return;
         }
 
-        GeneratorDisposable<T, S> gd = new GeneratorDisposable<T, S>(observer, generator, disposeState, state);
+        GeneratorDisposable<T, S> gd = new GeneratorDisposable<>(observer, generator, disposeState, state);
         observer.onSubscribe(gd);
         gd.run();
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupBy.java
@@ -44,7 +44,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
 
     @Override
     public void subscribeActual(Observer<? super GroupedObservable<K, V>> t) {
-        source.subscribe(new GroupByObserver<T, K, V>(t, keySelector, valueSelector, bufferSize, delayError));
+        source.subscribe(new GroupByObserver<>(t, keySelector, valueSelector, bufferSize, delayError));
     }
 
     public static final class GroupByObserver<T, K, V> extends AtomicInteger implements Observer<T>, Disposable {
@@ -70,7 +70,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
             this.valueSelector = valueSelector;
             this.bufferSize = bufferSize;
             this.delayError = delayError;
-            this.groups = new ConcurrentHashMap<Object, GroupedUnicast<K, V>>();
+            this.groups = new ConcurrentHashMap<>();
             this.lazySet(1);
         }
 
@@ -139,7 +139,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
 
         @Override
         public void onError(Throwable t) {
-            List<GroupedUnicast<K, V>> list = new ArrayList<GroupedUnicast<K, V>>(groups.values());
+            List<GroupedUnicast<K, V>> list = new ArrayList<>(groups.values());
             groups.clear();
 
             for (GroupedUnicast<K, V> e : list) {
@@ -151,7 +151,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
 
         @Override
         public void onComplete() {
-            List<GroupedUnicast<K, V>> list = new ArrayList<GroupedUnicast<K, V>>(groups.values());
+            List<GroupedUnicast<K, V>> list = new ArrayList<>(groups.values());
             groups.clear();
 
             for (GroupedUnicast<K, V> e : list) {
@@ -191,8 +191,8 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
         final State<T, K> state;
 
         public static <T, K> GroupedUnicast<K, T> createWith(K key, int bufferSize, GroupByObserver<?, K, T> parent, boolean delayError) {
-            State<T, K> state = new State<T, K>(bufferSize, parent, key, delayError);
-            return new GroupedUnicast<K, T>(key, state);
+            State<T, K> state = new State<>(bufferSize, parent, key, delayError);
+            return new GroupedUnicast<>(key, state);
         }
 
         protected GroupedUnicast(K key, State<T, K> state) {
@@ -232,7 +232,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
 
         final AtomicBoolean cancelled = new AtomicBoolean();
 
-        final AtomicReference<Observer<? super T>> actual = new AtomicReference<Observer<? super T>>();
+        final AtomicReference<Observer<? super T>> actual = new AtomicReference<>();
 
         final AtomicInteger once = new AtomicInteger();
 
@@ -242,7 +242,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
         static final int ABANDONED_HAS_SUBSCRIBER = ABANDONED | HAS_SUBSCRIBER;
 
         State(int bufferSize, GroupByObserver<?, K, T> parent, K key, boolean delayError) {
-            this.queue = new SpscLinkedArrayQueue<T>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
             this.parent = parent;
             this.key = key;
             this.delayError = delayError;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupJoin.java
@@ -58,7 +58,7 @@ public final class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> ex
     protected void subscribeActual(Observer<? super R> observer) {
 
         GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
-                new GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>(observer, leftEnd, rightEnd, resultSelector);
+                new GroupJoinDisposable<>(observer, leftEnd, rightEnd, resultSelector);
 
         observer.onSubscribe(parent);
 
@@ -130,10 +130,10 @@ public final class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> ex
                 BiFunction<? super TLeft, ? super Observable<TRight>, ? extends R> resultSelector) {
             this.downstream = actual;
             this.disposables = new CompositeDisposable();
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize());
-            this.lefts = new LinkedHashMap<Integer, UnicastSubject<TRight>>();
-            this.rights = new LinkedHashMap<Integer, TRight>();
-            this.error = new AtomicReference<Throwable>();
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize());
+            this.lefts = new LinkedHashMap<>();
+            this.rights = new LinkedHashMap<>();
+            this.error = new AtomicReference<>();
             this.leftEnd = leftEnd;
             this.rightEnd = rightEnd;
             this.resultSelector = resultSelector;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableHide.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableHide.java
@@ -31,7 +31,7 @@ public final class ObservableHide<T> extends AbstractObservableWithUpstream<T, T
 
     @Override
     protected void subscribeActual(Observer<? super T> o) {
-        source.subscribe(new HideDisposable<T>(o));
+        source.subscribe(new HideDisposable<>(o));
     }
 
     static final class HideDisposable<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableIgnoreElements.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableIgnoreElements.java
@@ -24,7 +24,7 @@ public final class ObservableIgnoreElements<T> extends AbstractObservableWithUps
 
     @Override
     public void subscribeActual(final Observer<? super T> t) {
-        source.subscribe(new IgnoreObservable<T>(t));
+        source.subscribe(new IgnoreObservable<>(t));
     }
 
     static final class IgnoreObservable<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableIgnoreElementsCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableIgnoreElementsCompletable.java
@@ -28,12 +28,12 @@ public final class ObservableIgnoreElementsCompletable<T> extends Completable im
 
     @Override
     public void subscribeActual(final CompletableObserver t) {
-        source.subscribe(new IgnoreObservable<T>(t));
+        source.subscribe(new IgnoreObservable<>(t));
     }
 
     @Override
     public Observable<T> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableIgnoreElements<T>(source));
+        return RxJavaPlugins.onAssembly(new ObservableIgnoreElements<>(source));
     }
 
     static final class IgnoreObservable<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableInternalHelper.java
@@ -44,7 +44,7 @@ public final class ObservableInternalHelper {
     }
 
     public static <T, S> BiFunction<S, Emitter<T>, S> simpleGenerator(Consumer<Emitter<T>> consumer) {
-        return new SimpleGenerator<T, S>(consumer);
+        return new SimpleGenerator<>(consumer);
     }
 
     static final class SimpleBiGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
@@ -62,7 +62,7 @@ public final class ObservableInternalHelper {
     }
 
     public static <T, S> BiFunction<S, Emitter<T>, S> simpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
-        return new SimpleBiGenerator<T, S>(consumer);
+        return new SimpleBiGenerator<>(consumer);
     }
 
     static final class ItemDelayFunction<T, U> implements Function<T, ObservableSource<T>> {
@@ -75,12 +75,12 @@ public final class ObservableInternalHelper {
         @Override
         public ObservableSource<T> apply(final T v) throws Throwable {
             ObservableSource<U> o = Objects.requireNonNull(itemDelay.apply(v), "The itemDelay returned a null ObservableSource");
-            return new ObservableTake<U>(o, 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+            return new ObservableTake<>(o, 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
         }
     }
 
     public static <T, U> Function<T, ObservableSource<T>> itemDelay(final Function<? super T, ? extends ObservableSource<U>> itemDelay) {
-        return new ItemDelayFunction<T, U>(itemDelay);
+        return new ItemDelayFunction<>(itemDelay);
     }
 
     static final class ObserverOnNext<T> implements Consumer<T> {
@@ -91,7 +91,7 @@ public final class ObservableInternalHelper {
         }
 
         @Override
-        public void accept(T v) throws Exception {
+        public void accept(T v) {
             observer.onNext(v);
         }
     }
@@ -104,7 +104,7 @@ public final class ObservableInternalHelper {
         }
 
         @Override
-        public void accept(Throwable v) throws Exception {
+        public void accept(Throwable v) {
             observer.onError(v);
         }
     }
@@ -117,21 +117,21 @@ public final class ObservableInternalHelper {
         }
 
         @Override
-        public void run() throws Exception {
+        public void run() {
             observer.onComplete();
         }
     }
 
     public static <T> Consumer<T> observerOnNext(Observer<T> observer) {
-        return new ObserverOnNext<T>(observer);
+        return new ObserverOnNext<>(observer);
     }
 
     public static <T> Consumer<Throwable> observerOnError(Observer<T> observer) {
-        return new ObserverOnError<T>(observer);
+        return new ObserverOnError<>(observer);
     }
 
     public static <T> Action observerOnComplete(Observer<T> observer) {
-        return new ObserverOnComplete<T>(observer);
+        return new ObserverOnComplete<>(observer);
     }
 
     static final class FlatMapWithCombinerInner<U, R, T> implements Function<U, R> {
@@ -163,14 +163,14 @@ public final class ObservableInternalHelper {
         public ObservableSource<R> apply(final T t) throws Throwable {
             @SuppressWarnings("unchecked")
             ObservableSource<U> u = (ObservableSource<U>)Objects.requireNonNull(mapper.apply(t), "The mapper returned a null ObservableSource");
-            return new ObservableMap<U, R>(u, new FlatMapWithCombinerInner<U, R, T>(combiner, t));
+            return new ObservableMap<>(u, new FlatMapWithCombinerInner<U, R, T>(combiner, t));
         }
     }
 
     public static <T, U, R> Function<T, ObservableSource<R>> flatMapWithCombiner(
             final Function<? super T, ? extends ObservableSource<? extends U>> mapper,
                     final BiFunction<? super T, ? super U, ? extends R> combiner) {
-        return new FlatMapWithCombinerOuter<T, R, U>(combiner, mapper);
+        return new FlatMapWithCombinerOuter<>(combiner, mapper);
     }
 
     static final class FlatMapIntoIterable<T, U> implements Function<T, ObservableSource<U>> {
@@ -182,36 +182,36 @@ public final class ObservableInternalHelper {
 
         @Override
         public ObservableSource<U> apply(T t) throws Throwable {
-            return new ObservableFromIterable<U>(Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Iterable"));
+            return new ObservableFromIterable<>(Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Iterable"));
         }
     }
 
     public static <T, U> Function<T, ObservableSource<U>> flatMapIntoIterable(final Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        return new FlatMapIntoIterable<T, U>(mapper);
+        return new FlatMapIntoIterable<>(mapper);
     }
 
     enum MapToInt implements Function<Object, Object> {
         INSTANCE;
         @Override
-        public Object apply(Object t) throws Exception {
+        public Object apply(Object t) {
             return 0;
         }
     }
 
     public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent) {
-        return new ReplaySupplier<T>(parent);
+        return new ReplaySupplier<>(parent);
     }
 
     public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent, final int bufferSize, boolean eagerTruncate) {
-        return new BufferedReplaySupplier<T>(parent, bufferSize, eagerTruncate);
+        return new BufferedReplaySupplier<>(parent, bufferSize, eagerTruncate);
     }
 
     public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
-        return new BufferedTimedReplaySupplier<T>(parent, bufferSize, time, unit, scheduler, eagerTruncate);
+        return new BufferedTimedReplaySupplier<>(parent, bufferSize, time, unit, scheduler, eagerTruncate);
     }
 
     public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
-        return new TimedReplayCallable<T>(parent, time, unit, scheduler, eagerTruncate);
+        return new TimedReplayCallable<>(parent, time, unit, scheduler, eagerTruncate);
     }
 
     static final class ReplaySupplier<T> implements Supplier<ConnectableObservable<T>> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableJoin.java
@@ -56,7 +56,7 @@ public final class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
     protected void subscribeActual(Observer<? super R> observer) {
 
         JoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R> parent =
-                new JoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>(
+                new JoinDisposable<>(
                         observer, leftEnd, rightEnd, resultSelector);
 
         observer.onSubscribe(parent);
@@ -115,10 +115,10 @@ public final class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
                         BiFunction<? super TLeft, ? super TRight, ? extends R> resultSelector) {
             this.downstream = actual;
             this.disposables = new CompositeDisposable();
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize());
-            this.lefts = new LinkedHashMap<Integer, TLeft>();
-            this.rights = new LinkedHashMap<Integer, TRight>();
-            this.error = new AtomicReference<Throwable>();
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize());
+            this.lefts = new LinkedHashMap<>();
+            this.rights = new LinkedHashMap<>();
+            this.error = new AtomicReference<>();
             this.leftEnd = leftEnd;
             this.rightEnd = rightEnd;
             this.resultSelector = resultSelector;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableJust.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableJust.java
@@ -30,7 +30,7 @@ public final class ObservableJust<T> extends Observable<T> implements ScalarSupp
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        ScalarDisposable<T> sd = new ScalarDisposable<T>(observer, value);
+        ScalarDisposable<T> sd = new ScalarDisposable<>(observer, value);
         observer.onSubscribe(sd);
         sd.run();
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableLastMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableLastMaybe.java
@@ -35,7 +35,7 @@ public final class ObservableLastMaybe<T> extends Maybe<T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new LastObserver<T>(observer));
+        source.subscribe(new LastObserver<>(observer));
     }
 
     static final class LastObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableLastSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableLastSingle.java
@@ -40,7 +40,7 @@ public final class ObservableLastSingle<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new LastObserver<T>(observer, defaultItem));
+        source.subscribe(new LastObserver<>(observer, defaultItem));
     }
 
     static final class LastObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMapNotification.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMapNotification.java
@@ -40,7 +40,7 @@ public final class ObservableMapNotification<T, R> extends AbstractObservableWit
 
     @Override
     public void subscribeActual(Observer<? super ObservableSource<? extends R>> t) {
-        source.subscribe(new MapNotificationObserver<T, R>(t, onNextMapper, onErrorMapper, onCompleteSupplier));
+        source.subscribe(new MapNotificationObserver<>(t, onNextMapper, onErrorMapper, onCompleteSupplier));
     }
 
     static final class MapNotificationObserver<T, R>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMaterialize.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMaterialize.java
@@ -25,7 +25,7 @@ public final class ObservableMaterialize<T> extends AbstractObservableWithUpstre
 
     @Override
     public void subscribeActual(Observer<? super Notification<T>> t) {
-        source.subscribe(new MaterializeObserver<T>(t));
+        source.subscribe(new MaterializeObserver<>(t));
     }
 
     static final class MaterializeObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithCompletable.java
@@ -38,7 +38,7 @@ public final class ObservableMergeWithCompletable<T> extends AbstractObservableW
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
+        MergeWithObserver<T> parent = new MergeWithObserver<>(observer);
         observer.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
@@ -63,7 +63,7 @@ public final class ObservableMergeWithCompletable<T> extends AbstractObservableW
 
         MergeWithObserver(Observer<? super T> downstream) {
             this.downstream = downstream;
-            this.mainDisposable = new AtomicReference<Disposable>();
+            this.mainDisposable = new AtomicReference<>();
             this.otherObserver = new OtherObserver(this);
             this.errors = new AtomicThrowable();
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithMaybe.java
@@ -40,7 +40,7 @@ public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUps
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
+        MergeWithObserver<T> parent = new MergeWithObserver<>(observer);
         observer.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
@@ -75,8 +75,8 @@ public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUps
 
         MergeWithObserver(Observer<? super T> downstream) {
             this.downstream = downstream;
-            this.mainDisposable = new AtomicReference<Disposable>();
-            this.otherObserver = new OtherObserver<T>(this);
+            this.mainDisposable = new AtomicReference<>();
+            this.otherObserver = new OtherObserver<>(this);
             this.errors = new AtomicThrowable();
         }
 
@@ -162,7 +162,7 @@ public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUps
         SimplePlainQueue<T> getOrCreateQueue() {
             SimplePlainQueue<T> q = queue;
             if (q == null) {
-                q = new SpscLinkedArrayQueue<T>(bufferSize());
+                q = new SpscLinkedArrayQueue<>(bufferSize());
                 queue = q;
             }
             return q;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableMergeWithSingle.java
@@ -40,7 +40,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        MergeWithObserver<T> parent = new MergeWithObserver<T>(observer);
+        MergeWithObserver<T> parent = new MergeWithObserver<>(observer);
         observer.onSubscribe(parent);
         source.subscribe(parent);
         other.subscribe(parent.otherObserver);
@@ -75,8 +75,8 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
 
         MergeWithObserver(Observer<? super T> downstream) {
             this.downstream = downstream;
-            this.mainDisposable = new AtomicReference<Disposable>();
-            this.otherObserver = new OtherObserver<T>(this);
+            this.mainDisposable = new AtomicReference<>();
+            this.otherObserver = new OtherObserver<>(this);
             this.errors = new AtomicThrowable();
         }
 
@@ -157,7 +157,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
         SimplePlainQueue<T> getOrCreateQueue() {
             SimplePlainQueue<T> q = queue;
             if (q == null) {
-                q = new SpscLinkedArrayQueue<T>(bufferSize());
+                q = new SpscLinkedArrayQueue<>(bufferSize());
                 queue = q;
             }
             return q;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableObserveOn.java
@@ -42,7 +42,7 @@ public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream
         } else {
             Scheduler.Worker w = scheduler.createWorker();
 
-            source.subscribe(new ObserveOnObserver<T>(observer, w, delayError, bufferSize));
+            source.subscribe(new ObserveOnObserver<>(observer, w, delayError, bufferSize));
         }
     }
 
@@ -101,7 +101,7 @@ public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream
                     }
                 }
 
-                queue = new SpscLinkedArrayQueue<T>(bufferSize);
+                queue = new SpscLinkedArrayQueue<>(bufferSize);
 
                 downstream.onSubscribe(this);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorNext.java
@@ -31,7 +31,7 @@ public final class ObservableOnErrorNext<T> extends AbstractObservableWithUpstre
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        OnErrorNextObserver<T> parent = new OnErrorNextObserver<T>(t, nextSupplier);
+        OnErrorNextObserver<T> parent = new OnErrorNextObserver<>(t, nextSupplier);
         t.onSubscribe(parent.arbiter);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorReturn.java
@@ -28,7 +28,7 @@ public final class ObservableOnErrorReturn<T> extends AbstractObservableWithUpst
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new OnErrorReturnObserver<T>(t, valueSupplier));
+        source.subscribe(new OnErrorReturnObserver<>(t, valueSupplier));
     }
 
     static final class OnErrorReturnObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublish.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublish.java
@@ -46,7 +46,7 @@ implements HasUpstreamObservableSource<T> {
 
     public ObservablePublish(ObservableSource<T> source) {
         this.source = source;
-        this.current = new AtomicReference<PublishConnection<T>>();
+        this.current = new AtomicReference<>();
     }
 
     @Override
@@ -58,7 +58,7 @@ implements HasUpstreamObservableSource<T> {
             conn = current.get();
 
             if (conn == null || conn.isDisposed()) {
-                PublishConnection<T> fresh = new PublishConnection<T>(current);
+                PublishConnection<T> fresh = new PublishConnection<>(current);
                 if (!current.compareAndSet(conn, fresh)) {
                     continue;
                 }
@@ -89,7 +89,7 @@ implements HasUpstreamObservableSource<T> {
             conn = current.get();
             // we don't create a fresh connection if the current is terminated
             if (conn == null) {
-                PublishConnection<T> fresh = new PublishConnection<T>(current);
+                PublishConnection<T> fresh = new PublishConnection<>(current);
                 if (!current.compareAndSet(conn, fresh)) {
                     continue;
                 }
@@ -98,7 +98,7 @@ implements HasUpstreamObservableSource<T> {
             break;
         }
 
-        InnerDisposable<T> inner = new InnerDisposable<T>(observer, conn);
+        InnerDisposable<T> inner = new InnerDisposable<>(observer, conn);
         observer.onSubscribe(inner);
         if (conn.add(inner)) {
             if (inner.isDisposed()) {
@@ -152,7 +152,7 @@ implements HasUpstreamObservableSource<T> {
         PublishConnection(AtomicReference<PublishConnection<T>> current) {
             this.connect = new AtomicBoolean();
             this.current = current;
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
             lazySet(EMPTY);
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublishSelector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublishSelector.java
@@ -52,14 +52,14 @@ public final class ObservablePublishSelector<T, R> extends AbstractObservableWit
             return;
         }
 
-        TargetObserver<T, R> o = new TargetObserver<T, R>(observer);
+        TargetObserver<R> o = new TargetObserver<>(observer);
 
         target.subscribe(o);
 
-        source.subscribe(new SourceObserver<T, R>(subject, o));
+        source.subscribe(new SourceObserver<>(subject, o));
     }
 
-    static final class SourceObserver<T, R> implements Observer<T> {
+    static final class SourceObserver<T> implements Observer<T> {
 
         final PublishSubject<T> subject;
 
@@ -91,7 +91,7 @@ public final class ObservablePublishSelector<T, R> extends AbstractObservableWit
         }
     }
 
-    static final class TargetObserver<T, R>
+    static final class TargetObserver<R>
     extends AtomicReference<Disposable> implements Observer<R>, Disposable {
         private static final long serialVersionUID = 854110278590336484L;
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRange.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRange.java
@@ -71,7 +71,7 @@ public final class ObservableRange extends Observable<Integer> {
 
         @Nullable
         @Override
-        public Integer poll() throws Exception {
+        public Integer poll() {
             long i = index;
             if (i != end) {
                 index = i + 1;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRangeLong.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRangeLong.java
@@ -68,7 +68,7 @@ public final class ObservableRangeLong extends Observable<Long> {
 
         @Nullable
         @Override
-        public Long poll() throws Exception {
+        public Long poll() {
             long i = index;
             if (i != end) {
                 index = i + 1;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReduceMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReduceMaybe.java
@@ -41,7 +41,7 @@ public final class ObservableReduceMaybe<T> extends Maybe<T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new ReduceObserver<T>(observer, reducer));
+        source.subscribe(new ReduceObserver<>(observer, reducer));
     }
 
     static final class ReduceObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReduceSeedSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReduceSeedSingle.java
@@ -45,7 +45,7 @@ public final class ObservableReduceSeedSingle<T, R> extends Single<R> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super R> observer) {
-        source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
+        source.subscribe(new ReduceSeedObserver<>(observer, reducer, seed));
     }
 
     static final class ReduceSeedObserver<T, R> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReduceWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReduceWithSingle.java
@@ -53,6 +53,6 @@ public final class ObservableReduceWithSingle<T, R> extends Single<R> {
             EmptyDisposable.error(ex, observer);
             return;
         }
-        source.subscribe(new ReduceSeedObserver<T, R>(observer, reducer, seed));
+        source.subscribe(new ReduceSeedObserver<>(observer, reducer, seed));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCount.java
@@ -81,7 +81,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
             }
         }
 
-        source.subscribe(new RefCountObserver<T>(observer, this, conn));
+        source.subscribe(new RefCountObserver<>(observer, this, conn));
 
         if (connect) {
             source.connect(conn);
@@ -166,7 +166,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
         }
 
         @Override
-        public void accept(Disposable t) throws Exception {
+        public void accept(Disposable t) {
             DisposableHelper.replace(this, t);
             synchronized (parent) {
                 if (disconnectedEarly) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRepeat.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRepeat.java
@@ -31,7 +31,7 @@ public final class ObservableRepeat<T> extends AbstractObservableWithUpstream<T,
         SequentialDisposable sd = new SequentialDisposable();
         observer.onSubscribe(sd);
 
-        RepeatObserver<T> rs = new RepeatObserver<T>(observer, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sd, source);
+        RepeatObserver<T> rs = new RepeatObserver<>(observer, count != Long.MAX_VALUE ? count - 1 : Long.MAX_VALUE, sd, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRepeatUntil.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRepeatUntil.java
@@ -33,7 +33,7 @@ public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstre
         SequentialDisposable sd = new SequentialDisposable();
         observer.onSubscribe(sd);
 
-        RepeatUntilObserver<T> rs = new RepeatUntilObserver<T>(observer, until, sd, source);
+        RepeatUntilObserver<T> rs = new RepeatUntilObserver<>(observer, until, sd, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRepeatWhen.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRepeatWhen.java
@@ -52,7 +52,7 @@ public final class ObservableRepeatWhen<T> extends AbstractObservableWithUpstrea
             return;
         }
 
-        RepeatWhenObserver<T> parent = new RepeatWhenObserver<T>(observer, signaller, source);
+        RepeatWhenObserver<T> parent = new RepeatWhenObserver<>(observer, signaller, source);
         observer.onSubscribe(parent);
 
         other.subscribe(parent.inner);
@@ -87,7 +87,7 @@ public final class ObservableRepeatWhen<T> extends AbstractObservableWithUpstrea
             this.wip = new AtomicInteger();
             this.error = new AtomicThrowable();
             this.inner = new InnerRepeatObserver();
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryBiPredicate.java
@@ -35,7 +35,7 @@ public final class ObservableRetryBiPredicate<T> extends AbstractObservableWithU
         SequentialDisposable sa = new SequentialDisposable();
         observer.onSubscribe(sa);
 
-        RetryBiObserver<T> rs = new RetryBiObserver<T>(observer, predicate, sa, source);
+        RetryBiObserver<T> rs = new RetryBiObserver<>(observer, predicate, sa, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryPredicate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryPredicate.java
@@ -37,7 +37,7 @@ public final class ObservableRetryPredicate<T> extends AbstractObservableWithUps
         SequentialDisposable sa = new SequentialDisposable();
         observer.onSubscribe(sa);
 
-        RepeatObserver<T> rs = new RepeatObserver<T>(observer, count, predicate, sa, source);
+        RepeatObserver<T> rs = new RepeatObserver<>(observer, count, predicate, sa, source);
         rs.subscribeNext();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryWhen.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryWhen.java
@@ -52,7 +52,7 @@ public final class ObservableRetryWhen<T> extends AbstractObservableWithUpstream
             return;
         }
 
-        RepeatWhenObserver<T> parent = new RepeatWhenObserver<T>(observer, signaller, source);
+        RepeatWhenObserver<T> parent = new RepeatWhenObserver<>(observer, signaller, source);
         observer.onSubscribe(parent);
 
         other.subscribe(parent.inner);
@@ -87,7 +87,7 @@ public final class ObservableRetryWhen<T> extends AbstractObservableWithUpstream
             this.wip = new AtomicInteger();
             this.error = new AtomicThrowable();
             this.inner = new InnerRepeatObserver();
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSampleTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSampleTimed.java
@@ -38,11 +38,11 @@ public final class ObservableSampleTimed<T> extends AbstractObservableWithUpstre
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        SerializedObserver<T> serial = new SerializedObserver<T>(t);
+        SerializedObserver<T> serial = new SerializedObserver<>(t);
         if (emitLast) {
-            source.subscribe(new SampleTimedEmitLast<T>(serial, period, unit, scheduler));
+            source.subscribe(new SampleTimedEmitLast<>(serial, period, unit, scheduler));
         } else {
-            source.subscribe(new SampleTimedNoLast<T>(serial, period, unit, scheduler));
+            source.subscribe(new SampleTimedNoLast<>(serial, period, unit, scheduler));
         }
     }
 
@@ -55,7 +55,7 @@ public final class ObservableSampleTimed<T> extends AbstractObservableWithUpstre
         final TimeUnit unit;
         final Scheduler scheduler;
 
-        final AtomicReference<Disposable> timer = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> timer = new AtomicReference<>();
 
         Disposable upstream;
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSampleWithObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSampleWithObservable.java
@@ -34,11 +34,11 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        SerializedObserver<T> serial = new SerializedObserver<T>(t);
+        SerializedObserver<T> serial = new SerializedObserver<>(t);
         if (emitLast) {
-            source.subscribe(new SampleMainEmitLast<T>(serial, other));
+            source.subscribe(new SampleMainEmitLast<>(serial, other));
         } else {
-            source.subscribe(new SampleMainNoLast<T>(serial, other));
+            source.subscribe(new SampleMainNoLast<>(serial, other));
         }
     }
 
@@ -50,7 +50,7 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
         final Observer<? super T> downstream;
         final ObservableSource<?> sampler;
 
-        final AtomicReference<Disposable> other = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> other = new AtomicReference<>();
 
         Disposable upstream;
 
@@ -65,7 +65,7 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
                 this.upstream = d;
                 downstream.onSubscribe(this);
                 if (other.get() == null) {
-                    sampler.subscribe(new SamplerObserver<T>(this));
+                    sampler.subscribe(new SamplerObserver<>(this));
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScalarXMap.java
@@ -88,7 +88,7 @@ public final class ObservableScalarXMap {
                     EmptyDisposable.complete(observer);
                     return true;
                 }
-                ScalarDisposable<R> sd = new ScalarDisposable<R>(observer, u);
+                ScalarDisposable<R> sd = new ScalarDisposable<>(observer, u);
                 observer.onSubscribe(sd);
                 sd.run();
             } else {
@@ -112,7 +112,7 @@ public final class ObservableScalarXMap {
      */
     public static <T, U> Observable<U> scalarXMap(T value,
             Function<? super T, ? extends ObservableSource<? extends U>> mapper) {
-        return RxJavaPlugins.onAssembly(new ScalarXMapObservable<T, U>(value, mapper));
+        return RxJavaPlugins.onAssembly(new ScalarXMapObservable<>(value, mapper));
     }
 
     /**
@@ -159,7 +159,7 @@ public final class ObservableScalarXMap {
                     EmptyDisposable.complete(observer);
                     return;
                 }
-                ScalarDisposable<R> sd = new ScalarDisposable<R>(observer, u);
+                ScalarDisposable<R> sd = new ScalarDisposable<>(observer, u);
                 observer.onSubscribe(sd);
                 sd.run();
             } else {
@@ -205,7 +205,7 @@ public final class ObservableScalarXMap {
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() {
             if (get() == FUSED) {
                 lazySet(ON_COMPLETE);
                 return value;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScan.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScan.java
@@ -31,7 +31,7 @@ public final class ObservableScan<T> extends AbstractObservableWithUpstream<T, T
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new ScanObserver<T>(t, accumulator));
+        source.subscribe(new ScanObserver<>(t, accumulator));
     }
 
     static final class ScanObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScanSeed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableScanSeed.java
@@ -43,7 +43,7 @@ public final class ObservableScanSeed<T, R> extends AbstractObservableWithUpstre
             return;
         }
 
-        source.subscribe(new ScanSeedObserver<T, R>(t, accumulator, r));
+        source.subscribe(new ScanSeedObserver<>(t, accumulator, r));
     }
 
     static final class ScanSeedObserver<T, R> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSequenceEqual.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSequenceEqual.java
@@ -38,7 +38,7 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
 
     @Override
     public void subscribeActual(Observer<? super Boolean> observer) {
-        EqualCoordinator<T> ec = new EqualCoordinator<T>(observer, bufferSize, first, second, comparer);
+        EqualCoordinator<T> ec = new EqualCoordinator<>(observer, bufferSize, first, second, comparer);
         observer.onSubscribe(ec);
         ec.subscribe();
     }
@@ -69,8 +69,8 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
             @SuppressWarnings("unchecked")
             EqualObserver<T>[] as = new EqualObserver[2];
             this.observers = as;
-            as[0] = new EqualObserver<T>(this, 0, bufferSize);
-            as[1] = new EqualObserver<T>(this, 1, bufferSize);
+            as[0] = new EqualObserver<>(this, 0, bufferSize);
+            as[1] = new EqualObserver<>(this, 1, bufferSize);
             this.resources = new ArrayCompositeDisposable(2);
         }
 
@@ -226,7 +226,7 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
         EqualObserver(EqualCoordinator<T> parent, int index, int bufferSize) {
             this.parent = parent;
             this.index = index;
-            this.queue = new SpscLinkedArrayQueue<T>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSequenceEqualSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSequenceEqualSingle.java
@@ -40,14 +40,14 @@ public final class ObservableSequenceEqualSingle<T> extends Single<Boolean> impl
 
     @Override
     public void subscribeActual(SingleObserver<? super Boolean> observer) {
-        EqualCoordinator<T> ec = new EqualCoordinator<T>(observer, bufferSize, first, second, comparer);
+        EqualCoordinator<T> ec = new EqualCoordinator<>(observer, bufferSize, first, second, comparer);
         observer.onSubscribe(ec);
         ec.subscribe();
     }
 
     @Override
     public Observable<Boolean> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableSequenceEqual<T>(first, second, comparer, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableSequenceEqual<>(first, second, comparer, bufferSize));
     }
 
     static final class EqualCoordinator<T> extends AtomicInteger implements Disposable {
@@ -76,8 +76,8 @@ public final class ObservableSequenceEqualSingle<T> extends Single<Boolean> impl
             @SuppressWarnings("unchecked")
             EqualObserver<T>[] as = new EqualObserver[2];
             this.observers = as;
-            as[0] = new EqualObserver<T>(this, 0, bufferSize);
-            as[1] = new EqualObserver<T>(this, 1, bufferSize);
+            as[0] = new EqualObserver<>(this, 0, bufferSize);
+            as[1] = new EqualObserver<>(this, 1, bufferSize);
             this.resources = new ArrayCompositeDisposable(2);
         }
 
@@ -230,7 +230,7 @@ public final class ObservableSequenceEqualSingle<T> extends Single<Boolean> impl
         EqualObserver(EqualCoordinator<T> parent, int index, int bufferSize) {
             this.parent = parent;
             this.index = index;
-            this.queue = new SpscLinkedArrayQueue<T>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSerialized.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSerialized.java
@@ -22,6 +22,6 @@ public final class ObservableSerialized<T> extends AbstractObservableWithUpstrea
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new SerializedObserver<T>(observer));
+        source.subscribe(new SerializedObserver<>(observer));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSingleMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSingleMaybe.java
@@ -28,7 +28,7 @@ public final class ObservableSingleMaybe<T> extends Maybe<T> {
 
     @Override
     public void subscribeActual(MaybeObserver<? super T> t) {
-        source.subscribe(new SingleElementObserver<T>(t));
+        source.subscribe(new SingleElementObserver<>(t));
     }
 
     static final class SingleElementObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSingleSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSingleSingle.java
@@ -33,7 +33,7 @@ public final class ObservableSingleSingle<T> extends Single<T> {
 
     @Override
     public void subscribeActual(SingleObserver<? super T> t) {
-        source.subscribe(new SingleElementObserver<T>(t, defaultValue));
+        source.subscribe(new SingleElementObserver<>(t, defaultValue));
     }
 
     static final class SingleElementObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkip.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkip.java
@@ -26,7 +26,7 @@ public final class ObservableSkip<T> extends AbstractObservableWithUpstream<T, T
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new SkipObserver<T>(observer, n));
+        source.subscribe(new SkipObserver<>(observer, n));
     }
 
     static final class SkipObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipLast.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipLast.java
@@ -29,7 +29,7 @@ public final class ObservableSkipLast<T> extends AbstractObservableWithUpstream<
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new SkipLastObserver<T>(observer, skip));
+        source.subscribe(new SkipLastObserver<>(observer, skip));
     }
 
     static final class SkipLastObserver<T> extends ArrayDeque<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipLastTimed.java
@@ -40,7 +40,7 @@ public final class ObservableSkipLastTimed<T> extends AbstractObservableWithUpst
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new SkipLastTimedObserver<T>(t, time, unit, scheduler, bufferSize, delayError));
+        source.subscribe(new SkipLastTimedObserver<>(t, time, unit, scheduler, bufferSize, delayError));
     }
 
     static final class SkipLastTimedObserver<T> extends AtomicInteger implements Observer<T>, Disposable {
@@ -65,7 +65,7 @@ public final class ObservableSkipLastTimed<T> extends AbstractObservableWithUpst
             this.time = time;
             this.unit = unit;
             this.scheduler = scheduler;
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
             this.delayError = delayError;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipUntil.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipUntil.java
@@ -28,13 +28,13 @@ public final class ObservableSkipUntil<T, U> extends AbstractObservableWithUpstr
     @Override
     public void subscribeActual(Observer<? super T> child) {
 
-        final SerializedObserver<T> serial = new SerializedObserver<T>(child);
+        final SerializedObserver<T> serial = new SerializedObserver<>(child);
 
         final ArrayCompositeDisposable frc = new ArrayCompositeDisposable(2);
 
         serial.onSubscribe(frc);
 
-        final SkipUntilObserver<T> sus = new SkipUntilObserver<T>(serial, frc);
+        final SkipUntilObserver<T> sus = new SkipUntilObserver<>(serial, frc);
 
         other.subscribe(new SkipUntil(frc, sus, serial));
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipWhile.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipWhile.java
@@ -28,7 +28,7 @@ public final class ObservableSkipWhile<T> extends AbstractObservableWithUpstream
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new SkipWhileObserver<T>(observer, predicate));
+        source.subscribe(new SkipWhileObserver<>(observer, predicate));
     }
 
     static final class SkipWhileObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSubscribeOn.java
@@ -29,7 +29,7 @@ public final class ObservableSubscribeOn<T> extends AbstractObservableWithUpstre
 
     @Override
     public void subscribeActual(final Observer<? super T> observer) {
-        final SubscribeOnObserver<T> parent = new SubscribeOnObserver<T>(observer);
+        final SubscribeOnObserver<T> parent = new SubscribeOnObserver<>(observer);
 
         observer.onSubscribe(parent);
 
@@ -45,7 +45,7 @@ public final class ObservableSubscribeOn<T> extends AbstractObservableWithUpstre
 
         SubscribeOnObserver(Observer<? super T> downstream) {
             this.downstream = downstream;
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchIfEmpty.java
@@ -26,7 +26,7 @@ public final class ObservableSwitchIfEmpty<T> extends AbstractObservableWithUpst
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        SwitchIfEmptyObserver<T> parent = new SwitchIfEmptyObserver<T>(t, other);
+        SwitchIfEmptyObserver<T> parent = new SwitchIfEmptyObserver<>(t, other);
         t.onSubscribe(parent.arbiter);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchMap.java
@@ -48,7 +48,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
             return;
         }
 
-        source.subscribe(new SwitchMapObserver<T, R>(t, mapper, bufferSize, delayErrors));
+        source.subscribe(new SwitchMapObserver<>(t, mapper, bufferSize, delayErrors));
     }
 
     static final class SwitchMapObserver<T, R> extends AtomicInteger implements Observer<T>, Disposable {
@@ -68,11 +68,11 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
 
         Disposable upstream;
 
-        final AtomicReference<SwitchMapInnerObserver<T, R>> active = new AtomicReference<SwitchMapInnerObserver<T, R>>();
+        final AtomicReference<SwitchMapInnerObserver<T, R>> active = new AtomicReference<>();
 
         static final SwitchMapInnerObserver<Object, Object> CANCELLED;
         static {
-            CANCELLED = new SwitchMapInnerObserver<Object, Object>(null, -1L, 1);
+            CANCELLED = new SwitchMapInnerObserver<>(null, -1L, 1);
             CANCELLED.cancel();
         }
 
@@ -116,7 +116,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                 return;
             }
 
-            SwitchMapInnerObserver<T, R> nextInner = new SwitchMapInnerObserver<T, R>(this, c, bufferSize);
+            SwitchMapInnerObserver<T, R> nextInner = new SwitchMapInnerObserver<>(this, c, bufferSize);
 
             for (;;) {
                 inner = active.get();
@@ -364,7 +364,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
                     }
                 }
 
-                queue = new SpscLinkedArrayQueue<R>(bufferSize);
+                queue = new SpscLinkedArrayQueue<>(bufferSize);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTake.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTake.java
@@ -27,7 +27,7 @@ public final class ObservableTake<T> extends AbstractObservableWithUpstream<T, T
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new TakeObserver<T>(observer, limit));
+        source.subscribe(new TakeObserver<>(observer, limit));
     }
 
     static final class TakeObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLast.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLast.java
@@ -29,7 +29,7 @@ public final class ObservableTakeLast<T> extends AbstractObservableWithUpstream<
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new TakeLastObserver<T>(t, count));
+        source.subscribe(new TakeLastObserver<>(t, count));
     }
 
     static final class TakeLastObserver<T> extends ArrayDeque<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLastOne.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLastOne.java
@@ -24,7 +24,7 @@ public final class ObservableTakeLastOne<T> extends AbstractObservableWithUpstre
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new TakeLastOneObserver<T>(observer));
+        source.subscribe(new TakeLastOneObserver<>(observer));
     }
 
     static final class TakeLastOneObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeLastTimed.java
@@ -42,7 +42,7 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new TakeLastTimedObserver<T>(t, count, time, unit, scheduler, bufferSize, delayError));
+        source.subscribe(new TakeLastTimedObserver<>(t, count, time, unit, scheduler, bufferSize, delayError));
     }
 
     static final class TakeLastTimedObserver<T>
@@ -69,7 +69,7 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
             this.time = time;
             this.unit = unit;
             this.scheduler = scheduler;
-            this.queue = new SpscLinkedArrayQueue<Object>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
             this.delayError = delayError;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeUntil.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeUntil.java
@@ -31,7 +31,7 @@ public final class ObservableTakeUntil<T, U> extends AbstractObservableWithUpstr
 
     @Override
     public void subscribeActual(Observer<? super T> child) {
-        TakeUntilMainObserver<T, U> parent = new TakeUntilMainObserver<T, U>(child);
+        TakeUntilMainObserver<T, U> parent = new TakeUntilMainObserver<>(child);
         child.onSubscribe(parent);
 
         other.subscribe(parent.otherObserver);
@@ -53,7 +53,7 @@ public final class ObservableTakeUntil<T, U> extends AbstractObservableWithUpstr
 
         TakeUntilMainObserver(Observer<? super T> downstream) {
             this.downstream = downstream;
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
             this.otherObserver = new OtherObserver();
             this.error = new AtomicThrowable();
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeUntilPredicate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeUntilPredicate.java
@@ -29,7 +29,7 @@ public final class ObservableTakeUntilPredicate<T> extends AbstractObservableWit
 
     @Override
     public void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new TakeUntilPredicateObserver<T>(observer, predicate));
+        source.subscribe(new TakeUntilPredicateObserver<>(observer, predicate));
     }
 
     static final class TakeUntilPredicateObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeWhile.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeWhile.java
@@ -29,7 +29,7 @@ public final class ObservableTakeWhile<T> extends AbstractObservableWithUpstream
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new TakeWhileObserver<T>(t, predicate));
+        source.subscribe(new TakeWhileObserver<>(t, predicate));
     }
 
     static final class TakeWhileObserver<T> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleFirstTimed.java
@@ -38,8 +38,8 @@ public final class ObservableThrottleFirstTimed<T> extends AbstractObservableWit
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new DebounceTimedObserver<T>(
-                new SerializedObserver<T>(t),
+        source.subscribe(new DebounceTimedObserver<>(
+                new SerializedObserver<>(t),
                 timeout, unit, scheduler.createWorker()));
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleLatest.java
@@ -53,7 +53,7 @@ public final class ObservableThrottleLatest<T> extends AbstractObservableWithUps
 
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
-        source.subscribe(new ThrottleLatestObserver<T>(observer, timeout, unit, scheduler.createWorker(), emitLast));
+        source.subscribe(new ThrottleLatestObserver<>(observer, timeout, unit, scheduler.createWorker(), emitLast));
     }
 
     static final class ThrottleLatestObserver<T>
@@ -93,7 +93,7 @@ public final class ObservableThrottleLatest<T> extends AbstractObservableWithUps
             this.unit = unit;
             this.worker = worker;
             this.emitLast = emitLast;
-            this.latest = new AtomicReference<T>();
+            this.latest = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeInterval.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeInterval.java
@@ -32,7 +32,7 @@ public final class ObservableTimeInterval<T> extends AbstractObservableWithUpstr
 
     @Override
     public void subscribeActual(Observer<? super Timed<T>> t) {
-        source.subscribe(new TimeIntervalObserver<T>(t, unit, scheduler));
+        source.subscribe(new TimeIntervalObserver<>(t, unit, scheduler));
     }
 
     static final class TimeIntervalObserver<T> implements Observer<T>, Disposable {
@@ -75,7 +75,7 @@ public final class ObservableTimeInterval<T> extends AbstractObservableWithUpstr
             long last = lastTime;
             lastTime = now;
             long delta = now - last;
-            downstream.onNext(new Timed<T>(t, delta, unit));
+            downstream.onNext(new Timed<>(t, delta, unit));
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeout.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeout.java
@@ -44,12 +44,12 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
         if (other == null) {
-            TimeoutObserver<T> parent = new TimeoutObserver<T>(observer, itemTimeoutIndicator);
+            TimeoutObserver<T> parent = new TimeoutObserver<>(observer, itemTimeoutIndicator);
             observer.onSubscribe(parent);
             parent.startFirstTimeout(firstTimeoutIndicator);
             source.subscribe(parent);
         } else {
-            TimeoutFallbackObserver<T> parent = new TimeoutFallbackObserver<T>(observer, itemTimeoutIndicator, other);
+            TimeoutFallbackObserver<T> parent = new TimeoutFallbackObserver<>(observer, itemTimeoutIndicator, other);
             observer.onSubscribe(parent);
             parent.startFirstTimeout(firstTimeoutIndicator);
             source.subscribe(parent);
@@ -77,7 +77,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             this.downstream = actual;
             this.itemTimeoutIndicator = itemTimeoutIndicator;
             this.task = new SequentialDisposable();
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
         }
 
         @Override
@@ -206,7 +206,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
             this.task = new SequentialDisposable();
             this.fallback = fallback;
             this.index = new AtomicLong();
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutTimed.java
@@ -41,12 +41,12 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
     @Override
     protected void subscribeActual(Observer<? super T> observer) {
         if (other == null) {
-            TimeoutObserver<T> parent = new TimeoutObserver<T>(observer, timeout, unit, scheduler.createWorker());
+            TimeoutObserver<T> parent = new TimeoutObserver<>(observer, timeout, unit, scheduler.createWorker());
             observer.onSubscribe(parent);
             parent.startTimeout(0L);
             source.subscribe(parent);
         } else {
-            TimeoutFallbackObserver<T> parent = new TimeoutFallbackObserver<T>(observer, timeout, unit, scheduler.createWorker(), other);
+            TimeoutFallbackObserver<T> parent = new TimeoutFallbackObserver<>(observer, timeout, unit, scheduler.createWorker(), other);
             observer.onSubscribe(parent);
             parent.startTimeout(0L);
             source.subscribe(parent);
@@ -76,7 +76,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
             this.unit = unit;
             this.worker = worker;
             this.task = new SequentialDisposable();
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
         }
 
         @Override
@@ -196,7 +196,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
             this.fallback = fallback;
             this.task = new SequentialDisposable();
             this.index = new AtomicLong();
-            this.upstream = new AtomicReference<Disposable>();
+            this.upstream = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToList.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToList.java
@@ -49,7 +49,7 @@ extends AbstractObservableWithUpstream<T, U> {
             EmptyDisposable.error(e, t);
             return;
         }
-        source.subscribe(new ToListObserver<T, U>(t, coll));
+        source.subscribe(new ToListObserver<>(t, coll));
     }
 
     static final class ToListObserver<T, U extends Collection<? super T>> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToListSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableToListSingle.java
@@ -53,12 +53,12 @@ extends Single<U> implements FuseToObservable<U> {
             EmptyDisposable.error(e, t);
             return;
         }
-        source.subscribe(new ToListObserver<T, U>(t, coll));
+        source.subscribe(new ToListObserver<>(t, coll));
     }
 
     @Override
     public Observable<U> fuseToObservable() {
-        return RxJavaPlugins.onAssembly(new ObservableToList<T, U>(source, collectionSupplier));
+        return RxJavaPlugins.onAssembly(new ObservableToList<>(source, collectionSupplier));
     }
 
     static final class ToListObserver<T, U extends Collection<? super T>> implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUnsubscribeOn.java
@@ -29,7 +29,7 @@ public final class ObservableUnsubscribeOn<T> extends AbstractObservableWithUpst
 
     @Override
     public void subscribeActual(Observer<? super T> t) {
-        source.subscribe(new UnsubscribeObserver<T>(t, scheduler));
+        source.subscribe(new UnsubscribeObserver<>(t, scheduler));
     }
 
     static final class UnsubscribeObserver<T> extends AtomicBoolean implements Observer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUsing.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUsing.java
@@ -67,7 +67,7 @@ public final class ObservableUsing<T, D> extends Observable<T> {
             return;
         }
 
-        UsingObserver<T, D> us = new UsingObserver<T, D>(observer, resource, disposer, eager);
+        UsingObserver<T, D> us = new UsingObserver<>(observer, resource, disposer, eager);
 
         source.subscribe(us);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindow.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindow.java
@@ -36,9 +36,9 @@ public final class ObservableWindow<T> extends AbstractObservableWithUpstream<T,
     @Override
     public void subscribeActual(Observer<? super Observable<T>> t) {
         if (count == skip) {
-            source.subscribe(new WindowExactObserver<T>(t, count, capacityHint));
+            source.subscribe(new WindowExactObserver<>(t, count, capacityHint));
         } else {
-            source.subscribe(new WindowSkipObserver<T>(t, count, skip, capacityHint));
+            source.subscribe(new WindowSkipObserver<>(t, count, skip, capacityHint));
         }
     }
 
@@ -81,7 +81,7 @@ public final class ObservableWindow<T> extends AbstractObservableWithUpstream<T,
             if (w == null && !cancelled) {
                 w = UnicastSubject.create(capacityHint, this);
                 window = w;
-                intercept = new ObservableWindowSubscribeIntercept<T>(w);
+                intercept = new ObservableWindowSubscribeIntercept<>(w);
                 downstream.onNext(intercept);
             }
 
@@ -169,7 +169,7 @@ public final class ObservableWindow<T> extends AbstractObservableWithUpstream<T,
             this.count = count;
             this.skip = skip;
             this.capacityHint = capacityHint;
-            this.windows = new ArrayDeque<UnicastSubject<T>>();
+            this.windows = new ArrayDeque<>();
         }
 
         @Override
@@ -194,7 +194,7 @@ public final class ObservableWindow<T> extends AbstractObservableWithUpstream<T,
             if (i % s == 0 && !cancelled) {
                 wip.getAndIncrement();
                 UnicastSubject<T> w = UnicastSubject.create(capacityHint, this);
-                intercept = new ObservableWindowSubscribeIntercept<T>(w);
+                intercept = new ObservableWindowSubscribeIntercept<>(w);
                 ws.offer(w);
                 downstream.onNext(intercept);
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundary.java
@@ -36,7 +36,7 @@ public final class ObservableWindowBoundary<T, B> extends AbstractObservableWith
 
     @Override
     public void subscribeActual(Observer<? super Observable<T>> observer) {
-        WindowBoundaryMainObserver<T, B> parent = new WindowBoundaryMainObserver<T, B>(observer, capacityHint);
+        WindowBoundaryMainObserver<T, B> parent = new WindowBoundaryMainObserver<>(observer, capacityHint);
 
         observer.onSubscribe(parent);
         other.subscribe(parent.boundaryObserver);
@@ -75,10 +75,10 @@ public final class ObservableWindowBoundary<T, B> extends AbstractObservableWith
         WindowBoundaryMainObserver(Observer<? super Observable<T>> downstream, int capacityHint) {
             this.downstream = downstream;
             this.capacityHint = capacityHint;
-            this.boundaryObserver = new WindowBoundaryInnerObserver<T, B>(this);
-            this.upstream = new AtomicReference<Disposable>();
+            this.boundaryObserver = new WindowBoundaryInnerObserver<>(this);
+            this.upstream = new AtomicReference<>();
             this.windows = new AtomicInteger(1);
-            this.queue = new MpscLinkedQueue<Object>();
+            this.queue = new MpscLinkedQueue<>();
             this.errors = new AtomicThrowable();
             this.stopWindows = new AtomicBoolean();
         }
@@ -230,7 +230,7 @@ public final class ObservableWindowBoundary<T, B> extends AbstractObservableWith
                         window = w;
                         windows.getAndIncrement();
 
-                        ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<T>(w);
+                        ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<>(w);
                         downstream.onNext(intercept);
                         if (intercept.tryAbandon()) {
                             w.onComplete();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -46,7 +46,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
 
     @Override
     public void subscribeActual(Observer<? super Observable<T>> t) {
-        source.subscribe(new WindowBoundaryMainObserver<T, B, V>(
+        source.subscribe(new WindowBoundaryMainObserver<>(
                 t, open, closingIndicator, bufferSize));
     }
 
@@ -85,16 +85,16 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
         WindowBoundaryMainObserver(Observer<? super Observable<T>> downstream,
                 ObservableSource<B> open, Function<? super B, ? extends ObservableSource<V>> closingIndicator, int bufferSize) {
             this.downstream = downstream;
-            this.queue = new MpscLinkedQueue<Object>();
+            this.queue = new MpscLinkedQueue<>();
             this.open = open;
             this.closingIndicator = closingIndicator;
             this.bufferSize = bufferSize;
             this.resources = new CompositeDisposable();
-            this.windows = new ArrayList<UnicastSubject<T>>();
+            this.windows = new ArrayList<>();
             this.windowCount = new AtomicLong(1L);
             this.downstreamDisposed = new AtomicBoolean();
             this.error = new AtomicThrowable();
-            this.startObserver = new WindowStartObserver<B>(this);
+            this.startObserver = new WindowStartObserver<>(this);
             this.requested = new AtomicLong();
         }
 
@@ -167,7 +167,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
         }
 
         void open(B startValue) {
-            queue.offer(new WindowStartItem<B>(startValue));
+            queue.offer(new WindowStartItem<>(startValue));
             drain();
         }
 
@@ -249,7 +249,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
 
                                 windowCount.getAndIncrement();
                                 UnicastSubject<T> newWindow = UnicastSubject.create(bufferSize, this);
-                                WindowEndObserverIntercept<T, V> endObserver = new WindowEndObserverIntercept<T, V>(this, newWindow);
+                                WindowEndObserverIntercept<T, V> endObserver = new WindowEndObserverIntercept<>(this, newWindow);
 
                                 downstream.onNext(endObserver);
 
@@ -371,7 +371,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
             WindowEndObserverIntercept(WindowBoundaryMainObserver<T, ?, V> parent, UnicastSubject<T> window) {
                 this.parent = parent;
                 this.window = window;
-                this.upstream = new AtomicReference<Disposable>();
+                this.upstream = new AtomicReference<>();
                 this.once = new AtomicBoolean();
             }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowTimed.java
@@ -53,18 +53,18 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
     protected void subscribeActual(Observer<? super Observable<T>> downstream) {
         if (timespan == timeskip) {
             if (maxSize == Long.MAX_VALUE) {
-                source.subscribe(new WindowExactUnboundedObserver<T>(
+                source.subscribe(new WindowExactUnboundedObserver<>(
                         downstream,
                         timespan, unit, scheduler, bufferSize));
                 return;
             }
-            source.subscribe(new WindowExactBoundedObserver<T>(
+            source.subscribe(new WindowExactBoundedObserver<>(
                         downstream,
                         timespan, unit, scheduler,
                         bufferSize, maxSize, restartTimerOnMaxSize));
             return;
         }
-        source.subscribe(new WindowSkipObserver<T>(downstream,
+        source.subscribe(new WindowSkipObserver<>(downstream,
                 timespan, timeskip, unit, scheduler.createWorker(), bufferSize));
     }
 
@@ -96,7 +96,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
         AbstractWindowObserver(Observer<? super Observable<T>> downstream, long timespan, TimeUnit unit, int bufferSize) {
             this.downstream = downstream;
-            this.queue = new MpscLinkedQueue<Object>();
+            this.queue = new MpscLinkedQueue<>();
             this.timespan = timespan;
             this.unit = unit;
             this.bufferSize = bufferSize;
@@ -194,7 +194,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
 
                 emitted = 1;
 
-                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<T>(window);
+                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<>(window);
                 downstream.onNext(intercept);
 
                 timer.replace(scheduler.schedulePeriodicallyDirect(this, timespan, timespan, unit));
@@ -267,7 +267,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                                 window = UnicastSubject.create(bufferSize, windowRunnable);
                                 this.window = window;
 
-                                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<T>(window);
+                                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<>(window);
                                 downstream.onNext(intercept);
 
                                 if (intercept.tryAbandon()) {
@@ -344,7 +344,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 windowCount.getAndIncrement();
                 window = UnicastSubject.create(bufferSize, this);
 
-                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<T>(window);
+                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<>(window);
                 downstream.onNext(intercept);
 
                 Runnable boundaryTask = new WindowBoundaryRunnable(this, 1L);
@@ -466,7 +466,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 window = UnicastSubject.create(bufferSize, this);
                 this.window = window;
 
-                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<T>(window);
+                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<>(window);
                 downstream.onNext(intercept);
 
                 if (restartTimerOnMaxSize) {
@@ -515,7 +515,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             super(actual, timespan, unit, bufferSize);
             this.timeskip = timeskip;
             this.worker = worker;
-            this.windows = new LinkedList<UnicastSubject<T>>();
+            this.windows = new LinkedList<>();
         }
 
         @Override
@@ -527,7 +527,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                 UnicastSubject<T> window = UnicastSubject.create(bufferSize, this);
                 windows.add(window);
 
-                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<T>(window);
+                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<>(window);
                 downstream.onNext(intercept);
 
                 worker.schedule(new WindowBoundaryRunnable(this, false), timespan, unit);
@@ -591,7 +591,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                                 UnicastSubject<T> window = UnicastSubject.create(bufferSize, this);
                                 windows.add(window);
 
-                                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<T>(window);
+                                ObservableWindowSubscribeIntercept<T> intercept = new ObservableWindowSubscribeIntercept<>(window);
                                 downstream.onNext(intercept);
 
                                 worker.schedule(new WindowBoundaryRunnable(this, false), timespan, unit);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWithLatestFrom.java
@@ -35,8 +35,8 @@ public final class ObservableWithLatestFrom<T, U, R> extends AbstractObservableW
 
     @Override
     public void subscribeActual(Observer<? super R> t) {
-        final SerializedObserver<R> serial = new SerializedObserver<R>(t);
-        final WithLatestFromObserver<T, U, R> wlf = new WithLatestFromObserver<T, U, R>(serial, combiner);
+        final SerializedObserver<R> serial = new SerializedObserver<>(t);
+        final WithLatestFromObserver<T, U, R> wlf = new WithLatestFromObserver<>(serial, combiner);
 
         serial.onSubscribe(wlf);
 
@@ -53,9 +53,9 @@ public final class ObservableWithLatestFrom<T, U, R> extends AbstractObservableW
 
         final BiFunction<? super T, ? super U, ? extends R> combiner;
 
-        final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
-        final AtomicReference<Disposable> other = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> other = new AtomicReference<>();
 
         WithLatestFromObserver(Observer<? super R> actual, BiFunction<? super T, ? super U, ? extends R> combiner) {
             this.downstream = actual;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -82,11 +82,11 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
         }
 
         if (n == 0) {
-            new ObservableMap<T, R>(source, new SingletonArrayFunc()).subscribeActual(observer);
+            new ObservableMap<>(source, new SingletonArrayFunc()).subscribeActual(observer);
             return;
         }
 
-        WithLatestFromObserver<T, R> parent = new WithLatestFromObserver<T, R>(observer, combiner, n);
+        WithLatestFromObserver<T, R> parent = new WithLatestFromObserver<>(observer, combiner, n);
         observer.onSubscribe(parent);
         parent.subscribe(others, n);
 
@@ -121,8 +121,8 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
                 s[i] = new WithLatestInnerObserver(this, i);
             }
             this.observers = s;
-            this.values = new AtomicReferenceArray<Object>(n);
-            this.upstream = new AtomicReference<Disposable>();
+            this.values = new AtomicReferenceArray<>(n);
+            this.upstream = new AtomicReference<>();
             this.error = new AtomicThrowable();
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZip.java
@@ -68,7 +68,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
             return;
         }
 
-        ZipCoordinator<T, R> zc = new ZipCoordinator<T, R>(observer, zipper, count, delayError);
+        ZipCoordinator<T, R> zc = new ZipCoordinator<>(observer, zipper, count, delayError);
         zc.subscribe(sources, bufferSize);
     }
 
@@ -98,7 +98,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
             ZipObserver<T, R>[] s = observers;
             int len = s.length;
             for (int i = 0; i < len; i++) {
-                s[i] = new ZipObserver<T, R>(this, bufferSize);
+                s[i] = new ZipObserver<>(this, bufferSize);
             }
             // this makes sure the contents of the observers array is visible
             this.lazySet(0);
@@ -263,11 +263,11 @@ public final class ObservableZip<T, R> extends Observable<R> {
         volatile boolean done;
         Throwable error;
 
-        final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+        final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
         ZipObserver(ZipCoordinator<T, R> parent, int bufferSize) {
             this.parent = parent;
-            this.queue = new SpscLinkedArrayQueue<T>(bufferSize);
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObserverResourceWrapper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObserverResourceWrapper.java
@@ -25,7 +25,7 @@ public final class ObserverResourceWrapper<T> extends AtomicReference<Disposable
 
     final Observer<? super T> downstream;
 
-    final AtomicReference<Disposable> upstream = new AtomicReference<Disposable>();
+    final AtomicReference<Disposable> upstream = new AtomicReference<>();
 
     public ObserverResourceWrapper(Observer<? super T> downstream) {
         this.downstream = downstream;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleCache.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleCache.java
@@ -39,12 +39,12 @@ public final class SingleCache<T> extends Single<T> implements SingleObserver<T>
     public SingleCache(SingleSource<? extends T> source) {
         this.source = source;
         this.wip = new AtomicInteger();
-        this.observers = new AtomicReference<CacheDisposable<T>[]>(EMPTY);
+        this.observers = new AtomicReference<>(EMPTY);
     }
 
     @Override
     protected void subscribeActual(final SingleObserver<? super T> observer) {
-        CacheDisposable<T> d = new CacheDisposable<T>(observer, this);
+        CacheDisposable<T> d = new CacheDisposable<>(observer, this);
         observer.onSubscribe(d);
 
         if (add(d)) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleCreate.java
@@ -33,7 +33,7 @@ public final class SingleCreate<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        Emitter<T> parent = new Emitter<T>(observer);
+        Emitter<T> parent = new Emitter<>(observer);
         observer.onSubscribe(parent);
 
         try {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayWithCompletable.java
@@ -33,7 +33,7 @@ public final class SingleDelayWithCompletable<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        other.subscribe(new OtherObserver<T>(observer, source));
+        other.subscribe(new OtherObserver<>(observer, source));
     }
 
     static final class OtherObserver<T>
@@ -66,7 +66,7 @@ public final class SingleDelayWithCompletable<T> extends Single<T> {
 
         @Override
         public void onComplete() {
-            source.subscribe(new ResumeSingleObserver<T>(this, downstream));
+            source.subscribe(new ResumeSingleObserver<>(this, downstream));
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayWithObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayWithObservable.java
@@ -34,7 +34,7 @@ public final class SingleDelayWithObservable<T, U> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        other.subscribe(new OtherSubscriber<T, U>(observer, source));
+        other.subscribe(new OtherSubscriber<>(observer, source));
     }
 
     static final class OtherSubscriber<T, U>
@@ -84,7 +84,7 @@ public final class SingleDelayWithObservable<T, U> extends Single<T> {
                 return;
             }
             done = true;
-            source.subscribe(new ResumeSingleObserver<T>(this, downstream));
+            source.subscribe(new ResumeSingleObserver<>(this, downstream));
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayWithPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayWithPublisher.java
@@ -37,7 +37,7 @@ public final class SingleDelayWithPublisher<T, U> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        other.subscribe(new OtherSubscriber<T, U>(observer, source));
+        other.subscribe(new OtherSubscriber<>(observer, source));
     }
 
     static final class OtherSubscriber<T, U>
@@ -92,7 +92,7 @@ public final class SingleDelayWithPublisher<T, U> extends Single<T> {
                 return;
             }
             done = true;
-            source.subscribe(new ResumeSingleObserver<T>(this, downstream));
+            source.subscribe(new ResumeSingleObserver<>(this, downstream));
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDelayWithSingle.java
@@ -33,7 +33,7 @@ public final class SingleDelayWithSingle<T, U> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        other.subscribe(new OtherObserver<T, U>(observer, source));
+        other.subscribe(new OtherObserver<>(observer, source));
     }
 
     static final class OtherObserver<T, U>
@@ -61,7 +61,7 @@ public final class SingleDelayWithSingle<T, U> extends Single<T> {
 
         @Override
         public void onSuccess(U value) {
-            source.subscribe(new ResumeSingleObserver<T>(this, downstream));
+            source.subscribe(new ResumeSingleObserver<>(this, downstream));
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDematerialize.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDematerialize.java
@@ -42,7 +42,7 @@ public final class SingleDematerialize<T, R> extends Maybe<R> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super R> observer) {
-        source.subscribe(new DematerializeObserver<T, R>(observer, selector));
+        source.subscribe(new DematerializeObserver<>(observer, selector));
     }
 
     static final class DematerializeObserver<T, R> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDetach.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDetach.java
@@ -33,7 +33,7 @@ public final class SingleDetach<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new DetachSingleObserver<T>(observer));
+        source.subscribe(new DetachSingleObserver<>(observer));
     }
 
     static final class DetachSingleObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoAfterSuccess.java
@@ -39,7 +39,7 @@ public final class SingleDoAfterSuccess<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new DoAfterObserver<T>(observer, onAfterSuccess));
+        source.subscribe(new DoAfterObserver<>(observer, onAfterSuccess));
     }
 
     static final class DoAfterObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoAfterTerminate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoAfterTerminate.java
@@ -39,7 +39,7 @@ public final class SingleDoAfterTerminate<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new DoAfterTerminateObserver<T>(observer, onAfterTerminate));
+        source.subscribe(new DoAfterTerminateObserver<>(observer, onAfterTerminate));
     }
 
     static final class DoAfterTerminateObserver<T> implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoFinally.java
@@ -41,7 +41,7 @@ public final class SingleDoFinally<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new DoFinallyObserver<T>(observer, onFinally));
+        source.subscribe(new DoFinallyObserver<>(observer, onFinally));
     }
 
     static final class DoFinallyObserver<T> extends AtomicInteger implements SingleObserver<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoOnDispose.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoOnDispose.java
@@ -35,7 +35,7 @@ public final class SingleDoOnDispose<T> extends Single<T> {
     @Override
     protected void subscribeActual(final SingleObserver<? super T> observer) {
 
-        source.subscribe(new DoOnDisposeObserver<T>(observer, onDispose));
+        source.subscribe(new DoOnDisposeObserver<>(observer, onDispose));
     }
 
     static final class DoOnDisposeObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleDoOnSubscribe.java
@@ -38,7 +38,7 @@ public final class SingleDoOnSubscribe<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(final SingleObserver<? super T> observer) {
-        source.subscribe(new DoOnSubscribeSingleObserver<T>(observer, onSubscribe));
+        source.subscribe(new DoOnSubscribeSingleObserver<>(observer, onSubscribe));
     }
 
     static final class DoOnSubscribeSingleObserver<T> implements SingleObserver<T> {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapCompletable.java
@@ -39,7 +39,7 @@ public final class SingleFlatMapCompletable<T> extends Completable {
 
     @Override
     protected void subscribeActual(CompletableObserver observer) {
-        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<T>(observer, mapper);
+        FlatMapCompletableObserver<T> parent = new FlatMapCompletableObserver<>(observer, mapper);
         observer.onSubscribe(parent);
         source.subscribe(parent);
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapIterableFlowable.java
@@ -48,7 +48,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> s) {
-        source.subscribe(new FlatMapIterableObserver<T, R>(s, mapper));
+        source.subscribe(new FlatMapIterableObserver<>(s, mapper));
     }
 
     static final class FlatMapIterableObserver<T, R>
@@ -273,7 +273,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
 
         @Nullable
         @Override
-        public R poll() throws Exception {
+        public R poll() {
             Iterator<? extends R> iterator = it;
 
             if (iterator != null) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapIterableObservable.java
@@ -44,7 +44,7 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new FlatMapIterableObserver<T, R>(observer, mapper));
+        source.subscribe(new FlatMapIterableObserver<>(observer, mapper));
     }
 
     static final class FlatMapIterableObserver<T, R>
@@ -183,7 +183,7 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
 
         @Nullable
         @Override
-        public R poll() throws Exception {
+        public R poll() {
             Iterator<? extends R> iterator = it;
 
             if (iterator != null) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleFlatMapPublisher.java
@@ -56,7 +56,7 @@ public final class SingleFlatMapPublisher<T, R> extends Flowable<R> {
 
     @Override
     protected void subscribeActual(Subscriber<? super R> downstream) {
-        source.subscribe(new SingleFlatMapPublisherObserver<T, R>(downstream, mapper));
+        source.subscribe(new SingleFlatMapPublisherObserver<>(downstream, mapper));
     }
 
     static final class SingleFlatMapPublisherObserver<S, T> extends AtomicLong
@@ -73,7 +73,7 @@ public final class SingleFlatMapPublisher<T, R> extends Flowable<R> {
                 Function<? super S, ? extends Publisher<? extends T>> mapper) {
             this.downstream = actual;
             this.mapper = mapper;
-            this.parent = new AtomicReference<Subscription>();
+            this.parent = new AtomicReference<>();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleInternalHelper.java
@@ -36,17 +36,17 @@ public final class SingleInternalHelper {
         INSTANCE;
 
         @Override
-        public NoSuchElementException call() throws Exception {
+        public NoSuchElementException call() {
             return new NoSuchElementException();
         }
 
         @Override
-        public NoSuchElementException get() throws Throwable {
+        public NoSuchElementException get() {
             return new NoSuchElementException();
         }
     }
 
-    public static <T> Supplier<NoSuchElementException> emptyThrower() {
+    public static Supplier<NoSuchElementException> emptyThrower() {
         return NoSuchElementCallable.INSTANCE;
     }
 
@@ -79,7 +79,7 @@ public final class SingleInternalHelper {
 
         @Override
         public Flowable<T> next() {
-            return new SingleToFlowable<T>(sit.next());
+            return new SingleToFlowable<>(sit.next());
         }
 
         @Override
@@ -98,12 +98,12 @@ public final class SingleInternalHelper {
 
         @Override
         public Iterator<Flowable<T>> iterator() {
-            return new ToFlowableIterator<T>(sources.iterator());
+            return new ToFlowableIterator<>(sources.iterator());
         }
     }
 
     public static <T> Iterable<? extends Flowable<T>> iterableToFlowable(final Iterable<? extends SingleSource<? extends T>> sources) {
-        return new ToFlowableIterable<T>(sources);
+        return new ToFlowableIterable<>(sources);
     }
 
     @SuppressWarnings("rawtypes")

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleMaterialize.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleMaterialize.java
@@ -34,6 +34,6 @@ public final class SingleMaterialize<T> extends Single<Notification<T>> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super Notification<T>> observer) {
-        source.subscribe(new MaterializeSingleObserver<T>(observer));
+        source.subscribe(new MaterializeSingleObserver<>(observer));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleObserveOn.java
@@ -32,7 +32,7 @@ public final class SingleObserveOn<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(final SingleObserver<? super T> observer) {
-        source.subscribe(new ObserveOnSingleObserver<T>(observer, scheduler));
+        source.subscribe(new ObserveOnSingleObserver<>(observer, scheduler));
     }
 
     static final class ObserveOnSingleObserver<T> extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleResumeNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleResumeNext.java
@@ -36,7 +36,7 @@ public final class SingleResumeNext<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(final SingleObserver<? super T> observer) {
-        source.subscribe(new ResumeMainSingleObserver<T>(observer, nextFunction));
+        source.subscribe(new ResumeMainSingleObserver<>(observer, nextFunction));
     }
 
     static final class ResumeMainSingleObserver<T> extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleSubscribeOn.java
@@ -31,7 +31,7 @@ public final class SingleSubscribeOn<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(final SingleObserver<? super T> observer) {
-        final SubscribeOnObserver<T> parent = new SubscribeOnObserver<T>(observer, source);
+        final SubscribeOnObserver<T> parent = new SubscribeOnObserver<>(observer, source);
         observer.onSubscribe(parent);
 
         Disposable f = scheduler.scheduleDirect(parent);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleTakeUntil.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleTakeUntil.java
@@ -43,7 +43,7 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        TakeUntilMainObserver<T> parent = new TakeUntilMainObserver<T>(observer);
+        TakeUntilMainObserver<T> parent = new TakeUntilMainObserver<>(observer);
         observer.onSubscribe(parent);
 
         other.subscribe(parent.other);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleTimeout.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleTimeout.java
@@ -47,7 +47,7 @@ public final class SingleTimeout<T> extends Single<T> {
     @Override
     protected void subscribeActual(final SingleObserver<? super T> observer) {
 
-        TimeoutMainObserver<T> parent = new TimeoutMainObserver<T>(observer, other, timeout, unit);
+        TimeoutMainObserver<T> parent = new TimeoutMainObserver<>(observer, other, timeout, unit);
         observer.onSubscribe(parent);
 
         DisposableHelper.replace(parent.task, scheduler.scheduleDirect(parent, timeout, unit));
@@ -103,9 +103,9 @@ public final class SingleTimeout<T> extends Single<T> {
             this.other = other;
             this.timeout = timeout;
             this.unit = unit;
-            this.task = new AtomicReference<Disposable>();
+            this.task = new AtomicReference<>();
             if (other != null) {
-                this.fallback = new TimeoutFallbackObserver<T>(actual);
+                this.fallback = new TimeoutFallbackObserver<>(actual);
             } else {
                 this.fallback = null;
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleToObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleToObservable.java
@@ -44,7 +44,7 @@ public final class SingleToObservable<T> extends Observable<T> {
      * @since 2.2
      */
     public static <T> SingleObserver<T> create(Observer<? super T> downstream) {
-        return new SingleToObservableObserver<T>(downstream);
+        return new SingleToObservableObserver<>(downstream);
     }
 
     static final class SingleToObservableObserver<T>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleUnsubscribeOn.java
@@ -37,7 +37,7 @@ public final class SingleUnsubscribeOn<T> extends Single<T> {
 
     @Override
     protected void subscribeActual(SingleObserver<? super T> observer) {
-        source.subscribe(new UnsubscribeOnSingleObserver<T>(observer, scheduler));
+        source.subscribe(new UnsubscribeOnSingleObserver<>(observer, scheduler));
     }
 
     static final class UnsubscribeOnSingleObserver<T> extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleZipArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleZipArray.java
@@ -40,11 +40,11 @@ public final class SingleZipArray<T, R> extends Single<R> {
         int n = sources.length;
 
         if (n == 1) {
-            sources[0].subscribe(new SingleMap.MapSingleObserver<T, R>(observer, new SingletonArrayFunc()));
+            sources[0].subscribe(new SingleMap.MapSingleObserver<>(observer, new SingletonArrayFunc()));
             return;
         }
 
-        ZipCoordinator<T, R> parent = new ZipCoordinator<T, R>(observer, n, zipper);
+        ZipCoordinator<T, R> parent = new ZipCoordinator<>(observer, n, zipper);
 
         observer.onSubscribe(parent);
 
@@ -83,7 +83,7 @@ public final class SingleZipArray<T, R> extends Single<R> {
             this.zipper = zipper;
             ZipSingleObserver<T>[] o = new ZipSingleObserver[n];
             for (int i = 0; i < n; i++) {
-                o[i] = new ZipSingleObserver<T>(this, i);
+                o[i] = new ZipSingleObserver<>(this, i);
             }
             this.observers = o;
             this.values = new Object[n];

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleZipIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleZipIterable.java
@@ -61,11 +61,11 @@ public final class SingleZipIterable<T, R> extends Single<R> {
         }
 
         if (n == 1) {
-            a[0].subscribe(new SingleMap.MapSingleObserver<T, R>(observer, new SingletonArrayFunc()));
+            a[0].subscribe(new SingleMap.MapSingleObserver<>(observer, new SingletonArrayFunc()));
             return;
         }
 
-        ZipCoordinator<T, R> parent = new ZipCoordinator<T, R>(observer, n, zipper);
+        ZipCoordinator<T, R> parent = new ZipCoordinator<>(observer, n, zipper);
 
         observer.onSubscribe(parent);
 

--- a/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
@@ -32,9 +32,9 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
     private final AtomicReference<LinkedQueueNode<T>> consumerNode;
 
     public MpscLinkedQueue() {
-        producerNode = new AtomicReference<LinkedQueueNode<T>>();
-        consumerNode = new AtomicReference<LinkedQueueNode<T>>();
-        LinkedQueueNode<T> node = new LinkedQueueNode<T>();
+        producerNode = new AtomicReference<>();
+        consumerNode = new AtomicReference<>();
+        LinkedQueueNode<T> node = new LinkedQueueNode<>();
         spConsumerNode(node);
         xchgProducerNode(node); // this ensures correct construction: StoreLoad
     }
@@ -59,7 +59,7 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
         if (null == e) {
             throw new NullPointerException("Null is not a valid element");
         }
-        final LinkedQueueNode<T> nextNode = new LinkedQueueNode<T>(e);
+        final LinkedQueueNode<T> nextNode = new LinkedQueueNode<>(e);
         final LinkedQueueNode<T> prevProducerNode = xchgProducerNode(nextNode);
         // Should a producer thread get interrupted here the chain WILL be broken until that thread is resumed
         // and completes the store in prev.next.

--- a/src/main/java/io/reactivex/rxjava3/internal/queue/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/queue/SpscLinkedArrayQueue.java
@@ -48,7 +48,7 @@ public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
     public SpscLinkedArrayQueue(final int bufferSize) {
         int p2capacity = Pow2.roundToPowerOfTwo(Math.max(8, bufferSize));
         int mask = p2capacity - 1;
-        AtomicReferenceArray<Object> buffer = new AtomicReferenceArray<Object>(p2capacity + 1);
+        AtomicReferenceArray<Object> buffer = new AtomicReferenceArray<>(p2capacity + 1);
         producerBuffer = buffer;
         producerMask = mask;
         adjustLookAheadStep(p2capacity);
@@ -100,7 +100,7 @@ public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
     private void resize(final AtomicReferenceArray<Object> oldBuffer, final long currIndex, final int offset, final T e,
             final long mask) {
         final int capacity = oldBuffer.length();
-        final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<Object>(capacity);
+        final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<>(capacity);
         producerBuffer = newBuffer;
         producerLookAhead = currIndex + mask - 1;
         soElement(newBuffer, offset, e); // StoreStore
@@ -247,7 +247,7 @@ public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
         buffer.lazySet(offset, e);
     }
 
-    private static <E> Object lvElement(AtomicReferenceArray<Object> buffer, int offset) {
+    private static Object lvElement(AtomicReferenceArray<Object> buffer, int offset) {
         return buffer.get(offset);
     }
 
@@ -273,7 +273,7 @@ public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
             soProducerIndex(p + 2);
         } else {
             final int capacity = buffer.length();
-            final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<Object>(capacity);
+            final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<>(capacity);
             producerBuffer = newBuffer;
 
             pi = calcWrappedOffset(p, m);

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/AbstractDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/AbstractDirectTask.java
@@ -37,9 +37,9 @@ implements Disposable, SchedulerRunnableIntrospection {
 
     protected Thread runner;
 
-    protected static final FutureTask<Void> FINISHED = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+    protected static final FutureTask<Void> FINISHED = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
-    protected static final FutureTask<Void> DISPOSED = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+    protected static final FutureTask<Void> DISPOSED = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
     AbstractDirectTask(Runnable runnable) {
         this.runnable = runnable;

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ComputationScheduler.java
@@ -135,7 +135,7 @@ public final class ComputationScheduler extends Scheduler implements SchedulerMu
      */
     public ComputationScheduler(ThreadFactory threadFactory) {
         this.threadFactory = threadFactory;
-        this.pool = new AtomicReference<FixedSchedulerPool>(NONE);
+        this.pool = new AtomicReference<>(NONE);
         start();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/DisposeOnCancel.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/DisposeOnCancel.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava3.internal.schedulers;
 
 import java.util.concurrent.*;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.disposables.Disposable;
 
 /**
@@ -46,13 +47,12 @@ final class DisposeOnCancel implements Future<Object> {
     }
 
     @Override
-    public Object get() throws InterruptedException, ExecutionException {
+    public Object get() {
         return null;
     }
 
     @Override
-    public Object get(long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
+    public Object get(long timeout, @NonNull TimeUnit unit) {
         return null;
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
@@ -140,7 +140,7 @@ public final class ExecutorScheduler extends Scheduler {
 
         public ExecutorWorker(Executor executor, boolean interruptibleWorker, boolean fair) {
             this.executor = executor;
-            this.queue = new MpscLinkedQueue<Runnable>();
+            this.queue = new MpscLinkedQueue<>();
             this.interruptibleWorker = interruptibleWorker;
             this.fair = fair;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTask.java
@@ -39,18 +39,18 @@ final class InstantPeriodicTask implements Callable<Void>, Disposable {
 
     Thread runner;
 
-    static final FutureTask<Void> CANCELLED = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null);
+    static final FutureTask<Void> CANCELLED = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
     InstantPeriodicTask(Runnable task, ExecutorService executor) {
         super();
         this.task = task;
-        this.first = new AtomicReference<Future<?>>();
-        this.rest = new AtomicReference<Future<?>>();
+        this.first = new AtomicReference<>();
+        this.rest = new AtomicReference<>();
         this.executor = executor;
     }
 
     @Override
-    public Void call() throws Exception {
+    public Void call() {
         runner = Thread.currentThread();
         try {
             task.run();

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/IoScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/IoScheduler.java
@@ -77,7 +77,7 @@ public final class IoScheduler extends Scheduler {
 
         CachedWorkerPool(long keepAliveTime, TimeUnit unit, ThreadFactory threadFactory) {
             this.keepAliveTime = unit != null ? unit.toNanos(keepAliveTime) : 0L;
-            this.expiringWorkerQueue = new ConcurrentLinkedQueue<ThreadWorker>();
+            this.expiringWorkerQueue = new ConcurrentLinkedQueue<>();
             this.allWorkers = new CompositeDisposable();
             this.threadFactory = threadFactory;
 
@@ -164,7 +164,7 @@ public final class IoScheduler extends Scheduler {
      */
     public IoScheduler(ThreadFactory threadFactory) {
         this.threadFactory = threadFactory;
-        this.pool = new AtomicReference<CachedWorkerPool>(NONE);
+        this.pool = new AtomicReference<>(NONE);
         start();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/RxThreadFactory.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/RxThreadFactory.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.rxjava3.internal.schedulers;
 
+import io.reactivex.rxjava3.annotations.NonNull;
+
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -47,7 +49,7 @@ public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
     }
 
     @Override
-    public Thread newThread(Runnable r) {
+    public Thread newThread(@NonNull Runnable r) {
         StringBuilder nameBuilder = new StringBuilder(prefix).append('-').append(incrementAndGet());
 
 //        if (CREATE_TRACE) {

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
@@ -32,7 +32,7 @@ public final class ScheduledDirectTask extends AbstractDirectTask implements Cal
     }
 
     @Override
-    public Void call() throws Exception {
+    public Void call() {
         runner = Thread.currentThread();
         try {
             runnable.run();

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
@@ -47,12 +47,12 @@ public final class SchedulerPoolFactory {
     public static final int PURGE_PERIOD_SECONDS;
 
     static final AtomicReference<ScheduledExecutorService> PURGE_THREAD =
-            new AtomicReference<ScheduledExecutorService>();
+            new AtomicReference<>();
 
     // Upcast to the Map interface here to avoid 8.x compatibility issues.
     // See http://stackoverflow.com/a/32955708/61158
     static final Map<ScheduledThreadPoolExecutor, Object> POOLS =
-            new ConcurrentHashMap<ScheduledThreadPoolExecutor, Object>();
+            new ConcurrentHashMap<>();
 
     /**
      * Starts the purge thread if not already started.
@@ -134,7 +134,7 @@ public final class SchedulerPoolFactory {
 
     static final class SystemPropertyAccessor implements Function<String, String> {
         @Override
-        public String apply(String t) throws Throwable {
+        public String apply(String t) {
             return System.getProperty(t);
         }
     }
@@ -160,7 +160,7 @@ public final class SchedulerPoolFactory {
     static final class ScheduledTask implements Runnable {
         @Override
         public void run() {
-            for (ScheduledThreadPoolExecutor e : new ArrayList<ScheduledThreadPoolExecutor>(POOLS.keySet())) {
+            for (ScheduledThreadPoolExecutor e : new ArrayList<>(POOLS.keySet())) {
                 if (e.isShutdown()) {
                     POOLS.remove(e);
                 } else {

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SingleScheduler.java
@@ -28,7 +28,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 public final class SingleScheduler extends Scheduler {
 
     final ThreadFactory threadFactory;
-    final AtomicReference<ScheduledExecutorService> executor = new AtomicReference<ScheduledExecutorService>();
+    final AtomicReference<ScheduledExecutorService> executor = new AtomicReference<>();
 
     /** The name of the system property for setting the thread priority for this Scheduler. */
     private static final String KEY_SINGLE_PRIORITY = "rx3.single-priority";

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/TrampolineScheduler.java
@@ -66,7 +66,7 @@ public final class TrampolineScheduler extends Scheduler {
     }
 
     static final class TrampolineWorker extends Scheduler.Worker implements Disposable {
-        final PriorityBlockingQueue<TimedRunnable> queue = new PriorityBlockingQueue<TimedRunnable>();
+        final PriorityBlockingQueue<TimedRunnable> queue = new PriorityBlockingQueue<>();
 
         private final AtomicInteger wip = new AtomicInteger();
 

--- a/src/main/java/io/reactivex/rxjava3/internal/subscribers/FutureSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/subscribers/FutureSubscriber.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.rxjava3.core.FlowableSubscriber;
@@ -42,7 +43,7 @@ implements FlowableSubscriber<T>, Future<T>, Subscription {
 
     public FutureSubscriber() {
         super(1);
-        this.upstream = new AtomicReference<Subscription>();
+        this.upstream = new AtomicReference<>();
     }
 
     @Override
@@ -91,7 +92,7 @@ implements FlowableSubscriber<T>, Future<T>, Subscription {
     }
 
     @Override
-    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    public T get(long timeout, @NonNull TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (getCount() != 0) {
             BlockingHelper.verifyNonBlocking();
             if (!await(timeout, unit)) {

--- a/src/main/java/io/reactivex/rxjava3/internal/subscribers/StrictSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/subscribers/StrictSubscriber.java
@@ -57,7 +57,7 @@ implements FlowableSubscriber<T>, Subscription {
         this.downstream = downstream;
         this.error = new AtomicThrowable();
         this.requested = new AtomicLong();
-        this.upstream = new AtomicReference<Subscription>();
+        this.upstream = new AtomicReference<>();
         this.once = new AtomicBoolean();
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/subscribers/SubscriberResourceWrapper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/subscribers/SubscriberResourceWrapper.java
@@ -28,7 +28,7 @@ public final class SubscriberResourceWrapper<T> extends AtomicReference<Disposab
 
     final Subscriber<? super T> downstream;
 
-    final AtomicReference<Subscription> upstream = new AtomicReference<Subscription>();
+    final AtomicReference<Subscription> upstream = new AtomicReference<>();
 
     public SubscriberResourceWrapper(Subscriber<? super T> downstream) {
         this.downstream = downstream;

--- a/src/main/java/io/reactivex/rxjava3/internal/subscriptions/AsyncSubscription.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/subscriptions/AsyncSubscription.java
@@ -35,8 +35,8 @@ public final class AsyncSubscription extends AtomicLong implements Subscription,
     final AtomicReference<Disposable> resource;
 
     public AsyncSubscription() {
-        resource = new AtomicReference<Disposable>();
-        actual = new AtomicReference<Subscription>();
+        resource = new AtomicReference<>();
+        actual = new AtomicReference<>();
     }
 
     public AsyncSubscription(Disposable resource) {

--- a/src/main/java/io/reactivex/rxjava3/internal/subscriptions/SubscriptionArbiter.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/subscriptions/SubscriptionArbiter.java
@@ -63,7 +63,7 @@ public class SubscriptionArbiter extends AtomicInteger implements Subscription {
 
     public SubscriptionArbiter(boolean cancelOnReplace) {
         this.cancelOnReplace = cancelOnReplace;
-        missedSubscription = new AtomicReference<Subscription>();
+        missedSubscription = new AtomicReference<>();
         missedRequested = new AtomicLong();
         missedProduced = new AtomicLong();
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/util/ArrayListSupplier.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/ArrayListSupplier.java
@@ -32,10 +32,10 @@ public enum ArrayListSupplier implements Supplier<List<Object>>, Function<Object
 
     @Override
     public List<Object> get() {
-        return new ArrayList<Object>();
+        return new ArrayList<>();
     }
 
     @Override public List<Object> apply(Object o) {
-        return new ArrayList<Object>();
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/util/ConnectConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/ConnectConsumer.java
@@ -23,7 +23,7 @@ public final class ConnectConsumer implements Consumer<Disposable> {
     public Disposable disposable;
 
     @Override
-    public void accept(Disposable t) throws Exception {
+    public void accept(Disposable t) {
         this.disposable = t;
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/ExceptionHelper.java
@@ -52,7 +52,7 @@ public final class ExceptionHelper {
      */
     public static final Throwable TERMINATED = new Termination();
 
-    public static <T> boolean addThrowable(AtomicReference<Throwable> field, Throwable exception) {
+    public static boolean addThrowable(AtomicReference<Throwable> field, Throwable exception) {
         for (;;) {
             Throwable current = field.get();
 
@@ -73,7 +73,7 @@ public final class ExceptionHelper {
         }
     }
 
-    public static <T> Throwable terminate(AtomicReference<Throwable> field) {
+    public static Throwable terminate(AtomicReference<Throwable> field) {
         Throwable current = field.get();
         if (current != TERMINATED) {
             current = field.getAndSet(TERMINATED);
@@ -87,8 +87,8 @@ public final class ExceptionHelper {
      * @return the list of Throwables flattened in a depth-first manner
      */
     public static List<Throwable> flatten(Throwable t) {
-        List<Throwable> list = new ArrayList<Throwable>();
-        ArrayDeque<Throwable> deque = new ArrayDeque<Throwable>();
+        List<Throwable> list = new ArrayList<>();
+        ArrayDeque<Throwable> deque = new ArrayDeque<>();
         deque.offer(t);
 
         while (!deque.isEmpty()) {

--- a/src/main/java/io/reactivex/rxjava3/internal/util/HashMapSupplier.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/HashMapSupplier.java
@@ -26,6 +26,6 @@ public enum HashMapSupplier implements Supplier<Map<Object, Object>> {
     }
 
     @Override public Map<Object, Object> get() {
-        return new HashMap<Object, Object>();
+        return new HashMap<>();
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/util/LinkedArrayList.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/LinkedArrayList.java
@@ -92,7 +92,7 @@ public class LinkedArrayList {
     public String toString() {
         final int cap = capacityHint;
         final int s = size;
-        final List<Object> list = new ArrayList<Object>(s + 1);
+        final List<Object> list = new ArrayList<>(s + 1);
 
         Object[] h = head();
         int j = 0;

--- a/src/main/java/io/reactivex/rxjava3/internal/util/ListAddBiConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/ListAddBiConsumer.java
@@ -28,7 +28,7 @@ public enum ListAddBiConsumer implements BiFunction<List, Object, List> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public List apply(List t1, Object t2) throws Exception {
+    public List apply(List t1, Object t2) {
         t1.add(t2);
         return t1;
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/util/MergerBiFunction.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/MergerBiFunction.java
@@ -30,12 +30,12 @@ public final class MergerBiFunction<T> implements BiFunction<List<T>, List<T>, L
     }
 
     @Override
-    public List<T> apply(List<T> a, List<T> b) throws Exception {
+    public List<T> apply(List<T> a, List<T> b) {
         int n = a.size() + b.size();
         if (n == 0) {
-            return new ArrayList<T>();
+            return new ArrayList<>();
         }
-        List<T> both = new ArrayList<T>(n);
+        List<T> both = new ArrayList<>(n);
 
         Iterator<T> at = a.iterator();
         Iterator<T> bt = b.iterator();

--- a/src/main/java/io/reactivex/rxjava3/internal/util/QueueDrainHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/QueueDrainHelper.java
@@ -212,9 +212,9 @@ public final class QueueDrainHelper {
      */
     public static <T> SimpleQueue<T> createQueue(int capacityHint) {
         if (capacityHint < 0) {
-            return new SpscLinkedArrayQueue<T>(-capacityHint);
+            return new SpscLinkedArrayQueue<>(-capacityHint);
         }
-        return new SpscArrayQueue<T>(capacityHint);
+        return new SpscArrayQueue<>(capacityHint);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/internal/util/SorterFunction.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/SorterFunction.java
@@ -26,7 +26,7 @@ public final class SorterFunction<T> implements Function<List<T>, List<T>> {
     }
 
     @Override
-    public List<T> apply(List<T> t) throws Exception {
+    public List<T> apply(List<T> t) {
         Collections.sort(t, comparator);
         return t;
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/util/VolatileSizeArrayList.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/VolatileSizeArrayList.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.rxjava3.internal.util;
 
+import io.reactivex.rxjava3.annotations.NonNull;
+
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -29,11 +31,11 @@ public final class VolatileSizeArrayList<T> extends AtomicInteger implements Lis
     final ArrayList<T> list;
 
     public VolatileSizeArrayList() {
-        list = new ArrayList<T>();
+        list = new ArrayList<>();
     }
 
     public VolatileSizeArrayList(int initialCapacity) {
-        list = new ArrayList<T>(initialCapacity);
+        list = new ArrayList<>(initialCapacity);
     }
 
     @Override
@@ -62,7 +64,7 @@ public final class VolatileSizeArrayList<T> extends AtomicInteger implements Lis
     }
 
     @Override
-    public <E> E[] toArray(E[] a) {
+    public <E> E[] toArray(@NonNull E[] a) {
         return list.toArray(a);
     }
 
@@ -81,33 +83,33 @@ public final class VolatileSizeArrayList<T> extends AtomicInteger implements Lis
     }
 
     @Override
-    public boolean containsAll(Collection<?> c) {
+    public boolean containsAll(@NonNull Collection<?> c) {
         return list.containsAll(c);
     }
 
     @Override
-    public boolean addAll(Collection<? extends T> c) {
+    public boolean addAll(@NonNull Collection<? extends T> c) {
         boolean b = list.addAll(c);
         lazySet(list.size());
         return b;
     }
 
     @Override
-    public boolean addAll(int index, Collection<? extends T> c) {
+    public boolean addAll(int index, @NonNull Collection<? extends T> c) {
         boolean b = list.addAll(index, c);
         lazySet(list.size());
         return b;
     }
 
     @Override
-    public boolean removeAll(Collection<?> c) {
+    public boolean removeAll(@NonNull Collection<?> c) {
         boolean b = list.removeAll(c);
         lazySet(list.size());
         return b;
     }
 
     @Override
-    public boolean retainAll(Collection<?> c) {
+    public boolean retainAll(@NonNull Collection<?> c) {
         boolean b = list.retainAll(c);
         lazySet(list.size());
         return b;

--- a/src/main/java/io/reactivex/rxjava3/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/parallel/ParallelFlowable.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.*;
 import io.reactivex.rxjava3.internal.jdk8.*;
 import io.reactivex.rxjava3.internal.operators.parallel.*;
-import io.reactivex.rxjava3.internal.operators.parallel.ParallelReduceFull;
 import io.reactivex.rxjava3.internal.subscriptions.EmptySubscription;
 import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
@@ -161,7 +160,7 @@ public abstract class ParallelFlowable<@NonNull T> {
         ObjectHelper.verifyPositive(parallelism, "parallelism");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
 
-        return RxJavaPlugins.onAssembly(new ParallelFromPublisher<T>(source, parallelism, prefetch));
+        return RxJavaPlugins.onAssembly(new ParallelFromPublisher<>(source, parallelism, prefetch));
     }
 
     /**
@@ -185,7 +184,7 @@ public abstract class ParallelFlowable<@NonNull T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     public final <R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper");
-        return RxJavaPlugins.onAssembly(new ParallelMap<T, R>(this, mapper));
+        return RxJavaPlugins.onAssembly(new ParallelMap<>(this, mapper));
     }
 
     /**
@@ -215,7 +214,7 @@ public abstract class ParallelFlowable<@NonNull T> {
     public final <R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper, @NonNull ParallelFailureHandling errorHandler) {
         Objects.requireNonNull(mapper, "mapper");
         Objects.requireNonNull(errorHandler, "errorHandler is null");
-        return RxJavaPlugins.onAssembly(new ParallelMapTry<T, R>(this, mapper, errorHandler));
+        return RxJavaPlugins.onAssembly(new ParallelMapTry<>(this, mapper, errorHandler));
     }
 
     /**
@@ -246,7 +245,7 @@ public abstract class ParallelFlowable<@NonNull T> {
     public final <R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         Objects.requireNonNull(mapper, "mapper");
         Objects.requireNonNull(errorHandler, "errorHandler is null");
-        return RxJavaPlugins.onAssembly(new ParallelMapTry<T, R>(this, mapper, errorHandler));
+        return RxJavaPlugins.onAssembly(new ParallelMapTry<>(this, mapper, errorHandler));
     }
 
     /**
@@ -620,8 +619,8 @@ public abstract class ParallelFlowable<@NonNull T> {
         Objects.requireNonNull(comparator, "comparator is null");
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
         int ch = capacityHint / parallelism() + 1;
-        ParallelFlowable<List<T>> railReduced = reduce(Functions.<T>createArrayList(ch), ListAddBiConsumer.<T>instance());
-        ParallelFlowable<List<T>> railSorted = railReduced.map(new SorterFunction<T>(comparator));
+        ParallelFlowable<List<T>> railReduced = reduce(Functions.createArrayList(ch), ListAddBiConsumer.instance());
+        ParallelFlowable<List<T>> railSorted = railReduced.map(new SorterFunction<>(comparator));
 
         return RxJavaPlugins.onAssembly(new ParallelSortedJoin<>(railSorted, comparator));
     }
@@ -673,10 +672,10 @@ public abstract class ParallelFlowable<@NonNull T> {
         ObjectHelper.verifyPositive(capacityHint, "capacityHint");
 
         int ch = capacityHint / parallelism() + 1;
-        ParallelFlowable<List<T>> railReduced = reduce(Functions.<T>createArrayList(ch), ListAddBiConsumer.<T>instance());
-        ParallelFlowable<List<T>> railSorted = railReduced.map(new SorterFunction<T>(comparator));
+        ParallelFlowable<List<T>> railReduced = reduce(Functions.createArrayList(ch), ListAddBiConsumer.instance());
+        ParallelFlowable<List<T>> railSorted = railReduced.map(new SorterFunction<>(comparator));
 
-        Flowable<List<T>> merged = railSorted.reduce(new MergerBiFunction<T>(comparator));
+        Flowable<List<T>> merged = railSorted.reduce(new MergerBiFunction<>(comparator));
 
         return RxJavaPlugins.onAssembly(merged);
     }
@@ -1008,7 +1007,7 @@ public abstract class ParallelFlowable<@NonNull T> {
     public final <C> ParallelFlowable<C> collect(@NonNull Supplier<? extends C> collectionSupplier, @NonNull BiConsumer<? super C, ? super T> collector) {
         Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
         Objects.requireNonNull(collector, "collector is null");
-        return RxJavaPlugins.onAssembly(new ParallelCollect<T, C>(this, collectionSupplier, collector));
+        return RxJavaPlugins.onAssembly(new ParallelCollect<>(this, collectionSupplier, collector));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
@@ -558,7 +558,7 @@ public final class MulticastProcessor<T> extends FlowableProcessor<T> {
                         }
 
                         if (as != bs) {
-                            continue outer;
+                            continue;
                         }
 
                         if (done && q.isEmpty()) {

--- a/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 /**
  * Replays events to Subscribers.
  * <p>
- * The {@code ReplayProcessor} supports the following item retainment strategies:
+ * The {@code ReplayProcessor} supports the following item retention strategies:
  * <ul>
  * <li>{@link #create()} and {@link #create(int)}: retains and replays all events to current and
  * future {@code Subscriber}s.
@@ -173,7 +173,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplayProcessor<T> create() {
-        return new ReplayProcessor<>(new UnboundedReplayBuffer<T>(16));
+        return new ReplayProcessor<>(new UnboundedReplayBuffer<>(16));
     }
 
     /**
@@ -194,7 +194,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplayProcessor<T> create(int capacityHint) {
-        return new ReplayProcessor<>(new UnboundedReplayBuffer<T>(capacityHint));
+        return new ReplayProcessor<>(new UnboundedReplayBuffer<>(capacityHint));
     }
 
     /**
@@ -220,7 +220,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplayProcessor<T> createWithSize(int maxSize) {
-        return new ReplayProcessor<>(new SizeBoundReplayBuffer<T>(maxSize));
+        return new ReplayProcessor<>(new SizeBoundReplayBuffer<>(maxSize));
     }
 
     /**
@@ -238,7 +238,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
      */
     @CheckReturnValue
     /* test */ static <T> ReplayProcessor<T> createUnbounded() {
-        return new ReplayProcessor<>(new SizeBoundReplayBuffer<T>(Integer.MAX_VALUE));
+        return new ReplayProcessor<>(new SizeBoundReplayBuffer<>(Integer.MAX_VALUE));
     }
 
     /**
@@ -276,7 +276,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplayProcessor<T> createWithTime(long maxAge, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return new ReplayProcessor<>(new SizeAndTimeBoundReplayBuffer<T>(Integer.MAX_VALUE, maxAge, unit, scheduler));
+        return new ReplayProcessor<>(new SizeAndTimeBoundReplayBuffer<>(Integer.MAX_VALUE, maxAge, unit, scheduler));
     }
 
     /**
@@ -316,7 +316,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplayProcessor<T> createWithTimeAndSize(long maxAge, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int maxSize) {
-        return new ReplayProcessor<>(new SizeAndTimeBoundReplayBuffer<T>(maxSize, maxAge, unit, scheduler));
+        return new ReplayProcessor<>(new SizeAndTimeBoundReplayBuffer<>(maxSize, maxAge, unit, scheduler));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/rxjava3/schedulers/Schedulers.java
@@ -112,8 +112,8 @@ public final class Schedulers {
      * before the {@link Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.computation-threads} (int): sets the number of threads in the {@link #computation()} Scheduler, default is the number of available CPUs</li>
-     * <li>{@code rx3.computation-priority} (int): sets the thread priority of the {@link #computation()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
+     * <li>{@code rx3.computation-threads} (int): sets the number of threads in the {@code computation()} Scheduler, default is the number of available CPUs</li>
+     * <li>{@code rx3.computation-priority} (int): sets the thread priority of the {@code computation()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
      * <p>
      * The default value of this scheduler can be overridden at initialization time via the
@@ -157,8 +157,8 @@ public final class Schedulers {
      * before the {@link Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.io-keep-alive-time} (long): sets the keep-alive time of the {@link #io()} Scheduler workers, default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
-     * <li>{@code rx3.io-priority} (int): sets the thread priority of the {@link #io()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
+     * <li>{@code rx3.io-keep-alive-time} (long): sets the keep-alive time of the {@code io()} Scheduler workers, default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
+     * <li>{@code rx3.io-priority} (int): sets the thread priority of the {@code io()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
      * <p>
      * The default value of this scheduler can be overridden at initialization time via the
@@ -216,7 +216,7 @@ public final class Schedulers {
      * before the {@link Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.newthread-priority} (int): sets the thread priority of the {@link #newThread()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
+     * <li>{@code rx3.newthread-priority} (int): sets the thread priority of the {@code newThread()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
      * <p>
      * The default value of this scheduler can be overridden at initialization time via the
@@ -265,7 +265,7 @@ public final class Schedulers {
      * before the {@link Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.single-priority} (int): sets the thread priority of the {@link #single()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
+     * <li>{@code rx3.single-priority} (int): sets the thread priority of the {@code single()} Scheduler, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
      * <p>
      * The default value of this scheduler can be overridden at initialization time via the
@@ -522,28 +522,28 @@ public final class Schedulers {
 
     static final class IOTask implements Supplier<Scheduler> {
         @Override
-        public Scheduler get() throws Exception {
+        public Scheduler get() {
             return IoHolder.DEFAULT;
         }
     }
 
     static final class NewThreadTask implements Supplier<Scheduler> {
         @Override
-        public Scheduler get() throws Exception {
+        public Scheduler get() {
             return NewThreadHolder.DEFAULT;
         }
     }
 
     static final class SingleTask implements Supplier<Scheduler> {
         @Override
-        public Scheduler get() throws Exception {
+        public Scheduler get() {
             return SingleHolder.DEFAULT;
         }
     }
 
     static final class ComputationTask implements Supplier<Scheduler> {
         @Override
-        public Scheduler get() throws Exception {
+        public Scheduler get() {
             return ComputationHolder.DEFAULT;
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
@@ -160,7 +160,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplaySubject<T> create() {
-        return new ReplaySubject<>(new UnboundedReplayBuffer<T>(16));
+        return new ReplaySubject<>(new UnboundedReplayBuffer<>(16));
     }
 
     /**
@@ -181,7 +181,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplaySubject<T> create(int capacityHint) {
-        return new ReplaySubject<>(new UnboundedReplayBuffer<T>(capacityHint));
+        return new ReplaySubject<>(new UnboundedReplayBuffer<>(capacityHint));
     }
 
     /**
@@ -207,7 +207,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplaySubject<T> createWithSize(int maxSize) {
-        return new ReplaySubject<>(new SizeBoundReplayBuffer<T>(maxSize));
+        return new ReplaySubject<>(new SizeBoundReplayBuffer<>(maxSize));
     }
 
     /**
@@ -224,7 +224,7 @@ public final class ReplaySubject<T> extends Subject<T> {
      * @return the created subject
      */
     /* test */ static <T> ReplaySubject<T> createUnbounded() {
-        return new ReplaySubject<>(new SizeBoundReplayBuffer<T>(Integer.MAX_VALUE));
+        return new ReplaySubject<>(new SizeBoundReplayBuffer<>(Integer.MAX_VALUE));
     }
 
     /**
@@ -262,7 +262,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplaySubject<T> createWithTime(long maxAge, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return new ReplaySubject<>(new SizeAndTimeBoundReplayBuffer<T>(Integer.MAX_VALUE, maxAge, unit, scheduler));
+        return new ReplaySubject<>(new SizeAndTimeBoundReplayBuffer<>(Integer.MAX_VALUE, maxAge, unit, scheduler));
     }
 
     /**
@@ -302,7 +302,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @CheckReturnValue
     @NonNull
     public static <T> ReplaySubject<T> createWithTimeAndSize(long maxAge, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, int maxSize) {
-        return new ReplaySubject<>(new SizeAndTimeBoundReplayBuffer<T>(maxSize, maxAge, unit, scheduler));
+        return new ReplaySubject<>(new SizeAndTimeBoundReplayBuffer<>(maxSize, maxAge, unit, scheduler));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 /**
  * A Subject that queues up events until a single {@link Observer} subscribes to it, replays
  * those events to it until the {@code Observer} catches up and then switches to relaying events live to
- * this single {@code Observer} until this {@code UnicastSubject} terminates or the {@code Observer} unsubscribes.
+ * this single {@code Observer} until this {@code UnicastSubject} terminates or the {@code Observer} disposes.
  * <p>
  * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/UnicastSubject.png" alt="">
  * <p>
@@ -48,10 +48,10 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  *     optionally delays an error it receives and replays it after the regular items have been emitted.</li>
  * <li>{@link #create(int, Runnable)} - creates an empty, unbounded {@code UnicastSubject}
  *     with a hint about how many <b>total</b> items one expects to retain and a callback that will be
- *     called exactly once when the {@code UnicastSubject} gets terminated or the single {@code Observer} unsubscribes.</li>
+ *     called exactly once when the {@code UnicastSubject} gets terminated or the single {@code Observer} disposes.</li>
  * <li>{@link #create(int, Runnable, boolean)} - creates an empty, unbounded {@code UnicastSubject}
  *     with a hint about how many <b>total</b> items one expects to retain and a callback that will be
- *     called exactly once when the {@code UnicastSubject} gets terminated or the single {@code Observer} unsubscribes
+ *     called exactly once when the {@code UnicastSubject} gets terminated or the single {@code Observer} disposes
  *     and optionally delays an error it receives and replays it after the regular items have been emitted.</li>
  * </ul>
  * <p>
@@ -510,7 +510,7 @@ public final class UnicastSubject<T> extends Subject<T> {
 
         @Nullable
         @Override
-        public T poll() throws Exception {
+        public T poll() {
             return queue.poll();
         }
 


### PR DESCRIPTION
- Use diamond where possible
- Remove type arguments where they can be now inferred under Java 8
- Fix spelling errors
- Remove unnecessary `throws` declarations