### PR TITLE
3.x: Add onErrorComplete to Flowable, Observable and Single

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -19,6 +19,7 @@ import java.util.stream.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.flowables.*;
@@ -28,7 +29,7 @@ import io.reactivex.rxjava3.internal.fuseable.ScalarSupplier;
 import io.reactivex.rxjava3.internal.jdk8.*;
 import io.reactivex.rxjava3.internal.operators.flowable.*;
 import io.reactivex.rxjava3.internal.operators.mixed.*;
-import io.reactivex.rxjava3.internal.operators.observable.ObservableFromPublisher;
+import io.reactivex.rxjava3.internal.operators.observable.*;
 import io.reactivex.rxjava3.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.rxjava3.internal.subscribers.*;
 import io.reactivex.rxjava3.internal.util.*;
@@ -12306,6 +12307,55 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @NonNull
     public final Flowable<T> onBackpressureLatest() {
         return RxJavaPlugins.onAssembly(new FlowableOnBackpressureLatest<>(this));
+    }
+
+    /**
+     * Returns a {@code Flowable} instance that if the current {@code Flowable} emits an error, it will emit an {@code onComplete}
+     * and swallow the throwable.
+     * <p>
+     * <img width="640" height="372" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.onErrorComplete.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator doesn't interfere with backpressure which is determined by the current {@code Flowable}'s backpressure
+     *  behavior.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new {@code Flowable} instance
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @NonNull
+    public final Flowable<T> onErrorComplete() {
+        return onErrorComplete(Functions.alwaysTrue());
+    }
+
+    /**
+     * Returns a {@code Flowable} instance that if the current {@code Flowable} emits an error and the predicate returns
+     * {@code true}, it will emit an {@code onComplete} and swallow the throwable.
+     * <p>
+     * <img width="640" height="201" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.onErrorComplete.f.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator doesn't interfere with backpressure which is determined by the current {@code Flowable}'s backpressure
+     *  behavior.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param predicate the predicate to call when an {@link Throwable} is emitted which should return {@code true}
+     * if the {@code Throwable} should be swallowed and replaced with an {@code onComplete}.
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code predicate} is {@code null}
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.PASS_THROUGH)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
+    public final Flowable<T> onErrorComplete(@NonNull Predicate<? super Throwable> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+
+        return RxJavaPlugins.onAssembly(new FlowableOnErrorComplete<>(this, predicate));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -12322,6 +12322,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new {@code Flowable} instance
+     * @since 3.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -12347,6 +12348,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * if the {@code Throwable} should be swallowed and replaced with an {@code onComplete}.
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code predicate} is {@code null}
+     * @since 3.0.0
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -4042,6 +4042,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a {@code Maybe} instance that if this {@code Maybe} emits an error, it will emit an {@code onComplete}
      * and swallow the throwable.
+     * <p>
+     * <img width="640" height="372" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorComplete.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -4058,6 +4060,8 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Returns a {@code Maybe} instance that if this {@code Maybe} emits an error and the predicate returns
      * {@code true}, it will emit an {@code onComplete} and swallow the throwable.
+     * <p>
+     * <img width="640" height="220" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorComplete.f.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -10347,6 +10347,47 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     }
 
     /**
+     * Returns an {@code Observable} instance that if the current {@code Observable} emits an error, it will emit an {@code onComplete}
+     * and swallow the throwable.
+     * <p>
+     * <img width="640" height="373" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.onErrorComplete.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new {@code Observable} instance
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
+    public final Observable<T> onErrorComplete() {
+        return onErrorComplete(Functions.alwaysTrue());
+    }
+
+    /**
+     * Returns an {@code Observable} instance that if the current {@code Observable} emits an error and the predicate returns
+     * {@code true}, it will emit an {@code onComplete} and swallow the throwable.
+     * <p>
+     * <img width="640" height="215" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.onErrorComplete.f.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param predicate the predicate to call when an {@link Throwable} is emitted which should return {@code true}
+     * if the {@code Throwable} should be swallowed and replaced with an {@code onComplete}.
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code predicate} is {@code null}
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Observable<T> onErrorComplete(@NonNull Predicate<? super Throwable> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+
+        return RxJavaPlugins.onAssembly(new ObservableOnErrorComplete<>(this, predicate));
+    }
+
+    /**
      * Resumes the flow with an {@link ObservableSource} returned for the failure {@link Throwable} of the current {@code Observable} by a
      * function instead of signaling the error via {@code onError}.
      * <p>

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -10356,6 +10356,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new {@code Observable} instance
+     * @since 3.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -10377,6 +10378,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * if the {@code Throwable} should be swallowed and replaced with an {@code onComplete}.
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code predicate} is {@code null}
+     * @since 3.0.0
      */
     @CheckReturnValue
     @NonNull

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -3440,6 +3440,49 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     }
 
     /**
+     * Returns a {@link Maybe} instance that if the current {@code Single} emits an error, it will emit an {@code onComplete}
+     * and swallow the throwable.
+     * <p>
+     * <img width="640" height="554" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorComplete.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @return the new {@code Maybe} instance
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
+    public final Maybe<T> onErrorComplete() {
+        return onErrorComplete(Functions.alwaysTrue());
+    }
+
+    /**
+     * Returns a {@link Maybe} instance that if this {@code Single} emits an error and the predicate returns
+     * {@code true}, it will emit an {@code onComplete} and swallow the throwable.
+     * <p>
+     * <img width="640" height="220" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorComplete.f.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorComplete} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param predicate the predicate to call when an {@link Throwable} is emitted which should return {@code true}
+     * if the {@code Throwable} should be swallowed and replaced with an {@code onComplete}.
+     * @return the new {@code Maybe} instance
+     * @throws NullPointerException if {@code predicate} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Maybe<T> onErrorComplete(@NonNull Predicate<? super Throwable> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+
+        return RxJavaPlugins.onAssembly(new SingleOnErrorComplete<>(this, predicate));
+    }
+
+    /**
      * Resumes the flow with a {@link SingleSource} returned for the failure {@link Throwable} of the current {@code Single} by a
      * function instead of signaling the error via {@code onError}.
      * <p>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorComplete.java
@@ -25,6 +25,7 @@ import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
  * that Throwable.
  * 
  * @param <T> the value type
+ * @since 3.0.0
  */
 public final class FlowableOnErrorComplete<T> extends AbstractFlowableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorComplete.java
