### PR TITLE
3.x: Fix Junit 4.13 deprecated API use

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
@@ -20,15 +20,14 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.*;
-import org.junit.rules.ExpectedException;
+import org.junit.Test;
 import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Observer;
-import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.Predicate;
 import io.reactivex.rxjava3.internal.functions.Functions;
@@ -39,9 +38,6 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class TestObserverTest extends RxJavaTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void assertTestObserver() {
@@ -56,50 +52,44 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertNotMatchCount() {
-        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
-        oi.subscribe(subscriber);
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+            TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+            oi.subscribe(subscriber);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message format
-//        thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
-
-        subscriber.assertValue(1);
-        subscriber.assertValueCount(2);
-        subscriber.assertComplete().assertNoErrors();
+            subscriber.assertValue(1);
+            subscriber.assertValueCount(2);
+            subscriber.assertComplete().assertNoErrors();
+        });
     }
 
     @Test
     public void assertNotMatchValue() {
-        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
-        oi.subscribe(subscriber);
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+            TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+            oi.subscribe(subscriber);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message format
-//        thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
-
-        subscriber.assertValues(1, 3);
-        subscriber.assertValueCount(2);
-        subscriber.assertComplete().assertNoErrors();
+            subscriber.assertValues(1, 3);
+            subscriber.assertValueCount(2);
+            subscriber.assertComplete().assertNoErrors();
+        });
     }
 
     @Test
     public void assertTerminalEventNotReceived() {
-        PublishProcessor<Integer> p = PublishProcessor.create();
-        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
-        p.subscribe(subscriber);
+        assertThrows(AssertionError.class, () -> {
+            PublishProcessor<Integer> p = PublishProcessor.create();
+            TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+            p.subscribe(subscriber);
 
-        p.onNext(1);
-        p.onNext(2);
+            p.onNext(1);
+            p.onNext(2);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message format
-//        thrown.expectMessage("No terminal events received.");
-
-        subscriber.assertValues(1, 2);
-        subscriber.assertValueCount(2);
-        subscriber.assertComplete().assertNoErrors();
+            subscriber.assertValues(1, 2);
+            subscriber.assertValueCount(2);
+            subscriber.assertComplete().assertNoErrors();
+        });
     }
 
     @Test
@@ -853,16 +843,16 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestObserver<Object> to = new TestObserver<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestObserver<Object> to = new TestObserver<>();
 
-        Observable.empty().subscribe(to);
+            Observable.empty().subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        to.assertValue(new Predicate<Object>() {
-            @Override public boolean test(final Object o) throws Exception {
-                return false;
-            }
+            to.assertValue(new Predicate<Object>() {
+                @Override public boolean test(final Object o) throws Exception {
+                    return false;
+                }
+            });
         });
     }
 
