### PR TITLE
3.x: Improve JavaDocs of Maybe

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -21,7 +21,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.*;
 import io.reactivex.rxjava3.internal.fuseable.*;
@@ -46,10 +46,10 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
  *     onSubscribe (onSuccess | onError | onComplete)?
  * </code></pre>
  * <p>
- * Note that {@code onSuccess}, {@code onError} and {@code onComplete} are mutually exclusive events; unlike {@code Observable},
+ * Note that {@code onSuccess}, {@code onError} and {@code onComplete} are mutually exclusive events; unlike {@link Observable},
  * {@code onSuccess} is never followed by {@code onError} or {@code onComplete}.
  * <p>
- * Like {@link Observable}, a running {@code Maybe} can be stopped through the {@link Disposable} instance
+ * Like {@code Observable}, a running {@code Maybe} can be stopped through the {@link Disposable} instance
  * provided to consumers through {@link MaybeObserver#onSubscribe}.
  * <p>
  * Like an {@code Observable}, a {@code Maybe} is lazy, can be either "hot" or "cold", synchronous or
@@ -61,7 +61,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
  * <p>
  * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/maybe.png" alt="">
  * <p>
- * See {@link Flowable} or {@link Observable} for the
+ * See {@link Flowable} or {@code Observable} for the
  * implementation of the Reactive Pattern for a stream or vector of values.
  * <p>
  * Example:
@@ -112,8 +112,8 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
-     * Runs multiple MaybeSources and signals the events of the first one that signals (disposing
-     * the rest).
+     * Runs multiple {@link MaybeSource}s provided by an {@link Iterable} sequence and
+     * signals the events of the first one that signals (disposing the rest).
      * <p>
      * <img width="640" height="519" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.amb.png" alt="">
      * <dl>
@@ -121,9 +121,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code amb} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources the Iterable sequence of sources. A subscription to each source will
-     *            occur in the same order as in the Iterable.
-     * @return the new Maybe instance
+     * @param sources the {@code Iterable} sequence of sources. A subscription to each source will
+     *            occur in the same order as in the {@code Iterable}.
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -134,7 +135,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Runs multiple MaybeSources and signals the events of the first one that signals (disposing
+     * Runs multiple {@link MaybeSource}s and signals the events of the first one that signals (disposing
      * the rest).
      * <p>
      * <img width="640" height="519" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.ambArray.png" alt="">
@@ -145,7 +146,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T> the value type
      * @param sources the array of sources. A subscription to each source will
      *            occur in the same order as in the array.
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -164,8 +165,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources provided by
-     * an Iterable sequence.
+     * Concatenate the single values, in a non-overlapping fashion, of the {@link MaybeSource} sources provided by
+     * an {@link Iterable} sequence as a {@link Flowable} sequence.
      * <p>
      * <img width="640" height="526" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.i.png" alt="">
      * <dl>
@@ -175,8 +176,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources the Iterable sequence of MaybeSource instances
-     * @return the new Flowable instance
+     * @param sources the {@code Iterable} sequence of {@code MaybeSource} instances
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
@@ -188,7 +190,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that emits the items emitted by two MaybeSources, one after the other.
+     * Returns a {@link Flowable} that emits the items emitted by two {@link MaybeSource}s, one after the other.
      * <p>
      * <img width="640" height="422" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
      * <dl>
@@ -200,10 +202,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a MaybeSource to be concatenated
+     *            a {@code MaybeSource} to be concatenated
      * @param source2
-     *            a MaybeSource to be concatenated
-     * @return a Flowable that emits items emitted by the two source MaybeSources, one after the other.
+     *            a {@code MaybeSource} to be concatenated
+     * @return a {@code Flowable} that emits items emitted by the two source {@code MaybeSource}s, one after the other.
+     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -217,7 +220,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that emits the items emitted by three MaybeSources, one after the other.
+     * Returns a {@link Flowable} that emits the items emitted by three {@link MaybeSource}s, one after the other.
      * <p>
      * <img width="640" height="422" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
      * <dl>
@@ -229,12 +232,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a MaybeSource to be concatenated
+     *            a {@code MaybeSource} to be concatenated
      * @param source2
-     *            a MaybeSource to be concatenated
+     *            a {@code MaybeSource} to be concatenated
      * @param source3
-     *            a MaybeSource to be concatenated
-     * @return a Flowable that emits items emitted by the three source MaybeSources, one after the other.
+     *            a {@code MaybeSource} to be concatenated
+     * @return a {@code Flowable} that emits items emitted by the three source {@code MaybeSource}s, one after the other.
+     * @throws NullPointerException if {@code source1}, {@code source2} or {@code source3} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -250,7 +254,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that emits the items emitted by four MaybeSources, one after the other.
+     * Returns a {@link Flowable} that emits the items emitted by four {@link MaybeSource}s, one after the other.
      * <p>
      * <img width="640" height="422" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
      * <dl>
@@ -262,14 +266,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a MaybeSource to be concatenated
+     *            a {@code MaybeSource} to be concatenated
      * @param source2
-     *            a MaybeSource to be concatenated
+     *            a {@code MaybeSource} to be concatenated
      * @param source3
-     *            a MaybeSource to be concatenated
+     *            a {@code MaybeSource} to be concatenated
      * @param source4
-     *            a MaybeSource to be concatenated
-     * @return a Flowable that emits items emitted by the four source MaybeSources, one after the other.
+     *            a {@code MaybeSource} to be concatenated
+     * @return a {@code Flowable} that emits items emitted by the four source {@code MaybeSource}s, one after the other.
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code source4} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -286,21 +291,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources provided by
-     * a Publisher sequence.
+     * Concatenate the single values, in a non-overlapping fashion, of the {@link MaybeSource} sources provided by
+     * a {@link Publisher} sequence as a {@link Flowable} sequence.
      * <p>
      * <img width="640" height="416" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.p.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer and
      *  expects the {@code Publisher} to honor backpressure as well. If the sources {@code Publisher}
-     *  violates this, a {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException} is signalled.</dd>
+     *  violates this, a {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException} is signaled.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources the Publisher of MaybeSource instances
-     * @return the new Flowable instance
+     * @param sources the {@code Publisher} of {@code MaybeSource} instances
+     * @return the new {@code Flowable} instance
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
@@ -311,22 +316,24 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources provided by
-     * a Publisher sequence.
+     * Concatenate the single values, in a non-overlapping fashion, of the {@link MaybeSource} sources provided by
+     * a {@link Publisher} sequence as a {@link Flowable} sequence.
      * <p>
      * <img width="640" height="416" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.pn.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer and
      *  expects the {@code Publisher} to honor backpressure as well. If the sources {@code Publisher}
-     *  violates this, a {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException} is signalled.</dd>
+     *  violates this, a {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException} is signaled.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources the Publisher of MaybeSource instances
-     * @param prefetch the number of MaybeSources to prefetch from the Publisher
-     * @return the new Flowable instance
+     * @param sources the {@code Publisher} of {@code MaybeSource} instances
+     * @param prefetch the number of {@code MaybeSource}s to prefetch from the {@code Publisher}
+     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws IllegalArgumentException if {@code prefetch} is non-positive
+     * @return the new {@code Flowable} instance
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
@@ -340,7 +347,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenate the single values, in a non-overlapping fashion, of the MaybeSource sources in the array.
+     * Concatenate the single values, in a non-overlapping fashion, of the {@link MaybeSource} sources in the array
+     * as a {@link Flowable} sequence.
      * <p>
      * <img width="640" height="526" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatArray.png" alt="">
      * <dl>
@@ -350,8 +358,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources the array of MaybeSource instances
-     * @return the new Flowable instance
+     * @param sources the array of {@code MaybeSource} instances
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
@@ -372,8 +381,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenates a variable number of MaybeSource sources and delays errors from any of them
-     * till all terminate.
+     * Concatenates a variable number of {@link MaybeSource} sources and delays errors from any of them
+     * till all terminate as a {@link Flowable} sequence.
      * <p>
      * <img width="640" height="425" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatArrayDelayError.png" alt="">
      * <dl>
@@ -384,8 +393,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      * @param sources the array of sources
      * @param <T> the common base value type
-     * @return the new Flowable instance
-     * @throws NullPointerException if sources is null
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
@@ -405,10 +414,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenates a sequence of MaybeSource eagerly into a single stream of values.
+     * Concatenates a sequence of {@link MaybeSource} eagerly into a {@link Flowable} sequence.
      * <p>
      * Eager concatenation means that once a subscriber subscribes, this operator subscribes to all of the
-     * source MaybeSources. The operator buffers the value emitted by these MaybeSources and then drains them
+     * source {@code MaybeSource}s. The operator buffers the value emitted by these {@code MaybeSource}s and then drains them
      * in order, each one after the previous one completes.
      * <p>
      * <img width="640" height="489" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatArrayEager.png" alt="">
@@ -419,8 +428,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources a sequence of MaybeSources that need to be eagerly concatenated
-     * @return the new Flowable instance with the specified concatenation behavior
+     * @param sources a sequence of {@code MaybeSource}s that need to be eagerly concatenated
+     * @return the new {@code Flowable} instance with the specified concatenation behavior
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
@@ -433,8 +442,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenates the Iterable sequence of MaybeSources into a single sequence by subscribing to each MaybeSource,
-     * one after the other, one at a time and delays any errors till the all inner MaybeSources terminate.
+     * Concatenates the {@link Iterable} sequence of {@link MaybeSource}s into a single sequence by subscribing to each {@code MaybeSource},
+     * one after the other, one at a time and delays any errors till the all inner {@code MaybeSource}s terminate
+     * as a {@link Flowable} sequence.
      * <p>
      * <img width="640" height="469" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatDelayError.i.png" alt="">
      * <dl>
@@ -445,8 +455,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param <T> the common element base type
-     * @param sources the Iterable sequence of MaybeSources
-     * @return the new Flowable with the concatenating behavior
+     * @param sources the {@code Iterable} sequence of {@code MaybeSource}s
+     * @return the new {@code Flowable} with the concatenating behavior
+     * @throws NullPointerException if {@code sources} is {@code null}
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
@@ -459,8 +470,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenates the Publisher sequence of Publishers into a single sequence by subscribing to each inner Publisher,
-     * one after the other, one at a time and delays any errors till the all inner and the outer Publishers terminate.
+     * Concatenates the {@link Publisher} sequence of {@link MaybeSource}s into a single sequence by subscribing to each inner {@code MaybeSource},
+     * one after the other, one at a time and delays any errors till the all inner and the outer {@code Publisher} terminate
+     * as a {@link Flowable} sequence.
      * <p>
      * <img width="640" height="360" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatDelayError.p.png" alt="">
      * <dl>
@@ -471,8 +483,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param <T> the common element base type
-     * @param sources the Publisher sequence of Publishers
-     * @return the new Publisher with the concatenating behavior
+     * @param sources the {@code Publisher} sequence of {@code MaybeSource}s
+     * @return the new {@code Flowable} with the concatenating behavior
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @BackpressureSupport(BackpressureKind.FULL)
@@ -484,10 +496,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenates a sequence of MaybeSources eagerly into a single stream of values.
+     * Concatenates a sequence of {@link MaybeSource}s eagerly into a {@link Flowable} sequence.
      * <p>
      * Eager concatenation means that once a subscriber subscribes, this operator subscribes to all of the
-     * source MaybeSources. The operator buffers the values emitted by these MaybeSources and then drains them
+     * source {@code MaybeSource}s. The operator buffers the values emitted by these {@code MaybeSource}s and then drains them
      * in order, each one after the previous one completes.
      * <p>
      * <img width="640" height="526" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatEager.i.png" alt="">
@@ -498,8 +510,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources a sequence of MaybeSource that need to be eagerly concatenated
-     * @return the new Flowable instance with the specified concatenation behavior
+     * @param sources a sequence of {@code MaybeSource} that need to be eagerly concatenated
+     * @return the new {@code Flowable} instance with the specified concatenation behavior
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
@@ -511,24 +523,24 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Concatenates a Publisher sequence of MaybeSources eagerly into a single stream of values.
+     * Concatenates a {@link Publisher} sequence of {@link MaybeSource}s eagerly into a {@link Flowable} sequence.
      * <p>
      * Eager concatenation means that once a subscriber subscribes, this operator subscribes to all of the
-     * emitted source Publishers as they are observed. The operator buffers the values emitted by these
-     * Publishers and then drains them in order, each one after the previous one completes.
+     * emitted source {@code MaybeSource}s as they are observed. The operator buffers the values emitted by these
+     * {@code MaybeSource}s and then drains them in order, each one after the previous one completes.
      * <p>
      * <img width="640" height="511" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatEager.p.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Backpressure is honored towards the downstream and the outer Publisher is
