### PR TITLE
3.x: Rename to combineLatestArrayDelayError

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -461,7 +461,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
      *   {@link MissingBackpressureException}) and may lead to {@link OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -481,9 +481,9 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @NonNull
-    public static <T, @NonNull R> Flowable<R> combineLatestDelayError(@NonNull Publisher<? extends T>[] sources,
+    public static <T, @NonNull R> Flowable<R> combineLatestArrayDelayError(@NonNull Publisher<? extends T>[] sources,
             @NonNull Function<? super Object[], ? extends R> combiner) {
-        return combineLatestDelayError(sources, combiner, bufferSize());
+        return combineLatestArrayDelayError(sources, combiner, bufferSize());
     }
 
     /**
@@ -509,7 +509,7 @@ public abstract class Flowable<T> implements Publisher<T> {
      *   are requested in a bounded manner, however, their backpressure is not enforced (the operator won't signal
      *   {@link MissingBackpressureException}) and may lead to {@link OutOfMemoryError} due to internal buffer bloat.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -532,7 +532,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <T, @NonNull R> Flowable<R> combineLatestDelayError(@NonNull Publisher<? extends T>[] sources,
+    public static <T, @NonNull R> Flowable<R> combineLatestArrayDelayError(@NonNull Publisher<? extends T>[] sources,
             @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -868,7 +868,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -887,10 +887,10 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <T, R> Observable<R> combineLatestDelayError(
+    public static <T, R> Observable<R> combineLatestArrayDelayError(
             @NonNull ObservableSource<? extends T>[] sources,
             @NonNull Function<? super Object[], ? extends R> combiner) {
-        return combineLatestDelayError(sources, combiner, bufferSize());
+        return combineLatestArrayDelayError(sources, combiner, bufferSize());
     }
 
     /**
@@ -914,7 +914,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/combineLatestDelayError.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code combineLatestDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code combineLatestArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T>
@@ -936,7 +936,7 @@ public abstract class Observable<T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T, R> Observable<R> combineLatestDelayError(@NonNull ObservableSource<? extends T>[] sources,
+    public static <T, R> Observable<R> combineLatestArrayDelayError(@NonNull ObservableSource<? extends T>[] sources,
             @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(combiner, "combiner is null");

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1073,7 +1073,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
             .test()
             .assertResult(expected);
 
-            Flowable.combineLatestDelayError(sources, new Function<Object[], List<Object>>() {
+            Flowable.combineLatestArrayDelayError(sources, new Function<Object[], List<Object>>() {
                 @Override
                 public List<Object> apply(Object[] t) throws Exception {
                     return Arrays.asList(t);
@@ -1104,7 +1104,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     public void combineLatestDelayErrorArrayOfSources() {
 
-        Flowable.combineLatestDelayError(new Flowable[] {
+        Flowable.combineLatestArrayDelayError(new Flowable[] {
                 Flowable.just(1), Flowable.just(2)
         }, new Function<Object[], Object>() {
             @Override
@@ -1120,7 +1120,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     public void combineLatestDelayErrorArrayOfSourcesWithError() {
 
-        Flowable.combineLatestDelayError(new Flowable[] {
+        Flowable.combineLatestArrayDelayError(new Flowable[] {
                 Flowable.just(1), Flowable.just(2).concatWith(Flowable.<Integer>error(new TestException()))
         }, new Function<Object[], Object>() {
             @Override
@@ -1171,7 +1171,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void combineLatestDelayErrorEmpty() {
-        assertSame(Flowable.empty(), Flowable.combineLatestDelayError(new Flowable[0], Functions.<Object[]>identity(), 16));
+        assertSame(Flowable.empty(), Flowable.combineLatestArrayDelayError(new Flowable[0], Functions.<Object[]>identity(), 16));
     }
 
     @Test
@@ -1295,7 +1295,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void errorDelayed() {
-        Flowable.combineLatestDelayError(
+        Flowable.combineLatestArrayDelayError(
                 new Publisher[] { Flowable.error(new TestException()), Flowable.just(1) },
                 new Function<Object[], Object>() {
                     @Override
@@ -1312,7 +1312,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void errorDelayed2() {
-        Flowable.combineLatestDelayError(
+        Flowable.combineLatestArrayDelayError(
                 new Publisher[] { Flowable.error(new TestException()).startWithItem(1), Flowable.empty() },
                 new Function<Object[], Object>() {
                     @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCombineLatestTest.java
@@ -789,7 +789,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     public void combineLatestDelayErrorArrayOfSources() {
 
-        Observable.combineLatestDelayError(new ObservableSource[] {
+        Observable.combineLatestArrayDelayError(new ObservableSource[] {
                 Observable.just(1), Observable.just(2)
         }, new Function<Object[], Object>() {
             @Override
@@ -805,7 +805,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     public void combineLatestDelayErrorArrayOfSourcesWithError() {
 
-        Observable.combineLatestDelayError(new ObservableSource[] {
+        Observable.combineLatestArrayDelayError(new ObservableSource[] {
                 Observable.just(1), Observable.just(2).concatWith(Observable.<Integer>error(new TestException()))
         }, new Function<Object[], Object>() {
             @Override
@@ -856,7 +856,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void combineLatestDelayErrorEmpty() {
-        assertSame(Observable.empty(), Observable.combineLatestDelayError(new ObservableSource[0], Functions.<Object[]>identity(), 16));
+        assertSame(Observable.empty(), Observable.combineLatestArrayDelayError(new ObservableSource[0], Functions.<Object[]>identity(), 16));
     }
 
     @Test
@@ -923,7 +923,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void errorDelayed() {
-        Observable.combineLatestDelayError(
+        Observable.combineLatestArrayDelayError(
                 new ObservableSource[] { Observable.error(new TestException()), Observable.just(1) },
                 new Function<Object[], Object>() {
                     @Override
@@ -940,7 +940,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void errorDelayed2() {
-        Observable.combineLatestDelayError(
+        Observable.combineLatestArrayDelayError(
                 new ObservableSource[] { Observable.error(new TestException()).startWithItem(1), Observable.empty() },
                 new Function<Object[], Object>() {
                     @Override

--- a/src/test/java/io/reactivex/rxjava3/tck/CombineLatestArrayDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/CombineLatestArrayDelayErrorTckTest.java
@@ -26,7 +26,7 @@ public class CombineLatestArrayDelayErrorTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return
-            Flowable.combineLatestDelayError(
+            Flowable.combineLatestArrayDelayError(
                 new Publisher[] { Flowable.just(1L), Flowable.fromIterable(iterate(elements)) },
                 new Function<Object[], Long>() {
                     @Override


### PR DESCRIPTION
The operator missed a rename with 2.x to match the `combineLatestArray` variant.

Resolves #6820