@@ -881,46 +871,46 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestObserver<Integer> to = new TestObserver<>();
+        assertThrows("Value not present", AssertionError.class, () -> {
+            TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.just(1).subscribe(to);
+            Observable.just(1).subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value not present");
-        to.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o != 1;
-            }
+            to.assertValue(new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o != 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestObserver<Integer> to = new TestObserver<>();
+        assertThrows("Value present but other values as well", AssertionError.class, () -> {
+            TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.just(1, 2).subscribe(to);
+            Observable.just(1, 2).subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value present but other values as well");
-        to.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            to.assertValue(new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestObserver<Object> to = new TestObserver<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestObserver<Object> to = new TestObserver<>();
 
-        Observable.empty().subscribe(to);
+            Observable.empty().subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        to.assertValueAt(0, new Predicate<Object>() {
-            @Override public boolean test(final Object o) throws Exception {
-                return false;
-            }
+            to.assertValueAt(0, new Predicate<Object>() {
+                @Override public boolean test(final Object o) throws Exception {
+                    return false;
+                }
+            });
         });
     }
 
@@ -939,43 +929,43 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestObserver<Integer> to = new TestObserver<>();
+        assertThrows("Value not present", AssertionError.class, () -> {
+            TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.just(1, 2, 3).subscribe(to);
+            Observable.just(1, 2, 3).subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value not present");
-        to.assertValueAt(2, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o != 3;
-            }
+            to.assertValueAt(2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o != 3;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestObserver<Integer> to = new TestObserver<>();
+        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.just(1, 2).subscribe(to);
+            Observable.just(1, 2).subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        to.assertValueAt(2, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            to.assertValueAt(2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtIndexEmpty() {
-        TestObserver<Object> to = new TestObserver<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestObserver<Object> to = new TestObserver<>();
 
-        Observable.empty().subscribe(to);
+            Observable.empty().subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        to.assertValueAt(0, "a");
+            to.assertValueAt(0, "a");
+        });
     }
 
     @Test
@@ -989,24 +979,24 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        TestObserver<String> to = new TestObserver<>();
+        assertThrows("expected: b (class: String) but was: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
 
-        Observable.just("a", "b", "c").subscribe(to);
+            Observable.just("a", "b", "c").subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("expected: b (class: String) but was: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)");
-        to.assertValueAt(2, "b");
+            to.assertValueAt(2, "b");
+        });
     }
 
     @Test
     public void assertValueAtIndexInvalidIndex() {
-        TestObserver<String> to = new TestObserver<>();
+        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
 
-        Observable.just("a", "b").subscribe(to);
+            Observable.just("a", "b").subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        to.assertValueAt(2, "c");
+            to.assertValueAt(2, "c");
+        });
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
@@ -21,8 +21,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.*;
-import org.junit.rules.ExpectedException;
+import org.junit.Test;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
 
@@ -38,9 +37,6 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class TestSubscriberTest extends RxJavaTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void assertTestSubscriber() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
@@ -55,53 +51,47 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertNotMatchCount() {
-        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
-        oi.subscribe(ts);
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            oi.subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message pattern
-        // thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
-
-        ts.assertValues(1);
-        ts.assertValueCount(2);
-        ts.assertComplete();
-        ts.assertNoErrors();
+            ts.assertValues(1);
+            ts.assertValueCount(2);
+            ts.assertComplete();
+            ts.assertNoErrors();
+        });
     }
 
     @Test
     public void assertNotMatchValue() {
-        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
-        oi.subscribe(ts);
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            oi.subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message pattern
-        // thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
-
-        ts.assertValues(1, 3);
-        ts.assertValueCount(2);
-        ts.assertComplete();
-        ts.assertNoErrors();
+            ts.assertValues(1, 3);
+            ts.assertValueCount(2);
+            ts.assertComplete();
+            ts.assertNoErrors();
+        });
     }
 
     @Test
     public void assertTerminalEventNotReceived() {
-        PublishProcessor<Integer> p = PublishProcessor.create();
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
-        p.subscribe(ts);
+        assertThrows(AssertionError.class, () -> {
+            PublishProcessor<Integer> p = PublishProcessor.create();
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+            p.subscribe(ts);
 
-        p.onNext(1);
-        p.onNext(2);
+            p.onNext(1);
+            p.onNext(2);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message pattern
-        // thrown.expectMessage("No terminal events received.");
-
-        ts.assertValues(1, 2);
-        ts.assertValueCount(2);
-        ts.assertComplete();
-        ts.assertNoErrors();
+            ts.assertValues(1, 2);
+            ts.assertValueCount(2);
+            ts.assertComplete();
+            ts.assertNoErrors();
+        });
     }
 
     @Test