+     *  <dd>Backpressure is honored towards the downstream and the outer {@code Publisher} is
      *  expected to support backpressure. Violating this assumption, the operator will
      *  signal {@link io.reactivex.rxjava3.exceptions.MissingBackpressureException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param sources a sequence of Publishers that need to be eagerly concatenated
-     * @return the new Publisher instance with the specified concatenation behavior
+     * @param sources a sequence of {@code MaybeSource}s that need to be eagerly concatenated
+     * @return the new {@code Flowable} instance with the specified concatenation behavior
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
@@ -540,7 +552,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Provides an API (via a cold Maybe) that bridges the reactive world with the callback-style world.
+     * Provides an API (via a cold {@code Maybe}) that bridges the reactive world with the callback-style world.
      * <p>
      * Example:
      * <pre><code>
@@ -571,15 +583,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Whenever a {@link MaybeObserver} subscribes to the returned {@code Maybe}, the provided
      * {@link MaybeOnSubscribe} callback is invoked with a fresh instance of a {@link MaybeEmitter}
      * that will interact only with that specific {@code MaybeObserver}. If this {@code MaybeObserver}
-     * disposes the flow (making {@link MaybeEmitter#isDisposed} return true),
+     * disposes the flow (making {@link MaybeEmitter#isDisposed} return {@code true}),
      * other observers subscribed to the same returned {@code Maybe} are not affected.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code create} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param onSubscribe the emitter that is called when a MaybeObserver subscribes to the returned {@code Maybe}
-     * @return the new Maybe instance
+     * @param onSubscribe the emitter that is called when a {@code MaybeObserver} subscribes to the returned {@code Maybe}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onSubscribe} is {@code null}
      * @see MaybeOnSubscribe
      * @see Cancellable
      */
@@ -592,16 +605,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls a Supplier for each individual MaybeObserver to return the actual MaybeSource source to
+     * Calls a {@link Supplier} for each individual {@link MaybeObserver} to return the actual {@link MaybeSource} source to
      * be subscribed to.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param maybeSupplier the Supplier that is called for each individual MaybeObserver and
-     * returns a MaybeSource instance to subscribe to
-     * @return the new Maybe instance
+     * @param maybeSupplier the {@code Supplier} that is called for each individual {@code MaybeObserver} and
+     * returns a {@code MaybeSource} instance to subscribe to
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code maybeSupplier} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -612,7 +626,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a (singleton) Maybe instance that calls {@link MaybeObserver#onComplete onComplete}
+     * Returns a (singleton) {@code Maybe} instance that calls {@link MaybeObserver#onComplete onComplete}
      * immediately.
      * <p>
      * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/empty.png" alt="">
@@ -621,7 +635,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code empty} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -632,7 +646,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that invokes a subscriber's {@link MaybeObserver#onError onError} method when the
+     * Returns a {@code Maybe} that invokes a subscriber's {@link MaybeObserver#onError onError} method when the
      * subscriber subscribes to it.
      * <p>
      * <img width="640" height="447" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.error.png" alt="">
@@ -641,25 +655,26 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param exception
-     *            the particular Throwable to pass to {@link MaybeObserver#onError onError}
+     * @param error
+     *            the particular {@link Throwable} to pass to {@link MaybeObserver#onError onError}
      * @param <T>
-     *            the type of the item (ostensibly) emitted by the Maybe
-     * @return a Maybe that invokes the subscriber's {@link MaybeObserver#onError onError} method when
+     *            the type of the item (ostensibly) emitted by the {@code Maybe}
+     * @return a {@code Maybe} that invokes the subscriber's {@link MaybeObserver#onError onError} method when
      *         the subscriber subscribes to it
+     * @throws NullPointerException if {@code error} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> error(@NonNull Throwable exception) {
-        Objects.requireNonNull(exception, "exception is null");
-        return RxJavaPlugins.onAssembly(new MaybeError<>(exception));
+    public static <T> Maybe<T> error(@NonNull Throwable error) {
+        Objects.requireNonNull(error, "error is null");
+        return RxJavaPlugins.onAssembly(new MaybeError<>(error));
     }
 
     /**
-     * Returns a Maybe that invokes a {@link MaybeObserver}'s {@link MaybeObserver#onError onError} method when the
-     * MaybeObserver subscribes to it.
+     * Returns a {@code Maybe} that invokes a {@link MaybeObserver}'s {@link MaybeObserver#onError onError} method when the
+     * {@code MaybeObserver} subscribes to it.
      * <p>
      * <img width="640" height="190" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/error.png" alt="">
      * <dl>
@@ -668,11 +683,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param supplier
-     *            a Supplier factory to return a Throwable for each individual MaybeObserver
+     *            a {@link Supplier} factory to return a {@link Throwable} for each individual {@code MaybeObserver}
      * @param <T>
-     *            the type of the items (ostensibly) emitted by the Maybe
-     * @return a Maybe that invokes the {@link MaybeObserver}'s {@link MaybeObserver#onError onError} method when
-     *         the MaybeObserver subscribes to it
+     *            the type of the items (ostensibly) emitted by the {@code Maybe}
+     * @return a {@code Maybe} that invokes the {@code MaybeObserver.onError} method when
+     *         the {@code MaybeObserver} subscribes to it
+     * @throws NullPointerException if {@code supplier} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
     @CheckReturnValue
@@ -684,13 +700,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe instance that runs the given Action for each subscriber and
+     * Returns a {@code Maybe} instance that runs the given {@link Action} for each subscriber and
      * emits either its exception or simply completes.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromAction} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
-     *  <dd> If the {@link Action} throws an exception, the respective {@link Throwable} is
+     *  <dd> If the {@code Action} throws an exception, the respective {@link Throwable} is
      *  delivered to the downstream via {@link MaybeObserver#onError(Throwable)},
      *  except when the downstream has disposed this {@code Maybe} source.
      *  In this latter case, the {@code Throwable} is delivered to the global error handler via
@@ -698,29 +714,29 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  </dd>
      * </dl>
      * @param <T> the target type
-     * @param run the runnable to run for each subscriber
-     * @return the new Maybe instance
-     * @throws NullPointerException if run is null
+     * @param action the {@code Action} to run for each subscriber
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code action} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromAction(@NonNull Action run) {
-        Objects.requireNonNull(run, "run is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromAction<>(run));
+    public static <T> Maybe<T> fromAction(@NonNull Action action) {
+        Objects.requireNonNull(action, "action is null");
+        return RxJavaPlugins.onAssembly(new MaybeFromAction<>(action));
     }
 
     /**
-     * Wraps a CompletableSource into a Maybe.
+     * Wraps a {@link CompletableSource} into a {@code Maybe}.
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the target type
-     * @param completableSource the CompletableSource to convert from
-     * @return the new Maybe instance
-     * @throws NullPointerException if completable is null
+     * @param completableSource the {@code CompletableSource} to convert from
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code completableSource} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -731,16 +747,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Wraps a SingleSource into a Maybe.
+     * Wraps a {@link SingleSource} into a {@code Maybe}.
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the target type
-     * @param singleSource the SingleSource to convert from
-     * @return the new Maybe instance
-     * @throws NullPointerException if single is null
+     * @param singleSource the {@code SingleSource} to convert from
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code singleSource} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -751,17 +767,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a {@link Maybe} that invokes the given {@link Callable} for each individual {@link MaybeObserver} that
-     * subscribes and emits the resulting non-null item via {@code onSuccess} while
+     * Returns a {@code Maybe} that invokes the given {@link Callable} for each individual {@link MaybeObserver} that
+     * subscribes and emits the resulting non-{@code null} item via {@code onSuccess} while
      * considering a {@code null} result from the {@code Callable} as indication for valueless completion
      * via {@code onComplete}.
      * <p>
      * This operator allows you to defer the execution of the given {@code Callable} until a {@code MaybeObserver}
-     * subscribes to the  returned {@link Maybe}. In other terms, this source operator evaluates the given
+     * subscribes to the  returned {@code Maybe}. In other terms, this source operator evaluates the given
      * {@code Callable} "lazily".
      * <p>
      * Note that the {@code null} handling of this operator differs from the similar source operators in the other
-     * {@link io.reactivex.rxjava3.core base reactive classes}. Those operators signal a {@code NullPointerException} if the value returned by their
+     * {@link io.reactivex.rxjava3.core base reactive classes}. Those operators signal a {@link NullPointerException} if the value returned by their
      * {@code Callable} is {@code null} while this {@code fromCallable} considers it to indicate the
      * returned {@code Maybe} is empty.
      * <dl>
@@ -778,11 +794,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param callable
-     *         a {@link Callable} instance whose execution should be deferred and performed for each individual
-     *         {@code MaybeObserver} that subscribes to the returned {@link Maybe}.
+     *         a {@code Callable} instance whose execution should be deferred and performed for each individual
+     *         {@code MaybeObserver} that subscribes to the returned {@code Maybe}.
      * @param <T>
-     *         the type of the item emitted by the {@link Maybe}.
-     * @return a new Maybe instance
+     *         the type of the item emitted by the {@code Maybe}.
+     * @return a new {@code Maybe} instance
+     * @throws NullPointerException if {@code callable} is {@code null}
      * @see #defer(Supplier)
      * @see #fromSupplier(Supplier)
      */
@@ -795,29 +812,29 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts a {@link Future} into a Maybe, treating a null result as an indication of emptiness.
+     * Converts a {@link Future} into a {@code Maybe}, treating a {@code null} result as an indication of emptiness.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/from.Future.png" alt="">
      * <p>
-     * You can convert any object that supports the {@link Future} interface into a Maybe that emits the
-     * return value of the {@link Future#get} method of that object, by passing the object into the {@code from}
-     * method.
+     * The operator calls {@link Future#get()}, which is a blocking method, on the subscription thread.
+     * It is recommended applying {@link #subscribeOn(Scheduler)} to move this blocking wait to a
+     * background thread, and if the {@link Scheduler} supports it, interrupt the wait when the flow
+     * is disposed.
      * <p>
-     * <em>Important note:</em> This Maybe is blocking; you cannot dispose it.
-     * <p>
-     * Unlike 1.x, disposing the Maybe won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, disposing the {@code Maybe} won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureMaybe.doOnDispose(() -> future.cancel(true));}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@code Scheduler}.</dd>
      * </dl>
      *
      * @param future
-     *            the source {@link Future}
+     *            the source {@code Future}
      * @param <T>
-     *            the type of object that the {@link Future} returns, and also the type of item to be emitted by
-     *            the resulting Maybe
-     * @return a Maybe that emits the item from the source {@link Future}
+     *            the type of object that the {@code Future} returns, and also the type of item to be emitted by
+     *            the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the item from the source {@code Future}
+     * @throws NullPointerException if {@code future} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
     @CheckReturnValue
@@ -829,33 +846,33 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts a {@link Future} into a Maybe, with a timeout on the Future.
+     * Converts a {@link Future} into a {@code Maybe}, with a timeout on the {@code Future}.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/from.Future.png" alt="">
      * <p>
-     * You can convert any object that supports the {@link Future} interface into a Maybe that emits the
-     * return value of the {@link Future#get} method of that object, by passing the object into the {@code fromFuture}
-     * method.
+     * The operator calls {@link Future#get(long, TimeUnit)}, which is a blocking method, on the subscription thread.
+     * It is recommended applying {@link #subscribeOn(Scheduler)} to move this blocking wait to a
+     * background thread, and if the {@link Scheduler} supports it, interrupt the wait when the flow
+     * is disposed.
      * <p>
-     * Unlike 1.x, disposing the Maybe won't cancel the future. If necessary, one can use composition to achieve the
+     * Unlike 1.x, disposing the {@code Maybe} won't cancel the future. If necessary, one can use composition to achieve the
      * cancellation effect: {@code futureMaybe.doOnCancel(() -> future.cancel(true));}.
-     * <p>
-     * <em>Important note:</em> This Maybe is blocking on the thread it gets subscribed on; you cannot dispose it.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code fromFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code fromFuture} does not operate by default on a particular {@code Scheduler}.</dd>
      * </dl>
      *
      * @param future
-     *            the source {@link Future}
+     *            the source {@code Future}
      * @param timeout
      *            the maximum time to wait before calling {@code get}
      * @param unit
      *            the {@link TimeUnit} of the {@code timeout} argument
      * @param <T>
-     *            the type of object that the {@link Future} returns, and also the type of item to be emitted by
-     *            the resulting Maybe
-     * @return a Maybe that emits the item from the source {@link Future}
+     *            the type of object that the {@code Future} returns, and also the type of item to be emitted by
+     *            the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the item from the source {@code Future}
+     * @throws NullPointerException if {@code future} or {@code unit} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      */
     @CheckReturnValue
@@ -868,16 +885,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe instance that runs the given Action for each subscriber and
+     * Returns a {@code Maybe} instance that runs the given {@link Runnable} for each subscriber and
      * emits either its exception or simply completes.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromRunnable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the target type
-     * @param run the runnable to run for each subscriber
-     * @return the new Maybe instance
-     * @throws NullPointerException if run is null
+     * @param run the {@code Runnable} to run for each subscriber
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code run} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -888,19 +905,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a {@link Maybe} that invokes the given {@link Supplier} for each individual {@link MaybeObserver} that
-     * subscribes and emits the resulting non-null item via {@code onSuccess} while
+     * Returns a {@code Maybe} that invokes the given {@link Supplier} for each individual {@link MaybeObserver} that
+     * subscribes and emits the resulting non-{@code null} item via {@code onSuccess} while
      * considering a {@code null} result from the {@code Supplier} as indication for valueless completion
      * via {@code onComplete}.
      * <p>
      * This operator allows you to defer the execution of the given {@code Supplier} until a {@code MaybeObserver}
-     * subscribes to the  returned {@link Maybe}. In other terms, this source operator evaluates the given
+     * subscribes to the  returned {@code Maybe}. In other terms, this source operator evaluates the given
      * {@code Supplier} "lazily".
      * <p>
      * <img width="640" height="311" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.fromSupplier.png" alt="">
      * <p>
      * Note that the {@code null} handling of this operator differs from the similar source operators in the other
-     * {@link io.reactivex.rxjava3.core base reactive classes}. Those operators signal a {@code NullPointerException} if the value returned by their
+     * {@link io.reactivex.rxjava3.core base reactive classes}. Those operators signal a {@link NullPointerException} if the value returned by their
      * {@code Supplier} is {@code null} while this {@code fromSupplier} considers it to indicate the
      * returned {@code Maybe} is empty.
      * <dl>
@@ -917,11 +934,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param supplier
-     *         a {@link Supplier} instance whose execution should be deferred and performed for each individual
-     *         {@code MaybeObserver} that subscribes to the returned {@link Maybe}.
+     *         a {@code Supplier} instance whose execution should be deferred and performed for each individual
+     *         {@code MaybeObserver} that subscribes to the returned {@code Maybe}.
      * @param <T>
-     *         the type of the item emitted by the {@link Maybe}.
-     * @return a new Maybe instance
+     *         the type of the item emitted by the {@code Maybe}.
+     * @return a new {@code Maybe} instance
+     * @throws NullPointerException if {@code supplier} is {@code null}
      * @see #defer(Supplier)
      * @see #fromCallable(Callable)
      * @since 3.0.0
@@ -951,6 +969,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T>
      *            the type of that item
      * @return a {@code Maybe} that emits {@code item}
+     * @throws NullPointerException if {@code item} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/just.html">ReactiveX operators documentation: Just</a>
      */
     @CheckReturnValue
@@ -962,21 +981,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Merges an Iterable sequence of MaybeSource instances into a single Flowable sequence,
-     * running all MaybeSources at once.
+     * Merges an {@link Iterable} sequence of {@link MaybeSource} instances into a single {@link Flowable} sequence,
+     * running all {@code MaybeSource}s at once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
+     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
      *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@code CompositeException} containing two or more of the various error signals.
+     *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
+     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable)} to merge sources and terminate only when all source {@code MaybeSource}s
@@ -984,8 +1003,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  </dd>
      * </dl>
      * @param <T> the common and resulting value type
-     * @param sources the Iterable sequence of MaybeSource sources
-     * @return the new Flowable instance
+     * @param sources the {@code Iterable} sequence of {@code MaybeSource} sources
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
      * @see #mergeDelayError(Iterable)
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -997,21 +1017,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Merges a Flowable sequence of MaybeSource instances into a single Flowable sequence,
-     * running all MaybeSources at once.
+     * Merges a {@link Publisher} sequence of {@link MaybeSource} instances into a single {@link Flowable} sequence,
+     * running all {@code MaybeSource}s at once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
+     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
      *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@code CompositeException} containing two or more of the various error signals.
+     *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
+     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher)} to merge sources and terminate only when all source {@code MaybeSource}s
@@ -1019,8 +1039,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  </dd>
      * </dl>
      * @param <T> the common and resulting value type
-     * @param sources the Flowable sequence of MaybeSource sources
-     * @return the new Flowable instance
+     * @param sources the {@code Flowable} sequence of {@code MaybeSource} sources
+     * @return the new {@code Flowable} instance
      * @see #mergeDelayError(Publisher)
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1032,21 +1052,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Merges a Flowable sequence of MaybeSource instances into a single Flowable sequence,
-     * running at most maxConcurrency MaybeSources at once.
+     * Merges a {@link Publisher} sequence of {@link MaybeSource} instances into a single {@link Flowable} sequence,
+     * running at most maxConcurrency {@code MaybeSource}s at once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
+     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
      *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@code CompositeException} containing two or more of the various error signals.
+     *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
+     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, int)} to merge sources and terminate only when all source {@code MaybeSource}s
@@ -1054,9 +1074,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  </dd>
      * </dl>
      * @param <T> the common and resulting value type
-     * @param sources the Flowable sequence of MaybeSource sources
-     * @param maxConcurrency the maximum number of concurrently running MaybeSources
-     * @return the new Flowable instance
+     * @param sources the {@code Flowable} sequence of {@code MaybeSource} sources
+     * @param maxConcurrency the maximum number of concurrently running {@code MaybeSource}s
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
      * @see #mergeDelayError(Publisher, int)
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1071,7 +1093,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens a {@code MaybeSource} that emits a {@code MaybeSource} into a single {@code MaybeSource} that emits the item
+     * Flattens a {@link MaybeSource} that emits a {@code MaybeSource} into a single {@code MaybeSource} that emits the item
      * emitted by the nested {@code MaybeSource}, without any transformation.
      * <p>
      * <img width="640" height="393" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.oo.png" alt="">
@@ -1079,8 +1101,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * <dt><b>Error handling:</b></dt>
-     * <dd>The resulting {@code Maybe} emits the outer source's or the inner {@code MaybeSource}'s {@code Throwable} as is.
-     * Unlike the other {@code merge()} operators, this operator won't and can't produce a {@code CompositeException} because there is
+     * <dd>The resulting {@code Maybe} emits the outer source's or the inner {@code MaybeSource}'s {@link Throwable} as is.
+     * Unlike the other {@code merge()} operators, this operator won't and can't produce a {@link CompositeException} because there is
      * only one possibility for the outer or the inner {@code MaybeSource} to emit an {@code onError} signal.
      * Therefore, there is no need for a {@code mergeDelayError(MaybeSource<MaybeSource<T>>)} operator.
      * </dd>
@@ -1091,6 +1113,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            a {@code MaybeSource} that emits a {@code MaybeSource}
      * @return a {@code Maybe} that emits the item that is the result of flattening the {@code MaybeSource} emitted
      *         by {@code source}
+     * @throws NullPointerException if {@code source} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @CheckReturnValue
@@ -1103,11 +1126,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens two MaybeSources into a single Flowable, without any transformation.
+     * Flattens two {@link MaybeSource}s into a single {@link Flowable}, without any transformation.
      * <p>
      * <img width="640" height="483" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple MaybeSources so that they appear as a single Flowable, by
+     * You can combine items emitted by multiple {@code MaybeSource}s so that they appear as a single {@code Flowable}, by
      * using the {@code merge} method.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1115,13 +1138,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
+     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
      *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@code CompositeException} containing two or more of the various error signals.
+     *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
+     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(MaybeSource, MaybeSource)} to merge sources and terminate only when all source {@code MaybeSource}s
@@ -1131,10 +1154,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source2
-     *            a MaybeSource to be merged
-     * @return a Flowable that emits all of the items emitted by the source MaybeSources
+     *            a {@code MaybeSource} to be merged
+     * @return a {@code Flowable} that emits all of the items emitted by the source {@code MaybeSource}s
+     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #mergeDelayError(MaybeSource, MaybeSource)
      */
@@ -1151,11 +1175,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens three MaybeSources into a single Flowable, without any transformation.
+     * Flattens three {@link MaybeSource}s into a single {@link Flowable}, without any transformation.
      * <p>
      * <img width="640" height="483" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple MaybeSources so that they appear as a single Flowable, by using
+     * You can combine items emitted by multiple {@code MaybeSource}s so that they appear as a single {@code Flowable}, by using
      * the {@code merge} method.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1163,13 +1187,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
+     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
      *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@code CompositeException} containing two or more of the various error signals.
+     *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
+     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(MaybeSource, MaybeSource, MaybeSource)} to merge sources and terminate only when all source {@code MaybeSource}s
@@ -1179,12 +1203,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source2
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source3
-     *            a MaybeSource to be merged
-     * @return a Flowable that emits all of the items emitted by the source MaybeSources
+     *            a {@code MaybeSource} to be merged
+     * @return a {@code Flowable} that emits all of the items emitted by the source {@code MaybeSource}s
+     * @throws NullPointerException if {@code source1}, {@code source2} or {@code source3} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #mergeDelayError(MaybeSource, MaybeSource, MaybeSource)
      */
@@ -1203,11 +1228,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens four MaybeSources into a single Flowable, without any transformation.
+     * Flattens four {@link MaybeSource}s into a single {@link Flowable}, without any transformation.
      * <p>
      * <img width="640" height="483" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple MaybeSources so that they appear as a single Flowable, by using
+     * You can combine items emitted by multiple {@code MaybeSource}s so that they appear as a single {@code Flowable}, by using
      * the {@code merge} method.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1215,13 +1240,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
+     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
      *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@code CompositeException} containing two or more of the various error signals.
+     *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
+     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(MaybeSource, MaybeSource, MaybeSource, MaybeSource)} to merge sources and terminate only when all source {@code MaybeSource}s
@@ -1231,14 +1256,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common value type
      * @param source1
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source2
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source3
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source4
-     *            a MaybeSource to be merged
-     * @return a Flowable that emits all of the items emitted by the source MaybeSources
+     *            a {@code MaybeSource} to be merged
+     * @return a {@code Flowable} that emits all of the items emitted by the source {@code MaybeSource}s
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code source4} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @see #mergeDelayError(MaybeSource, MaybeSource, MaybeSource, MaybeSource)
      */
@@ -1258,21 +1284,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Merges an array sequence of MaybeSource instances into a single Flowable sequence,
-     * running all MaybeSources at once.
+     * Merges an array sequence of {@link MaybeSource} instances into a single {@link Flowable} sequence,
+     * running all {@code MaybeSource}s at once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@code Throwable} via {@code onError}, the resulting
+     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
      *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
      *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@code CompositeException} containing two or more of the various error signals.
