### PR TITLE
3.x: Add Completable.onErrorResumeWith

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -2086,6 +2086,33 @@ public abstract class Completable implements CompletableSource {
         Objects.requireNonNull(fallbackSupplier, "fallbackSupplier is null");
         return RxJavaPlugins.onAssembly(new CompletableResumeNext(this, fallbackSupplier));
     }
+    /**
+     * Resumes the flow with the given {@link CompletableSource} when the current {@code Completable} fails instead of
+     * signaling the error via {@code onError}.
+     * <p>
+     * <img width="640" height="409" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.onErrorResumeWith.png" alt="">
+     * <p>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorResumeWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param fallback
+     *            the next {@code CompletableSource} that will take over if the current {@code Completable} encounters
+     *            an error
+     * @return the new {@code Completable} instance
+     * @throws NullPointerException if {@code fallback} is {@code null}
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Completable onErrorResumeWith(@NonNull CompletableSource fallback) {
+        Objects.requireNonNull(fallback, "fallback is null");
+        return onErrorResumeNext(Functions.justFunction(fallback));
+    }
 
     /**
      * Nulls out references to the upstream producer and downstream {@link CompletableObserver} if

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -4084,7 +4084,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Resumes the flow with the given {@link MaybeSource} when the current {@code Maybe} fails instead of
      * signaling the error via {@code onError}.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
+     * <img width="640" height="298" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorResumeWith.png" alt="">
      * <p>
      * You can use this to prevent errors from propagating or to supply fallback data should errors be
      * encountered.
@@ -4112,7 +4112,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Resumes the flow with a {@link MaybeSource} returned for the failure {@link Throwable} of the current {@code Maybe} by a
      * function instead of signaling the error via {@code onError}.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="">
+     * <img width="640" height="298" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorResumeNext.png" alt="">
      * <p>
      * You can use this to prevent errors from propagating or to supply fallback data should errors be
      * encountered.

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableResumeNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableResumeNextTest.java
@@ -13,18 +13,19 @@
 
 package io.reactivex.rxjava3.internal.operators.completable;
 
+import static org.mockito.Mockito.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.TestException;
-import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class CompletableResumeNextTest extends RxJavaTest {
 
     @Test
-    public void resumeWithError() {
+    public void resumeNextError() {
         Completable.error(new TestException())
         .onErrorResumeNext(Functions.justFunction(Completable.error(new TestException("second"))))
         .to(TestHelper.<Object>testConsumer())
@@ -57,5 +58,29 @@ public class CompletableResumeNextTest extends RxJavaTest {
                 Completable.error(new TestException())
                 .onErrorResumeNext(Functions.justFunction(Completable.never()))
         );
+    }
+
+    @Test
+    public void resumeWithNoError() throws Throwable {
+        Action action = mock(Action.class);
+
+        Completable.complete()
+        .onErrorResumeWith(Completable.fromAction(action))
+        .test()
+        .assertResult();
+
+        verify(action, never()).run();
+    }
+
+    @Test
+    public void resumeWithError() throws Throwable {
+        Action action = mock(Action.class);
+
+        Completable.error(new TestException())
+        .onErrorResumeWith(Completable.fromAction(action))
+        .test()
+        .assertResult();
+
+        verify(action).run();
     }
 }


### PR DESCRIPTION
This PR adds the missing `Completable.onErrorResumeWith` present in the rest of the base classes.

Also marbles for `Maybe.onErrorResumeNext` and `Maybe.onErrorResumeWith` have been updated.

Related #6852, #5806

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.onErrorResumeWith.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorResumeNext.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorResumeWith.png)