### PR TITLE
3.x: [Java 8] Add flattenStreamAsX to Maybe/Single

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -6517,6 +6517,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *            the scheduler where the {@code mapper} function will be executed
      * @return an Observable that emits the result of applying the transformation function to each item emitted
      *         by the source ObservableSource and concatenating the ObservableSources obtained from this transformation
+     * @since 3.0.0
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -15,10 +15,12 @@ package io.reactivex.rxjava3.core;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 import org.reactivestreams.Publisher;
 
 import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.*;
@@ -2799,6 +2801,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *            source Single
      * @return the new Flowable instance
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #flattenStreamAsFlowable(Function)
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
@@ -2826,6 +2829,7 @@ public abstract class Single<T> implements SingleSource<T> {
      *            source Single
      * @return the new Observable instance
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @see #flattenStreamAsObservable(Function)
      */
     @CheckReturnValue
     @NonNull
@@ -4307,5 +4311,88 @@ public abstract class Single<T> implements SingleSource<T> {
     @NonNull
     public final CompletionStage<T> toCompletionStage() {
         return subscribeWith(new CompletionStageConsumer<>(false, null));
+    }
+
+    /**
+     * Maps the upstream succecss value into a Java {@link Stream} and emits its
+     * items to the downstream consumer as a {@link Flowable}.
+     * <img width="640" height="247" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenStreamAsFlowable.s.png" alt="">
+     * <p>
+     * The operator closes the {@code Stream} upon cancellation and when it terminates. Exceptions raised when
+     * closing a {@code Stream} are routed to the global error handler ({@link RxJavaPlugins#onError(Throwable)}.
+     * If a {@code Stream} should not be closed, turn it into an {@link Iterable} and use {@link #flattenAsFlowable(Function)}:
+     * <pre><code>
+     * source.flattenAsFlowable(item -&gt; createStream(item)::iterator);
+     * </code></pre>
+     * <p>
+     * Primitive streams are not supported and items have to be boxed manually (e.g., via {@link IntStream#boxed()}):
+     * <pre><code>
+     * source.flattenStreamAsFlowable(item -&gt; IntStream.rangeClosed(1, 10).boxed());
+     * </code></pre>
+     * <p>
+     * {@code Stream} does not support concurrent usage so creating and/or consuming the same instance multiple times
+     * from multiple threads can lead to undefined behavior.
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream and iterates the given {@code Stream}
+     *  on demand (i.e., when requested).</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code flattenStreamAsFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <R> the element type of the {@code Stream} and the output {@code Flowable}
+     * @param mapper the function that receives the upstream success item and should
+     * return a {@code Stream} of values to emit.
+     * @return the new Flowable instance
+     * @since 3.0.0
+     * @see #flattenAsFlowable(Function)
+     * @see #flattenStreamAsObservable(Function)
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    @NonNull
+    public final <R> Flowable<R> flattenStreamAsFlowable(@NonNull Function<? super T, ? extends Stream<? extends R>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return RxJavaPlugins.onAssembly(new SingleFlattenStreamAsFlowable<>(this, mapper));
+    }
+
+    /**
+     * Maps the upstream succecss value into a Java {@link Stream} and emits its
+     * items to the downstream consumer as an {@link Observable}.
+     * <p>
+     * <img width="640" height="247" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenStreamAsObservable.s.png" alt="">
+     * <p>
+     * The operator closes the {@code Stream} upon cancellation and when it terminates. Exceptions raised when
+     * closing a {@code Stream} are routed to the global error handler ({@link RxJavaPlugins#onError(Throwable)}.
+     * If a {@code Stream} should not be closed, turn it into an {@link Iterable} and use {@link #flattenAsFlowable(Function)}:
+     * <pre><code>
+     * source.flattenAsObservable(item -&gt; createStream(item)::iterator);
+     * </code></pre>
+     * <p>
+     * Primitive streams are not supported and items have to be boxed manually (e.g., via {@link IntStream#boxed()}):
+     * <pre><code>
+     * source.flattenStreamAsObservable(item -&gt; IntStream.rangeClosed(1, 10).boxed());
+     * </code></pre>
+     * <p>
+     * {@code Stream} does not support concurrent usage so creating and/or consuming the same instance multiple times
+     * from multiple threads can lead to undefined behavior.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code flattenStreamAsObservable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <R> the element type of the {@code Stream} and the output {@code Observable}
+     * @param mapper the function that receives the upstream success item and should
+     * return a {@code Stream} of values to emit.
+     * @return the new Observable instance
+     * @since 3.0.0
+     * @see #flattenAsObservable(Function)
+     * @see #flattenStreamAsFlowable(Function)
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
+    public final <R> Observable<R> flattenStreamAsObservable(@NonNull Function<? super T, ? extends Stream<? extends R>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return RxJavaPlugins.onAssembly(new SingleFlattenStreamAsObservable<>(this, mapper));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsFlowable.java
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.internal.subscriptions.*;
+import io.reactivex.rxjava3.internal.util.BackpressureHelper;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Map the success value into a Java {@link Stream} and emits its values.
+ *
+ * @param <T> the source value type
+ * @param <R> the output value type
+ * @since 3.0.0
+ */
+public final class MaybeFlattenStreamAsFlowable<T, R> extends Flowable<R> {
+
+    final Maybe<T> source;
+
+    final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+    public MaybeFlattenStreamAsFlowable(Maybe<T> source, Function<? super T, ? extends Stream<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull Subscriber<? super R> s) {
+        source.subscribe(new FlattenStreamMultiObserver<>(s, mapper));
+    }
+
+    static final class FlattenStreamMultiObserver<T, R>
+    extends BasicIntQueueSubscription<R>
+    implements MaybeObserver<T>, SingleObserver<T> {
+
+        private static final long serialVersionUID = 7363336003027148283L;
+
+        final Subscriber<? super R> downstream;
+
+        final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+        final AtomicLong requested;
+
+        Disposable upstream;
+
+        volatile Iterator<? extends R> iterator;
+
+        AutoCloseable close;
+
+        boolean once;
+
+        volatile boolean cancelled;
+
+        boolean outputFused;
+
+        long emitted;
+
+        FlattenStreamMultiObserver(Subscriber<? super R> downstream, Function<? super T, ? extends Stream<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+            this.requested = new AtomicLong();
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(@NonNull T t) {
+            try {
+                Stream<? extends R> stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
+                Iterator<? extends R> iterator = stream.iterator();
+                AutoCloseable c = stream;
+
+                if (!iterator.hasNext()) {
+                    downstream.onComplete();
+                    close(c);
+                    return;
+                }
+                this.iterator = iterator;
+                this.close = stream;
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+            drain();
+        }
+
+        @Override
+        public void onError(@NonNull Throwable e) {
+            downstream.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            upstream.dispose();
+            if (!outputFused) {
+                drain();
+            }
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            if ((mode & ASYNC) != 0) {
+                outputFused = true;
+                return ASYNC;
+            }
+            return NONE;
+        }
+
+        @Override
+        public @Nullable R poll() throws Throwable {
+            Iterator<? extends R> it = iterator;
+            if (it != null) {
+                if (once) {
+                    if (!it.hasNext()) {
+                        clear();
+                        return null;
+                    }
+                } else {
+                    once = true;
+                }
+                return it.next();
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            Iterator<? extends R> it = iterator;
+            if (it != null) {
+                if (!once) {
+                    return false;
+                }
+                if (it.hasNext()) {
+                    return false;
+                }
+                clear();
+            }
+            return true;
+        }
+
+        @Override
+        public void clear() {
+            iterator = null;
+            AutoCloseable close = this.close;
+            this.close = null;
+            close(close);
+        }
+
+        void close(AutoCloseable c) {
+            try {
+                if (c != null) {
+                    c.close();
+                }
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            Subscriber<? super R> downstream = this.downstream;
+            long emitted = this.emitted;
+            long requested = this.requested.get();
+            Iterator<? extends R> it = iterator;
+
+            for (;;) {
+
+                if (cancelled) {
+                    clear();
+                } else {
+                    if (outputFused) {
+                        if (it != null) {
+                            downstream.onNext(null);
+                            downstream.onComplete();
+                        }
+                    } else {
+                        if (it != null && emitted != requested) {
+                            R item;
+                            try {
+                                item = it.next();
+                            } catch (Throwable ex) {
+                                Exceptions.throwIfFatal(ex);
+                                downstream.onError(ex);
+                                cancelled = true;
+                                continue;
+                            }
+
+                            if (cancelled) {
+                                continue;
+                            }
+
+                            downstream.onNext(item);
+                            emitted++;
+
+                            if (cancelled) {
+                                continue;
+                            }
+
+                            boolean has;
+                            try {
+                                has = it.hasNext();
+                            } catch (Throwable ex) {
+                                Exceptions.throwIfFatal(ex);
+                                downstream.onError(ex);
+                                cancelled = true;
+                                continue;
+                            }
+
+                            if (cancelled) {
+                                continue;
+                            }
+
+                            if (!has) {
+                                downstream.onComplete();
+                                cancelled = true;
+                            }
+                            continue;
+                        }
+                    }
+                }
+
+                this.emitted = emitted;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    return;
+                }
+
+                requested = this.requested.get();
+                if (it == null) {
+                    it = iterator;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsObservable.java
@@ -1,0 +1,262 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.internal.observers.BasicIntQueueDisposable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Map the success value into a Java {@link Stream} and emits its values.
+ *
+ * @param <T> the source value type
+ * @param <R> the output value type
+ * @since 3.0.0
+ */
+public final class MaybeFlattenStreamAsObservable<T, R> extends Observable<R> {
+
+    final Maybe<T> source;
+
+    final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+    public MaybeFlattenStreamAsObservable(Maybe<T> source, Function<? super T, ? extends Stream<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull Observer<? super R> s) {
+        source.subscribe(new FlattenStreamMultiObserver<>(s, mapper));
+    }
+
+    static final class FlattenStreamMultiObserver<T, R>
+    extends BasicIntQueueDisposable<R>
+    implements MaybeObserver<T>, SingleObserver<T> {
+
+        private static final long serialVersionUID = 7363336003027148283L;
+
+        final Observer<? super R> downstream;
+
+        final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+        Disposable upstream;
+
+        volatile Iterator<? extends R> iterator;
+
+        AutoCloseable close;
+
+        boolean once;
+
+        volatile boolean disposed;
+
+        boolean outputFused;
+
+        FlattenStreamMultiObserver(Observer<? super R> downstream, Function<? super T, ? extends Stream<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Disposable d) {
+            if (DisposableHelper.validate(this.upstream, d)) {
+                this.upstream = d;
+
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onSuccess(@NonNull T t) {
+            try {
+                Stream<? extends R> stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
+                Iterator<? extends R> iterator = stream.iterator();
+                AutoCloseable c = stream;
+
+                if (!iterator.hasNext()) {
+                    downstream.onComplete();
+                    close(c);
+                    return;
+                }
+                this.iterator = iterator;
+                this.close = stream;
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                downstream.onError(ex);
+                return;
+            }
+            drain();
+        }
+
+        @Override
+        public void onError(@NonNull Throwable e) {
+            downstream.onError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            downstream.onComplete();
+        }
+
+        @Override
+        public void dispose() {
+            disposed = true;
+            upstream.dispose();
+            if (!outputFused) {
+                drain();
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+
+        @Override
+        public int requestFusion(int mode) {
+            if ((mode & ASYNC) != 0) {
+                outputFused = true;
+                return ASYNC;
+            }
+            return NONE;
+        }
+
+        @Override
+        public @Nullable R poll() throws Throwable {
+            Iterator<? extends R> it = iterator;
+            if (it != null) {
+                if (once) {
+                    if (!it.hasNext()) {
+                        clear();
+                        return null;
+                    }
+                } else {
+                    once = true;
+                }
+                return it.next();
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            Iterator<? extends R> it = iterator;
+            if (it != null) {
+                if (!once) {
+                    return false;
+                }
+                if (it.hasNext()) {
+                    return false;
+                }
+                clear();
+            }
+            return true;
+        }
+
+        @Override
+        public void clear() {
+            iterator = null;
+            AutoCloseable close = this.close;
+            this.close = null;
+            close(close);
+        }
+
+        void close(AutoCloseable c) {
+            try {
+                if (c != null) {
+                    c.close();
+                }
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                RxJavaPlugins.onError(ex);
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            Observer<? super R> downstream = this.downstream;
+            Iterator<? extends R> it = iterator;
+
+            for (;;) {
+
+                if (disposed) {
+                    clear();
+                } else {
+                    if (outputFused) {
+                        downstream.onNext(null);
+                        downstream.onComplete();
+                    } else {
+                        R item;
+                        try {
+                            item = it.next();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            downstream.onError(ex);
+                            disposed = true;
+                            continue;
+                        }
+
+                        if (disposed) {
+                            continue;
+                        }
+
+                        downstream.onNext(item);
+
+                        if (disposed) {
+                            continue;
+                        }
+
+                        boolean has;
+                        try {
+                            has = it.hasNext();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            downstream.onError(ex);
+                            disposed = true;
+                            continue;
+                        }
+
+                        if (disposed) {
+                            continue;
+                        }
+
+                        if (!has) {
+                            downstream.onComplete();
+                            disposed = true;
+                        }
+                        continue;
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsFlowable.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.jdk8.MaybeFlattenStreamAsFlowable.FlattenStreamMultiObserver;
+
+/**
+ * Map the success value into a Java {@link Stream} and emits its values.
+ *
+ * @param <T> the source value type
+ * @param <R> the output value type
+ * @since 3.0.0
+ */
+public final class SingleFlattenStreamAsFlowable<T, R> extends Flowable<R> {
+
+    final Single<T> source;
+
+    final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+    public SingleFlattenStreamAsFlowable(Single<T> source, Function<? super T, ? extends Stream<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull Subscriber<? super R> s) {
+        source.subscribe(new FlattenStreamMultiObserver<>(s, mapper));
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsObservable.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.Stream;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.jdk8.MaybeFlattenStreamAsObservable.FlattenStreamMultiObserver;
+
+/**
+ * Map the success value into a Java {@link Stream} and emits its values.
+ *
+ * @param <T> the source value type
+ * @param <R> the output value type
+ * @since 3.0.0
+ */
+public final class SingleFlattenStreamAsObservable<T, R> extends Observable<R> {
+
+    final Single<T> source;
+
+    final Function<? super T, ? extends Stream<? extends R>> mapper;
+
+    public SingleFlattenStreamAsObservable(Single<T> source, Function<? super T, ? extends Stream<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull Observer<? super R> s) {
+        source.subscribe(new FlattenStreamMultiObserver<>(s, mapper));
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsFlowableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsFlowableTckTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class MaybeFlattenStreamAsFlowableTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        return
+                Maybe.just(1).flattenStreamAsFlowable(v -> IntStream.range(0, (int)elements).boxed())
+            ;
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Maybe.just(1).flattenStreamAsFlowable(v -> stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsFlowableTest.java
@@ -1,0 +1,453 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.subjects.MaybeSubject;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import io.reactivex.rxjava3.testsupport.*;
+
+public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
+
+    @Test
+    public void successJust() {
+        Maybe.just(1)
+        .flattenStreamAsFlowable(Stream::of)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void successEmpty() {
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> Stream.of())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void successMany() {
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> Stream.of(2, 3, 4, 5, 6))
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void successManyTake() {
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> Stream.of(2, 3, 4, 5, 6))
+        .take(3)
+        .test()
+        .assertResult(2, 3, 4);
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Stream<? extends Integer>> f = mock(Function.class);
+
+        Maybe.<Integer>empty()
+        .flattenStreamAsFlowable(f)
+        .test()
+        .assertResult();
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void error() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Stream<? extends Integer>> f = mock(Function.class);
+
+        Maybe.<Integer>error(new TestException())
+        .flattenStreamAsFlowable(f)
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void mapperCrash() {
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Maybe.never().flattenStreamAsFlowable(Stream::of));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(m -> m.flattenStreamAsFlowable(Stream::of));
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(MaybeSubject.create().flattenStreamAsFlowable(Stream::of));
+    }
+
+    @Test
+    public void fusedEmpty() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of())
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void fusedJust() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of(v))
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1);
+    }
+
+    @Test
+    public void fusedMany() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fusedManyRejected() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.SYNC);
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void manyBackpressured() {
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> IntStream.rangeClosed(1, 5).boxed())
+        .test(0L)
+        .assertEmpty()
+        .requestMore(2)
+        .assertValuesOnly(1, 2)
+        .requestMore(2)
+        .assertValuesOnly(1, 2, 3, 4)
+        .requestMore(1)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void manyBackpressured2() {
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> IntStream.rangeClosed(1, 5).boxed())
+        .rebatchRequests(1)
+        .test(0L)
+        .assertEmpty()
+        .requestMore(2)
+        .assertValuesOnly(1, 2)
+        .requestMore(2)
+        .assertValuesOnly(1, 2, 3, 4)
+        .requestMore(1)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void fusedStreamAvailableLater() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        ms
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertEmpty();
+
+        ms.onSuccess(1);
+
+        ts
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fused() throws Throwable {
+        AtomicReference<QueueSubscription<Integer>> qsr = new AtomicReference<>();
+
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        ms
+        .flattenStreamAsFlowable(Stream::of)
+        .subscribe(new FlowableSubscriber<Integer>() {
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void onSubscribe(@NonNull Subscription s) {
+                qsr.set((QueueSubscription<Integer>)s);
+            }
+        });
+
+        QueueSubscription<Integer> qs = qsr.get();
+
+        assertEquals(QueueFuseable.ASYNC, qs.requestFusion(QueueFuseable.ASYNC));
+
+        assertTrue(qs.isEmpty());
+        assertNull(qs.poll());
+
+        ms.onSuccess(1);
+
+        assertFalse(qs.isEmpty());
+        assertEquals(1, qs.poll().intValue());
+
+        assertTrue(qs.isEmpty());
+        assertNull(qs.poll());
+
+        qs.cancel();
+
+        assertTrue(qs.isEmpty());
+        assertNull(qs.poll());
+    }
+
+    @Test
+    public void requestOneByOne() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> Stream.of(1, 2, 3, 4, 5))
+        .subscribe(new FlowableSubscriber<Integer>() {
+
+            Subscription upstream;
+
+            @Override
+            public void onSubscribe(@NonNull Subscription s) {
+                ts.onSubscribe(new BooleanSubscription());
+                upstream = s;
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                ts.onNext(t);
+                upstream.request(1);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                ts.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                ts.onComplete();
+            }
+        });
+
+        ts.assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void streamCloseCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Maybe.just(1)
+            .flattenStreamAsFlowable(v -> Stream.of(v).onClose(() -> { throw new TestException(); }))
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void hasNextThrowsInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int count;
+
+            @Override
+            public boolean hasNext() {
+                if (count++ > 0) {
+                    throw new TestException();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> stream)
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void nextThrowsInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                throw new TestException();
+            }
+        });
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> stream)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void cancelAfterHasNextInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int count;
+
+            @Override
+            public boolean hasNext() {
+                if (count++ > 0) {
+                    ts.cancel();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> stream)
+        .subscribeWith(ts)
+        .assertValuesOnly(1);
+    }
+
+    @Test
+    public void cancelAfterNextInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                ts.cancel();
+                return 1;
+            }
+        });
+
+        Maybe.just(1)
+        .flattenStreamAsFlowable(v -> stream)
+        .subscribeWith(ts)
+        .assertEmpty();
+    }
+
+    @Test
+    public void requestSuccessRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            MaybeSubject<Integer> ms = MaybeSubject.create();
+
+            TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+
+            ms.flattenStreamAsFlowable(Stream::of)
+            .subscribe(ts);
+
+            Runnable r1 = () -> ms.onSuccess(1);
+            Runnable r2 = () -> ts.request(1);
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsObservableTest.java
@@ -1,0 +1,431 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subjects.MaybeSubject;
+import io.reactivex.rxjava3.testsupport.*;
+
+public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
+
+    @Test
+    public void successJust() {
+        Maybe.just(1)
+        .flattenStreamAsObservable(Stream::of)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void successEmpty() {
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> Stream.of())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void successMany() {
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> Stream.of(2, 3, 4, 5, 6))
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void successManyTake() {
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> Stream.of(2, 3, 4, 5, 6))
+        .take(3)
+        .test()
+        .assertResult(2, 3, 4);
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Stream<? extends Integer>> f = mock(Function.class);
+
+        Maybe.<Integer>empty()
+        .flattenStreamAsObservable(f)
+        .test()
+        .assertResult();
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void error() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Stream<? extends Integer>> f = mock(Function.class);
+
+        Maybe.<Integer>error(new TestException())
+        .flattenStreamAsObservable(f)
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void mapperCrash() {
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Maybe.never().flattenStreamAsObservable(Stream::of));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeMaybeToObservable(m -> m.flattenStreamAsObservable(Stream::of));
+    }
+
+    @Test
+    public void fusedEmpty() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
+
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> Stream.<Integer>of())
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void fusedJust() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
+
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> Stream.<Integer>of(v))
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1);
+    }
+
+    @Test
+    public void fusedMany() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
+
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fusedManyRejected() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.SYNC);
+
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fusedStreamAvailableLater() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
+
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        ms
+        .flattenStreamAsObservable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertEmpty();
+
+        ms.onSuccess(1);
+
+        to
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fused() throws Throwable {
+        AtomicReference<QueueDisposable<Integer>> qdr = new AtomicReference<>();
+
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        ms
+        .flattenStreamAsObservable(Stream::of)
+        .subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void onSubscribe(Disposable d) {
+                qdr.set((QueueDisposable<Integer>)d);
+            }
+        });
+
+        QueueDisposable<Integer> qd = qdr.get();
+
+        assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ASYNC));
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+
+        ms.onSuccess(1);
+
+        assertFalse(qd.isEmpty());
+        assertEquals(1, qd.poll().intValue());
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+
+        qd.dispose();
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+    }
+
+    @Test
+    public void fused2() throws Throwable {
+        AtomicReference<QueueDisposable<Integer>> qdr = new AtomicReference<>();
+
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        ms
+        .flattenStreamAsObservable(v -> Stream.of(v, v + 1))
+        .subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void onSubscribe(Disposable d) {
+                qdr.set((QueueDisposable<Integer>)d);
+            }
+        });
+
+        QueueDisposable<Integer> qd = qdr.get();
+
+        assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ASYNC));
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+
+        ms.onSuccess(1);
+
+        assertFalse(qd.isEmpty());
+        assertEquals(1, qd.poll().intValue());
+
+        assertFalse(qd.isEmpty());
+        assertEquals(2, qd.poll().intValue());
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+
+        qd.dispose();
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+    }
+
+    @Test
+    public void streamCloseCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Maybe.just(1)
+            .flattenStreamAsObservable(v -> Stream.of(v).onClose(() -> { throw new TestException(); }))
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void hasNextThrowsInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int count;
+
+            @Override
+            public boolean hasNext() {
+                if (count++ > 0) {
+                    throw new TestException();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> stream)
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void nextThrowsInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                throw new TestException();
+            }
+        });
+
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> stream)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void cancelAfterHasNextInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+
+        TestObserver<Integer> to = new TestObserver<>();
+
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int count;
+
+            @Override
+            public boolean hasNext() {
+                if (count++ > 0) {
+                    to.dispose();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> stream)
+        .subscribeWith(to)
+        .assertValuesOnly(1);
+    }
+
+    @Test
+    public void cancelAfterNextInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+
+        TestObserver<Integer> to = new TestObserver<>();
+
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                to.dispose();
+                return 1;
+            }
+        });
+
+        Maybe.just(1)
+        .flattenStreamAsObservable(v -> stream)
+        .subscribeWith(to)
+        .assertEmpty();
+    }
+
+    @Test
+    public void cancelSuccessRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            MaybeSubject<Integer> ms = MaybeSubject.create();
+
+            TestObserver<Integer> to = new TestObserver<>();
+
+            ms.flattenStreamAsObservable(Stream::of)
+            .subscribe(to);
+
+            Runnable r1 = () -> ms.onSuccess(1);
+            Runnable r2 = () -> to.dispose();
+
+            TestHelper.race(r1, r2);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsFlowableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsFlowableTckTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import java.util.stream.*;
+
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.tck.BaseTck;
+
+@Test
+public class SingleFlattenStreamAsFlowableTckTest extends BaseTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(final long elements) {
+        return
+                Single.just(1).flattenStreamAsFlowable(v -> IntStream.range(0, (int)elements).boxed())
+            ;
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        Stream<Integer> stream = Stream.of(1);
+        stream.forEach(v -> { });
+        return Single.just(1).flattenStreamAsFlowable(v -> stream);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsFlowableTest.java
@@ -1,0 +1,440 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.subjects.SingleSubject;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import io.reactivex.rxjava3.testsupport.*;
+
+public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
+
+    @Test
+    public void successJust() {
+        Single.just(1)
+        .flattenStreamAsFlowable(Stream::of)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void successEmpty() {
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> Stream.of())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void successMany() {
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> Stream.of(2, 3, 4, 5, 6))
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void successManyTake() {
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> Stream.of(2, 3, 4, 5, 6))
+        .take(3)
+        .test()
+        .assertResult(2, 3, 4);
+    }
+
+    @Test
+    public void error() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Stream<? extends Integer>> f = mock(Function.class);
+
+        Single.<Integer>error(new TestException())
+        .flattenStreamAsFlowable(f)
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void mapperCrash() {
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Single.never().flattenStreamAsFlowable(Stream::of));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingleToFlowable(m -> m.flattenStreamAsFlowable(Stream::of));
+    }
+
+    @Test
+    public void badRequest() {
+        TestHelper.assertBadRequestReported(SingleSubject.create().flattenStreamAsFlowable(Stream::of));
+    }
+
+    @Test
+    public void fusedEmpty() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of())
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void fusedJust() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of(v))
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1);
+    }
+
+    @Test
+    public void fusedMany() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fusedManyRejected() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.SYNC);
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void manyBackpressured() {
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> IntStream.rangeClosed(1, 5).boxed())
+        .test(0L)
+        .assertEmpty()
+        .requestMore(2)
+        .assertValuesOnly(1, 2)
+        .requestMore(2)
+        .assertValuesOnly(1, 2, 3, 4)
+        .requestMore(1)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void manyBackpressured2() {
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> IntStream.rangeClosed(1, 5).boxed())
+        .rebatchRequests(1)
+        .test(0L)
+        .assertEmpty()
+        .requestMore(2)
+        .assertValuesOnly(1, 2)
+        .requestMore(2)
+        .assertValuesOnly(1, 2, 3, 4)
+        .requestMore(1)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void fusedStreamAvailableLater() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        ts.setInitialFusionMode(QueueFuseable.ANY);
+
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        ss
+        .flattenStreamAsFlowable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(ts);
+
+        ts.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertEmpty();
+
+        ss.onSuccess(1);
+
+        ts
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fused() throws Throwable {
+        AtomicReference<QueueSubscription<Integer>> qsr = new AtomicReference<>();
+
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        ss
+        .flattenStreamAsFlowable(Stream::of)
+        .subscribe(new FlowableSubscriber<Integer>() {
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void onSubscribe(@NonNull Subscription s) {
+                qsr.set((QueueSubscription<Integer>)s);
+            }
+        });
+
+        QueueSubscription<Integer> qs = qsr.get();
+
+        assertEquals(QueueFuseable.ASYNC, qs.requestFusion(QueueFuseable.ASYNC));
+
+        assertTrue(qs.isEmpty());
+        assertNull(qs.poll());
+
+        ss.onSuccess(1);
+
+        assertFalse(qs.isEmpty());
+        assertEquals(1, qs.poll().intValue());
+
+        assertTrue(qs.isEmpty());
+        assertNull(qs.poll());
+
+        qs.cancel();
+
+        assertTrue(qs.isEmpty());
+        assertNull(qs.poll());
+    }
+
+    @Test
+    public void requestOneByOne() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> Stream.of(1, 2, 3, 4, 5))
+        .subscribe(new FlowableSubscriber<Integer>() {
+
+            Subscription upstream;
+
+            @Override
+            public void onSubscribe(@NonNull Subscription s) {
+                ts.onSubscribe(new BooleanSubscription());
+                upstream = s;
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                ts.onNext(t);
+                upstream.request(1);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                ts.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                ts.onComplete();
+            }
+        });
+
+        ts.assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void streamCloseCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Single.just(1)
+            .flattenStreamAsFlowable(v -> Stream.of(v).onClose(() -> { throw new TestException(); }))
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void hasNextThrowsInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int count;
+
+            @Override
+            public boolean hasNext() {
+                if (count++ > 0) {
+                    throw new TestException();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> stream)
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void nextThrowsInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                throw new TestException();
+            }
+        });
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> stream)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void cancelAfterHasNextInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int count;
+
+            @Override
+            public boolean hasNext() {
+                if (count++ > 0) {
+                    ts.cancel();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> stream)
+        .subscribeWith(ts)
+        .assertValuesOnly(1);
+    }
+
+    @Test
+    public void cancelAfterNextInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                ts.cancel();
+                return 1;
+            }
+        });
+
+        Single.just(1)
+        .flattenStreamAsFlowable(v -> stream)
+        .subscribeWith(ts)
+        .assertEmpty();
+    }
+
+    @Test
+    public void requestSuccessRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            SingleSubject<Integer> ss = SingleSubject.create();
+
+            TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
+
+            ss.flattenStreamAsFlowable(Stream::of)
+            .subscribe(ts);
+
+            Runnable r1 = () -> ss.onSuccess(1);
+            Runnable r2 = () -> ts.request(1);
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/SingleFlattenStreamAsObservableTest.java
@@ -1,0 +1,418 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.jdk8;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subjects.SingleSubject;
+import io.reactivex.rxjava3.testsupport.*;
+
+public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
+
+    @Test
+    public void successJust() {
+        Single.just(1)
+        .flattenStreamAsObservable(Stream::of)
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void successEmpty() {
+        Single.just(1)
+        .flattenStreamAsObservable(v -> Stream.of())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void successMany() {
+        Single.just(1)
+        .flattenStreamAsObservable(v -> Stream.of(2, 3, 4, 5, 6))
+        .test()
+        .assertResult(2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void successManyTake() {
+        Single.just(1)
+        .flattenStreamAsObservable(v -> Stream.of(2, 3, 4, 5, 6))
+        .take(3)
+        .test()
+        .assertResult(2, 3, 4);
+    }
+
+    @Test
+    public void error() throws Throwable {
+        @SuppressWarnings("unchecked")
+        Function<? super Integer, Stream<? extends Integer>> f = mock(Function.class);
+
+        Single.<Integer>error(new TestException())
+        .flattenStreamAsObservable(f)
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(f, never()).apply(any());
+    }
+
+    @Test
+    public void mapperCrash() {
+        Single.just(1)
+        .flattenStreamAsObservable(v -> { throw new TestException(); })
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void dispose() {
+        TestHelper.checkDisposed(Single.never().flattenStreamAsObservable(Stream::of));
+    }
+
+    @Test
+    public void doubleOnSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingleToObservable(m -> m.flattenStreamAsObservable(Stream::of));
+    }
+
+    @Test
+    public void fusedEmpty() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
+
+        Single.just(1)
+        .flattenStreamAsObservable(v -> Stream.<Integer>of())
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult();
+    }
+
+    @Test
+    public void fusedJust() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
+
+        Single.just(1)
+        .flattenStreamAsObservable(v -> Stream.<Integer>of(v))
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1);
+    }
+
+    @Test
+    public void fusedMany() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
+
+        Single.just(1)
+        .flattenStreamAsObservable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fusedManyRejected() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.SYNC);
+
+        Single.just(1)
+        .flattenStreamAsObservable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fusedStreamAvailableLater() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+        to.setInitialFusionMode(QueueFuseable.ANY);
+
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        ss
+        .flattenStreamAsObservable(v -> Stream.<Integer>of(v, v + 1, v + 2))
+        .subscribe(to);
+
+        to.assertFuseable()
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertEmpty();
+
+        ss.onSuccess(1);
+
+        to
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void fused() throws Throwable {
+        AtomicReference<QueueDisposable<Integer>> qdr = new AtomicReference<>();
+
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        ss
+        .flattenStreamAsObservable(Stream::of)
+        .subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void onSubscribe(Disposable d) {
+                qdr.set((QueueDisposable<Integer>)d);
+            }
+        });
+
+        QueueDisposable<Integer> qd = qdr.get();
+
+        assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ASYNC));
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+
+        ss.onSuccess(1);
+
+        assertFalse(qd.isEmpty());
+        assertEquals(1, qd.poll().intValue());
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+
+        qd.dispose();
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+    }
+
+    @Test
+    public void fused2() throws Throwable {
+        AtomicReference<QueueDisposable<Integer>> qdr = new AtomicReference<>();
+
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        ss
+        .flattenStreamAsObservable(v -> Stream.of(v, v + 1))
+        .subscribe(new Observer<Integer>() {
+
+            @Override
+            public void onNext(Integer t) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void onSubscribe(Disposable d) {
+                qdr.set((QueueDisposable<Integer>)d);
+            }
+        });
+
+        QueueDisposable<Integer> qd = qdr.get();
+
+        assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ASYNC));
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+
+        ss.onSuccess(1);
+
+        assertFalse(qd.isEmpty());
+        assertEquals(1, qd.poll().intValue());
+
+        assertFalse(qd.isEmpty());
+        assertEquals(2, qd.poll().intValue());
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+
+        qd.dispose();
+
+        assertTrue(qd.isEmpty());
+        assertNull(qd.poll());
+    }
+
+    @Test
+    public void streamCloseCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Single.just(1)
+            .flattenStreamAsObservable(v -> Stream.of(v).onClose(() -> { throw new TestException(); }))
+            .test()
+            .assertResult(1);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
+    }
+
+    @Test
+    public void hasNextThrowsInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int count;
+
+            @Override
+            public boolean hasNext() {
+                if (count++ > 0) {
+                    throw new TestException();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Single.just(1)
+        .flattenStreamAsObservable(v -> stream)
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void nextThrowsInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                throw new TestException();
+            }
+        });
+
+        Single.just(1)
+        .flattenStreamAsObservable(v -> stream)
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void cancelAfterHasNextInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+
+        TestObserver<Integer> to = new TestObserver<>();
+
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            int count;
+
+            @Override
+            public boolean hasNext() {
+                if (count++ > 0) {
+                    to.dispose();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        });
+
+        Single.just(1)
+        .flattenStreamAsObservable(v -> stream)
+        .subscribeWith(to)
+        .assertValuesOnly(1);
+    }
+
+    @Test
+    public void cancelAfterNextInDrain() {
+        @SuppressWarnings("unchecked")
+        Stream<Integer> stream = mock(Stream.class);
+
+        TestObserver<Integer> to = new TestObserver<>();
+
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                to.dispose();
+                return 1;
+            }
+        });
+
+        Single.just(1)
+        .flattenStreamAsObservable(v -> stream)
+        .subscribeWith(to)
+        .assertEmpty();
+    }
+
+    @Test
+    public void cancelSuccessRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            SingleSubject<Integer> ss = SingleSubject.create();
+
+            TestObserver<Integer> to = new TestObserver<>();
+
+            ss.flattenStreamAsObservable(Stream::of)
+            .subscribe(to);
+
+            Runnable r1 = () -> ss.onSuccess(1);
+            Runnable r2 = () -> to.dispose();
+
+            TestHelper.race(r1, r2);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/validators/JavadocForAnnotations.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/JavadocForAnnotations.java
@@ -156,9 +156,9 @@ public class JavadocForAnnotations {
                                         ;
                                         int lc = lineNumber(sourceCode, idx);
 
-                                        e.append(" at io.reactivex.").append(baseClassName)
-                                        .append(" (").append(baseClassName).append(".java:")
-                                        .append(lc).append(")").append("\r\n\r\n");
+                                        e.append(" at io.reactivex.rxjava3.core.").append(baseClassName)
+                                        .append(".method(").append(baseClassName).append(".java:")
+                                        .append(lc).append(")").append("\r\n");
                                     }
                                 }
                             }