+     *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@code UndeliverableException} errors. Similarly, {@code Throwable}s
+     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeArrayDelayError(MaybeSource...)} to merge sources and terminate only when all source {@code MaybeSource}s
@@ -1280,8 +1306,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  </dd>
      * </dl>
      * @param <T> the common and resulting value type
-     * @param sources the array sequence of MaybeSource sources
-     * @return the new Flowable instance
+     * @param sources the array sequence of {@code MaybeSource} sources
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
      * @see #mergeArrayDelayError(MaybeSource...)
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1303,18 +1330,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens an array of MaybeSources into one Flowable, in a way that allows a Subscriber to receive all
-     * successfully emitted items from each of the source MaybeSources without being interrupted by an error
+     * Flattens an array of {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to receive all
+     * successfully emitted items from each of the source {@code MaybeSource}s without being interrupted by an error
      * notification from one of them.
      * <p>
-     * This behaves like {@link #merge(Publisher)} except that if any of the merged MaybeSources notify of an
+     * This behaves like {@link #merge(Publisher)} except that if any of the merged {@code MaybeSource}s notify of an
      * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged MaybeSources have finished emitting items.
+     * error notification until all of the merged {@code MaybeSource}s have finished emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its Subscribers once.
+     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -1324,9 +1351,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common element base type
      * @param sources
-     *            the Iterable of MaybeSources
-     * @return a Flowable that emits items that are the result of flattening the items emitted by the
-     *         MaybeSources in the Iterable
+     *            the array of {@code MaybeSource}s
+     * @return a {@code Flowable} that emits items that are the result of flattening the items emitted by the
+     *         {@code MaybeSource}s in the array
+     * @throws NullPointerException if {@code sources} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -1343,18 +1371,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens an Iterable of MaybeSources into one Flowable, in a way that allows a Subscriber to receive all
-     * successfully emitted items from each of the source MaybeSources without being interrupted by an error
+     * Flattens an {@link Iterable} sequence of {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to receive all
+     * successfully emitted items from each of the source {@code MaybeSource}s without being interrupted by an error
      * notification from one of them.
      * <p>
-     * This behaves like {@link #merge(Publisher)} except that if any of the merged MaybeSources notify of an
+     * This behaves like {@link #merge(Publisher)} except that if any of the merged {@code MaybeSource}s notify of an
      * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged MaybeSources have finished emitting items.
+     * error notification until all of the merged {@code MaybeSource}s have finished emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its Subscribers once.
+     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -1364,9 +1392,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common element base type
      * @param sources
-     *            the Iterable of MaybeSources
-     * @return a Flowable that emits items that are the result of flattening the items emitted by the
-     *         MaybeSources in the Iterable
+     *            the {@code Iterable} of {@code MaybeSource}s
+     * @return a {@code Flowable} that emits items that are the result of flattening the items emitted by the
+     *         {@code MaybeSource}s in the {@code Iterable}
+     * @throws NullPointerException if {@code sources} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -1379,18 +1408,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens a Publisher that emits MaybeSources into one Publisher, in a way that allows a Subscriber to
-     * receive all successfully emitted items from all of the source MaybeSources without being interrupted by
-     * an error notification from one of them or even the main Publisher.
+     * Flattens a {@link Publisher} that emits {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to
+     * receive all successfully emitted items from all of the source {@code MaybeSource}s without being interrupted by
+     * an error notification from one of them or even the main {@code Publisher}.
      * <p>
-     * This behaves like {@link #merge(Publisher)} except that if any of the merged MaybeSources notify of an
+     * This behaves like {@link #merge(Publisher)} except that if any of the merged {@code MaybeSource}s notify of an
      * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged MaybeSources and the main Publisher have finished emitting items.
+     * error notification until all of the merged {@code MaybeSource}s and the main {@code Publisher} have finished emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its Subscribers once.
+     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed
@@ -1401,9 +1430,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common element base type
      * @param sources
-     *            a Publisher that emits MaybeSources
-     * @return a Flowable that emits all of the items emitted by the Publishers emitted by the
-     *         {@code source} Publisher
+     *            a {@code Publisher} that emits {@code MaybeSource}s
+     * @return a {@code Flowable} that emits all of the items emitted by the {@code MaybeSource}s emitted by the
+     *         {@code source} {@code Publisher}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1415,18 +1444,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens a Publisher that emits MaybeSources into one Publisher, in a way that allows a Subscriber to
-     * receive all successfully emitted items from all of the source MaybeSources without being interrupted by
-     * an error notification from one of them or even the main Publisher as well as limiting the total number of active MaybeSources.
+     * Flattens a {@link Publisher} that emits {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to
+     * receive all successfully emitted items from all of the source {@code MaybeSource}s without being interrupted by
+     * an error notification from one of them or even the main {@code Publisher} as well as limiting the total number of active {@code MaybeSource}s.
      * <p>
-     * This behaves like {@link #merge(Publisher, int)} except that if any of the merged MaybeSources notify of an
+     * This behaves like {@link #merge(Publisher, int)} except that if any of the merged {@code MaybeSource}s notify of an
      * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged MaybeSources and the main Publisher have finished emitting items.
+     * error notification until all of the merged {@code MaybeSource}s and the main {@code Publisher} have finished emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged Publishers send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its Subscribers once.
+     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed
@@ -1437,10 +1466,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>History: 2.1.9 - experimental
      * @param <T> the common element base type
      * @param sources
-     *            a Publisher that emits MaybeSources
-     * @param maxConcurrency the maximum number of active inner MaybeSources to be merged at a time
-     * @return a Flowable that emits all of the items emitted by the Publishers emitted by the
-     *         {@code source} Publisher
+     *            a {@code Publisher} that emits {@code MaybeSource}s
+     * @param maxConcurrency the maximum number of active inner {@code MaybeSource}s to be merged at a time
+     * @return a {@code Flowable} that emits all of the items emitted by the {@code MaybeSource}s emitted by the
+     *         {@code source} {@code Publisher}
+     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @since 2.2
      */
@@ -1456,18 +1487,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens two MaybeSources into one Flowable, in a way that allows a Subscriber to receive all
-     * successfully emitted items from each of the source MaybeSources without being interrupted by an error
+     * Flattens two {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to receive all
+     * successfully emitted items from each of the source {@code MaybeSource}s without being interrupted by an error
      * notification from one of them.
      * <p>
-     * This behaves like {@link #merge(MaybeSource, MaybeSource)} except that if any of the merged MaybeSources
+     * This behaves like {@link #merge(MaybeSource, MaybeSource)} except that if any of the merged {@code MaybeSource}s
      * notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from
-     * propagating that error notification until all of the merged MaybeSources have finished emitting items.
+     * propagating that error notification until all of the merged {@code MaybeSource}s have finished emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if both merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its Subscribers once.
+     * Even if both merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -1477,10 +1508,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common element base type
      * @param source1
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source2
-     *            a MaybeSource to be merged
-     * @return a Flowable that emits all of the items that are emitted by the two source MaybeSources
+     *            a {@code MaybeSource} to be merged
+     * @return a {@code Flowable} that emits all of the items that are emitted by the two source {@code MaybeSource}s
+     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1494,19 +1526,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens three MaybeSource into one Flowable, in a way that allows a Subscriber to receive all
-     * successfully emitted items from all of the source MaybeSources without being interrupted by an error
+     * Flattens three {@link MaybeSource} into one {@link Flowable}, in a way that allows a subscriber to receive all
+     * successfully emitted items from all of the source {@code MaybeSource}s without being interrupted by an error
      * notification from one of them.
      * <p>
      * This behaves like {@link #merge(MaybeSource, MaybeSource, MaybeSource)} except that if any of the merged
-     * MaybeSources notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain
-     * from propagating that error notification until all of the merged MaybeSources have finished emitting
+     * {@code MaybeSource}s notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain
+     * from propagating that error notification until all of the merged {@code MaybeSource}s have finished emitting
      * items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its Subscribers once.
+     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -1516,12 +1548,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common element base type
      * @param source1
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source2
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source3
-     *            a MaybeSource to be merged
-     * @return a Flowable that emits all of the items that are emitted by the source MaybeSources
+     *            a {@code MaybeSource} to be merged
+     * @return a {@code Flowable} that emits all of the items that are emitted by the source {@code MaybeSource}s
+     * @throws NullPointerException if {@code source1}, {@code source2} or {@code source3} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1537,19 +1570,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens four MaybeSources into one Flowable, in a way that allows a Subscriber to receive all
-     * successfully emitted items from all of the source MaybeSources without being interrupted by an error
+     * Flattens four {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to receive all
+     * successfully emitted items from all of the source {@code MaybeSource}s without being interrupted by an error
      * notification from one of them.
      * <p>
      * This behaves like {@link #merge(MaybeSource, MaybeSource, MaybeSource, MaybeSource)} except that if any of
-     * the merged MaybeSources notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
-     * will refrain from propagating that error notification until all of the merged MaybeSources have finished
+     * the merged {@code MaybeSource}s notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
+     * will refrain from propagating that error notification until all of the merged {@code MaybeSource}s have finished
      * emitting items.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.png" alt="">
      * <p>
-     * Even if multiple merged MaybeSources send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its Subscribers once.
+     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
+     * invoke the {@code onError} method of its subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
@@ -1559,14 +1592,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <T> the common element base type
      * @param source1
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source2
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source3
-     *            a MaybeSource to be merged
+     *            a {@code MaybeSource} to be merged
      * @param source4
-     *            a MaybeSource to be merged
-     * @return a Flowable that emits all of the items that are emitted by the source MaybeSources
+     *            a {@code MaybeSource} to be merged
+     * @return a {@code Flowable} that emits all of the items that are emitted by the source {@code MaybeSource}s
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code source4} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -1584,19 +1618,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that never sends any items or notifications to a {@link MaybeObserver}.
+     * Returns a {@code Maybe} that never sends any items or notifications to a {@link MaybeObserver}.
      * <p>
      * <img width="640" height="185" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/never.png" alt="">
      * <p>
-     * This Maybe is useful primarily for testing purposes.
+     * This {@code Maybe} is useful primarily for testing purposes.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code never} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
-     *            the type of items (not) emitted by the Maybe
-     * @return a Maybe that never emits any items or sends any notifications to a {@link MaybeObserver}
+     *            the type of items (not) emitted by the {@code Maybe}
+     * @return a {@code Maybe} that never emits any items or sends any notifications to a {@code MaybeObserver}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Never</a>
      */
     @CheckReturnValue
@@ -1608,8 +1642,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Single that emits a Boolean value that indicates whether two MaybeSource sequences are the
-     * same by comparing the items emitted by each MaybeSource pairwise.
+     * Returns a {@link Single} that emits a {@link Boolean} value that indicates whether two {@link MaybeSource} sequences are the
+     * same by comparing the items emitted by each {@code MaybeSource} pairwise.
      * <p>
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.png" alt="">
      * <dl>
@@ -1618,12 +1652,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param source1
-     *            the first MaybeSource to compare
+     *            the first {@code MaybeSource} to compare
      * @param source2
-     *            the second MaybeSource to compare
+     *            the second {@code MaybeSource} to compare
      * @param <T>
-     *            the type of items emitted by each MaybeSource
-     * @return a Single that emits a Boolean value that indicates whether the two sequences are the same
+     *            the type of items emitted by each {@code MaybeSource}
+     * @return a {@code Single} that emits a {@code Boolean} value that indicates whether the two sequences are the same
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
      */
     @CheckReturnValue
@@ -1634,8 +1668,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Single that emits a Boolean value that indicates whether two MaybeSources are the
-     * same by comparing the items emitted by each MaybeSource pairwise based on the results of a specified
+     * Returns a {@link Single} that emits a {@link Boolean} value that indicates whether two {@link MaybeSource}s are the
+     * same by comparing the items emitted by each {@code MaybeSource} pairwise based on the results of a specified
      * equality function.
      * <p>
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.png" alt="">
@@ -1645,15 +1679,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param source1
-     *            the first MaybeSource to compare
+     *            the first {@code MaybeSource} to compare
      * @param source2
-     *            the second MaybeSource to compare
+     *            the second {@code MaybeSource} to compare
      * @param isEqual
-     *            a function used to compare items emitted by each MaybeSource
+     *            a function used to compare items emitted by each {@code MaybeSource}
      * @param <T>
-     *            the type of items emitted by each MaybeSource
-     * @return a Single that emits a Boolean value that indicates whether the two MaybeSource sequences
+     *            the type of items emitted by each {@code MaybeSource}
+     * @return a {@code Single} that emits a {@code Boolean} value that indicates whether the two {@code MaybeSource} sequences
      *         are the same according to the specified function
+     * @throws NullPointerException if {@code source1}, {@code source2} or {@code isEqual} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
      */
     @CheckReturnValue
@@ -1668,7 +1703,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits {@code 0L} after a specified delay.
+     * Returns a {@code Maybe} that emits {@code 0L} after a specified delay.
      * <p>
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.png" alt="">
      * <dl>
@@ -1680,7 +1715,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            the initial delay before emitting a single {@code 0L}
      * @param unit
      *            time units to use for {@code delay}
-     * @return a Maybe that emits {@code 0L} after a specified delay
+     * @return a {@code Maybe} that emits {@code 0L} after a specified delay
      * @see <a href="http://reactivex.io/documentation/operators/timer.html">ReactiveX operators documentation: Timer</a>
      */
     @CheckReturnValue
@@ -1691,12 +1726,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits {@code 0L} after a specified delay on a specified Scheduler.
+     * Returns a {@code Maybe} that emits {@code 0L} after a specified delay on a specified {@link Scheduler}.
      * <p>
      * <img width="640" height="200" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
      * @param delay
@@ -1704,8 +1739,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param unit
      *            time units to use for {@code delay}
      * @param scheduler
-     *            the {@link Scheduler} to use for scheduling the item
-     * @return a Maybe that emits {@code 0L} after a specified delay, on a specified Scheduler
+     *            the {@code Scheduler} to use for scheduling the item
+     * @return a {@code Maybe} that emits {@code 0L} after a specified delay, on a specified {@code Scheduler}
+     * @throws NullPointerException if {@code unit} or {@code scheduler} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/timer.html">ReactiveX operators documentation: Timer</a>
      */
     @CheckReturnValue
@@ -1719,15 +1755,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * <strong>Advanced use only:</strong> creates a Maybe instance without
-     * any safeguards by using a callback that is called with a MaybeObserver.
+     * <strong>Advanced use only:</strong> creates a {@code Maybe} instance without
+     * any safeguards by using a callback that is called with a {@link MaybeObserver}.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code unsafeCreate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param onSubscribe the function that is called with the subscribing MaybeObserver
-     * @return the new Maybe instance
+     * @param onSubscribe the function that is called with the subscribing {@code MaybeObserver}
+     * @return the new {@code Maybe} instance
      */
     @CheckReturnValue
     @NonNull
@@ -1741,8 +1777,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Constructs a Maybe that creates a dependent resource object which is disposed of when the
-     * upstream terminates or the downstream calls dispose().
+     * Constructs a {@code Maybe} that creates a dependent resource object which is disposed of when the
+     * generated {@link MaybeSource} terminates or the downstream calls dispose().
      * <p>
      * <img width="640" height="400" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/using.png" alt="">
      * <dl>
@@ -1750,15 +1786,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <T> the element type of the generated MaybeSource
+     * @param <T> the element type of the generated {@code MaybeSource}
      * @param <D> the type of the resource associated with the output sequence
      * @param resourceSupplier
-     *            the factory function to create a resource object that depends on the Maybe
+     *            the factory function to create a resource object that depends on the {@code Maybe}
      * @param sourceSupplier
-     *            the factory function to create a MaybeSource
+     *            the factory function to create a {@code MaybeSource}
      * @param resourceDisposer
      *            the function that will dispose of the resource
-     * @return the Maybe whose lifetime controls the lifetime of the dependent resource object
+     * @return the {@code Maybe} whose lifetime controls the lifetime of the dependent resource object
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
      */
     @CheckReturnValue
@@ -1771,24 +1807,24 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Constructs a Maybe that creates a dependent resource object which is disposed of just before
-     * termination if you have set {@code disposeEagerly} to {@code true} and a downstream dispose() does not occur
-     * before termination. Otherwise resource disposal will occur on call to dispose().  Eager disposal is
-     * particularly appropriate for a synchronous Maybe that reuses resources. {@code disposeAction} will
-     * only be called once per subscription.
+     * Constructs a {@code Maybe} that creates a dependent resource object which is disposed first ({code eager == true})
+     * when the generated {@link MaybeSource} terminates or the downstream disposes; or after ({code eager == false}).
      * <p>
      * <img width="640" height="400" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/using.png" alt="">
+     * <p>
+     * Eager disposal is particularly appropriate for a synchronous {@code Maybe} that reuses resources. {@code disposeAction} will
+     * only be called once per subscription.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code using} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <T> the element type of the generated MaybeSource
+     * @param <T> the element type of the generated {@code MaybeSource}
      * @param <D> the type of the resource associated with the output sequence
      * @param resourceSupplier
-     *            the factory function to create a resource object that depends on the Maybe
+     *            the factory function to create a resource object that depends on the {@code Maybe}
      * @param sourceSupplier
-     *            the factory function to create a MaybeSource
+     *            the factory function to create a {@code MaybeSource}
      * @param resourceDisposer
      *            the function that will dispose of the resource
      * @param eager
@@ -1796,7 +1832,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            or just before the emission of a terminal event ({@code onSuccess}, {@code onComplete} or {@code onError}).
      *            If {@code false} the resource disposal will happen either on a {@code dispose()} call after the upstream is disposed
      *            or just after the emission of a terminal event ({@code onSuccess}, {@code onComplete} or {@code onError}).
-     * @return the Maybe whose lifetime controls the lifetime of the dependent resource object
+     * @return the {@code Maybe} whose lifetime controls the lifetime of the dependent resource object
+     * @throws NullPointerException if {@code resourceSupplier}, {@code sourceSupplier} or {@code resourceDisposer} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
      */
     @CheckReturnValue
@@ -1812,7 +1849,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Wraps a MaybeSource instance into a new Maybe instance if not already a Maybe
+     * Wraps a {@link MaybeSource} instance into a new {@code Maybe} instance if not already a {@code Maybe}
      * instance.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -1820,7 +1857,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      * @param <T> the value type
      * @param source the source to wrap
-     * @return the Maybe wrapper or the source cast to Maybe (if possible)
+     * @return the {@code Maybe} wrapper or the source cast to {@code Maybe} (if possible)
      */
     @CheckReturnValue
     @NonNull
@@ -1834,16 +1871,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * items emitted, in sequence, by an Iterable of other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * items emitted, in sequence, by an {@link Iterable} of other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="341" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.i.png" alt="">
      * <p>
      * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
      * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
-     * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
+     * {@code Function<Integer[], R>} passed to the method would trigger a {@link ClassCastException}.
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1853,11 +1890,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T> the common value type
      * @param <R> the zipped result type
      * @param sources
-     *            an Iterable of source MaybeSources
+     *            an {@code Iterable} of source {@code MaybeSource}s
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting Maybe
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code zipper} or {@code sources} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -1870,12 +1908,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * two items emitted, in sequence, by two other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * two items emitted, in sequence, by two other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="434" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.n.png" alt="">
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1886,13 +1924,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T2> the value type of the second source
      * @param <R> the zipped result type
      * @param source1
-     *            the first source MaybeSource
+     *            the first source {@code MaybeSource}
      * @param source2
-     *            a second source MaybeSource
+     *            a second source {@code MaybeSource}
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results
-     *            in an item that will be emitted by the resulting Maybe
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results
+     *            in an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code source1}, {@code source2} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -1908,12 +1947,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * three items emitted, in sequence, by three other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * three items emitted, in sequence, by three other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="434" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.n.png" alt="">
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1925,15 +1964,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T3> the value type of the third source
      * @param <R> the zipped result type
      * @param source1
-     *            the first source MaybeSource
+     *            the first source {@code MaybeSource}
      * @param source2
-     *            a second source MaybeSource
+     *            a second source {@code MaybeSource}
      * @param source3
-     *            a third source MaybeSource
+     *            a third source {@code MaybeSource}
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting Maybe
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -1950,12 +1990,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * four items emitted, in sequence, by four other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * four items emitted, in sequence, by four other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="434" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.n.png" alt="">
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -1968,17 +2008,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T4> the value type of the fourth source
      * @param <R> the zipped result type
      * @param source1
-     *            the first source MaybeSource
+     *            the first source {@code MaybeSource}
      * @param source2
-     *            a second source MaybeSource
+     *            a second source {@code MaybeSource}
      * @param source3
-     *            a third source MaybeSource
+     *            a third source {@code MaybeSource}
      * @param source4
-     *            a fourth source MaybeSource
+     *            a fourth source {@code MaybeSource}
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting Maybe
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3},
+     *                              {@code source4} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -1997,12 +2039,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * five items emitted, in sequence, by five other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * five items emitted, in sequence, by five other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="434" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.n.png" alt="">
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2016,19 +2058,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T5> the value type of the fifth source
      * @param <R> the zipped result type
      * @param source1
-     *            the first source MaybeSource
+     *            the first source {@code MaybeSource}
      * @param source2
-     *            a second source MaybeSource
+     *            a second source {@code MaybeSource}
      * @param source3
-     *            a third source MaybeSource
+     *            a third source {@code MaybeSource}
      * @param source4
-     *            a fourth source MaybeSource
+     *            a fourth source {@code MaybeSource}
      * @param source5
-     *            a fifth source MaybeSource
+     *            a fifth source {@code MaybeSource}
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting Maybe
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3},
+     *                              {@code source4}, {@code source5} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -2048,12 +2092,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * six items emitted, in sequence, by six other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * six items emitted, in sequence, by six other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="434" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.n.png" alt="">
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2068,21 +2112,23 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T6> the value type of the sixth source
      * @param <R> the zipped result type
      * @param source1
-     *            the first source MaybeSource
+     *            the first source {@code MaybeSource}
      * @param source2
-     *            a second source MaybeSource
+     *            a second source {@code MaybeSource}
      * @param source3
-     *            a third source MaybeSource
+     *            a third source {@code MaybeSource}
      * @param source4
-     *            a fourth source MaybeSource
+     *            a fourth source {@code MaybeSource}
      * @param source5
-     *            a fifth source MaybeSource
+     *            a fifth source {@code MaybeSource}
      * @param source6
-     *            a sixth source MaybeSource
+     *            a sixth source {@code MaybeSource}
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting Maybe
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3},
+     *                              {@code source4}, {@code source5}, {@code source6} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -2103,12 +2149,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * seven items emitted, in sequence, by seven other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * seven items emitted, in sequence, by seven other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="434" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.n.png" alt="">
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2124,23 +2170,26 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T7> the value type of the seventh source
      * @param <R> the zipped result type
      * @param source1
-     *            the first source MaybeSource
+     *            the first source {@code MaybeSource}
      * @param source2
-     *            a second source MaybeSource
+     *            a second source {@code MaybeSource}
      * @param source3
-     *            a third source MaybeSource
+     *            a third source {@code MaybeSource}
      * @param source4
-     *            a fourth source MaybeSource
+     *            a fourth source {@code MaybeSource}
      * @param source5
-     *            a fifth source MaybeSource
+     *            a fifth source {@code MaybeSource}
      * @param source6
-     *            a sixth source MaybeSource
+     *            a sixth source {@code MaybeSource}
      * @param source7
-     *            a seventh source MaybeSource
+     *            a seventh source {@code MaybeSource}
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting Maybe
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3},
+     *                              {@code source4}, {@code source5}, {@code source6},
+     *                              {@code source7} or {@code zipper} is {@code null}
+     * @return a {@code Maybe} that emits the zipped results
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -2163,12 +2212,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * eight items emitted, in sequence, by eight other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * eight items emitted, in sequence, by eight other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="434" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.n.png" alt="">
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2185,25 +2234,28 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T8> the value type of the eighth source
      * @param <R> the zipped result type
      * @param source1
-     *            the first source MaybeSource
+     *            the first source {@code MaybeSource}
      * @param source2
-     *            a second source MaybeSource
+     *            a second source {@code MaybeSource}
      * @param source3
-     *            a third source MaybeSource
+     *            a third source {@code MaybeSource}
      * @param source4
-     *            a fourth source MaybeSource
+     *            a fourth source {@code MaybeSource}
      * @param source5
-     *            a fifth source MaybeSource
+     *            a fifth source {@code MaybeSource}
      * @param source6
-     *            a sixth source MaybeSource
+     *            a sixth source {@code MaybeSource}
      * @param source7
-     *            a seventh source MaybeSource
+     *            a seventh source {@code MaybeSource}
      * @param source8
-     *            an eighth source MaybeSource
+     *            an eighth source {@code MaybeSource}
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting Maybe
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3},
+     *                              {@code source4}, {@code source5}, {@code source6},
+     *                              {@code source7}, {@code source8} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -2227,12 +2279,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * nine items emitted, in sequence, by nine other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * nine items emitted, in sequence, by nine other {@link MaybeSource}s.
      * <p>
      * <img width="640" height="434" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zip.n.png" alt="">
      * <p>
-     * This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2249,27 +2301,30 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T9> the value type of the ninth source
      * @param <R> the zipped result type
      * @param source1
-     *            the first source MaybeSource
+     *            the first source {@code MaybeSource}
      * @param source2
-     *            a second source MaybeSource
+     *            a second source {@code MaybeSource}
      * @param source3
-     *            a third source MaybeSource
+     *            a third source {@code MaybeSource}
      * @param source4
-     *            a fourth source MaybeSource
+     *            a fourth source {@code MaybeSource}
      * @param source5
-     *            a fifth source MaybeSource
+     *            a fifth source {@code MaybeSource}
      * @param source6
-     *            a sixth source MaybeSource
+     *            a sixth source {@code MaybeSource}
      * @param source7
-     *            a seventh source MaybeSource
+     *            a seventh source {@code MaybeSource}
      * @param source8
-     *            an eighth source MaybeSource
+     *            an eighth source {@code MaybeSource}
      * @param source9
-     *            a ninth source MaybeSource
+     *            a ninth source {@code MaybeSource}
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting MaybeSource
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3},
+     *                              {@code source4}, {@code source5}, {@code source6},
+     *                              {@code source7}, {@code source8}, {@code source9} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -2295,16 +2350,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified combiner function applied to combinations of
-     * items emitted, in sequence, by an array of other MaybeSources.
+     * Returns a {@code Maybe} that emits the results of a specified combiner function applied to combinations of
+     * items emitted, in sequence, by an array of other {@link MaybeSource}s.
      * <p>
      * Note on method signature: since Java doesn't allow creating a generic array with {@code new T[]}, the
      * implementation of this operator has to create an {@code Object[]} instead. Unfortunately, a
-     * {@code Function<Integer[], R>} passed to the method would trigger a {@code ClassCastException}.
+     * {@code Function<Integer[], R>} passed to the method would trigger a {@link ClassCastException}.
      *
      * <p>
      * <img width="640" height="341" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zipArray.png" alt="">
-     * <p>This operator terminates eagerly if any of the source MaybeSources signal an onError or onComplete. This
+     * <p>This operator terminates eagerly if any of the source {@code MaybeSource}s signal an {@code onError} or {@code onComplete}. This
      * also means it is possible some sources may not get subscribed to at all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -2314,11 +2369,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <T> the common element type
      * @param <R> the result type
      * @param sources
-     *            an array of source MaybeSources
+     *            an array of source {@code MaybeSource}s
      * @param zipper
-     *            a function that, when applied to an item emitted by each of the source MaybeSources, results in
-     *            an item that will be emitted by the resulting MaybeSource
-     * @return a Maybe that emits the zipped results
+     *            a function that, when applied to an item emitted by each of the source {@code MaybeSource}s, results in
+     *            an item that will be emitted by the resulting {@code Maybe}
+     * @return a {@code Maybe} that emits the zipped results
+     * @throws NullPointerException if {@code sources} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -2340,7 +2396,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     // ------------------------------------------------------------------
 
     /**
-     * Mirrors the MaybeSource (current or provided) that first signals an event.
+     * Mirrors the {@link MaybeSource} (current or provided) that first signals an event.
      * <p>
      * <img width="640" height="385" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/amb.png" alt="">
      * <dl>
@@ -2349,10 +2405,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param other
-     *            a MaybeSource competing to react first. A subscription to this provided source will occur after
+     *            a {@code MaybeSource} competing to react first. A subscription to this provided source will occur after
      *            subscribing to the current source.
-     * @return a Maybe that emits the same sequence as whichever of the source MaybeSources first
-     *         signalled
+     * @return a {@code Maybe} that emits the same sequence as whichever of the source {@code MaybeSource}s first
+     *         signaled
+     * @throws NullPointerException if {@code other} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/amb.html">ReactiveX operators documentation: Amb</a>
      */
     @CheckReturnValue
@@ -2364,8 +2421,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Waits in a blocking fashion until the current Maybe signals a success value (which is returned),
-     * null if completed or an exception (which is propagated).
+     * Waits in a blocking fashion until the current {@code Maybe} signals a success value (which is returned),
+     * {@code null} if completed or an exception (which is propagated).
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code blockingGet} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -2386,7 +2443,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Waits in a blocking fashion until the current Maybe signals a success value (which is returned),
+     * Waits in a blocking fashion until the current {@code Maybe} signals a success value (which is returned),
      * defaultValue if completed or an exception (which is propagated).
      * <dl>
      * <dt><b>Scheduler:</b></dt>
@@ -2396,13 +2453,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * into {@link RuntimeException} and throws that. Otherwise, {@code RuntimeException}s and
      * {@link Error}s are rethrown as they are.</dd>
      * </dl>
-     * @param defaultValue the default item to return if this Maybe is empty
+     * @param defaultValue the default item to return if this {@code Maybe} is empty
      * @return the success value
+     * @throws NullPointerException if {@code defaultValue} is {@code null}
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @Nullable
-    public final T blockingGet(@Nullable T defaultValue) {
+    @NonNull
+    public final T blockingGet(@NonNull T defaultValue) {
         Objects.requireNonNull(defaultValue, "defaultValue is null");
         BlockingMultiObserver<T> observer = new BlockingMultiObserver<>();
         subscribe(observer);
@@ -2410,13 +2468,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that subscribes to this Maybe lazily, caches its event
+     * Returns a {@code Maybe} that subscribes to this {@code Maybe} lazily, caches its event
      * and replays it, to all the downstream subscribers.
      * <p>
      * <img width="640" height="410" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/cache.png" alt="">
      * <p>
      * The operator subscribes only when the first downstream subscriber subscribes and maintains
-     * a single subscription towards this Maybe.
+     * a single subscription towards this {@code Maybe}.
      * <p>
      * <em>Note:</em> You sacrifice the ability to dispose the origin when you use the {@code cache}.
      * <dl>
@@ -2424,7 +2482,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code cache} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Maybe that, when first subscribed to, caches all of its items and notifications for the
+     * @return a {@code Maybe} that, when first subscribed to, caches all of its items and notifications for the
      *         benefit of subsequent subscribers
      * @see <a href="http://reactivex.io/documentation/operators/replay.html">ReactiveX operators documentation: Replay</a>
      */
@@ -2436,8 +2494,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Casts the success value of the current Maybe into the target type or signals a
-     * ClassCastException if not compatible.
+     * Casts the success value of the current {@code Maybe} into the target type or signals a
+     * {@link ClassCastException} if not compatible.
      * <p>
      * <img width="640" height="318" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.cast.png" alt="">
      * <dl>
@@ -2445,8 +2503,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code cast} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the target type
-     * @param clazz the type token to use for casting the success result from the current Maybe
-     * @return the new Maybe instance
+     * @param clazz the type token to use for casting the success result from the current {@code Maybe}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code clazz} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -2457,21 +2516,22 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Transform a Maybe by applying a particular Transformer function to it.
+     * Transform a {@code Maybe} by applying a particular {@link MaybeTransformer} function to it.
      * <p>
-     * This method operates on the Maybe itself whereas {@link #lift} operates on the Maybe's MaybeObservers.
+     * This method operates on the {@code Maybe} itself whereas {@link #lift} operates on the {@code Maybe}'s {@link MaybeObserver}s.
      * <p>
-     * If the operator you are creating is designed to act on the individual item emitted by a Maybe, use
-     * {@link #lift}. If your operator is designed to transform the source Maybe as a whole (for instance, by
+     * If the operator you are creating is designed to act on the individual item emitted by a {@code Maybe}, use
+     * {@link #lift}. If your operator is designed to transform the source {@code Maybe} as a whole (for instance, by
      * applying a particular set of existing RxJava operators to it) use {@code compose}.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code compose} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <R> the value type of the Maybe returned by the transformer function
-     * @param transformer the transformer function, not null
-     * @return a Maybe, transformed by the transformer function
+     * @param <R> the value type of the {@code Maybe} returned by the transformer function
+     * @param transformer the transformer function, not {@code null}
+     * @return a {@code Maybe}, transformed by the transformer function
+     * @throws NullPointerException if {@code transformer} is {@code null}
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Implementing-Your-Own-Operators">RxJava wiki: Implementing Your Own Operators</a>
      */
     @SuppressWarnings("unchecked")
@@ -2483,20 +2543,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that is based on applying a specified function to the item emitted by the source Maybe,
-     * where that function returns a MaybeSource.
+     * Returns a {@code Maybe} that is based on applying a specified function to the item emitted by the source {@code Maybe},
+     * where that function returns a {@link MaybeSource}.
      * <p>
      * <img width="640" height="356" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code concatMap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * <p>Note that flatMap and concatMap for Maybe is the same operation.
+     * <p>Note that flatMap and concatMap for {@code Maybe} is the same operation.
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns a MaybeSource
-     * @return the Maybe returned from {@code func} when applied to the item emitted by the source Maybe
+     *            a function that, when applied to the item emitted by the source {@code Maybe}, returns a {@code MaybeSource}
+     * @return the {@code Maybe} returned from {@code mapper} when applied to the item emitted by the source {@code Maybe}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @throws NullPointerException if {@code mapper} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -2507,7 +2568,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that emits the items emitted from the current MaybeSource, then the next, one after
+     * Returns a {@link Flowable} that emits the items emitted from the current {@code Maybe}, then the {@code other} {@link MaybeSource}, one after
      * the other, without interleaving them.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concat.png" alt="">
@@ -2519,9 +2580,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param other
-     *            a MaybeSource to be concatenated after the current
-     * @return a Flowable that emits items emitted by the two source MaybeSources, one after the other,
+     *            a {@code MaybeSource} to be concatenated after the current
+     * @return a {@code Flowable} that emits items emitted by the two source {@code MaybeSource}s, one after the other,
      *         without interleaving them
+     * @throws NullPointerException if {@code other} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -2534,7 +2596,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Single that emits a Boolean that indicates whether the source Maybe emitted a
+     * Returns a {@link Single} that emits a {@link Boolean} that indicates whether the source {@code Maybe} emitted a
      * specified item.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.contains.o.png" alt="">
@@ -2544,9 +2606,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param item
-     *            the item to search for in the emissions from the source Maybe, not null
-     * @return a Single that emits {@code true} if the specified item is emitted by the source Maybe,
-     *         or {@code false} if the source Maybe completes without emitting that item
+     *            the item to search for in the emissions from the source {@code Maybe}, not {@code null}
+     * @return a {@code Single} that emits {@code true} if the specified item is emitted by the source {@code Maybe},
+     *         or {@code false} if the source {@code Maybe} completes without emitting that item
+     * @throws NullPointerException if {@code item} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/contains.html">ReactiveX operators documentation: Contains</a>
      */
     @CheckReturnValue
@@ -2558,8 +2621,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Single that counts the total number of items emitted (0 or 1) by the source Maybe and emits
-     * this count as a 64-bit Long.
+     * Returns a {@link Single} that counts the total number of items emitted (0 or 1) by the source {@code Maybe} and emits
+     * this count as a 64-bit {@link Long}.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/longCount.png" alt="">
      * <dl>
@@ -2567,8 +2630,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code count} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Single that emits a single item: the number of items emitted by the source Maybe as a
-     *         64-bit Long item
+     * @return a {@code Single} that emits a single item: the number of items emitted by the source {@code Maybe} as a
+     *         64-bit {@code Long} item
      * @see <a href="http://reactivex.io/documentation/operators/count.html">ReactiveX operators documentation: Count</a>
      */
     @CheckReturnValue
@@ -2579,8 +2642,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Single that emits the item emitted by the source Maybe or a specified default item
-     * if the source Maybe is empty.
+     * Returns a {@link Single} that emits the item emitted by the source {@code Maybe} or a specified default item
+     * if the source {@code Maybe} is empty.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/defaultIfEmpty.png" alt="">
      * <dl>
@@ -2589,9 +2652,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param defaultItem
-     *            the item to emit if the source Maybe emits no items
-     * @return a Single that emits either the specified default item if the source Maybe emits no
-     *         item, or the item emitted by the source Maybe
+     *            the item to emit if the source {@code Maybe} emits no items
+     * @return a {@code Single} that emits either the specified default item if the source {@code Maybe} emits no
+     *         item, or the item emitted by the source {@code Maybe}
+     * @throws NullPointerException if {@code defaultItem} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/defaultifempty.html">ReactiveX operators documentation: DefaultIfEmpty</a>
      */
     @CheckReturnValue
@@ -2603,7 +2667,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that signals the events emitted by the source Maybe shifted forward in time by a
+     * Returns a {@code Maybe} that signals the events emitted by the source {@code Maybe} shifted forward in time by a
      * specified delay.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delay.png" alt="">
@@ -2616,7 +2680,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            the delay to shift the source by
      * @param unit
      *            the {@link TimeUnit} in which {@code period} is defined
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      * @see #delay(long, TimeUnit, Scheduler)
      */
@@ -2628,13 +2692,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that signals the events emitted by the source Maybe shifted forward in time by a
-     * specified delay running on the specified Scheduler.
+     * Returns a {@code Maybe} that signals the events emitted by the source {@code Maybe} shifted forward in time by a
+     * specified delay running on the specified {@link Scheduler}.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delay.s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>you specify which {@link Scheduler} this operator will use.</dd>
+     *  <dd>you specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
      * @param delay
@@ -2642,8 +2706,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param unit
      *            the time unit of {@code delay}
      * @param scheduler
-     *            the {@link Scheduler} to use for delaying
-     * @return the new Maybe instance
+     *            the {@code Scheduler} to use for delaying
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code unit} or {@code scheduler} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
     @CheckReturnValue
@@ -2656,7 +2721,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Delays the emission of this Maybe until the given Publisher signals an item or completes.
+     * Delays the emission of this {@code Maybe} until the given {@link Publisher} signals an item or completes.
      * <p>
      * <img width="640" height="450" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/delay.oo.png" alt="">
      * <dl>
@@ -2670,9 +2735,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <U>
      *            the subscription delay value type (ignored)
      * @param delayIndicator
-     *            the Publisher that gets subscribed to when this Maybe signals an event and that
-     *            signal is emitted when the Publisher signals an item or completes
-     * @return the new Maybe instance
+     *            the {@code Publisher} that gets subscribed to when this {@code Maybe} signals an event and that
+     *            signal is emitted when the {@code Publisher} signals an item or completes
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code delayIndicator} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
     @CheckReturnValue
@@ -2685,8 +2751,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that delays the subscription to this Maybe
-     * until the other Publisher emits an element or completes normally.
+     * Returns a {@code Maybe} that delays the subscription to this {@code Maybe}
+     * until the other {@link Publisher} emits an element or completes normally.
      * <p>
      * <img width="640" height="214" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.delaySubscription.p.png" alt="">
      * <dl>
@@ -2696,11 +2762,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param <U> the value type of the other Publisher, irrelevant
-     * @param subscriptionIndicator the other Publisher that should trigger the subscription
-     *        to this Publisher.
-     * @return a Maybe that delays the subscription to this Maybe
-     *         until the other Publisher emits an element or completes normally.
+     * @param <U> the value type of the other {@code Publisher}, irrelevant
+     * @param subscriptionIndicator the other {@code Publisher} that should trigger the subscription
+     *        to this {@code Publisher}.
+     * @throws NullPointerException if {@code subscriptionIndicator} is {@code null}
+     * @return a {@code Maybe} that delays the subscription to this {@code Maybe}
+     *         until the other {@code Publisher} emits an element or completes normally.
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @CheckReturnValue
@@ -2712,7 +2779,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that delays the subscription to the source Maybe by a given amount of time.
+     * Returns a {@code Maybe} that delays the subscription to the source {@code Maybe} by a given amount of time.
      * <p>
      * <img width="640" height="471" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.delaySubscription.t.png" alt="">
      * <dl>
@@ -2724,7 +2791,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            the time to delay the subscription
      * @param unit
      *            the time unit of {@code delay}
-     * @return a Maybe that delays the subscription to the source Maybe by the given amount
+     * @return a {@code Maybe} that delays the subscription to the source {@code Maybe} by the given amount
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      * @see #delaySubscription(long, TimeUnit, Scheduler)
      */
@@ -2736,13 +2803,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that delays the subscription to the source Maybe by a given amount of time,
-     * both waiting and subscribing on a given Scheduler.
+     * Returns a {@code Maybe} that delays the subscription to the source {@code Maybe} by a given amount of time,
+     * both waiting and subscribing on a given {@link Scheduler}.
      * <p>
      * <img width="640" height="420" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.delaySubscription.ts.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
      * @param delay
@@ -2750,9 +2817,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param unit
      *            the time unit of {@code delay}
      * @param scheduler
-     *            the Scheduler on which the waiting and subscription will happen
-     * @return a Maybe that delays the subscription to the source Maybe by a given
-     *         amount, waiting and subscribing on the given Scheduler
+     *            the {@code Scheduler} on which the waiting and subscription will happen
+     * @return a {@code Maybe} that delays the subscription to the source {@code Maybe} by a given
+     *         amount, waiting and subscribing on the given {@code Scheduler}
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
     @CheckReturnValue
@@ -2763,16 +2830,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the specified consumer with the success item after this item has been emitted to the downstream.
-     * <p>Note that the {@code onAfterNext} action is shared between subscriptions and as such
+     * Calls the specified {@link Consumer} with the success item after this item has been emitted to the downstream.
+     * <p>Note that the {@code onAfterSuccess} action is shared between subscriptions and as such
      * should be thread-safe.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code doAfterSuccess} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.0.1 - experimental
-     * @param onAfterSuccess the Consumer that will be called after emitting an item from upstream to the downstream
-     * @return the new Maybe instance
+     * @param onAfterSuccess the {@code Consumer} that will be called after emitting an item from upstream to the downstream
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onAfterSuccess} is {@code null}
      * @since 2.1
      */
     @CheckReturnValue
@@ -2784,7 +2852,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Registers an {@link Action} to be called when this Maybe invokes either
+     * Registers an {@link Action} to be called when this {@code Maybe} invokes either
      * {@link MaybeObserver#onComplete onSuccess},
      * {@link MaybeObserver#onComplete onComplete} or {@link MaybeObserver#onError onError}.
      * <p>
@@ -2795,9 +2863,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param onAfterTerminate
-     *            an {@link Action} to be invoked when the source Maybe finishes
-     * @return a Maybe that emits the same items as the source Maybe, then invokes the
-     *         {@link Action}
+     *            an {@code Action} to be invoked when the source {@code Maybe} finishes
+     * @return a {@code Maybe} that emits the same items as the source {@code Maybe}, then invokes the
+     *         {@code Action}
+     * @throws NullPointerException if {@code onAfterTerminate} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
     @CheckReturnValue
@@ -2815,7 +2884,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the specified action after this Maybe signals onSuccess, onError or onComplete or gets disposed by
+     * Calls the specified action after this {@code Maybe} signals {@code onSuccess}, {@code onError} or {@code onComplete} or gets disposed by
      * the downstream.
      * <p>In case of a race between a terminal event and a dispose call, the provided {@code onFinally} action
      * is executed once per subscription.
@@ -2826,8 +2895,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code doFinally} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.0.1 - experimental
-     * @param onFinally the action called when this Maybe terminates or gets disposed
-     * @return the new Maybe instance
+     * @param onFinally the action called when this {@code Maybe} terminates or gets disposed
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onFinally} is {@code null}
      * @since 2.1
      */
     @CheckReturnValue
@@ -2839,15 +2909,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the shared {@code Action} if a MaybeObserver subscribed to the current Maybe
-     * disposes the common Disposable it received via onSubscribe.
+     * Calls the shared {@link Action} if a {@link MaybeObserver} subscribed to the current {@code Maybe}
+     * disposes the common {@link Disposable} it received via {@code onSubscribe}.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnDispose} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param onDispose the action called when the subscription is disposed
-     * @throws NullPointerException if onDispose is null
-     * @return the new Maybe instance
+     * @throws NullPointerException if {@code onDispose} is {@code null}
+     * @return the new {@code Maybe} instance
      */
     @CheckReturnValue
     @NonNull
@@ -2864,7 +2934,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Modifies the source Maybe so that it invokes an action when it calls {@code onComplete}.
+     * Modifies the source {@code Maybe} so that it invokes an action when it calls {@code onComplete}.
      * <p>
      * <img width="640" height="358" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnComplete.m.png" alt="">
      * <dl>
@@ -2873,8 +2943,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param onComplete
-     *            the action to invoke when the source Maybe calls {@code onComplete}
-     * @return the new Maybe with the side-effecting behavior applied
+     *            the action to invoke when the source {@code Maybe} calls {@code onComplete}
+     * @return the new {@code Maybe} with the side-effecting behavior applied
+     * @throws NullPointerException if {@code onComplete} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      */
     @CheckReturnValue
@@ -2892,16 +2963,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the shared consumer with the error sent via onError for each
-     * MaybeObserver that subscribes to the current Maybe.
+     * Calls the shared {@link Consumer} with the error sent via {@code onError} for each
+     * {@link MaybeObserver} that subscribes to the current {@code Maybe}.
      * <p>
      * <img width="640" height="358" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnError.m.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param onError the consumer called with the success value of onError
-     * @return the new Maybe instance
+     * @param onError the consumer called with the success value of {@code onError}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onError} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -2918,20 +2990,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the given onEvent callback with the (success value, null) for an onSuccess, (null, throwable) for
-     * an onError or (null, null) for an onComplete signal from this Maybe before delivering said
+     * Calls the given {@code onEvent} callback with the (success value, {@code null}) for an {@code onSuccess}, ({@code null}, throwable) for
+     * an {@code onError} or ({@code null}, {@code null}) for an {@code onComplete} signal from this {@code Maybe} before delivering said
      * signal to the downstream.
      * <p>
      * <img width="640" height="297" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.doOnEvent.png" alt="">
      * <p>
