### PR TITLE
Rename Single.equals to Single.sequenceEqual

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -1393,7 +1393,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * @param source1 the first {@code SingleSource} instance
      * @param source2 the second {@code SingleSource} instance
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code first} or {@code second} is {@code null}
+     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
      * @since 2.0
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -1390,8 +1390,8 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <dd>{@code sequenceEqual} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the common value type
-     * @param first the first {@code SingleSource} instance
-     * @param second the second {@code SingleSource} instance
+     * @param source1 the first {@code SingleSource} instance
+     * @param source2 the second {@code SingleSource} instance
      * @return the new {@code Single} instance
      * @throws NullPointerException if {@code first} or {@code second} is {@code null}
      * @since 2.0
@@ -1399,10 +1399,10 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> sequenceEqual(@NonNull SingleSource<? extends T> first, @NonNull SingleSource<? extends T> second) { // NOPMD
-        Objects.requireNonNull(first, "first is null");
-        Objects.requireNonNull(second, "second is null");
-        return RxJavaPlugins.onAssembly(new SingleEquals<>(first, second));
+    public static <T> Single<Boolean> sequenceEqual(@NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2) { // NOPMD
+        Objects.requireNonNull(source1, "source1 is null");
+        Objects.requireNonNull(source2, "source2 is null");
+        return RxJavaPlugins.onAssembly(new SingleEquals<>(source1, source2));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -1387,7 +1387,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <img width="640" height="465" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.equals.png" alt="">
      * <dl>
      * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code equals} does not operate by default on a particular {@link Scheduler}.</dd>
+     * <dd>{@code sequenceEqual} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param <T> the common value type
      * @param first the first {@code SingleSource} instance
@@ -1399,7 +1399,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <T> Single<Boolean> equals(@NonNull SingleSource<? extends T> first, @NonNull SingleSource<? extends T> second) { // NOPMD
+    public static <T> Single<Boolean> sequenceEqual(@NonNull SingleSource<? extends T> first, @NonNull SingleSource<? extends T> second) { // NOPMD
         Objects.requireNonNull(first, "first is null");
         Objects.requireNonNull(second, "second is null");
         return RxJavaPlugins.onAssembly(new SingleEquals<>(first, second));

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleEqualsTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleEqualsTest.java
@@ -28,7 +28,7 @@ public class SingleEqualsTest extends RxJavaTest {
     public void bothError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Single.equals(Single.error(new TestException("One")), Single.error(new TestException("Two")))
+            Single.sequenceEqual(Single.error(new TestException("One")), Single.error(new TestException("Two")))
             .to(TestHelper.<Boolean>testConsumer())
             .assertFailureAndMessage(TestException.class, "One");
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleMiscTest.java
@@ -280,11 +280,11 @@ public class SingleMiscTest extends RxJavaTest {
 
     @Test
     public void equals() {
-        Single.equals(Single.just(1), Single.just(1).hide())
+        Single.sequenceEqual(Single.just(1), Single.just(1).hide())
         .test()
         .assertResult(true);
 
-        Single.equals(Single.just(1), Single.just(2))
+        Single.sequenceEqual(Single.just(1), Single.just(2))
         .test()
         .assertResult(false);
     }


### PR DESCRIPTION
Renamed Single.equals to Single.sequenceEqual and renamed argument names for consistent naming.

Resolves #6854