@@ -11,13 +11,14 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.rxjava3.internal.operators.maybe;
+package io.reactivex.rxjava3.internal.operators.flowable;
+
+import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
-import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.Predicate;
-import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 
 /**
  * Emits an onComplete if the source emits an onError and the predicate returns true for
@@ -25,47 +26,47 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
  * 
  * @param <T> the value type
  */
-public final class MaybeOnErrorComplete<T> extends AbstractMaybeWithUpstream<T, T> {
+public final class FlowableOnErrorComplete<T> extends AbstractFlowableWithUpstream<T, T> {
 
     final Predicate<? super Throwable> predicate;
 
-    public MaybeOnErrorComplete(MaybeSource<T> source,
+    public FlowableOnErrorComplete(Flowable<T> source,
             Predicate<? super Throwable> predicate) {
         super(source);
         this.predicate = predicate;
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new OnErrorCompleteMultiObserver<>(observer, predicate));
+    protected void subscribeActual(Subscriber<? super T> observer) {
+        source.subscribe(new OnErrorCompleteSubscriber<>(observer, predicate));
     }
 
-    public static final class OnErrorCompleteMultiObserver<T>
-    implements MaybeObserver<T>, SingleObserver<T>, Disposable {
+    public static final class OnErrorCompleteSubscriber<T>
+    implements FlowableSubscriber<T>, Subscription {
 
-        final MaybeObserver<? super T> downstream;
+        final Subscriber<? super T> downstream;
 
         final Predicate<? super Throwable> predicate;
 
-        Disposable upstream;
+        Subscription upstream;
 
-        public OnErrorCompleteMultiObserver(MaybeObserver<? super T> actual, Predicate<? super Throwable> predicate) {
+        public OnErrorCompleteSubscriber(Subscriber<? super T> actual, Predicate<? super Throwable> predicate) {
             this.downstream = actual;
             this.predicate = predicate;
         }
 
         @Override
-        public void onSubscribe(Disposable d) {
-            if (DisposableHelper.validate(this.upstream, d)) {
-                this.upstream = d;
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.validate(this.upstream, s)) {
+                this.upstream = s;
 
                 downstream.onSubscribe(this);
             }
         }
 
         @Override
-        public void onSuccess(T value) {
-            downstream.onSuccess(value);
+        public void onNext(T value) {
+            downstream.onNext(value);
         }
 
         @Override
@@ -93,13 +94,13 @@ public final class MaybeOnErrorComplete<T> extends AbstractMaybeWithUpstream<T, 
         }
 
         @Override
-        public void dispose() {
-            upstream.dispose();
+        public void cancel() {
+            upstream.cancel();
         }
 
         @Override
-        public boolean isDisposed() {
-            return upstream.isDisposed();
+        public void request(long n) {
+            upstream.request(n);
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorComplete.java
@@ -24,6 +24,7 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
  * that Throwable.
  * 
  * @param <T> the value type
+ * @since 3.0.0
  */
 public final class ObservableOnErrorComplete<T> extends AbstractObservableWithUpstream<T, T> {
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorComplete.java
@@ -11,7 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.rxjava3.internal.operators.maybe;
+package io.reactivex.rxjava3.internal.operators.observable;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -25,31 +25,31 @@ import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
  * 
  * @param <T> the value type
  */
-public final class MaybeOnErrorComplete<T> extends AbstractMaybeWithUpstream<T, T> {
+public final class ObservableOnErrorComplete<T> extends AbstractObservableWithUpstream<T, T> {
 
     final Predicate<? super Throwable> predicate;
 
-    public MaybeOnErrorComplete(MaybeSource<T> source,
+    public ObservableOnErrorComplete(ObservableSource<T> source,
             Predicate<? super Throwable> predicate) {
         super(source);
         this.predicate = predicate;
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new OnErrorCompleteMultiObserver<>(observer, predicate));
+    protected void subscribeActual(Observer<? super T> observer) {
+        source.subscribe(new OnErrorCompleteObserver<>(observer, predicate));
     }
 
-    public static final class OnErrorCompleteMultiObserver<T>
-    implements MaybeObserver<T>, SingleObserver<T>, Disposable {
+    public static final class OnErrorCompleteObserver<T>
+    implements Observer<T>, Disposable {
 
-        final MaybeObserver<? super T> downstream;
+        final Observer<? super T> downstream;
 
         final Predicate<? super Throwable> predicate;
 
         Disposable upstream;
 
-        public OnErrorCompleteMultiObserver(MaybeObserver<? super T> actual, Predicate<? super Throwable> predicate) {
+        public OnErrorCompleteObserver(Observer<? super T> actual, Predicate<? super Throwable> predicate) {
             this.downstream = actual;
             this.predicate = predicate;
         }
@@ -64,8 +64,8 @@ public final class MaybeOnErrorComplete<T> extends AbstractMaybeWithUpstream<T, 
         }
 
         @Override
-        public void onSuccess(T value) {
-            downstream.onSuccess(value);
+        public void onNext(T value) {
+            downstream.onNext(value);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleOnErrorComplete.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.single;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.functions.Predicate;
+import io.reactivex.rxjava3.internal.operators.maybe.MaybeOnErrorComplete;
+
+/**
+ * Emits an onComplete if the source emits an onError and the predicate returns true for
+ * that Throwable.
+ * 
+ * @param <T> the value type
+ * @since 3.0.0
+ */
+public final class SingleOnErrorComplete<T> extends Maybe<T> {
+
+    final Single<T> source;
+
+    final Predicate<? super Throwable> predicate;
+
+    public SingleOnErrorComplete(Single<T> source,
+            Predicate<? super Throwable> predicate) {
+        this.source = source;
+        this.predicate = predicate;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        source.subscribe(new MaybeOnErrorComplete.OnErrorCompleteMultiObserver<T>(observer, predicate));
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorCompleteTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnErrorCompleteTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.flowable;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import io.reactivex.rxjava3.testsupport.*;
+
+public class FlowableOnErrorCompleteTest {
+
+    @Test
+    public void normal() {
+        Flowable.range(1, 10)
+        .onErrorComplete()
+        .test()
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void normalBackpressured() {
+        Flowable.range(1, 10)
+        .onErrorComplete()
+        .test(0)
+        .assertEmpty()
+        .requestMore(3)
+        .assertValuesOnly(1, 2, 3)
+        .requestMore(3)
+        .assertValuesOnly(1, 2, 3, 4, 5, 6)
+        .requestMore(4)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void empty() {
+        Flowable.empty()
+        .onErrorComplete()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void error() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Flowable.error(new TestException())
+            .onErrorComplete()
+            .test()
+            .assertResult();
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorMatches() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Flowable.error(new TestException())
+            .onErrorComplete(error -> error instanceof TestException)
+            .test()
+            .assertResult();
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorNotMatches() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Flowable.error(new IOException())
+            .onErrorComplete(error -> error instanceof TestException)
+            .test()
+            .assertFailure(IOException.class);
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorPredicateCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            TestSubscriberEx<Object> ts = Flowable.error(new IOException())
+            .onErrorComplete(error -> { throw new TestException(); })
+            .subscribeWith(new TestSubscriberEx<>())
+            .assertFailure(CompositeException.class);
+
+            TestHelper.assertError(ts, 0, IOException.class);
+            TestHelper.assertError(ts, 1, TestException.class);
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void itemsThenError() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Flowable.range(1, 5)
+            .map(v -> 4 / (3 - v))
+            .onErrorComplete()
+            .test()
+            .assertResult(2, 4);
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void cancel() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = pp
+                .onErrorComplete()
+                .test();
+
+        assertTrue("No subscribers?!", pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse("Still subscribers?!", pp.hasSubscribers());
+    }
+
+    @Test
+    public void onSubscribe() {
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.onErrorComplete());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorCompleteTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableOnErrorCompleteTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.observable;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subjects.PublishSubject;
+import io.reactivex.rxjava3.testsupport.*;
+
+public class ObservableOnErrorCompleteTest {
+
+    @Test
+    public void normal() {
+        Observable.range(1, 10)
+        .onErrorComplete()
+        .test()
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void empty() {
+        Observable.empty()
+        .onErrorComplete()
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void error() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Observable.error(new TestException())
+            .onErrorComplete()
+            .test()
+            .assertResult();
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorMatches() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Observable.error(new TestException())
+            .onErrorComplete(error -> error instanceof TestException)
+            .test()
+            .assertResult();
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorNotMatches() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Observable.error(new IOException())
+            .onErrorComplete(error -> error instanceof TestException)
+            .test()
+            .assertFailure(IOException.class);
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorPredicateCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            TestObserverEx<Object> to = Observable.error(new IOException())
+            .onErrorComplete(error -> { throw new TestException(); })
+            .subscribeWith(new TestObserverEx<>())
+            .assertFailure(CompositeException.class);
+
+            TestHelper.assertError(to, 0, IOException.class);
+            TestHelper.assertError(to, 1, TestException.class);
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void itemsThenError() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Observable.range(1, 5)
+            .map(v -> 4 / (3 - v))
+            .onErrorComplete()
+            .test()
+            .assertResult(2, 4);
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void dispose() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Integer> to = ps
+                .onErrorComplete()
+                .test();
+
+        assertTrue("No subscribers?!", ps.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Still subscribers?!", ps.hasObservers());
+    }
+
+    @Test
+    public void onSubscribe() {
+        TestHelper.checkDoubleOnSubscribeObservable(f -> f.onErrorComplete());
+    }
+
+    @Test
+    public void isDisposed() {
+        TestHelper.checkDisposed(PublishSubject.create().onErrorComplete());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleOnErrorCompleteTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleOnErrorCompleteTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.single;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subjects.*;
+import io.reactivex.rxjava3.testsupport.*;
+
+public class SingleOnErrorCompleteTest {
+
+    @Test
+    public void normal() {
+        Single.just(1)
+        .onErrorComplete()
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void error() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Single.error(new TestException())
+            .onErrorComplete()
+            .test()
+            .assertResult();
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorMatches() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Single.error(new TestException())
+            .onErrorComplete(error -> error instanceof TestException)
+            .test()
+            .assertResult();
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorNotMatches() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            Single.error(new IOException())
+            .onErrorComplete(error -> error instanceof TestException)
+            .test()
+            .assertFailure(IOException.class);
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void errorPredicateCrash() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            TestObserverEx<Object> to = Single.error(new IOException())
+            .onErrorComplete(error -> { throw new TestException(); })
+            .subscribeWith(new TestObserverEx<>())
+            .assertFailure(CompositeException.class);
+
+            TestHelper.assertError(to, 0, IOException.class);
+            TestHelper.assertError(to, 1, TestException.class);
+
+            assertTrue("" + errors, errors.isEmpty());
+        });
+    }
+
+    @Test
+    public void dispose() {
+        SingleSubject<Integer> ss = SingleSubject.create();
+
+        TestObserver<Integer> to = ss
+                .onErrorComplete()
+                .test();
+
+        assertTrue("No subscribers?!", ss.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Still subscribers?!", ss.hasObservers());
+    }
+
+    @Test
+    public void onSubscribe() {
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe(f -> f.onErrorComplete());
+    }
+
+    @Test
+    public void isDisposed() {
+        TestHelper.checkDisposed(SingleSubject.create().onErrorComplete());
+    }
+}


### PR DESCRIPTION
Add the `onErrorComplete()` and `onErrorComplete(Predicate)` operators to the remaining base classes.

Also created the missing marble for `Maybe.onErrorComplete` + 1.

Related #6852, #5806 

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.onErrorComplete.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.onErrorComplete.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.onErrorComplete.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.onErrorComplete.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorComplete.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.onErrorComplete.f.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorComplete.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorComplete.f.png)