-     * Exceptions thrown from the callback will override the event so the downstream receives the
+     * The exceptions thrown from the callback will override the event so the downstream receives the
      * error instead of the original signal.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnEvent} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param onEvent the callback to call with the terminal event tuple
-     * @return the new Maybe instance
+     * @param onEvent the callback to call with the success value or the exception, whichever is not {@code null}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onEvent} is {@code null}
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2942,14 +3015,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the shared consumer with the Disposable sent through the onSubscribe for each
-     * MaybeObserver that subscribes to the current Maybe.
+     * Calls the shared {@link Consumer} with the {@link Disposable} sent through the {@code onSubscribe} for each
+     * {@link MaybeObserver} that subscribes to the current {@code Maybe}.
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnSubscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param onSubscribe the consumer called with the Disposable sent via onSubscribe
-     * @return the new Maybe instance
+     * @param onSubscribe the {@code Consumer} called with the {@code Disposable} sent via {@code onSubscribe}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onSubscribe} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -2966,8 +3040,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe instance that calls the given onTerminate callback
-     * just before this Maybe completes normally or with an exception.
+     * Returns a {@code Maybe} instance that calls the given onTerminate callback
+     * just before this {@code Maybe} completes normally or with an exception.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnTerminate.png" alt="">
      * <p>
