### PR TITLE
3.x: Add last missing throws tag to JavaDocs

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -213,7 +213,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static <T> Flowable<T> ambArray(Publisher<@NonNull ? extends T>... sources) {
+    public static <T> Flowable<T> ambArray(@NonNull Publisher<@NonNull ? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
         int len = sources.length;
         if (len == 0) {
@@ -1915,7 +1915,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * @param supplier
      *            a {@link Supplier} factory to return a {@link Throwable} for each individual {@code Subscriber}
      * @param <T>
-     *            the type of the items (ostensibly) emitted by the {@link Publisher}
+     *            the type of the items (ostensibly) emitted by the resulting {@code Flowable}
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code supplier} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
@@ -1944,7 +1944,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * @param throwable
      *            the particular {@link Throwable} to pass to {@link Subscriber#onError onError}
      * @param <T>
-     *            the type of the items (ostensibly) emitted by the {@link Publisher}
+     *            the type of the items (ostensibly) emitted by the resulting {@code Flowable}
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code throwable} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">ReactiveX operators documentation: Throw</a>
@@ -8760,6 +8760,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      *            then used to delay the emission of that item by the resulting {@code Flowable} until the {@code Publisher}
      *            returned from {@code itemDelay} emits an item
      * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code subscriptionIndicator} and {@code itemDelayIndicator} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      */
     @CheckReturnValue

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -681,6 +681,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      *            the type of object that the {@code Future} returns, and also the type of item to be emitted by
      *            the resulting {@code Single}
      * @return the new {@code Single} that emits the item from the source {@code Future}
+     * @throws NullPointerException if {@code future} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/from.html">ReactiveX operators documentation: From</a>
      * @see #fromFuture(Future, long, TimeUnit)
      * @see #fromCompletionStage(CompletionStage)

--- a/src/test/java/io/reactivex/rxjava3/internal/util/JavadocNoThrows.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/JavadocNoThrows.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.util;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+/**
+ * Scan the JavaDocs of the base classes and list those which do not have the {@code @throws} tag.
+ * The lack is not an error by itself but worth looking at.
+ */
+public final class JavadocNoThrows {
+
+    private JavadocNoThrows() {
+        throw new IllegalArgumentException("No instances!");
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (Class<?> clazz : CLASSES) {
+            String clazzName = clazz.getSimpleName();
+            String packageName = clazz.getPackage().getName();
+            File f = TestHelper.findSource(clazzName, packageName);
+
+            List<String> lines = Files.readAllLines(f.toPath());
+
+            for (int i = 1; i < lines.size(); i++) {
+                String line = lines.get(i).trim();
+
+                if (line.startsWith("/**")) {
+                    boolean found = false;
+                    for (int j = i + 1; j < lines.size(); j++) {
+
+                        String line2 = lines.get(j).trim();
+                        if (line2.startsWith("public")) {
+                            if (line2.endsWith("() {")) {
+                                found = true;
+                            }
+                            break;
+                        }
+                        if (line2.startsWith("* @throws")) {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found) {
+                        System.out.printf(" at %s.%s.method(%s.java:%s)%n%n", packageName, clazzName, clazzName, i + 1);
+                    }
+                }
+            }
+        }
+    }
+
+    static final Class<?>[] CLASSES = {
+            Flowable.class, Observable.class, Maybe.class, Single.class, Completable.class, ParallelFlowable.class
+    };
+}

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationNaming.java
@@ -523,6 +523,9 @@ public class ParamValidationNaming {
             new ValidatorStrings("stage", "* @throws NullPointerException"),
             new ValidatorStrings("stream", "* @throws NullPointerException"),
             new ValidatorStrings("collector", "* @throws NullPointerException"),
+            new ValidatorStrings("subscriptionIndicator", "* @throws NullPointerException"),
+            new ValidatorStrings("itemDelayIndicator", "* @throws NullPointerException"),
+            new ValidatorStrings("future", "* @throws NullPointerException"),
 
             new ValidatorStrings("parallelism", "* @throws IllegalArgumentException"),
             new ValidatorStrings("prefetch", "* @throws IllegalArgumentException"),


### PR DESCRIPTION
Added the last missing `@throws` tag to methods and one missing `@NonNull` annotation.

I included a small program that will list JavaDocs without `@throws` for future use.

Resolves #6829