### PR TITLE
3.x: Remove Maybe.onExceptionResumeNext

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -3939,7 +3939,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Maybe<T> onErrorResumeNext(@NonNull Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction) {
         Objects.requireNonNull(resumeFunction, "resumeFunction is null");
-        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<>(this, resumeFunction, true));
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<>(this, resumeFunction));
     }
 
     /**
@@ -3994,37 +3994,6 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     public final Maybe<T> onErrorReturnItem(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return onErrorReturn(Functions.justFunction(item));
-    }
-
-    /**
-     * Resumes the flow with the given {@link MaybeSource} when the current {@code Maybe} fails
-     * with an {@link Exception} subclass instead of signaling the error via {@code onError}.
-     * <p>
-     * This differs from {@link #onErrorResumeNext} in that this one does not handle {@link java.lang.Throwable}
-     * or {@link java.lang.Error} but lets those continue through.
-     * <p>
-     * <img width="640" height="333" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onExceptionResumeNextViaMaybe.png" alt="">
-     * <p>
-     * You can use this to prevent exceptions from propagating or to supply fallback data should exceptions be
-     * encountered.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code onExceptionResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param next
-     *            the next {@code MaybeSource} that will take over if the current {@code Maybe} encounters
-     *            an exception
-     * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code next} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
-     */
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onExceptionResumeNext(@NonNull MaybeSource<? extends T> next) {
-        Objects.requireNonNull(next, "next is null");
-        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<>(this, Functions.justFunction(next), false));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorNext.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorNext.java
@@ -31,19 +31,15 @@ public final class MaybeOnErrorNext<T> extends AbstractMaybeWithUpstream<T, T> {
 
     final Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction;
 
-    final boolean allowFatal;
-
     public MaybeOnErrorNext(MaybeSource<T> source,
-            Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction,
-                    boolean allowFatal) {
+            Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction) {
         super(source);
         this.resumeFunction = resumeFunction;
-        this.allowFatal = allowFatal;
     }
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new OnErrorNextMaybeObserver<>(observer, resumeFunction, allowFatal));
+        source.subscribe(new OnErrorNextMaybeObserver<>(observer, resumeFunction));
     }
 
     static final class OnErrorNextMaybeObserver<T>
@@ -56,14 +52,10 @@ public final class MaybeOnErrorNext<T> extends AbstractMaybeWithUpstream<T, T> {
 
         final Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction;
 
-        final boolean allowFatal;
-
         OnErrorNextMaybeObserver(MaybeObserver<? super T> actual,
-                Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction,
-                        boolean allowFatal) {
+                Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction) {
             this.downstream = actual;
             this.resumeFunction = resumeFunction;
-            this.allowFatal = allowFatal;
         }
 
         @Override
@@ -90,10 +82,6 @@ public final class MaybeOnErrorNext<T> extends AbstractMaybeWithUpstream<T, T> {
 
         @Override
         public void onError(Throwable e) {
-            if (!allowFatal && !(e instanceof Exception)) {
-                downstream.onError(e);
-                return;
-            }
             MaybeSource<? extends T> m;
 
             try {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorXTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeOnErrorXTest.java
@@ -99,22 +99,6 @@ public class MaybeOnErrorXTest extends RxJavaTest {
     }
 
     @Test
-    public void onExceptionResumeNext() {
-        Maybe.error(new TestException())
-        .onExceptionResumeNext(Maybe.just(1))
-        .test()
-        .assertResult(1);
-    }
-
-    @Test
-    public void onExceptionResumeNextPassthrough() {
-        Maybe.error(new AssertionError())
-        .onExceptionResumeNext(Maybe.just(1))
-        .test()
-        .assertFailure(AssertionError.class);
-    }
-
-    @Test
     public void onErrorResumeNextFunctionThrows() {
         TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
         .onErrorResumeNext(new Function<Throwable, Maybe<Object>>() {


### PR DESCRIPTION
It was always very peculiar to let only checked exceptions resumed.

Resolves #6842