@@ -2979,7 +3053,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      * <p>History: 2.2.7 - experimental
      * @param onTerminate the action to invoke when the consumer calls {@code onComplete} or {@code onError}
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onTerminate} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
      * @see #doOnTerminate(Action)
      * @since 3.0.0
@@ -2993,16 +3068,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Calls the shared consumer with the success value sent via onSuccess for each
-     * MaybeObserver that subscribes to the current Maybe.
+     * Calls the shared {@link Consumer} with the success value sent via {@code onSuccess} for each
+     * {@link MaybeObserver} that subscribes to the current {@code Maybe}.
      * <p>
      * <img width="640" height="358" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/doOnSuccess.m.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code doOnSuccess} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param onSuccess the consumer called with the success value of onSuccess
-     * @return the new Maybe instance
+     * @param onSuccess the {@code Consumer} called with the success value of the upstream
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onSuccess} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -3019,8 +3095,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Filters the success item of the Maybe via a predicate function and emitting it if the predicate
-     * returns true, completing otherwise.
+     * Filters the success item of the {@code Maybe} via a predicate function and emitting it if the predicate
+     * returns {@code true}, completing otherwise.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/filter.png" alt="">
      * <dl>
@@ -3029,10 +3105,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param predicate
-     *            a function that evaluates the item emitted by the source Maybe, returning {@code true}
+     *            a function that evaluates the item emitted by the source {@code Maybe}, returning {@code true}
      *            if it passes the filter
-     * @return a Maybe that emit the item emitted by the source Maybe that the filter
+     * @return a {@code Maybe} that emit the item emitted by the source {@code Maybe} that the filter
      *         evaluates as {@code true}
+     * @throws NullPointerException if {@code predicate} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/filter.html">ReactiveX operators documentation: Filter</a>
      */
     @CheckReturnValue
@@ -3044,20 +3121,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that is based on applying a specified function to the item emitted by the source Maybe,
-     * where that function returns a MaybeSource.
+     * Returns a {@code Maybe} that is based on applying a specified function to the item emitted by the source {@code Maybe},
+     * where that function returns a {@link MaybeSource}.
      * <p>
      * <img width="640" height="356" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * <p>Note that flatMap and concatMap for Maybe is the same operation.
+     * <p>Note that flatMap and concatMap for {@code Maybe} is the same operation.
      *
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns a MaybeSource
-     * @return the Maybe returned from {@code func} when applied to the item emitted by the source Maybe
+     *            a function that, when applied to the item emitted by the source {@code Maybe}, returns a {@code MaybeSource}
+     * @return the {@code Maybe} returned from {@code mapper} when applied to the item emitted by the source {@code Maybe}
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
@@ -3069,8 +3147,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Maps the onSuccess, onError or onComplete signals of this Maybe into MaybeSource and emits that
-     * MaybeSource's signals.
+     * Maps the {@code onSuccess}, {@code onError} or {@code onComplete} signals of this {@code Maybe} into {@link MaybeSource} and emits that
+     * {@code MaybeSource}'s signals.
      * <p>
      * <img width="640" height="354" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.mmm.png" alt="">
      * <dl>
@@ -3081,12 +3159,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <R>
      *            the result type
      * @param onSuccessMapper
-     *            a function that returns a MaybeSource to merge for the onSuccess item emitted by this Maybe
+     *            a function that returns a {@code MaybeSource} to merge for the {@code onSuccess} item emitted by this {@code Maybe}
      * @param onErrorMapper
-     *            a function that returns a MaybeSource to merge for an onError notification from this Maybe
+     *            a function that returns a {@code MaybeSource} to merge for an {@code onError} notification from this {@code Maybe}
      * @param onCompleteSupplier
-     *            a function that returns a MaybeSource to merge for an onComplete notification this Maybe
-     * @return the new Maybe instance
+     *            a function that returns a {@code MaybeSource} to merge for an {@code onComplete} notification this {@code Maybe}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code onSuccessMapper}, {@code onErrorMapper} or {@code onCompleteSupplier} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
@@ -3103,8 +3182,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the results of a specified function to the pair of values emitted by the
-     * source Maybe and a specified mapped MaybeSource.
+     * Returns a {@code Maybe} that emits the results of a specified function to the pair of values emitted by the
+     * source {@code Maybe} and a specified mapped {@link MaybeSource}.
      * <p>
      * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.png" alt="">
      * <dl>
@@ -3113,15 +3192,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param <U>
-     *            the type of items emitted by the MaybeSource returned by the {@code mapper} function
+     *            the type of items emitted by the {@code MaybeSource} returned by the {@code mapper} function
      * @param <R>
-     *            the type of items emitted by the resulting Maybe
+     *            the type of items emitted by the resulting {@code Maybe}
      * @param mapper
-     *            a function that returns a MaybeSource for the item emitted by the source Maybe
+     *            a function that returns a {@code MaybeSource} for the item emitted by the source {@code Maybe}
      * @param resultSelector
-     *            a function that combines one item emitted by each of the source and collection MaybeSource and
-     *            returns an item to be emitted by the resulting MaybeSource
-     * @return the new Maybe instance
+     *            a function that combines one item emitted by each of the source and collection {@code MaybeSource} and
+     *            returns an item to be emitted by the resulting {@code MaybeSource}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code mapper} or {@code resultSelector} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
@@ -3135,7 +3215,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Maps the success value of the upstream {@link Maybe} into an {@link Iterable} and emits its items as a
+     * Maps the success value of the upstream {@code Maybe} into an {@link Iterable} and emits its items as a
      * {@link Flowable} sequence.
      * <p>
      * <img width="640" height="373" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenAsFlowable.png" alt="">
