### PR TITLE
3.x: Fix method argument naming across types

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -332,21 +332,21 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code unsafeCreate} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param source the callback which will receive the {@link CompletableObserver} instances
+     * @param onSubscribe the callback which will receive the {@link CompletableObserver} instances
      * when the {@code Completable} is subscribed to.
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code source} is {@code null}
+     * @throws NullPointerException if {@code onSubscribe} is {@code null}
      * @throws IllegalArgumentException if {@code source} is a {@code Completable}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable unsafeCreate(@NonNull CompletableSource source) {
-        Objects.requireNonNull(source, "source is null");
-        if (source instanceof Completable) {
+    public static Completable unsafeCreate(@NonNull CompletableSource onSubscribe) {
+        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        if (onSubscribe instanceof Completable) {
             throw new IllegalArgumentException("Use of unsafeCreate(Completable)!");
         }
-        return RxJavaPlugins.onAssembly(new CompletableFromUnsafeSource(source));
+        return RxJavaPlugins.onAssembly(new CompletableFromUnsafeSource(onSubscribe));
     }
 
     /**
@@ -357,16 +357,16 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param completableSupplier the supplier that returns the {@code Completable} that will be subscribed to.
+     * @param supplier the supplier that returns the {@code Completable} that will be subscribed to.
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code completableSupplier} is {@code null}
+     * @throws NullPointerException if {@code supplier} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable defer(@NonNull Supplier<? extends CompletableSource> completableSupplier) {
-        Objects.requireNonNull(completableSupplier, "completableSupplier is null");
-        return RxJavaPlugins.onAssembly(new CompletableDefer(completableSupplier));
+    public static Completable defer(@NonNull Supplier<? extends CompletableSource> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        return RxJavaPlugins.onAssembly(new CompletableDefer(supplier));
     }
 
     /**
@@ -381,16 +381,16 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param errorSupplier the error supplier, not {@code null}
+     * @param supplier the error supplier, not {@code null}
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code errorSupplier} is {@code null}
+     * @throws NullPointerException if {@code supplier} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable error(@NonNull Supplier<? extends Throwable> errorSupplier) {
-        Objects.requireNonNull(errorSupplier, "errorSupplier is null");
-        return RxJavaPlugins.onAssembly(new CompletableErrorSupplier(errorSupplier));
+    public static Completable error(@NonNull Supplier<? extends Throwable> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        return RxJavaPlugins.onAssembly(new CompletableErrorSupplier(supplier));
     }
 
     /**
@@ -401,16 +401,16 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param error the {@code Throwable} instance to emit, not {@code null}
+     * @param throwable the {@code Throwable} instance to emit, not {@code null}
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code error} is {@code null}
+     * @throws NullPointerException if {@code throwable} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable error(@NonNull Throwable error) {
-        Objects.requireNonNull(error, "error is null");
-        return RxJavaPlugins.onAssembly(new CompletableError(error));
+    public static Completable error(@NonNull Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable is null");
+        return RxJavaPlugins.onAssembly(new CompletableError(throwable));
     }
 
     /**
@@ -429,16 +429,16 @@ public abstract class Completable implements CompletableSource {
      *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.rxjava3.exceptions.UndeliverableException UndeliverableException}.
      *  </dd>
      * </dl>
-     * @param run the {@code Action} to run for each subscribing {@link CompletableObserver}
+     * @param action the {@code Action} to run for each subscribing {@link CompletableObserver}
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code run} is {@code null}
+     * @throws NullPointerException if {@code action} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable fromAction(@NonNull Action run) {
-        Objects.requireNonNull(run, "run is null");
-        return RxJavaPlugins.onAssembly(new CompletableFromAction(run));
+    public static Completable fromAction(@NonNull Action action) {
+        Objects.requireNonNull(action, "action is null");
+        return RxJavaPlugins.onAssembly(new CompletableFromAction(action));
     }
 
     /**
@@ -1029,19 +1029,19 @@ public abstract class Completable implements CompletableSource {
      * </dl>
      * @param <R> the resource type
      * @param resourceSupplier the {@link Supplier} that returns a resource to be managed.
-     * @param completableFunction the {@link Function} that given a resource returns a {@code CompletableSource} instance that will be subscribed to
-     * @param disposer the {@link Consumer} that disposes the resource created by the resource supplier
+     * @param sourceSupplier the {@link Function} that given a resource returns a {@code CompletableSource} instance that will be subscribed to
+     * @param resourceCleanup the {@link Consumer} that disposes the resource created by the resource supplier
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code resourceSupplier}, {@code completableFunction}
-     *                              or {@code disposer} is {@code null}
+     * @throws NullPointerException if {@code resourceSupplier}, {@code sourceSupplier}
+     *                              or {@code resourceCleanup} is {@code null}
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <R> Completable using(@NonNull Supplier<R> resourceSupplier,
-            @NonNull Function<? super R, ? extends CompletableSource> completableFunction,
-            @NonNull Consumer<? super R> disposer) {
-        return using(resourceSupplier, completableFunction, disposer, true);
+            @NonNull Function<? super R, ? extends CompletableSource> sourceSupplier,
+            @NonNull Consumer<? super R> resourceCleanup) {
+        return using(resourceSupplier, sourceSupplier, resourceCleanup, true);
     }
 
     /**
@@ -1059,31 +1059,31 @@ public abstract class Completable implements CompletableSource {
      * </dl>
      * @param <R> the resource type
      * @param resourceSupplier the {@link Supplier} that returns a resource to be managed
-     * @param completableFunction the {@link Function} that given a resource returns a non-{@code null}
+     * @param sourceSupplier the {@link Function} that given a resource returns a non-{@code null}
      * {@code CompletableSource} instance that will be subscribed to
-     * @param disposer the {@link Consumer} that disposes the resource created by the resource supplier
+     * @param resourceCleanup the {@link Consumer} that disposes the resource created by the resource supplier
      * @param eager
      *            If {@code true} then resource disposal will happen either on a {@code dispose()} call before the upstream is disposed
      *            or just before the emission of a terminal event ({@code onComplete} or {@code onError}).
      *            If {@code false} the resource disposal will happen either on a {@code dispose()} call after the upstream is disposed
      *            or just after the emission of a terminal event ({@code onComplete} or {@code onError}).
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code resourceSupplier}, {@code completableFunction}
-     *                              or {@code disposer} is {@code null}
+     * @throws NullPointerException if {@code resourceSupplier}, {@code sourceSupplier}
+     *                              or {@code resourceCleanup} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <R> Completable using(
             @NonNull Supplier<R> resourceSupplier,
-            @NonNull Function<? super R, ? extends CompletableSource> completableFunction,
-            @NonNull Consumer<? super R> disposer,
+            @NonNull Function<? super R, ? extends CompletableSource> sourceSupplier,
+            @NonNull Consumer<? super R> resourceCleanup,
             boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
-        Objects.requireNonNull(completableFunction, "completableFunction is null");
-        Objects.requireNonNull(disposer, "disposer is null");
+        Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
+        Objects.requireNonNull(resourceCleanup, "resourceCleanup is null");
 
-        return RxJavaPlugins.onAssembly(new CompletableUsing<>(resourceSupplier, completableFunction, disposer, eager));
+        return RxJavaPlugins.onAssembly(new CompletableUsing<>(resourceSupplier, sourceSupplier, resourceCleanup, eager));
     }
 
     /**
@@ -1390,7 +1390,7 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code delay} does operate by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
-     * @param delay the delay time
+     * @param time the delay time
      * @param unit the delay unit
      * @return the new {@code Completable} instance
      * @throws NullPointerException if {@code unit} is {@code null}
@@ -1398,8 +1398,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
-    public final Completable delay(long delay, @NonNull TimeUnit unit) {
-        return delay(delay, unit, Schedulers.computation(), false);
+    public final Completable delay(long time, @NonNull TimeUnit unit) {
+        return delay(time, unit, Schedulers.computation(), false);
     }
 
     /**
@@ -1411,7 +1411,7 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code delay} operates on the {@code Scheduler} you specify.</dd>
      * </dl>
-     * @param delay the delay time
+     * @param time the delay time
      * @param unit the delay unit
      * @param scheduler the {@code Scheduler} to run the delayed completion on
      * @return the new {@code Completable} instance
@@ -1420,8 +1420,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final Completable delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return delay(delay, unit, scheduler, false);
+    public final Completable delay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+        return delay(time, unit, scheduler, false);
     }
 
     /**
@@ -1433,7 +1433,7 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code delay} operates on the {@code Scheduler} you specify.</dd>
      * </dl>
-     * @param delay the delay time
+     * @param time the delay time
      * @param unit the delay unit
      * @param scheduler the {@code Scheduler} to run the delayed completion on
      * @param delayError delay the error emission as well?
@@ -1443,10 +1443,10 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
+    public final Completable delay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean delayError) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new CompletableDelay(this, delay, unit, scheduler, delayError));
+        return RxJavaPlugins.onAssembly(new CompletableDelay(this, time, unit, scheduler, delayError));
     }
 
     /**
@@ -1459,7 +1459,7 @@ public abstract class Completable implements CompletableSource {
      * </dl>
      * <p>History: 2.2.3 - experimental
      *
-     * @param delay the time to delay the subscription
+     * @param time the time to delay the subscription
      * @param unit  the time unit of {@code delay}
      * @return the new {@code Completable} instance
      * @throws NullPointerException if {@code unit} is {@code null}
@@ -1469,8 +1469,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
-    public final Completable delaySubscription(long delay, @NonNull TimeUnit unit) {
-        return delaySubscription(delay, unit, Schedulers.computation());
+    public final Completable delaySubscription(long time, @NonNull TimeUnit unit) {
+        return delaySubscription(time, unit, Schedulers.computation());
     }
 
     /**
@@ -1483,7 +1483,7 @@ public abstract class Completable implements CompletableSource {
      *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      * <p>History: 2.2.3 - experimental
-     * @param delay     the time to delay the subscription
+     * @param time     the time to delay the subscription
      * @param unit      the time unit of {@code delay}
      * @param scheduler the {@code Scheduler} on which the waiting and subscription will happen
      * @return the new {@code Completable} instance
@@ -1494,8 +1494,8 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final Completable delaySubscription(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return Completable.timer(delay, unit, scheduler).andThen(this);
+    public final Completable delaySubscription(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+        return Completable.timer(time, unit, scheduler).andThen(this);
     }
 
     /**
@@ -1974,17 +1974,17 @@ public abstract class Completable implements CompletableSource {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param errorMapper the {@code mapper} {@code Function} that takes the error and should return a {@code CompletableSource} as
+     * @param fallbackSupplier the {@code mapper} {@code Function} that takes the error and should return a {@code CompletableSource} as
      * continuation.
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code errorMapper} is {@code null}
+     * @throws NullPointerException if {@code fallbackSupplier} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable onErrorResumeNext(@NonNull Function<? super Throwable, ? extends CompletableSource> errorMapper) {
-        Objects.requireNonNull(errorMapper, "errorMapper is null");
-        return RxJavaPlugins.onAssembly(new CompletableResumeNext(this, errorMapper));
+    public final Completable onErrorResumeNext(@NonNull Function<? super Throwable, ? extends CompletableSource> fallbackSupplier) {
+        Objects.requireNonNull(fallbackSupplier, "fallbackSupplier is null");
+        return RxJavaPlugins.onAssembly(new CompletableResumeNext(this, fallbackSupplier));
     }
 
     /**
@@ -2544,16 +2544,16 @@ public abstract class Completable implements CompletableSource {
      * </dl>
      * @param timeout the timeout value
      * @param unit the unit of {@code timeout}
-     * @param other the other {@code CompletableSource} instance to switch to in case of a timeout
+     * @param fallback the other {@code CompletableSource} instance to switch to in case of a timeout
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code unit} or {@code other} is {@code null}
+     * @throws NullPointerException if {@code unit} or {@code fallback} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
-    public final Completable timeout(long timeout, @NonNull TimeUnit unit, @NonNull CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
-        return timeout0(timeout, unit, Schedulers.computation(), other);
+    public final Completable timeout(long timeout, @NonNull TimeUnit unit, @NonNull CompletableSource fallback) {
+        Objects.requireNonNull(fallback, "fallback is null");
+        return timeout0(timeout, unit, Schedulers.computation(), fallback);
     }
 
     /**
@@ -2593,16 +2593,16 @@ public abstract class Completable implements CompletableSource {
      * @param timeout the timeout value
      * @param unit the unit of {@code timeout}
      * @param scheduler the {@code Scheduler} to use to wait for completion
-     * @param other the other {@code Completable} instance to switch to in case of a timeout
+     * @param fallback the other {@code Completable} instance to switch to in case of a timeout
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code unit}, {@code scheduler} or {@code other} is {@code null}
+     * @throws NullPointerException if {@code unit}, {@code scheduler} or {@code fallback} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Completable timeout(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, @NonNull CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
-        return timeout0(timeout, unit, scheduler, other);
+    public final Completable timeout(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, @NonNull CompletableSource fallback) {
+        Objects.requireNonNull(fallback, "fallback is null");
+        return timeout0(timeout, unit, scheduler, fallback);
     }
 
     /**
@@ -2616,18 +2616,18 @@ public abstract class Completable implements CompletableSource {
      * @param timeout the timeout value
      * @param unit the unit of {@code timeout}
      * @param scheduler the {@code Scheduler} to use to wait for completion
-     * @param other the other {@code Completable} instance to switch to in case of a timeout,
+     * @param fallback the other {@code Completable} instance to switch to in case of a timeout,
      * if {@code null} a {@link TimeoutException} is emitted instead
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code unit}, {@code scheduler} or {@code other} is {@code null}
+     * @throws NullPointerException if {@code unit}, {@code scheduler} or {@code fallback} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    private Completable timeout0(long timeout, TimeUnit unit, Scheduler scheduler, CompletableSource other) {
+    private Completable timeout0(long timeout, TimeUnit unit, Scheduler scheduler, CompletableSource fallback) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new CompletableTimeout(this, timeout, unit, scheduler, other));
+        return RxJavaPlugins.onAssembly(new CompletableTimeout(this, timeout, unit, scheduler, fallback));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -620,17 +620,17 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param maybeSupplier the {@code Supplier} that is called for each individual {@code MaybeObserver} and
+     * @param supplier the {@code Supplier} that is called for each individual {@code MaybeObserver} and
      * returns a {@code MaybeSource} instance to subscribe to
      * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code maybeSupplier} is {@code null}
+     * @throws NullPointerException if {@code supplier} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> defer(@NonNull Supplier<? extends MaybeSource<? extends T>> maybeSupplier) {
-        Objects.requireNonNull(maybeSupplier, "maybeSupplier is null");
-        return RxJavaPlugins.onAssembly(new MaybeDefer<>(maybeSupplier));
+    public static <T> Maybe<T> defer(@NonNull Supplier<? extends MaybeSource<? extends T>> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        return RxJavaPlugins.onAssembly(new MaybeDefer<>(supplier));
     }
 
     /**
@@ -663,20 +663,20 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param error
+     * @param throwable
      *            the particular {@link Throwable} to pass to {@link MaybeObserver#onError onError}
      * @param <T>
      *            the type of the item (ostensibly) emitted by the {@code Maybe}
      * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code error} is {@code null}
+     * @throws NullPointerException if {@code throwable} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> error(@NonNull Throwable error) {
-        Objects.requireNonNull(error, "error is null");
-        return RxJavaPlugins.onAssembly(new MaybeError<>(error));
+    public static <T> Maybe<T> error(@NonNull Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable is null");
+        return RxJavaPlugins.onAssembly(new MaybeError<>(throwable));
     }
 
     /**
@@ -760,16 +760,16 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code fromSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the target type
-     * @param singleSource the {@code SingleSource} to convert from
+     * @param single the {@code SingleSource} to convert from
      * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code singleSource} is {@code null}
+     * @throws NullPointerException if {@code single} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Maybe<T> fromSingle(@NonNull SingleSource<T> singleSource) {
-        Objects.requireNonNull(singleSource, "singleSource is null");
-        return RxJavaPlugins.onAssembly(new MaybeFromSingle<>(singleSource));
+    public static <T> Maybe<T> fromSingle(@NonNull SingleSource<T> single) {
+        Objects.requireNonNull(single, "single is null");
+        return RxJavaPlugins.onAssembly(new MaybeFromSingle<>(single));
     }
 
     /**
@@ -1799,9 +1799,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            the factory function to create a resource object that depends on the {@code Maybe}
      * @param sourceSupplier
      *            the factory function to create a {@code MaybeSource}
-     * @param resourceDisposer
+     * @param resourceCleanup
      *            the function that will dispose of the resource
      * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code resourceSupplier}, {@code sourceSupplier} or {@code resourceCleanup} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
      */
     @CheckReturnValue
@@ -1809,8 +1810,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @NonNull
     public static <T, D> Maybe<T> using(@NonNull Supplier<? extends D> resourceSupplier,
             @NonNull Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
-            @NonNull Consumer<? super D> resourceDisposer) {
-        return using(resourceSupplier, sourceSupplier, resourceDisposer, true);
+            @NonNull Consumer<? super D> resourceCleanup) {
+        return using(resourceSupplier, sourceSupplier, resourceCleanup, true);
     }
 
     /**
@@ -1832,7 +1833,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            the factory function to create a resource object that depends on the {@code Maybe}
      * @param sourceSupplier
      *            the factory function to create a {@code MaybeSource}
-     * @param resourceDisposer
+     * @param resourceCleanup
      *            the function that will dispose of the resource
      * @param eager
      *            If {@code true} then resource disposal will happen either on a {@code dispose()} call before the upstream is disposed
@@ -1840,7 +1841,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            If {@code false} the resource disposal will happen either on a {@code dispose()} call after the upstream is disposed
      *            or just after the emission of a terminal event ({@code onSuccess}, {@code onComplete} or {@code onError}).
      * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code resourceSupplier}, {@code sourceSupplier} or {@code resourceDisposer} is {@code null}
+     * @throws NullPointerException if {@code resourceSupplier}, {@code sourceSupplier} or {@code resourceCleanup} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/using.html">ReactiveX operators documentation: Using</a>
      */
     @CheckReturnValue
@@ -1848,11 +1849,11 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, D> Maybe<T> using(@NonNull Supplier<? extends D> resourceSupplier,
             @NonNull Function<? super D, ? extends MaybeSource<? extends T>> sourceSupplier,
-            @NonNull Consumer<? super D> resourceDisposer, boolean eager) {
+            @NonNull Consumer<? super D> resourceCleanup, boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
         Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
-        Objects.requireNonNull(resourceDisposer, "resourceDisposer is null");
-        return RxJavaPlugins.onAssembly(new MaybeUsing<T, D>(resourceSupplier, sourceSupplier, resourceDisposer, eager));
+        Objects.requireNonNull(resourceCleanup, "resourceCleanup is null");
+        return RxJavaPlugins.onAssembly(new MaybeUsing<T, D>(resourceSupplier, sourceSupplier, resourceCleanup, eager));
     }
 
     /**
@@ -2678,7 +2679,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>This version of {@code delay} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param delay
+     * @param time
      *            the delay to shift the source by
      * @param unit
      *            the {@link TimeUnit} in which {@code period} is defined
@@ -2690,8 +2691,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
-    public final Maybe<T> delay(long delay, @NonNull TimeUnit unit) {
-        return delay(delay, unit, Schedulers.computation());
+    public final Maybe<T> delay(long time, @NonNull TimeUnit unit) {
+        return delay(time, unit, Schedulers.computation());
     }
 
     /**
@@ -2704,7 +2705,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>you specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
-     * @param delay
+     * @param time
      *            the delay to shift the source by
      * @param unit
      *            the time unit of {@code delay}
@@ -2717,10 +2718,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final Maybe<T> delay(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+    public final Maybe<T> delay(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new MaybeDelay<>(this, Math.max(0L, delay), unit, scheduler));
+        return RxJavaPlugins.onAssembly(new MaybeDelay<>(this, Math.max(0L, time), unit, scheduler));
     }
 
     /**
@@ -2789,7 +2790,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>This version of {@code delaySubscription} operates by default on the {@code computation} {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param delay
+     * @param time
      *            the time to delay the subscription
      * @param unit
      *            the time unit of {@code delay}
@@ -2801,8 +2802,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
-    public final Maybe<T> delaySubscription(long delay, @NonNull TimeUnit unit) {
-        return delaySubscription(delay, unit, Schedulers.computation());
+    public final Maybe<T> delaySubscription(long time, @NonNull TimeUnit unit) {
+        return delaySubscription(time, unit, Schedulers.computation());
     }
 
     /**
@@ -2815,7 +2816,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
      * </dl>
      *
-     * @param delay
+     * @param time
      *            the time to delay the subscription
      * @param unit
      *            the time unit of {@code delay}
@@ -2828,8 +2829,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final Maybe<T> delaySubscription(long delay, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
-        return delaySubscription(Flowable.timer(delay, unit, scheduler));
+    public final Maybe<T> delaySubscription(long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+        return delaySubscription(Flowable.timer(time, unit, scheduler));
     }
 
     /**
@@ -3198,21 +3199,21 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *            the type of items emitted by the resulting {@code Maybe}
      * @param mapper
      *            a function that returns a {@code MaybeSource} for the item emitted by the current {@code Maybe}
-     * @param resultSelector
+     * @param combiner
      *            a function that combines one item emitted by each of the source and collection {@code MaybeSource} and
      *            returns an item to be emitted by the resulting {@code MaybeSource}
      * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code mapper} or {@code resultSelector} is {@code null}
+     * @throws NullPointerException if {@code mapper} or {@code combiner} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <U, R> Maybe<R> flatMap(@NonNull Function<? super T, ? extends MaybeSource<? extends U>> mapper,
-            @NonNull BiFunction<? super T, ? super U, ? extends R> resultSelector) {
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner) {
         Objects.requireNonNull(mapper, "mapper is null");
-        Objects.requireNonNull(resultSelector, "resultSelector is null");
-        return RxJavaPlugins.onAssembly(new MaybeFlatMapBiSelector<>(this, mapper, resultSelector));
+        Objects.requireNonNull(combiner, "combiner is null");
+        return RxJavaPlugins.onAssembly(new MaybeFlatMapBiSelector<>(this, mapper, combiner));
     }
 
     /**
@@ -3880,19 +3881,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code onErrorResumeWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param next
+     * @param fallback
      *            the next {@code MaybeSource} that will take over if the current {@code Maybe} encounters
      *            an error
      * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code next} is {@code null}
+     * @throws NullPointerException if {@code fallback} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorResumeWith(@NonNull MaybeSource<? extends T> next) {
-        Objects.requireNonNull(next, "next is null");
-        return onErrorResumeNext(Functions.justFunction(next));
+    public final Maybe<T> onErrorResumeWith(@NonNull MaybeSource<? extends T> fallback) {
+        Objects.requireNonNull(fallback, "fallback is null");
+        return onErrorResumeNext(Functions.justFunction(fallback));
     }
 
     /**
@@ -3908,19 +3909,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param resumeFunction
+     * @param fallbackSupplier
      *            a function that returns a {@code MaybeSource} that will take over if the current {@code Maybe} encounters
      *            an error
      * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code resumeFunction} is {@code null}
+     * @throws NullPointerException if {@code fallbackSupplier} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorResumeNext(@NonNull Function<? super Throwable, ? extends MaybeSource<? extends T>> resumeFunction) {
-        Objects.requireNonNull(resumeFunction, "resumeFunction is null");
-        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<>(this, resumeFunction));
+    public final Maybe<T> onErrorResumeNext(@NonNull Function<? super Throwable, ? extends MaybeSource<? extends T>> fallbackSupplier) {
+        Objects.requireNonNull(fallbackSupplier, "fallbackSupplier is null");
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorNext<>(this, fallbackSupplier));
     }
 
     /**
@@ -3936,19 +3937,19 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      *  <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param valueSupplier
+     * @param itemSupplier
      *            a function that returns a single value that will be emitted as success value
      *            the current {@code Maybe} signals an {@code onError} event
      * @return the new {@code Maybe} instance
-     * @throws NullPointerException if {@code valueSupplier} is {@code null}
+     * @throws NullPointerException if {@code itemSupplier} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Maybe<T> onErrorReturn(@NonNull Function<? super Throwable, ? extends T> valueSupplier) {
-        Objects.requireNonNull(valueSupplier, "valueSupplier is null");
-        return RxJavaPlugins.onAssembly(new MaybeOnErrorReturn<>(this, valueSupplier));
+    public final Maybe<T> onErrorReturn(@NonNull Function<? super Throwable, ? extends T> itemSupplier) {
+        Objects.requireNonNull(itemSupplier, "itemSupplier is null");
+        return RxJavaPlugins.onAssembly(new MaybeOnErrorReturn<>(this, itemSupplier));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -557,17 +557,17 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code defer} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param singleSupplier the {@code Supplier} that is called for each individual {@code SingleObserver} and
+     * @param supplier the {@code Supplier} that is called for each individual {@code SingleObserver} and
      * returns a {@code SingleSource} instance to subscribe to
-     * @throws NullPointerException if {@code singleSupplier} is {@code null}
+     * @throws NullPointerException if {@code supplier} is {@code null}
      * @return the new {@code Single} instance
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> defer(@NonNull Supplier<? extends SingleSource<? extends T>> singleSupplier) {
-        Objects.requireNonNull(singleSupplier, "singleSupplier is null");
-        return RxJavaPlugins.onAssembly(new SingleDefer<>(singleSupplier));
+    public static <T> Single<T> defer(@NonNull Supplier<? extends SingleSource<? extends T>> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        return RxJavaPlugins.onAssembly(new SingleDefer<>(supplier));
     }
 
     /**
@@ -579,17 +579,17 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the value type
-     * @param errorSupplier the {@link Supplier} that is called for each individual {@code SingleObserver} and
+     * @param supplier the {@link Supplier} that is called for each individual {@code SingleObserver} and
      * returns a {@code Throwable} instance to be emitted.
-     * @throws NullPointerException if {@code errorSupplier} is {@code null}
+     * @throws NullPointerException if {@code supplier} is {@code null}
      * @return the new {@code Single} instance
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> error(@NonNull Supplier<? extends Throwable> errorSupplier) {
-        Objects.requireNonNull(errorSupplier, "errorSupplier is null");
-        return RxJavaPlugins.onAssembly(new SingleError<>(errorSupplier));
+    public static <T> Single<T> error(@NonNull Supplier<? extends Throwable> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        return RxJavaPlugins.onAssembly(new SingleError<>(supplier));
     }
 
     /**
@@ -602,21 +602,21 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code error} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param exception
+     * @param throwable
      *            the particular {@link Throwable} to pass to {@link SingleObserver#onError onError}
      * @param <T>
      *            the type of the item (ostensibly) emitted by the {@code Single}
      * @return the new {@code Single} that invokes the subscriber's {@link SingleObserver#onError onError} method when
      *         the subscriber subscribes to it
-     * @throws NullPointerException if {@code exception} is {@code null}
+     * @throws NullPointerException if {@code throwable} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> error(@NonNull Throwable exception) {
-        Objects.requireNonNull(exception, "exception is null");
-        return error(Functions.justSupplier(exception));
+    public static <T> Single<T> error(@NonNull Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable is null");
+        return error(Functions.justSupplier(throwable));
     }
 
     /**
@@ -782,18 +782,18 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      *   <dd>{@code fromObservable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param observableSource the source sequence to wrap, not {@code null}
+     * @param observable the source sequence to wrap, not {@code null}
      * @param <T>
      *         the type of the item emitted by the {@code Single}.
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code observableSource} is {@code null}
+     * @throws NullPointerException if {@code observable} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<T> fromObservable(@NonNull ObservableSource<? extends T> observableSource) {
-        Objects.requireNonNull(observableSource, "observableSource is null");
-        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<>(observableSource, null));
+    public static <T> Single<T> fromObservable(@NonNull ObservableSource<? extends T> observable) {
+        Objects.requireNonNull(observable, "observable is null");
+        return RxJavaPlugins.onAssembly(new ObservableSingleSingle<>(observable, null));
     }
 
     /**
@@ -1446,22 +1446,23 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * @param <T> the value type of the {@code SingleSource} generated
      * @param <U> the resource type
      * @param resourceSupplier the {@link Supplier} called for each {@link SingleObserver} to generate a resource object
-     * @param singleFunction the function called with the returned resource
+     * @param sourceSupplier the function called with the returned resource
      *                  object from {@code resourceSupplier} and should return a {@code SingleSource} instance
      *                  to be run by the operator
-     * @param disposer the consumer of the generated resource that is called exactly once for
+     * @param resourceCleanup the consumer of the generated resource that is called exactly once for
      *                  that particular resource when the generated {@code SingleSource} terminates
      *                  (successfully or with an error) or gets disposed.
      * @return the new {@code Single} instance
+     * @throws NullPointerException if {@code resourceSupplier}, {@code sourceSupplier} and {@code resourceCleanup} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <T, U> Single<T> using(@NonNull Supplier<U> resourceSupplier,
-            @NonNull Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
-            @NonNull Consumer<? super U> disposer) {
-        return using(resourceSupplier, singleFunction, disposer, true);
+            @NonNull Function<? super U, ? extends SingleSource<? extends T>> sourceSupplier,
+            @NonNull Consumer<? super U> resourceCleanup) {
+        return using(resourceSupplier, sourceSupplier, resourceCleanup, true);
     }
 
     /**
@@ -1476,10 +1477,10 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * @param <T> the value type of the {@code SingleSource} generated
      * @param <U> the resource type
      * @param resourceSupplier the {@link Supplier} called for each {@link SingleObserver} to generate a resource object
-     * @param singleFunction the function called with the returned resource
+     * @param sourceSupplier the function called with the returned resource
      *                  object from {@code resourceSupplier} and should return a {@code SingleSource} instance
      *                  to be run by the operator
-     * @param disposer the consumer of the generated resource that is called exactly once for
+     * @param resourceCleanup the consumer of the generated resource that is called exactly once for
      *                  that particular resource when the generated {@code SingleSource} terminates
      *                  (successfully or with an error) or gets disposed.
      * @param eager
@@ -1488,7 +1489,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      *            If {@code false} the resource disposal will happen either on a {@code dispose()} call after the upstream is disposed
      *            or just after the emission of a terminal event ({@code onSuccess} or {@code onError}).
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code resourceSupplier}, {@code singleFunction} or {@code disposer} is {@code null}
+     * @throws NullPointerException if {@code resourceSupplier}, {@code sourceSupplier} or {@code resourceCleanup} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue
@@ -1496,14 +1497,14 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <T, U> Single<T> using(
             @NonNull Supplier<U> resourceSupplier,
-            @NonNull Function<? super U, ? extends SingleSource<? extends T>> singleFunction,
-            @NonNull Consumer<? super U> disposer,
+            @NonNull Function<? super U, ? extends SingleSource<? extends T>> sourceSupplier,
+            @NonNull Consumer<? super U> resourceCleanup,
             boolean eager) {
         Objects.requireNonNull(resourceSupplier, "resourceSupplier is null");
-        Objects.requireNonNull(singleFunction, "singleFunction is null");
-        Objects.requireNonNull(disposer, "disposer is null");
+        Objects.requireNonNull(sourceSupplier, "sourceSupplier is null");
+        Objects.requireNonNull(resourceCleanup, "resourceCleanup is null");
 
-        return RxJavaPlugins.onAssembly(new SingleUsing<>(resourceSupplier, singleFunction, disposer, eager));
+        return RxJavaPlugins.onAssembly(new SingleUsing<>(resourceSupplier, sourceSupplier, resourceCleanup, eager));
     }
 
     /**
@@ -2297,18 +2298,18 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param other the {@code CompletableSource} that has to complete before the subscription to the
+     * @param subscriptionIndicator the {@code CompletableSource} that has to complete before the subscription to the
      *              current {@code Single} happens
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code other} is {@code null}
+     * @throws NullPointerException if {@code subscriptionIndicator} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> delaySubscription(@NonNull CompletableSource other) {
-        Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<>(this, other));
+    public final Single<T> delaySubscription(@NonNull CompletableSource subscriptionIndicator) {
+        Objects.requireNonNull(subscriptionIndicator, "subscriptionIndicator is null");
+        return RxJavaPlugins.onAssembly(new SingleDelayWithCompletable<>(this, subscriptionIndicator));
     }
 
     /**
@@ -2323,18 +2324,18 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the element type of the other source
-     * @param other the {@code SingleSource} that has to complete before the subscription to the
+     * @param subscriptionIndicator the {@code SingleSource} that has to complete before the subscription to the
      *              current {@code Single} happens
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code other} is {@code null}
+     * @throws NullPointerException if {@code subscriptionIndicator} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<T> delaySubscription(@NonNull SingleSource<U> other) {
-        Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithSingle<>(this, other));
+    public final <U> Single<T> delaySubscription(@NonNull SingleSource<U> subscriptionIndicator) {
+        Objects.requireNonNull(subscriptionIndicator, "subscriptionIndicator is null");
+        return RxJavaPlugins.onAssembly(new SingleDelayWithSingle<>(this, subscriptionIndicator));
     }
 
     /**
@@ -2349,18 +2350,18 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the element type of the other source
-     * @param other the {@code ObservableSource} that has to signal a value or complete before the
+     * @param subscriptionIndicator the {@code ObservableSource} that has to signal a value or complete before the
      *              subscription to the current {@code Single} happens
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code other} is {@code null}
+     * @throws NullPointerException if {@code subscriptionIndicator} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<T> delaySubscription(@NonNull ObservableSource<U> other) {
-        Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithObservable<>(this, other));
+    public final <U> Single<T> delaySubscription(@NonNull ObservableSource<U> subscriptionIndicator) {
+        Objects.requireNonNull(subscriptionIndicator, "subscriptionIndicator is null");
+        return RxJavaPlugins.onAssembly(new SingleDelayWithObservable<>(this, subscriptionIndicator));
     }
 
     /**
@@ -2379,19 +2380,19 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code delaySubscription} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <U> the element type of the other source
-     * @param other the {@code Publisher} that has to signal a value or complete before the
+     * @param subscriptionIndicator the {@code Publisher} that has to signal a value or complete before the
      *              subscription to the current {@code Single} happens
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code other} is {@code null}
+     * @throws NullPointerException if {@code subscriptionIndicator} is {@code null}
      * @since 2.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <U> Single<T> delaySubscription(@NonNull Publisher<U> other) {
-        Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new SingleDelayWithPublisher<>(this, other));
+    public final <U> Single<T> delaySubscription(@NonNull Publisher<U> subscriptionIndicator) {
+        Objects.requireNonNull(subscriptionIndicator, "subscriptionIndicator is null");
+        return RxJavaPlugins.onAssembly(new SingleDelayWithPublisher<>(this, subscriptionIndicator));
     }
 
     /**
@@ -3154,15 +3155,16 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code contains} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param value the value to compare against the success value of this {@code Single}
+     * @param item the value to compare against the success value of this {@code Single}
      * @return the new {@code Single} instance
+     * @throws NullPointerException if {@code item} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final Single<Boolean> contains(@NonNull Object value) {
-        return contains(value, ObjectHelper.equalsPredicate());
+    public final Single<Boolean> contains(@NonNull Object item) {
+        return contains(item, ObjectHelper.equalsPredicate());
     }
 
     /**
@@ -3174,20 +3176,20 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code contains} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param value the value to compare against the success value of this {@code Single}
+     * @param item the value to compare against the success value of this {@code Single}
      * @param comparer the function that receives the success value of this {@code Single}, the value provided
      *                 and should return {@code true} if they are considered equal
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code value} or {@code comparer} is {@code null}
+     * @throws NullPointerException if {@code item} or {@code comparer} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<Boolean> contains(@NonNull Object value, @NonNull BiPredicate<Object, Object> comparer) {
-        Objects.requireNonNull(value, "value is null");
+    public final Single<Boolean> contains(@NonNull Object item, @NonNull BiPredicate<Object, Object> comparer) {
+        Objects.requireNonNull(item, "item is null");
         Objects.requireNonNull(comparer, "comparer is null");
-        return RxJavaPlugins.onAssembly(new SingleContains<>(this, value, comparer));
+        return RxJavaPlugins.onAssembly(new SingleContains<>(this, item, comparer));
     }
 
     /**
@@ -3264,19 +3266,19 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param resumeFunction
+     * @param itemSupplier
      *            a function that returns an item that the new {@code Single} will emit if the current {@code Single} encounters
      *            an error
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code resumeFunction} is {@code null}
+     * @throws NullPointerException if {@code itemSupplier} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> onErrorReturn(@NonNull Function<Throwable, ? extends T> resumeFunction) {
-        Objects.requireNonNull(resumeFunction, "resumeFunction is null");
-        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<>(this, resumeFunction, null));
+    public final Single<T> onErrorReturn(@NonNull Function<Throwable, ? extends T> itemSupplier) {
+        Objects.requireNonNull(itemSupplier, "itemSupplier is null");
+        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<>(this, itemSupplier, null));
     }
 
     /**
@@ -3287,17 +3289,17 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dt><b>Scheduler:</b></dt>
      * <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * @param value the value to signal if the current {@code Single} fails
+     * @param item the value to signal if the current {@code Single} fails
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws NullPointerException if {@code item} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> onErrorReturnItem(@NonNull T value) {
-        Objects.requireNonNull(value, "value is null");
-        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<>(this, null, value));
+    public final Single<T> onErrorReturnItem(@NonNull T item) {
+        Objects.requireNonNull(item, "item is null");
+        return RxJavaPlugins.onAssembly(new SingleOnErrorReturn<>(this, null, item));
     }
 
     /**
@@ -3359,9 +3361,9 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code onErrorResumeNext} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
-     * @param fallback a function that returns a {@code Single} that will take control if source {@code Single} encounters an error.
+     * @param fallbackSupplier a function that returns a {@code SingleSource} that will take control if source {@code Single} encounters an error.
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code fallback} is {@code null}
+     * @throws NullPointerException if {@code fallbackSupplier} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
      * @since .20
      */
@@ -3369,9 +3371,9 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Single<T> onErrorResumeNext(
-            @NonNull Function<? super Throwable, ? extends SingleSource<? extends T>> fallback) {
-        Objects.requireNonNull(fallback, "fallback is null");
-        return RxJavaPlugins.onAssembly(new SingleResumeNext<>(this, fallback));
+            @NonNull Function<? super Throwable, ? extends SingleSource<? extends T>> fallbackSupplier) {
+        Objects.requireNonNull(fallbackSupplier, "fallbackSupplier is null");
+        return RxJavaPlugins.onAssembly(new SingleResumeNext<>(this, fallbackSupplier));
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableMostRecentTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableMostRecentTest.java
@@ -26,10 +26,6 @@ import io.reactivex.rxjava3.processors.*;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 
 public class BlockingFlowableMostRecentTest extends RxJavaTest {
-    @Test
-    public void mostRecentNull() {
-        assertNull(Flowable.<Void>never().blockingMostRecent(null).iterator().next());
-    }
 
     @Test
     public void mostRecent() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableMostRecentTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableMostRecentTest.java
@@ -27,10 +27,6 @@ import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.reactivex.rxjava3.subjects.*;
 
 public class BlockingObservableMostRecentTest extends RxJavaTest {
-    @Test
-    public void mostRecentNull() {
-        assertNull(Observable.<Void>never().blockingMostRecent(null).iterator().next());
-    }
 
     static <T> Iterable<T> mostRecent(Observable<T> source, T initialValue) {
         return source.blockingMostRecent(initialValue);

--- a/src/test/java/io/reactivex/rxjava3/internal/util/OperatorArgumentNaming.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/OperatorArgumentNaming.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.util;
+
+import java.lang.reflect.*;
+import java.util.*;
+
+import org.reactivestreams.*;
+
+import com.google.common.base.Strings;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.core.Observable;
+
+/**
+ * Compare method argument naming across base classes.
+ * This is not a full test because some naming mismatch is legitimate, such as singular in Maybe/Single and
+ * plural in Flowable/Observable
+ */
+public final class OperatorArgumentNaming {
+
+    private OperatorArgumentNaming() {
+        throw new IllegalStateException("No instances!");
+    }
+
+    /** Classes to compare with each other. */
+    static final Class<?>[] CLASSES = { Flowable.class, Observable.class, Maybe.class, Single.class, Completable.class };
+
+    /** Types that refer to a reactive type and is generally matching the parent class; for comparison, these have to be unified. */
+    static final Set<Class<?>> BASE_TYPE_SET = new HashSet<>(Arrays.asList(
+            Flowable.class, Publisher.class, Subscriber.class, FlowableSubscriber.class,
+            Observable.class, ObservableSource.class, Observer.class,
+            Maybe.class, MaybeSource.class, MaybeObserver.class,
+            Single.class, SingleSource.class, SingleObserver.class,
+            Completable.class, CompletableSource.class, CompletableObserver.class
+    ));
+
+    public static void main(String[] args) {
+        // className -> methodName -> overloads -> arguments
+        Map<String, Map<String, List<List<ArgumentNameAndType>>>> map = new HashMap<>();
+
+        for (Class<?> clazz : CLASSES) {
+            Map<String, List<List<ArgumentNameAndType>>> classMethods = map.computeIfAbsent(clazz.getSimpleName(), v -> new HashMap<>());
+            for (Method method : clazz.getDeclaredMethods()) {
+                if (method.getDeclaringClass() == clazz && method.getParameterCount() != 0) {
+                    List<List<ArgumentNameAndType>> overloads = classMethods.computeIfAbsent(method.getName(), v -> new ArrayList<>());
+
+                    List<ArgumentNameAndType> overload = new ArrayList<>();
+                    overloads.add(overload);
+
+                    for (Parameter param : method.getParameters()) {
+                        String typeName;
+                        Class<?> type = param.getType();
+                        if (type.isArray()) {
+                            Class<?> componentType = type.getComponentType();
+                            if (BASE_TYPE_SET.contains(componentType)) {
+                                typeName = "BaseType";
+                            } else {
+                                typeName = type.getComponentType().getSimpleName() + "[]";
+                            }
+                        } else
+                        if (BASE_TYPE_SET.contains(type)) {
+                            typeName = "BaseType";
+                        } else {
+                            typeName = type.getSimpleName();
+                        }
+                        String name = param.getName();
+                        if (name.equals("bufferSize") || name.equals("prefetch") || name.equals("capacityHint")) {
+                            name = "bufferSize|prefetch|capacityHint";
+                        }
+                        if (name.equals("subscriber") || name.equals("observer")) {
+                            name = "subscriber|observer";
+                        }
+                        if (name.contains("onNext")) {
+                            name = name.replace("onNext", "onNext|onSuccess");
+                        } else
+                        if (name.contains("onSuccess")) {
+                            name = name.replace("onSuccess", "onNext|onSuccess");
+                        }
+                        overload.add(new ArgumentNameAndType(typeName, name));
+                    }
+                }
+            }
+        }
+
+        int counter = 0;
+
+        for (int i = 0; i < CLASSES.length - 1; i++) {
+            String firstName = CLASSES[i].getSimpleName();
+            Map<String, List<List<ArgumentNameAndType>>> firstClassMethods = map.get(firstName);
+            for (int j = i + 1; j < CLASSES.length; j++) {
+                String secondName = CLASSES[j].getSimpleName();
+                Map<String, List<List<ArgumentNameAndType>>> secondClassMethods = map.get(secondName);
+
+                for (Map.Entry<String, List<List<ArgumentNameAndType>>> methodOverloadsFirst : firstClassMethods.entrySet()) {
+
+                    List<List<ArgumentNameAndType>> methodOverloadsSecond = secondClassMethods.get(methodOverloadsFirst.getKey());
+
+                    if (methodOverloadsSecond != null) {
+                        for (List<ArgumentNameAndType> overloadFirst : methodOverloadsFirst.getValue()) {
+                            for (List<ArgumentNameAndType> overloadSecond : methodOverloadsSecond) {
+                                if (overloadFirst.size() == overloadSecond.size()) {
+                                    // Argument types match?
+                                    boolean match = true;
+                                    for (int k = 0; k < overloadFirst.size(); k++) {
+                                        if (!overloadFirst.get(k).type.equals(overloadSecond.get(k).type)) {
+                                            match = false;
+                                            break;
+                                        }
+                                    }
+                                    // Argument names match?
+                                    if (match) {
+                                        for (int k = 0; k < overloadFirst.size(); k++) {
+                                            if (!overloadFirst.get(k).name.equals(overloadSecond.get(k).name)) {
+                                                System.out.print("Argument naming mismatch #");
+                                                System.out.println(++counter);
+
+                                                System.out.print("  ");
+                                                System.out.print(Strings.padEnd(firstName, Math.max(firstName.length(), secondName.length()) + 1, ' '));
+                                                System.out.print(methodOverloadsFirst.getKey());
+                                                System.out.print("  ");
+                                                System.out.println(overloadFirst);
+
+                                                System.out.print("  ");
+                                                System.out.print(Strings.padEnd(secondName, Math.max(firstName.length(), secondName.length()) + 1, ' '));
+                                                System.out.print(methodOverloadsFirst.getKey());
+                                                System.out.print("  ");
+                                                System.out.println(overloadSecond);
+                                                System.out.println();
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static final class ArgumentNameAndType {
+        final String type;
+        final String name;
+
+        ArgumentNameAndType(String type, String name) {
+            this.type = type;
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return type + " " + name;
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -142,9 +142,6 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "delay", Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "delay", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE));
 
-        // null default is allowed
-        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "blockingMostRecent", Object.class));
-
         // negative time is considered as zero time
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "delaySubscription", Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "delaySubscription", Long.TYPE, TimeUnit.class, Scheduler.class));
@@ -389,9 +386,6 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "delay", Long.TYPE, TimeUnit.class, Boolean.TYPE));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "delay", Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "delay", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE));
-
-        // null default is allowed
-        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "blockingMostRecent", Object.class));
 
         // negative time is considered as zero time
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "delaySubscription", Long.TYPE, TimeUnit.class));

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
@@ -203,7 +203,7 @@ public class ParamValidationNaming {
 
                     int quote = line.indexOf('"', comma);
 
-                    String message = line.substring(quote + 1, quote + 2 + paramName.length());
+                    String message = line.substring(quote + 1, Math.min(line.length(), quote + 2 + paramName.length()));
 
                     if (line.contains("\"A Disposable")) {
                         continue;


### PR DESCRIPTION
Make method argument naming consistent between the base reactive classes, adjust some of the naming for all.

In addition, the null-check was missing from `blockingMostRecent`.

Resolves #6832 

The utility program has to be run manually to list the inconsistencies. The remaining inconsistency is due to `merge` because its argument is `sources` for `Flowable`/`Observable` but `source` for `Single`/`Maybe` nested.