### PR TITLE
Add `pull_request` to Wrapper Validation Triggers

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,5 @@
 name: "Validate Gradle Wrapper"
-on: [push]
+on: [push, pull_request]
 
 jobs:
   validation:


### PR DESCRIPTION
There was a bug where the action wouldn't trigger on contributions. Sorry about that.