@@ -3147,11 +3227,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param <U>
-     *            the type of item emitted by the resulting Iterable
+     *            the type of item emitted by the inner {@code Iterable}
      * @param mapper
-     *            a function that returns an Iterable sequence of values for when given an item emitted by the
-     *            source Maybe
-     * @return the new Flowable instance
+     *            a function that returns an {@code Iterable} sequence of values for when given an item emitted by the
+     *            source {@code Maybe}
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @see #flattenStreamAsFlowable(Function)
      */
@@ -3165,7 +3246,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Maps the success value of the upstream {@link Maybe} into an {@link Iterable} and emits its items as an
+     * Maps the success value of the upstream {@code Maybe} into an {@link Iterable} and emits its items as an
      * {@link Observable} sequence.
      * <p>
      * <img width="640" height="373" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenAsObservable.png" alt="">
@@ -3175,11 +3256,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param <U>
-     *            the type of item emitted by the resulting Iterable
+     *            the type of item emitted by the resulting {@code Iterable}
      * @param mapper
-     *            a function that returns an Iterable sequence of values for when given an item emitted by the
-     *            source Maybe
-     * @return the new Observable instance
+     *            a function that returns an {@code Iterable} sequence of values for when given an item emitted by the
+     *            source {@code Maybe}
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
@@ -3191,8 +3273,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns an Observable that is based on applying a specified function to the item emitted by the source Maybe,
-     * where that function returns an ObservableSource.
+     * Returns an {@link Observable} that is based on applying a specified function to the item emitted by the source {@code Maybe},
+     * where that function returns an {@link ObservableSource}.
      * <p>
      * <img width="640" height="356" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMap.png" alt="">
      * <dl>
@@ -3202,8 +3284,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns an ObservableSource
-     * @return the Observable returned from {@code func} when applied to the item emitted by the source Maybe
+     *            a function that, when applied to the item emitted by the source {@code Maybe}, returns an {@code ObservableSource}
+     * @return the {@code Observable} returned from {@code mapper} when applied to the item emitted by the source {@code Maybe}
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
@@ -3215,22 +3298,23 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that emits items based on applying a specified function to the item emitted by the
-     * source Maybe, where that function returns a Publisher.
+     * Returns a {@link Flowable} that emits items based on applying a specified function to the item emitted by the
+     * source {@code Maybe}, where that function returns a {@link Publisher}.
      * <p>
      * <img width="640" height="260" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMapPublisher.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned Flowable honors the downstream backpressure.</dd>
+     *  <dd>The returned {@code Flowable} honors the downstream backpressure.</dd>
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code flatMapPublisher} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns a
-     *            Flowable
-     * @return the Flowable returned from {@code func} when applied to the item emitted by the source Maybe
+     *            a function that, when applied to the item emitted by the source {@code Maybe}, returns a
+     *            {@code Flowable}
+     * @return the {@code Flowable} returned from {@code mapper} when applied to the item emitted by the source {@code Maybe}
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -3244,8 +3328,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Returns a {@link Single} based on applying a specified function to the item emitted by the
-     * source {@link Maybe}, where that function returns a {@link Single}.
-     * When this Maybe completes a {@link NoSuchElementException} will be thrown.
+     * source {@code Maybe}, where that function returns a {@code Single}.
+     * When this {@code Maybe} completes a {@link NoSuchElementException} will be thrown.
      * <p>
      * <img width="640" height="356" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMapSingle.png" alt="">
      * <dl>
@@ -3255,9 +3339,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns a
-     *            Single
-     * @return the Single returned from {@code mapper} when applied to the item emitted by the source Maybe
+     *            a function that, when applied to the item emitted by the source {@code Maybe}, returns a
+     *            {@code Single}
+     * @return the {@code Single} returned from {@code mapper} when applied to the item emitted by the source {@code Maybe}
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
@@ -3269,9 +3354,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a {@link Maybe} based on applying a specified function to the item emitted by the
-     * source {@link Maybe}, where that function returns a {@link Single}.
-     * When this Maybe just completes the resulting {@code Maybe} completes as well.
+     * Returns a {@code Maybe} based on applying a specified function to the item emitted by the
+     * source {@code Maybe}, where that function returns a {@link Single}.
+     * When this {@code Maybe} just completes the resulting {@code Maybe} completes as well.
      * <p>
      * <img width="640" height="356" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMapSingle.png" alt="">
      * <dl>
@@ -3282,9 +3367,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>History: 2.0.2 - experimental
      * @param <R> the result value type
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns a
-     *            Single
-     * @return the new Maybe instance
+     *            a function that, when applied to the item emitted by the source {@code Maybe}, returns a
+     *            {@code Single}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @since 2.1
      */
@@ -3298,7 +3384,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * Returns a {@link Completable} that completes based on applying a specified function to the item emitted by the
-     * source {@link Maybe}, where that function returns a {@link Completable}.
+     * source {@code Maybe}, where that function returns a {@code Completable}.
      * <p>
      * <img width="640" height="267" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.flatMapCompletable.png" alt="">
      * <dl>
@@ -3307,9 +3393,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param mapper
-     *            a function that, when applied to the item emitted by the source Maybe, returns a
-     *            Completable
-     * @return the Completable returned from {@code mapper} when applied to the item emitted by the source Maybe
+     *            a function that, when applied to the item emitted by the source {@code Maybe}, returns a
+     *            {@code Completable}
+     * @return the {@code Completable} returned from {@code mapper} when applied to the item emitted by the source {@code Maybe}
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
@@ -3321,7 +3408,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Hides the identity of this Maybe and its Disposable.
+     * Hides the identity of this {@code Maybe} and its {@link Disposable}.
      * <p>
      * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.hide.png" alt="">
      * <p>Allows preventing certain identity-based
@@ -3330,7 +3417,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code hide} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3340,7 +3427,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Ignores the item emitted by the source Maybe and only calls {@code onComplete} or {@code onError}.
+     * Returns a {@link Completable} that ignores the item emitted by the source {@code Maybe} and only calls {@code onComplete} or {@code onError}.
      * <p>
      * <img width="640" height="389" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.ignoreElement.png" alt="">
      * <dl>
@@ -3348,8 +3435,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code ignoreElement} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return an empty Completable that only calls {@code onComplete} or {@code onError}, based on which one is
-     *         called by the source Maybe
+     * @return an empty {@code Completable} that only calls {@code onComplete} or {@code onError}, based on which one is
+     *         called by the source {@code Maybe}
      * @see <a href="http://reactivex.io/documentation/operators/ignoreelements.html">ReactiveX operators documentation: IgnoreElements</a>
      */
     @CheckReturnValue
@@ -3360,7 +3447,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Single that emits {@code true} if the source Maybe is empty, otherwise {@code false}.
+     * Returns a {@link Single} that emits {@code true} if the source {@code Maybe} is empty, otherwise {@code false}.
      * <p>
      * <img width="640" height="320" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/isEmpty.png" alt="">
      * <dl>
@@ -3368,7 +3455,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code isEmpty} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Single that emits a Boolean
+     * @return a {@code Single} that emits {@code true} if the source {@code Maybe} is empty.
      * @see <a href="http://reactivex.io/documentation/operators/contains.html">ReactiveX operators documentation: Contains</a>
      */
     @CheckReturnValue
@@ -3382,7 +3469,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <strong>This method requires advanced knowledge about building operators, please consider
      * other standard composition methods first;</strong>
      * Returns a {@code Maybe} which, when subscribed to, invokes the {@link MaybeOperator#apply(MaybeObserver) apply(MaybeObserver)} method
-     * of the provided {@link MaybeOperator} for each individual downstream {@link Maybe} and allows the
+     * of the provided {@link MaybeOperator} for each individual downstream {@code Maybe} and allows the
      * insertion of a custom operator by accessing the downstream's {@link MaybeObserver} during this subscription phase
      * and providing a new {@code MaybeObserver}, containing the custom operator's intended business logic, that will be
      * used in the subscription process going further upstream.
@@ -3435,7 +3522,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *         if (str.length() &lt; 2) {
      *             downstream.onSuccess(str);
      *         } else {
-     *             // Maybe is usually expected to produce one of the onXXX events
+     *             // Maybe i {@code Maybe} ly expected to produce one of the onXXX events
      *             downstream.onComplete();
      *         }
      *     }
@@ -3507,23 +3594,24 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * class and creating a {@link MaybeTransformer} with it is recommended.
      * <p>
      * Note also that it is not possible to stop the subscription phase in {@code lift()} as the {@code apply()} method
-     * requires a non-null {@code MaybeObserver} instance to be returned, which is then unconditionally subscribed to
+     * requires a non-{@code null} {@code MaybeObserver} instance to be returned, which is then unconditionally subscribed to
      * the upstream {@code Maybe}. For example, if the operator decided there is no reason to subscribe to the
      * upstream source because of some optimization possibility or a failure to prepare the operator, it still has to
-     * return a {@code MaybeObserver} that should immediately dispose the upstream's {@code Disposable} in its
+     * return a {@code MaybeObserver} that should immediately dispose the upstream's {@link Disposable} in its
      * {@code onSubscribe} method. Again, using a {@code MaybeTransformer} and extending the {@code Maybe} is
      * a better option as {@link #subscribeActual} can decide to not subscribe to its upstream after all.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code lift} does not operate by default on a particular {@link Scheduler}, however, the
-     *  {@link MaybeOperator} may use a {@code Scheduler} to support its own asynchronous behavior.</dd>
+     *  {@code MaybeOperator} may use a {@code Scheduler} to support its own asynchronous behavior.</dd>
      * </dl>
      *
      * @param <R> the output value type
-     * @param lift the {@link MaybeOperator} that receives the downstream's {@code MaybeObserver} and should return
+     * @param lift the {@code MaybeOperator} that receives the downstream's {@code MaybeObserver} and should return
      *               a {@code MaybeObserver} with custom behavior to be used as the consumer for the current
      *               {@code Maybe}.
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code lift} is {@code null}
      * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0">RxJava wiki: Writing operators</a>
      * @see #compose(MaybeTransformer)
      */
@@ -3536,7 +3624,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that applies a specified function to the item emitted by the source Maybe and
+     * Returns a {@code Maybe} that applies a specified function to the item emitted by the source {@code Maybe} and
      * emits the result of this function application.
      * <p>
      * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.map.png" alt="">
@@ -3547,8 +3635,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <R> the result value type
      * @param mapper
-     *            a function to apply to the item emitted by the Maybe
-     * @return a Maybe that emits the item from the source Maybe, transformed by the specified function
+     *            a function to apply to the item emitted by the {@code Maybe}
+     * @return a {@code Maybe} that emits the item from the source {@code Maybe}, transformed by the specified function
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
      */
     @CheckReturnValue
@@ -3560,8 +3649,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Maps the signal types of this Maybe into a {@link Notification} of the same kind
-     * and emits it as a single success value to downstream.
+     * Maps the signal types of this {@code Maybe} into a {@link Notification} of the same kind
+     * and emits it as a {@link Single}'s {@code onSuccess} value to downstream.
      * <p>
      * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/materialize.png" alt="">
      * <dl>
@@ -3569,7 +3658,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code materialize} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.2.4 - experimental
-     * @return the new Single instance
+     * @return the new {@code Single} instance
      * @since 3.0.0
      * @see Single#dematerialize(Function)
      */
@@ -3581,11 +3670,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens this and another Maybe into a single Flowable, without any transformation.
+     * Flattens this {@code Maybe} and another {@link MaybeSource} into a single {@link Flowable}, without any transformation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.png" alt="">
      * <p>
-     * You can combine items emitted by multiple Maybes so that they appear as a single Flowable, by
+     * You can combine items emitted by multiple {@code Maybe}s so that they appear as a single {@code Flowable}, by
      * using the {@code mergeWith} method.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -3595,8 +3684,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param other
-     *            a MaybeSource to be merged
-     * @return a new Flowable instance
+     *            a {@code MaybeSource} to be merged
+     * @return a new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -3609,19 +3699,20 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Wraps a Maybe to emit its item (or notify of its error) on a specified {@link Scheduler},
+     * Wraps a {@code Maybe} to emit its item (or notify of its error) on a specified {@link Scheduler},
      * asynchronously.
      * <p>
      * <img width="640" height="182" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.observeOn.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>you specify which {@link Scheduler} this operator will use.</dd>
+     * <dd>you specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
      * @param scheduler
-     *            the {@link Scheduler} to notify subscribers on
-     * @return the new Maybe instance that its subscribers are notified on the specified
-     *         {@link Scheduler}
+     *            the {@code Scheduler} to notify subscribers on
+     * @return the new {@code Maybe} instance that its subscribers are notified on the specified
+     *         {@code Scheduler}
+     * @throws NullPointerException if {@code scheduler} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #subscribeOn
@@ -3635,8 +3726,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Filters the items emitted by a Maybe, only emitting its success value if that
-     * is an instance of the supplied Class.
+     * Filters the items emitted by a {@code Maybe}, only emitting its success value if that
+     * is an instance of the supplied {@link Class}.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ofClass.png" alt="">
      * <dl>
@@ -3646,8 +3737,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param <U> the output type
      * @param clazz
-     *            the class type to filter the items emitted by the source Maybe
-     * @return the new Maybe instance
+     *            the class type to filter the items emitted by the source {@code Maybe}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code clazz} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/filter.html">ReactiveX operators documentation: Filter</a>
      */
     @CheckReturnValue
@@ -3668,9 +3760,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      * <p>History: 2.1.7 - experimental
      * @param <R> the resulting object type
-     * @param converter the function that receives the current Maybe instance and returns a value
+     * @param converter the function that receives the current {@code Maybe} instance and returns a value
      * @return the converted value
-     * @throws NullPointerException if converter is null
+     * @throws NullPointerException if {@code converter} is {@code null}
      * @since 2.2
      */
     @CheckReturnValue
@@ -3680,15 +3772,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts this Maybe into a backpressure-aware Flowable instance composing cancellation
+     * Converts this {@code Maybe} into a backpressure-aware {@link Flowable} instance composing cancellation
      * through.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned Flowable honors the backpressure of the downstream.</dd>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new Flowable instance
+     * @return the new {@code Flowable} instance
      */
     @SuppressWarnings("unchecked")
     @BackpressureSupport(BackpressureKind.FULL)
@@ -3703,13 +3795,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts this Maybe into an Observable instance composing disposal
+     * Converts this {@code Maybe} into an {@link Observable} instance composing disposal
      * through.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new Observable instance
+     * @return the new {@code Observable} instance
      */
     @SuppressWarnings("unchecked")
     @CheckReturnValue
@@ -3723,13 +3815,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Converts this Maybe into a Single instance composing disposal
-     * through and turning an empty Maybe into a signal of NoSuchElementException.
+     * Converts this {@code Maybe} into a {@link Single} instance composing disposal
+     * through and turning an empty {@code Maybe} into a signal of {@link NoSuchElementException}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new Single instance
+     * @return the new {@code Single} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3739,13 +3831,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe instance that if this Maybe emits an error, it will emit an onComplete
+     * Returns a {@code Maybe} instance that if this {@code Maybe} emits an error, it will emit an {@code onComplete}
      * and swallow the throwable.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3755,15 +3847,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe instance that if this Maybe emits an error and the predicate returns
-     * true, it will emit an onComplete and swallow the throwable.
+     * Returns a {@code Maybe} instance that if this {@code Maybe} emits an error and the predicate returns
+     * {@code true}, it will emit an {@code onComplete} and swallow the throwable.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param predicate the predicate to call when an Throwable is emitted which should return true
-     * if the Throwable should be swallowed and replaced with an onComplete.
-     * @return the new Maybe instance
+     * @param predicate the predicate to call when an {@link Throwable} is emitted which should return {@code true}
+     * if the {@code Throwable} should be swallowed and replaced with an {@code onComplete}.
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code predicate} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -3775,7 +3868,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Instructs a Maybe to pass control to another {@link MaybeSource} rather than invoking
+     * Instructs a {@code Maybe} to pass control to another {@link MaybeSource} rather than invoking
      * {@link MaybeObserver#onError onError} if it encounters an error.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
@@ -3788,9 +3881,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param next
-     *            the next {@code MaybeSource} that will take over if the source Maybe encounters
+     *            the next {@code MaybeSource} that will take over if the source {@code Maybe} encounters
      *            an error
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code next} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
@@ -3802,7 +3896,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Instructs a Maybe to pass control to another Maybe rather than invoking
+     * Instructs a {@code Maybe} to pass control to another {@link MaybeSource} rather than invoking
      * {@link MaybeObserver#onError onError} if it encounters an error.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
@@ -3815,9 +3909,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param resumeFunction
-     *            a function that returns a MaybeSource that will take over if the source Maybe encounters
+     *            a function that returns a {@code MaybeSource} that will take over if the source {@code Maybe} encounters
      *            an error
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code resumeFunction} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
@@ -3829,7 +3924,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Instructs a Maybe to emit an item (returned by a specified function) rather than invoking
+     * Instructs a {@code Maybe} to emit an item (returned by a specified function) rather than invoking
      * {@link MaybeObserver#onError onError} if it encounters an error.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorReturn.png" alt="">
@@ -3843,8 +3938,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *
      * @param valueSupplier
      *            a function that returns a single value that will be emitted as success value
-     *            the current Maybe signals an onError event
-     * @return the new Maybe instance
+     *            the current {@code Maybe} signals an {@code onError} event
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code valueSupplier} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
@@ -3856,7 +3952,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Instructs a Maybe to emit an item (returned by a specified function) rather than invoking
+     * Instructs a {@code Maybe} to emit an item (returned by a specified function) rather than invoking
      * {@link MaybeObserver#onError onError} if it encounters an error.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorReturn.png" alt="">
@@ -3869,8 +3965,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param item
-     *            the value that is emitted as onSuccess in case this Maybe signals an onError
-     * @return the new Maybe instance
+     *            the value that is emitted as {@code onSuccess} in case this {@code Maybe} signals an {@code onError}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code item} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
@@ -3882,7 +3979,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Instructs a Maybe to pass control to another MaybeSource rather than invoking
+     * Instructs a {@code Maybe} to pass control to another {@link MaybeSource} rather than invoking
      * {@link MaybeObserver#onError onError} if it encounters an {@link java.lang.Exception}.
      * <p>
      * This differs from {@link #onErrorResumeNext} in that this one does not handle {@link java.lang.Throwable}
@@ -3898,9 +3995,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param next
-     *            the next MaybeSource that will take over if the source Maybe encounters
+     *            the next {@code MaybeSource} that will take over if the source {@code Maybe} encounters
      *            an exception
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code next} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
@@ -3912,16 +4010,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Nulls out references to the upstream producer and downstream MaybeObserver if
-     * the sequence is terminated or downstream calls dispose().
+     * Nulls out references to the upstream producer and downstream {@link MaybeObserver} if
+     * the sequence is terminated or downstream calls {@code dispose()}.
      * <p>
      * <img width="640" height="263" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onTerminateDetach.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onTerminateDetach} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return a Maybe which nulls out references to the upstream producer and downstream MaybeObserver if