@@ -1375,16 +1365,16 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestSubscriber<Object> ts = new TestSubscriber<>();
+        assertThrows(AssertionError.class, () -> {
+            TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.empty().subscribe(ts);
+            Flowable.empty().subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        ts.assertValue(new Predicate<Object>() {
-            @Override public boolean test(final Object o) throws Exception {
-                return false;
-            }
+            ts.assertValue(new Predicate<Object>() {
+                @Override public boolean test(final Object o) throws Exception {
+                    return false;
+                }
+            });
         });
     }
 
@@ -1403,46 +1393,46 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        assertThrows("Value not present", AssertionError.class, () -> {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.just(1).subscribe(ts);
+            Flowable.just(1).subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value not present");
-        ts.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o != 1;
-            }
+            ts.assertValue(new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o != 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        assertThrows("Value present but other values as well", AssertionError.class, () -> {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.just(1, 2).subscribe(ts);
+            Flowable.just(1, 2).subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value present but other values as well");
-        ts.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            ts.assertValue(new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestSubscriber<Object> ts = new TestSubscriber<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.empty().subscribe(ts);
+            Flowable.empty().subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        ts.assertValueAt(0, new Predicate<Object>() {
-            @Override public boolean test(final Object o) throws Exception {
-                return false;
-            }
+            ts.assertValueAt(0, new Predicate<Object>() {
+                @Override public boolean test(final Object o) throws Exception {
+                    return false;
+                }
+            });
         });
     }
 
@@ -1461,31 +1451,31 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        assertThrows("Value not present", AssertionError.class, () -> {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.just(1, 2, 3).subscribe(ts);
+            Flowable.just(1, 2, 3).subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value not present");
-        ts.assertValueAt(2, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o != 3;
-            }
+            ts.assertValueAt(2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o != 3;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestSubscriber<Integer> ts = new TestSubscriber<>();
+        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.just(1, 2).subscribe(ts);
+            Flowable.just(1, 2).subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        ts.assertValueAt(2, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            ts.assertValueAt(2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverExTest.java
@@ -20,14 +20,13 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.*;
-import org.junit.rules.ExpectedException;
+import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.core.RxJavaTest;
-import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
@@ -38,9 +37,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.*;
 
 public class TestObserverExTest extends RxJavaTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void assertTestObserverEx() {
@@ -55,32 +51,28 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertNotMatchCount() {
-        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
-        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
-        oi.subscribe(subscriber);
+        assertThrows(AssertionError.class, () -> {
+            Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+            TestObserverEx<Integer> subscriber = new TestObserverEx<>();
+            oi.subscribe(subscriber);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message format
-//        thrown.expectMessage("Number of items does not match. Provided: 1  Actual: 2");
-
-        subscriber.assertValue(1);
-        subscriber.assertValueCount(2);
-        subscriber.assertTerminated();
+            subscriber.assertValue(1);
+            subscriber.assertValueCount(2);
+            subscriber.assertTerminated();
+        });
     }
 
     @Test
     public void assertNotMatchValue() {
-        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
-        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
-        oi.subscribe(subscriber);
+        assertThrows(AssertionError.class, () -> {
+            Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+            TestObserverEx<Integer> subscriber = new TestObserverEx<>();
+            oi.subscribe(subscriber);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message format
-//        thrown.expectMessage("Value at index: 1 expected to be [3] (Integer) but was: [2] (Integer)");
-
-        subscriber.assertValues(1, 3);
-        subscriber.assertValueCount(2);
-        subscriber.assertTerminated();
+            subscriber.assertValues(1, 3);
+            subscriber.assertValueCount(2);
+            subscriber.assertTerminated();
+        });
     }
 
     @Test
@@ -96,34 +88,34 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertNeverAtMatchingValue() {
-        Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
-        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
-        oi.subscribe(subscriber);
+        assertThrows(AssertionError.class, () -> {
+            Observable<Integer> oi = Observable.fromIterable(Arrays.asList(1, 2));
+            TestObserverEx<Integer> subscriber = new TestObserverEx<>();
+            oi.subscribe(subscriber);
 
-        subscriber.assertValues(1, 2);
+            subscriber.assertValues(1, 2);
 
-        thrown.expect(AssertionError.class);
-
-        subscriber.assertNever(2);
-        subscriber.assertValueCount(2);
-        subscriber.assertTerminated();
+            subscriber.assertNever(2);
+            subscriber.assertValueCount(2);
+            subscriber.assertTerminated();
+        });
     }
 
     @Test
     public void assertNeverAtMatchingPredicate() {
-        TestObserverEx<Integer> to = new TestObserverEx<>();
+        assertThrows(AssertionError.class, () -> {
+            TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        Observable.just(1, 2).subscribe(to);
+            Observable.just(1, 2).subscribe(to);
 
-        to.assertValues(1, 2);
+            to.assertValues(1, 2);
 
-        thrown.expect(AssertionError.class);
-
-        to.assertNever(new Predicate<Integer>() {
-            @Override
-            public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            to.assertNever(new Predicate<Integer>() {
+                @Override
+                public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 
@@ -143,20 +135,18 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertTerminalEventNotReceived() {
-        PublishSubject<Integer> p = PublishSubject.create();
-        TestObserverEx<Integer> subscriber = new TestObserverEx<>();
-        p.subscribe(subscriber);
+        assertThrows(AssertionError.class, () -> {
+            PublishSubject<Integer> p = PublishSubject.create();
+            TestObserverEx<Integer> subscriber = new TestObserverEx<>();
+            p.subscribe(subscriber);
 
-        p.onNext(1);
-        p.onNext(2);
+            p.onNext(1);
+            p.onNext(2);
 
-        thrown.expect(AssertionError.class);
-        // FIXME different message format
-//        thrown.expectMessage("No terminal events received.");
-
-        subscriber.assertValues(1, 2);
-        subscriber.assertValueCount(2);
-        subscriber.assertTerminated();
+            subscriber.assertValues(1, 2);
+            subscriber.assertValueCount(2);
+            subscriber.assertTerminated();
+        });
     }
 
     @Test
@@ -1148,16 +1138,16 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestObserverEx<Object> to = new TestObserverEx<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestObserverEx<Object> to = new TestObserverEx<>();
 
-        Observable.empty().subscribe(to);
+            Observable.empty().subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        to.assertValue(new Predicate<Object>() {
-            @Override public boolean test(final Object o) throws Exception {
-                return false;
-            }
+            to.assertValue(new Predicate<Object>() {
+                @Override public boolean test(final Object o) throws Exception {
+                    return false;
+                }
+            });
         });
     }
 
@@ -1176,46 +1166,46 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestObserverEx<Integer> to = new TestObserverEx<>();
+        assertThrows("Value not present", AssertionError.class, () -> {
+            TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        Observable.just(1).subscribe(to);
+            Observable.just(1).subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value not present");
-        to.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o != 1;
-            }
+            to.assertValue(new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o != 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestObserverEx<Integer> to = new TestObserverEx<>();
+        assertThrows("Value present but other values as well", AssertionError.class, () -> {
+            TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        Observable.just(1, 2).subscribe(to);
+            Observable.just(1, 2).subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value present but other values as well");
-        to.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            to.assertValue(new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestObserverEx<Object> to = new TestObserverEx<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestObserverEx<Object> to = new TestObserverEx<>();
 
-        Observable.empty().subscribe(to);
+            Observable.empty().subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        to.assertValueAt(0, new Predicate<Object>() {
-            @Override public boolean test(final Object o) throws Exception {
-                return false;
-            }
+            to.assertValueAt(0, new Predicate<Object>() {
+                @Override public boolean test(final Object o) throws Exception {
+                    return false;
+                }
+            });
         });
     }
 
@@ -1234,43 +1224,43 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestObserverEx<Integer> to = new TestObserverEx<>();
+        assertThrows("Value not present", AssertionError.class, () -> {
+            TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        Observable.just(1, 2, 3).subscribe(to);
+            Observable.just(1, 2, 3).subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value not present");
-        to.assertValueAt(2, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o != 3;
-            }
+            to.assertValueAt(2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o != 3;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestObserverEx<Integer> to = new TestObserverEx<>();
+        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        Observable.just(1, 2).subscribe(to);
+            Observable.just(1, 2).subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        to.assertValueAt(2, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            to.assertValueAt(2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtIndexEmpty() {
-        TestObserverEx<Object> to = new TestObserverEx<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestObserverEx<Object> to = new TestObserverEx<>();
 
-        Observable.empty().subscribe(to);
+            Observable.empty().subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        to.assertValueAt(0, "a");
+            to.assertValueAt(0, "a");
+        });
     }
 
     @Test
@@ -1284,24 +1274,24 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        TestObserverEx<String> to = new TestObserverEx<>();
+        assertThrows("expected: b (class: String) but was: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserverEx<String> to = new TestObserverEx<>();
 
-        Observable.just("a", "b", "c").subscribe(to);
+            Observable.just("a", "b", "c").subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("expected: b (class: String) but was: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)");
-        to.assertValueAt(2, "b");
+            to.assertValueAt(2, "b");
+        });
     }
 
     @Test
     public void assertValueAtIndexInvalidIndex() {
-        TestObserverEx<String> to = new TestObserverEx<>();
+        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserverEx<String> to = new TestObserverEx<>();
 
-        Observable.just("a", "b").subscribe(to);
+            Observable.just("a", "b").subscribe(to);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        to.assertValueAt(2, "c");
+            to.assertValueAt(2, "c");
+        });
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberExTest.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberExTest.java
@@ -21,8 +21,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.*;
-import org.junit.rules.ExpectedException;
+import org.junit.Test;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
 
@@ -38,9 +37,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class TestSubscriberExTest extends RxJavaTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void assertTestSubscriberEx() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
@@ -54,28 +50,28 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertNotMatchCount() {
-        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
-        oi.subscribe(ts);
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+            oi.subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-
-        ts.assertValues(1);
-        ts.assertValueCount(2);
-        ts.assertTerminated();
+            ts.assertValues(1);
+            ts.assertValueCount(2);
+            ts.assertTerminated();
+        });
     }
 
     @Test
     public void assertNotMatchValue() {
-        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
-        oi.subscribe(ts);
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+            oi.subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-
-        ts.assertValues(1, 3);
-        ts.assertValueCount(2);
-        ts.assertTerminated();
+            ts.assertValues(1, 3);
+            ts.assertValueCount(2);
+            ts.assertTerminated();
+        });
     }
 
     @Test
@@ -91,34 +87,34 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertNeverAtMatchingValue() {
-        Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
-        oi.subscribe(ts);
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+            oi.subscribe(ts);
 
-        ts.assertValues(1, 2);
+            ts.assertValues(1, 2);
 
-        thrown.expect(AssertionError.class);
-
-        ts.assertNever(2);
-        ts.assertValueCount(2);
-        ts.assertTerminated();
+            ts.assertNever(2);
+            ts.assertValueCount(2);
+            ts.assertTerminated();
+        });
     }
 
     @Test
     public void assertNeverAtMatchingPredicate() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        assertThrows(AssertionError.class, () -> {
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        Flowable.just(1, 2).subscribe(ts);
+            Flowable.just(1, 2).subscribe(ts);
 
-        ts.assertValues(1, 2);
+            ts.assertValues(1, 2);
 
-        thrown.expect(AssertionError.class);
-
-        ts.assertNever(new Predicate<Integer>() {
-            @Override
-            public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            ts.assertNever(new Predicate<Integer>() {
+                @Override
+                public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 
@@ -138,18 +134,18 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertTerminalEventNotReceived() {
-        PublishProcessor<Integer> p = PublishProcessor.create();
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
-        p.subscribe(ts);
+        assertThrows(AssertionError.class, () -> {
+            PublishProcessor<Integer> p = PublishProcessor.create();
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+            p.subscribe(ts);
 
-        p.onNext(1);
-        p.onNext(2);
+            p.onNext(1);
+            p.onNext(2);
 
-        thrown.expect(AssertionError.class);
-
-        ts.assertValues(1, 2);
-        ts.assertValueCount(2);
-        ts.assertTerminated();
+            ts.assertValues(1, 2);
+            ts.assertValueCount(2);
+            ts.assertTerminated();
+        });
     }
 
     @Test
@@ -1587,16 +1583,16 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
-        Flowable.empty().subscribe(ts);
+            Flowable.empty().subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        ts.assertValue(new Predicate<Object>() {
-            @Override public boolean test(final Object o) throws Exception {
-                return false;
-            }
+            ts.assertValue(new Predicate<Object>() {
+                @Override public boolean test(final Object o) throws Exception {
+                    return false;
+                }
+            });
         });
     }
 
@@ -1615,46 +1611,46 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        assertThrows("Value not present", AssertionError.class, () -> {
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        Flowable.just(1).subscribe(ts);
+            Flowable.just(1).subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value not present");
-        ts.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o != 1;
-            }
+            ts.assertValue(new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o != 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        assertThrows("Value present but other values as well", AssertionError.class, () -> {
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        Flowable.just(1, 2).subscribe(ts);
+            Flowable.just(1, 2).subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value present but other values as well");
-        ts.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            ts.assertValue(new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
+        assertThrows("No values", AssertionError.class, () -> {
+            TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
-        Flowable.empty().subscribe(ts);
+            Flowable.empty().subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("No values");
-        ts.assertValueAt(0, new Predicate<Object>() {
-            @Override public boolean test(final Object o) throws Exception {
-                return false;
-            }
+            ts.assertValueAt(0, new Predicate<Object>() {
+                @Override public boolean test(final Object o) throws Exception {
+                    return false;
+                }
+            });
         });
     }
 
@@ -1673,31 +1669,31 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        assertThrows("Value not present", AssertionError.class, () -> {
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        Flowable.just(1, 2, 3).subscribe(ts);
+            Flowable.just(1, 2, 3).subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Value not present");
-        ts.assertValueAt(2, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o != 3;
-            }
+            ts.assertValueAt(2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o != 3;
+                }
+            });
         });
     }
 
     @Test
     public void assertValueAtInvalidIndex() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
+        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-        Flowable.just(1, 2).subscribe(ts);
+            Flowable.just(1, 2).subscribe(ts);
 
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
-        ts.assertValueAt(2, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
+            ts.assertValueAt(2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
         });
     }
 


### PR DESCRIPTION
JUnit 4.13 deprecated the use of `ExpectedException` in favor of `assertThrows`.