--- a/src/test/java/io/reactivex/rxjava3/validators/JavadocWording.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/JavadocWording.java
@@ -139,8 +139,11 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Flowable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Flowable")) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions Flowable but not in the signature\r\n at io.reactivex.rxjava3.core.")
-                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            Pattern p = Pattern.compile("@see\\s+#[A-Za-z0-9 _.,()]*Flowable");
+                            if (!p.matcher(m.javadoc).find()) {
+                                e.append("java.lang.RuntimeException: Maybe doc mentions Flowable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
                         }
                         jdx = idx + 6;
                     } else {
@@ -180,8 +183,11 @@ public class JavadocWording {
                     int idx = m.javadoc.indexOf("Observable", jdx);
                     if (idx >= 0) {
                         if (!m.signature.contains("Observable")) {
-                            e.append("java.lang.RuntimeException: Maybe doc mentions Observable but not in the signature\r\n at io.reactivex.rxjava3.core.")
-                            .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            Pattern p = Pattern.compile("@see\\s+#[A-Za-z0-9 _.,()]*Observable");
+                            if (!p.matcher(m.javadoc).find()) {
+                                e.append("java.lang.RuntimeException: Maybe doc mentions Observable but not in the signature\r\n at io.reactivex.rxjava3.core.")
+                                .append("Maybe.method(Maybe.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
+                            }
                         }
                         jdx = idx + 6;
                     } else {


### PR DESCRIPTION
Add
- `Maybe.flattenStreamAsFlowable`
- `Maybe.flattenStreamAsObservable`
- `Single.flattenStreamAsFlowable`
- `Single.flattenStreamAsObservable`

Related #6776

(In addition, adjust the validators to appreciate the new patterns.)

Marbles:

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenStreamAsFlowable.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenStreamAsObservable.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenStreamAsFlowable.s.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenStreamAsObservable.s.png)