-     * the sequence is terminated or downstream calls dispose()
+     * @return a {@code Maybe} which {@code null}s out references to the upstream producer and downstream {@code MaybeObserver} if
+     * the sequence is terminated or downstream calls {@code dispose()}
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -3931,7 +4029,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that repeats the sequence of items emitted by the source Maybe indefinitely.
+     * Returns a {@link Flowable} that repeats the sequence of items emitted by the source {@code Maybe} indefinitely.
      * <p>
      * <img width="640" height="309" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.o.png" alt="">
      * <dl>
@@ -3941,7 +4039,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code repeat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a Flowable that emits the items emitted by the source Maybe repeatedly and in sequence
+     * @return a {@code Flowable} that emits the items emitted by the source {@code Maybe} repeatedly and in sequence
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -3953,7 +4051,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that repeats the sequence of items emitted by the source Maybe at most
+     * Returns a {@link Flowable} that repeats the sequence of items emitted by the source {@code Maybe} at most
      * {@code count} times.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.on.png" alt="">
@@ -3965,9 +4063,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param times
-     *            the number of times the source Maybe items are repeated, a count of 0 will yield an empty
+     *            the number of times the source {@code Maybe} items are repeated, a count of 0 will yield an empty
      *            sequence
-     * @return a Flowable that repeats the sequence of items emitted by the source Maybe at most
+     * @return a {@code Flowable} that repeats the sequence of items emitted by the source {@code Maybe} at most
      *         {@code count} times
      * @throws IllegalArgumentException
      *             if {@code count} is less than zero
@@ -3982,8 +4080,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that repeats the sequence of items emitted by the source Maybe until
-     * the provided stop function returns true.
+     * Returns a {@link Flowable} that repeats the sequence of items emitted by the source {@code Maybe} until
+     * the provided stop function returns {@code true}.
      * <p>
      * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeat.on.png" alt="">
      * <dl>
@@ -3994,11 +4092,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param stop
-     *                a boolean supplier that is called when the current Flowable completes and unless it returns
-     *                false, the current Flowable is resubscribed
-     * @return the new Flowable instance
+     *                a boolean supplier that is called when the current {@code Flowable} completes and unless it returns
+     *                {@code false}, the current {@code Flowable} is resubscribed
+     * @return the new {@code Flowable} instance
      * @throws NullPointerException
-     *             if {@code stop} is null
+     *             if {@code stop} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -4010,25 +4108,25 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Flowable that emits the same values as the source Publisher with the exception of an
+     * Returns a {@link Flowable} that emits the same values as the source {@code Maybe} with the exception of an
      * {@code onComplete}. An {@code onComplete} notification from the source will result in the emission of
-     * a {@code void} item to the Publisher provided as an argument to the {@code notificationHandler}
-     * function. If that Publisher calls {@code onComplete} or {@code onError} then {@code repeatWhen} will
-     * call {@code onComplete} or {@code onError} on the child subscription. Otherwise, this Publisher will
-     * resubscribe to the source Publisher.
+     * a {@code void} item to the {@link Publisher} provided as an argument to the {@code notificationHandler}
+     * function. If that {@code Publisher} calls {@code onComplete} or {@code onError} then {@code repeatWhen} will
+     * call {@code onComplete} or {@code onError} on the child subscription. Otherwise, this {@code Publisher} will
+     * resubscribe to the source {@code Publisher}.
      * <p>
      * <img width="640" height="430" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/repeatWhen.f.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors downstream backpressure and expects the source {@code Publisher} to honor backpressure as well.
-     *  If this expectation is violated, the operator <em>may</em> throw an {@code IllegalStateException}.</dd>
+     *  If this expectation is violated, the operator <em>may</em> throw an {@link IllegalStateException}.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code repeatWhen} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param handler
-     *            receives a Publisher of notifications with which a user can complete or error, aborting the repeat.
-     * @return the source Publisher modified with repeat logic
+     *            receives a {@code Publisher} of notifications with which a user can complete or error, aborting the repeat.
+     * @return the source {@code Publisher} modified with repeat logic
      * @see <a href="http://reactivex.io/documentation/operators/repeat.html">ReactiveX operators documentation: Repeat</a>
      */
     @BackpressureSupport(BackpressureKind.FULL)
@@ -4040,19 +4138,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Maybe, resubscribing to it if it calls {@code onError}
+     * Returns a {@code Maybe} that mirrors the source {@code Maybe}, resubscribing to it if it calls {@code onError}
      * (infinite retry count).
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
      * <p>
-     * If the source Maybe calls {@link MaybeObserver#onError}, this method will resubscribe to the source
-     * Maybe rather than propagating the {@code onError} call.
+     * If the source {@code Maybe} calls {@link MaybeObserver#onError}, this method will resubscribe to the source
+     * {@code Maybe} rather than propagating the {@code onError} call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
      */
     @CheckReturnValue
@@ -4063,8 +4161,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Maybe, resubscribing to it if it calls {@code onError}
-     * and the predicate returns true for that specific exception and retry count.
+     * Returns a {@code Maybe} that mirrors the source {@code Maybe}, resubscribing to it if it calls {@code onError}
+     * and the predicate returns {@code true} for that specific exception and retry count.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
      * <dl>
@@ -4075,7 +4173,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param predicate
      *            the predicate that determines if a resubscription may happen in case of a specific exception
      *            and retry count
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      * @see #retry()
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
      */
@@ -4087,13 +4185,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Maybe, resubscribing to it if it calls {@code onError}
+     * Returns a {@code Maybe} that mirrors the source {@code Maybe}, resubscribing to it if it calls {@code onError}
      * up to a specified number of retries.
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retry.png" alt="">
      * <p>
-     * If the source Maybe calls {@link MaybeObserver#onError}, this method will resubscribe to the source
-     * Maybe for a maximum of {@code count} resubscriptions rather than propagating the
+     * If the source {@code Maybe} calls {@link MaybeObserver#onError}, this method will resubscribe to the source
+     * {@code Maybe} for a maximum of {@code count} resubscriptions rather than propagating the
      * {@code onError} call.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -4101,8 +4199,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param count
-     *            the number of times to resubscribe if the current Maybe fails
-     * @return the new Maybe instance
+     *            the number of times to resubscribe if the current {@code Maybe} fails
+     * @return the new {@code Maybe} instance
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
      */
     @CheckReturnValue
@@ -4113,15 +4211,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Retries at most times or until the predicate returns false, whichever happens first.
+     * Retries at most {@code times} or until the predicate returns {@code false}, whichever happens first.
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param times the number of times to resubscribe if the current Maybe fails
-     * @param predicate the predicate called with the failure Throwable and should return true to trigger a retry.
-     * @return the new Maybe instance
+     * @param times the number of times to resubscribe if the current {@code Maybe} fails
+     * @param predicate the predicate called with the failure {@link Throwable} and should return {@code true} to trigger a retry.
+     * @return the new {@code Maybe} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4131,14 +4229,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Retries the current Maybe if it fails and the predicate returns true.
+     * Retries the current {@code Maybe} if it fails and the predicate returns {@code true}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retry} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param predicate the predicate that receives the failure Throwable and should return true to trigger a retry.
-     * @return the new Maybe instance
+     * @param predicate the predicate that receives the failure {@link Throwable} and should return {@code true} to trigger a retry.
+     * @return the new {@code Maybe} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4148,13 +4246,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Retries until the given stop function returns true.
+     * Retries until the given stop function returns {@code true}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code retryUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param stop the function that should return true to stop retrying
-     * @return the new Maybe instance
+     * @param stop the function that should return {@code true} to stop retrying
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code stop} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -4165,12 +4264,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the same values as the source Maybe with the exception of an
+     * Returns a {@code Maybe} that emits the same values as the source {@code Maybe} with the exception of an
      * {@code onError}. An {@code onError} notification from the source will result in the emission of a
-     * {@link Throwable} item to the Publisher provided as an argument to the {@code notificationHandler}
-     * function. If that Publisher calls {@code onComplete} or {@code onError} then {@code retry} will call
-     * {@code onComplete} or {@code onError} on the child subscription. Otherwise, this Publisher will
-     * resubscribe to the source Publisher.
+     * {@link Throwable} item to the {@link Publisher} provided as an argument to the {@code notificationHandler}
+     * function. If that {@code Publisher} calls {@code onComplete} or {@code onError} then {@code retry} will call
+     * {@code onComplete} or {@code onError} on the child subscription. Otherwise, this {@code Publisher} will
+     * resubscribe to the source {@code Publisher}.
      * <p>
      * <img width="640" height="430" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retryWhen.f.png" alt="">
      * <p>
@@ -4205,7 +4304,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Note that the inner {@code Publisher} returned by the handler function should signal
      * either {@code onNext}, {@code onError} or {@code onComplete} in response to the received
      * {@code Throwable} to indicate the operator should retry or terminate. If the upstream to
-     * the operator is asynchronous, signalling onNext followed by onComplete immediately may
+     * the operator is asynchronous, signalling {@code onNext} followed by {@code onComplete} immediately may
      * result in the sequence to be completed immediately. Similarly, if this inner
      * {@code Publisher} signals {@code onError} or {@code onComplete} while the upstream is
      * active, the sequence is terminated with the same signal immediately.
@@ -4232,9 +4331,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param handler
-     *            receives a Publisher of notifications with which a user can complete or error, aborting the
+     *            receives a {@code Publisher} of notifications with which a user can complete or error, aborting the
      *            retry
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      * @see <a href="http://reactivex.io/documentation/operators/retry.html">ReactiveX operators documentation: Retry</a>
      */
     @CheckReturnValue
@@ -4246,18 +4345,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Subscribes to a Maybe and ignores {@code onSuccess} and {@code onComplete} emissions.
+     * Subscribes to a {@code Maybe} and ignores {@code onSuccess} and {@code onComplete} emissions.
      * <p>
-     * If the Maybe emits an error, it is wrapped into an
+     * If the {@code Maybe} emits an error, it is wrapped into an
      * {@link io.reactivex.rxjava3.exceptions.OnErrorNotImplementedException OnErrorNotImplementedException}
-     * and routed to the RxJavaPlugins.onError handler.
+     * and routed to the {@link RxJavaPlugins#onError(Throwable)} handler.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
-     *         the Maybe has finished sending them
+     *         the {@code Maybe} has finished sending them
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4267,22 +4366,22 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Subscribes to a Maybe and provides a callback to handle the items it emits.
+     * Subscribes to a {@code Maybe} and provides a callback to handle the items it emits.
      * <p>
-     * If the Maybe emits an error, it is wrapped into an
+     * If the {@code Maybe} emits an error, it is wrapped into an
      * {@link io.reactivex.rxjava3.exceptions.OnErrorNotImplementedException OnErrorNotImplementedException}
-     * and routed to the RxJavaPlugins.onError handler.
+     * and routed to the {@link RxJavaPlugins#onError(Throwable)} handler.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param onSuccess
-     *             the {@code Consumer<T>} you have designed to accept a success value from the Maybe
+     *             the {@code Consumer<T>} you have designed to accept a success value from the {@code Maybe}
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
-     *         the Maybe has finished sending them
+     *         the {@code Maybe} has finished sending them
      * @throws NullPointerException
-     *             if {@code onSuccess} is null
+     *             if {@code onSuccess} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     @CheckReturnValue
@@ -4293,7 +4392,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Subscribes to a Maybe and provides callbacks to handle the items it emits and any error
+     * Subscribes to a {@code Maybe} and provides callbacks to handle the items it emits and any error
      * notification it issues.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -4301,16 +4400,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param onSuccess
-     *             the {@code Consumer<T>} you have designed to accept a success value from the Maybe
+     *             the {@code Consumer<T>} you have designed to accept a success value from the {@code Maybe}
      * @param onError
      *             the {@code Consumer<Throwable>} you have designed to accept any error notification from the
-     *             Maybe
+     *             {@code Maybe}
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
-     *         the Maybe has finished sending them
+     *         the {@code Maybe} has finished sending them
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      * @throws NullPointerException
-     *             if {@code onSuccess} is null, or
-     *             if {@code onError} is null
+     *             if {@code onSuccess} is {@code null}, or
+     *             if {@code onError} is {@code null}
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4320,7 +4419,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Subscribes to a Maybe and provides callbacks to handle the items it emits and any error or
+     * Subscribes to a {@code Maybe} and provides callbacks to handle the items it emits and any error or
      * completion notification it issues.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -4328,19 +4427,18 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param onSuccess
-     *             the {@code Consumer<T>} you have designed to accept a success value from the Maybe
+     *             the {@code Consumer<T>} you have designed to accept a success value from the {@code Maybe}
      * @param onError
      *             the {@code Consumer<Throwable>} you have designed to accept any error notification from the
-     *             Maybe
+     *             {@code Maybe}
      * @param onComplete
-     *             the {@code Action} you have designed to accept a completion notification from the
-     *             Maybe
+     *             the {@link Action} you have designed to accept a completion notification from the
+     *             {@code Maybe}
      * @return a {@link Disposable} reference with which the caller can stop receiving items before
-     *         the Maybe has finished sending them
+     *         the {@code Maybe} has finished sending them
      * @throws NullPointerException
-     *             if {@code onSuccess} is null, or
-     *             if {@code onError} is null, or
-     *             if {@code onComplete} is null
+     *             if {@code onSuccess}, {@code onError} or
+     *             {@code onComplete} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/subscribe.html">ReactiveX operators documentation: Subscribe</a>
      */
     @CheckReturnValue
@@ -4380,22 +4478,23 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>There is no need to call any of the plugin hooks on the current {@code Maybe} instance or
      * the {@code MaybeObserver}; all hooks and basic safeguards have been
      * applied by {@link #subscribe(MaybeObserver)} before this method gets called.
-     * @param observer the MaybeObserver to handle, not null
+     * @param observer the {@code MaybeObserver} to handle, not {@code null}
      */
     protected abstract void subscribeActual(@NonNull MaybeObserver<? super T> observer);
 
     /**
-     * Asynchronously subscribes subscribers to this Maybe on the specified {@link Scheduler}.
+     * Asynchronously subscribes subscribers to this {@code Maybe} on the specified {@link Scheduler}.
      * <p>
      * <img width="640" height="752" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.subscribeOn.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>you specify which {@link Scheduler} this operator will use.</dd>
+     * <dd>you specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
      * @param scheduler
-     *            the {@link Scheduler} to perform subscription actions on
-     * @return the new Maybe instance that its subscriptions happen on the specified {@link Scheduler}
+     *            the {@code Scheduler} to perform subscription actions on
+     * @return the new {@code Maybe} instance that its subscriptions happen on the specified {@code Scheduler}
+     * @throws NullPointerException if {@code scheduler} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/subscribeon.html">ReactiveX operators documentation: SubscribeOn</a>
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #observeOn
@@ -4409,8 +4508,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Subscribes a given MaybeObserver (subclass) to this Maybe and returns the given
-     * MaybeObserver as is.
+     * Subscribes a given {@link MaybeObserver} (subclass) to this {@code Maybe} and returns the given
+     * {@code MaybeObserver} as is.
      * <p>Usage example:
      * <pre><code>
      * Maybe&lt;Integer&gt; source = Maybe.just(1);
@@ -4426,10 +4525,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code subscribeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param <E> the type of the MaybeObserver to use and return
-     * @param observer the MaybeObserver (subclass) to use and return, not null
+     * @param <E> the type of the {@code MaybeObserver} to use and return
+     * @param observer the {@code MaybeObserver} (subclass) to use and return, not {@code null}
      * @return the input {@code subscriber}
-     * @throws NullPointerException if {@code subscriber} is null
+     * @throws NullPointerException if {@code subscriber} is {@code null}
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4440,8 +4539,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the items emitted by the source Maybe or the items of an alternate
-     * MaybeSource if the current Maybe is empty.
+     * Returns a {@code Maybe} that emits the items emitted by the source {@code Maybe} or the items of an alternate
+     * {@link MaybeSource} if the current {@code Maybe} is empty.
      * <p>
      * <img width="640" height="445" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchifempty.m.png" alt="">
      * <dl>
@@ -4450,9 +4549,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param other
-     *              the alternate MaybeSource to subscribe to if the main does not emit any items
-     * @return  a Maybe that emits the items emitted by the source Maybe or the items of an
-     *          alternate MaybeSource if the source Maybe is empty.
+     *              the alternate {@code MaybeSource} to subscribe to if the main does not emit any items
+     * @return  a {@code Maybe} that emits the items emitted by the source {@code Maybe} or the items of an
+     *          alternate {@code MaybeSource} if the source {@code Maybe} is empty.
+     * @throws NullPointerException if {@code other} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -4463,8 +4563,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Single that emits the items emitted by the source Maybe or the item of an alternate
-     * SingleSource if the current Maybe is empty.
+     * Returns a {@link Single} that emits the items emitted by the source {@code Maybe} or the item of an alternate
+     * {@link SingleSource} if the current {@code Maybe} is empty.
      * <p>
      * <img width="640" height="445" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchifempty.m.png" alt="">
      * <dl>
@@ -4473,9 +4573,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      * <p>History: 2.1.4 - experimental
      * @param other
-     *              the alternate SingleSource to subscribe to if the main does not emit any items
-     * @return  a Single that emits the items emitted by the source Maybe or the item of an
-     *          alternate SingleSource if the source Maybe is empty.
+     *              the alternate {@code SingleSource} to subscribe to if the main does not emit any items
+     * @return a {@code Single} that emits the items emitted by the source {@code Maybe} or the item of an
+     *         alternate {@code SingleSource} if the source {@code Maybe} is empty.
+     * @throws NullPointerException if {@code other} is {@code null}
      * @since 2.2
      */
     @CheckReturnValue
@@ -4487,7 +4588,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the items emitted by the source Maybe until a second MaybeSource
+     * Returns a {@code Maybe} that emits the items emitted by the source {@code Maybe} until a second {@link MaybeSource}
      * emits an item.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
@@ -4497,11 +4598,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param other
-     *            the MaybeSource whose first emitted item will cause {@code takeUntil} to stop emitting items
-     *            from the source Maybe
+     *            the {@code MaybeSource} whose first emitted item will cause {@code takeUntil} to stop emitting items
+     *            from the source {@code Maybe}
      * @param <U>
      *            the type of items emitted by {@code other}
-     * @return a Maybe that emits the items emitted by the source Maybe until such time as {@code other} emits its first item
+     * @return a {@code Maybe} that emits the items emitted by the source {@code Maybe} until such time as {@code other} emits its first item
+     * @throws NullPointerException if {@code other} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      */
     @CheckReturnValue
@@ -4513,7 +4615,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that emits the item emitted by the source Maybe until a second Publisher
+     * Returns a {@code Maybe} that emits the item emitted by the source {@code Maybe} until a second {@link Publisher}
      * emits an item.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.png" alt="">
@@ -4526,11 +4628,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param other
-     *            the Publisher whose first emitted item will cause {@code takeUntil} to stop emitting items
-     *            from the source Publisher
+     *            the {@code Publisher} whose first emitted item will cause {@code takeUntil} to stop emitting items
+     *            from the source {@code Publisher}
      * @param <U>
      *            the type of items emitted by {@code other}
-     * @return a Maybe that emits the items emitted by the source Maybe until such time as {@code other} emits its first item
+     * @return a {@code Maybe} that emits the items emitted by the source {@code Maybe} until such time as {@code other} emits its first item
+     * @throws NullPointerException if {@code other} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
@@ -4543,9 +4646,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Maybe but applies a timeout policy for each emitted
+     * Returns a {@code Maybe} that mirrors the source {@code Maybe} but applies a timeout policy for each emitted
      * item. If the next item isn't emitted within the specified timeout duration starting from its predecessor,
-     * the resulting Maybe terminates and notifies MaybeObservers of a {@code TimeoutException}.
+     * the resulting {@code Maybe} terminates and notifies {@link MaybeObserver}s of a {@link TimeoutException}.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.1.png" alt="">
      * <dl>
@@ -4557,7 +4660,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            maximum duration between emitted items before a timeout occurs
      * @param timeUnit
      *            the unit of time that applies to the {@code timeout} argument.
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @CheckReturnValue
@@ -4568,9 +4671,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Maybe but applies a timeout policy for each emitted
+     * Returns a {@code Maybe} that mirrors the source {@code Maybe} but applies a timeout policy for each emitted
      * item. If the next item isn't emitted within the specified timeout duration starting from its predecessor,
-     * the source MaybeSource is disposed and resulting Maybe begins instead to mirror a fallback MaybeSource.
+     * the source {@link MaybeSource} is disposed and resulting {@code Maybe} begins instead to mirror a fallback {@code MaybeSource}.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2.png" alt="">
      * <dl>
@@ -4583,8 +4686,9 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param timeUnit
      *            the unit of time that applies to the {@code timeout} argument
      * @param fallback
-     *            the fallback MaybeSource to use in case of a timeout
-     * @return the new Maybe instance
+     *            the fallback {@code MaybeSource} to use in case of a timeout
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code timeUnit} or {@code fallback} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @CheckReturnValue
@@ -4596,15 +4700,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Maybe but applies a timeout policy for each emitted
-     * item using a specified Scheduler. If the next item isn't emitted within the specified timeout duration
-     * starting from its predecessor, the source MaybeSource is disposed and resulting Maybe begins instead
-     * to mirror a fallback MaybeSource.
+     * Returns a {@code Maybe} that mirrors the source {@code Maybe} but applies a timeout policy for each emitted
+     * item using a specified {@link Scheduler}. If the next item isn't emitted within the specified timeout duration
+     * starting from its predecessor, the source {@link MaybeSource} is disposed and resulting {@code Maybe} begins instead
+     * to mirror a fallback {@code MaybeSource}.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.2s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
      * @param timeout
@@ -4612,10 +4716,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param timeUnit
      *            the unit of time that applies to the {@code timeout} argument
      * @param fallback
-     *            the MaybeSource to use as the fallback in case of a timeout
+     *            the {@code MaybeSource} to use as the fallback in case of a timeout
      * @param scheduler
-     *            the {@link Scheduler} to run the timeout timers on
-     * @return the new Maybe instance
+     *            the {@code Scheduler} to run the timeout timers on
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code fallback}, {@code timeUnit} or {@code scheduler} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @CheckReturnValue
@@ -4627,15 +4732,15 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe that mirrors the source Maybe but applies a timeout policy for each emitted
-     * item, where this policy is governed on a specified Scheduler. If the next item isn't emitted within the
-     * specified timeout duration starting from its predecessor, the resulting Maybe terminates and
-     * notifies MaybeObservers of a {@code TimeoutException}.
+     * Returns a {@code Maybe} that mirrors the source {@code Maybe} but applies a timeout policy for each emitted
+     * item, where this policy is governed on a specified {@link Scheduler}. If the next item isn't emitted within the
+     * specified timeout duration starting from its predecessor, the resulting {@code Maybe} terminates and
+     * notifies {@link MaybeObserver}s of a {@link TimeoutException}.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/timeout.1s.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
      * @param timeout
@@ -4643,8 +4748,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param timeUnit
      *            the unit of time that applies to the {@code timeout} argument
      * @param scheduler
-     *            the Scheduler to run the timeout timers on
-     * @return the new Maybe instance
+     *            the {@code Scheduler} to run the timeout timers on
+     * @return the new {@code Maybe} instance
      * @see <a href="http://reactivex.io/documentation/operators/timeout.html">ReactiveX operators documentation: Timeout</a>
      */
     @CheckReturnValue
@@ -4662,9 +4767,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code timeout} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the value type of the
-     * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling onSuccess
-     * or onComplete.
-     * @return the new Maybe instance
+     * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling {@code onSuccess}
+     * or {@code onComplete}.
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code timeoutIndicator} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -4686,7 +4792,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling {@code onSuccess}
      * or {@code onComplete}.
      * @param fallback the {@code MaybeSource} that is subscribed to if the current {@code Maybe} times out
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code timeoutIndicator} or {@code fallback} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -4702,15 +4809,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * {@link TimeoutException} is signaled instead.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The {@code timeoutIndicator} {@link Publisher} is consumed in an unbounded manner and
+     *  <dd>The {@code timeoutIndicator} {@code Publisher} is consumed in an unbounded manner and
      *  is cancelled after its first item.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the value type of the
-     * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling {@code onSuccess}
+     * @param timeoutIndicator the {@code Publisher} that indicates the timeout by signaling {@code onSuccess}
      * or {@code onComplete}.
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code timeoutIndicator} is {@code null}
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @CheckReturnValue
@@ -4723,11 +4831,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
 
     /**
      * If the current {@code Maybe} didn't signal an event before the {@code timeoutIndicator} {@link Publisher} signals,
-     * the current {@code Maybe} is disposed and the {@code fallback} {@code MaybeSource} subscribed to
+     * the current {@code Maybe} is disposed and the {@code fallback} {@link MaybeSource} subscribed to
      * as a continuation.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The {@code timeoutIndicator} {@link Publisher} is consumed in an unbounded manner and
+     *  <dd>The {@code timeoutIndicator} {@code Publisher} is consumed in an unbounded manner and
      *  is cancelled after its first item.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeout} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -4736,7 +4844,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param timeoutIndicator the {@code MaybeSource} that indicates the timeout by signaling {@code onSuccess}
      * or {@code onComplete}
      * @param fallback the {@code MaybeSource} that is subscribed to if the current {@code Maybe} times out
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code timeoutIndicator} or {@code fallback} is {@code null}
      */
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @CheckReturnValue
@@ -4749,17 +4858,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a Maybe which makes sure when a MaybeObserver disposes the Disposable,
-     * that call is propagated up on the specified scheduler.
+     * Returns a {@code Maybe} which makes sure when a {@link MaybeObserver} disposes the {@link Disposable},
+     * that call is propagated up on the specified {@link Scheduler}.
      * <p>
      * <img width="640" height="700" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.unsubscribeOn.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code unsubscribeOn} calls dispose() of the upstream on the {@link Scheduler} you specify.</dd>
+     *  <dd>{@code unsubscribeOn} calls {@code dispose()} of the upstream on the {@code Scheduler} you specify.</dd>
      * </dl>
      * @param scheduler the target scheduler where to execute the disposal
-     * @return the new Maybe instance
-     * @throws NullPointerException if scheduler is null
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code scheduler} is {@code null}
      */
     @CheckReturnValue
     @NonNull
@@ -4770,12 +4879,12 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Waits until this and the other MaybeSource signal a success value then applies the given BiFunction
-     * to those values and emits the BiFunction's resulting value to downstream.
+     * Waits until this and the other {@link MaybeSource} signal a success value then applies the given {@link BiFunction}
+     * to those values and emits the {@code BiFunction}'s resulting value to downstream.
      *
      * <img width="640" height="451" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zipWith.png" alt="">
      *
-     * <p>If either this or the other MaybeSource is empty or signals an error, the resulting Maybe will
+     * <p>If either this or the other {@code MaybeSource} is empty or signals an error, the resulting {@code Maybe} will
      * terminate immediately and dispose the other source.
      *
      * <dl>
@@ -4784,15 +4893,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param <U>
-     *            the type of items emitted by the {@code other} MaybeSource
+     *            the type of items emitted by the {@code other} {@code MaybeSource}
      * @param <R>
-     *            the type of items emitted by the resulting Maybe
+     *            the type of items emitted by the resulting {@code Maybe}
      * @param other
-     *            the other MaybeSource
+     *            the other {@code MaybeSource}
      * @param zipper
-     *            a function that combines the pairs of items from the two MaybeSources to generate the items to
-     *            be emitted by the resulting Maybe
-     * @return the new Maybe instance
+     *            a function that combines the pairs of items from the two {@code MaybeSource}s to generate the items to
+     *            be emitted by the resulting {@code Maybe}
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code other} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
@@ -4808,13 +4918,13 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     // ------------------------------------------------------------------
 
     /**
-     * Creates a TestObserver and subscribes
-     * it to this Maybe.
+     * Creates a {@link TestObserver} and subscribes
+     * it to this {@code Maybe}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new TestObserver instance
+     * @return the new {@code TestObserver} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4826,14 +4936,14 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Creates a TestObserver optionally in cancelled state, then subscribes it to this Maybe.
+     * Creates a {@link TestObserver} optionally in cancelled state, then subscribes it to this {@code Maybe}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param dispose if true, the TestObserver will be dispose before subscribing to this
-     * Maybe.
-     * @return the new TestObserver instance
+     * @param dispose if {@code true}, the {@code TestObserver} will be disposed before subscribing to this
+     * {@code Maybe}.
+     * @return the new {@code TestObserver} instance
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -4871,7 +4981,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      * @param <T> the element type of the optional value
      * @param optional the optional value to convert into a {@code Maybe}
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code optional} is {@code null}
      * @since 3.0.0
      * @see #just(Object)
      * @see #empty()
@@ -4904,9 +5015,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code fromCompletionStage} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param <T> the element type of the CompletionStage
-     * @param stage the CompletionStage to convert to Maybe and signal its terminal value or error
-     * @return the new Maybe instance
+     * @param <T> the element type of the {@code CompletionStage}
+     * @param stage the {@code CompletionStage} to convert to {@code Maybe} and signal its terminal value or error
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code stage} is {@code null}
      * @since 3.0.0
      */
     @CheckReturnValue
@@ -4926,10 +5038,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code mapOptional} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param <R> the non-null output type
+     * @param <R> the non-{@code null} output type
      * @param mapper the function that receives the upstream success item and should return a <em>non-empty</em> {@code Optional}
      * to emit as the success output or an <em>empty</em> {@code Optional} to complete the {@code Maybe}
-     * @return the new Maybe instance
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @since 3.0.0
      * @see #map(Function)
      * @see #filter(Predicate)
@@ -4964,7 +5077,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toCompletionStage} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @return the new CompletionStage instance
+     * @return the new {@code CompletionStage} instance
      * @since 3.0.0
      * @see #toCompletionStage(Object)
      */
@@ -4997,7 +5110,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code toCompletionStage} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param defaultItem the item to signal if the upstream is empty
-     * @return the new CompletionStage instance
+     * @return the new {@code CompletionStage} instance
      * @since 3.0.0
      */
     @CheckReturnValue
@@ -5013,7 +5126,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <p>
      * <img width="640" height="247" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenStreamAsFlowable.m.png" alt="">
      * <p>
-     * The operator closes the {@code Stream} upon cancellation and when it terminates. Exceptions raised when
+     * The operator closes the {@code Stream} upon cancellation and when it terminates. The exceptions raised when
      * closing a {@code Stream} are routed to the global error handler ({@link RxJavaPlugins#onError(Throwable)}.
      * If a {@code Stream} should not be closed, turn it into an {@link Iterable} and use {@link #flattenAsFlowable(Function)}:
      * <pre><code>
@@ -5037,7 +5150,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <R> the element type of the {@code Stream} and the output {@code Flowable}
      * @param mapper the function that receives the upstream success item and should
      * return a {@code Stream} of values to emit.
-     * @return the new Flowable instance
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @since 3.0.0
      * @see #flattenAsFlowable(Function)
      * @see #flattenStreamAsObservable(Function)
@@ -5056,7 +5170,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * items to the downstream consumer as an {@link Observable}.
      * <img width="640" height="247" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenStreamAsObservable.m.png" alt="">
      * <p>
-     * The operator closes the {@code Stream} upon cancellation and when it terminates. Exceptions raised when
+     * The operator closes the {@code Stream} upon cancellation and when it terminates. The exceptions raised when
      * closing a {@code Stream} are routed to the global error handler ({@link RxJavaPlugins#onError(Throwable)}.
      * If a {@code Stream} should not be closed, turn it into an {@link Iterable} and use {@link #flattenAsObservable(Function)}:
      * <pre><code>
@@ -5077,7 +5191,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @param <R> the element type of the {@code Stream} and the output {@code Observable}
      * @param mapper the function that receives the upstream success item and should
      * return a {@code Stream} of values to emit.
-     * @return the new Observable instance
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code mapper} is {@code null}
      * @since 3.0.0
      * @see #flattenAsObservable(Function)
      * @see #flattenStreamAsFlowable(Function)

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -689,7 +689,6 @@ public abstract class Single<T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.from.Future.png" alt="">
      * <p>
-     * <p>
      * The operator calls {@link Future#get(long, TimeUnit)}, which is a blocking method, on the subscription thread.
      * It is recommended applying {@link #subscribeOn(Scheduler)} to move this blocking wait to a
      * background thread, and if the {@link Scheduler} supports it, interrupt the wait when the flow

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -4073,7 +4073,7 @@ public abstract class Single<T> implements SingleSource<T> {
      * <dd>{@code toFlowable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @return a {@lcode Flowable} that emits a single item T or an error.
+     * @return a {@code Flowable} that emits a single item T or an error.
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue

--- a/src/test/java/io/reactivex/rxjava3/validators/JavadocCodesAndLinks.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/JavadocCodesAndLinks.java
@@ -45,6 +45,11 @@ public class JavadocCodesAndLinks {
         checkSource("Single", "io.reactivex.rxjava3.core");
     }
 
+    @Test
+    public void checkMaybe() throws Exception {
+        checkSource("Maybe", "io.reactivex.rxjava3.core");
+    }
+
     static void checkSource(String baseClassName, String packageName) throws Exception {
         File f = TestHelper.findSource(baseClassName);
         if (f == null) {
@@ -388,7 +393,7 @@ public class JavadocCodesAndLinks {
 
             "List", "ArrayList", "HashMap", "HashSet", "CharSequence",
 
-            "TestSubscriber", "TestObserver"
+            "TestSubscriber", "TestObserver", "Class"
     );
 
     static final Set<String> ALWAYS_CODE = new HashSet<>(Arrays.asList(

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
@@ -221,7 +221,9 @@ public class ParamValidationNaming {
                     }
 
                     // FIXME enable for other types in separate PR!
-                    if (!baseClassName.equals("Completable") && !baseClassName.equals("Single")) {
+                    if (!baseClassName.equals("Completable")
+                            && !baseClassName.equals("Single")
+                            && !baseClassName.equals("Maybe")) {
                         continue;
                     }
 


### PR DESCRIPTION
Improve the javadocs by:
- Adding `{@code}` and `{@link}` tags
- Fixed wording and copy-paste mistakes
- Added `@throws` for the parameter validation exceptions