### PR TITLE
3.x: Add Maybe/Single/Completable switchOnNext & switchOnNextDelayError

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -1017,6 +1017,71 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
+     * Switches between {@link CompletableSource}s emitted by the source {@link Publisher} whenever
+     * a new {@code CompletableSource} is emitted, disposing the previously running {@code CompletableSource},
+     * exposing the success items as a {@code Completable} sequence.
+     * <p>
+     * <img width="640" height="518" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.switchOnNext.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The {@code sources} {@code Publisher} is consumed in an unbounded manner (requesting {@link Long#MAX_VALUE}).</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code switchOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>The returned sequence fails with the first error signaled by the {@code sources} {@code Publisher}
+     *  or the currently running {@code CompletableSource}, disposing the rest. Late errors are
+     *  forwarded to the global error handler via {@link RxJavaPlugins#onError(Throwable)}.</dd>
+     * </dl>
+     * @param sources the {@code Publisher} sequence of inner {@code CompletableSource}s to switch between
+     * @return the new {@code Completable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
+     * @since 3.0.0
+     * @see #switchOnNextDelayError(Publisher)
+     * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    public static Completable switchOnNext(@NonNull Publisher<@NonNull ? extends CompletableSource> sources) {
+        Objects.requireNonNull(sources, "sources is null");
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapCompletablePublisher<>(sources, Functions.identity(), false));
+    }
+
+    /**
+     * Switches between {@link CompletableSource}s emitted by the source {@link Publisher} whenever
+     * a new {@code CompletableSource} is emitted, disposing the previously running {@code CompletableSource},
+     * exposing the success items as a {@code Completable} sequence and delaying all errors from
+     * all of them until all terminate.
+     * <p>
+     * <img width="640" height="415" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.switchOnNextDelayError.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The {@code sources} {@code Publisher} is consumed in an unbounded manner (requesting {@link Long#MAX_VALUE}).</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code switchOnNextDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>The returned {@code Completable} collects all errors emitted by either the {@code sources}
+     *  {@code Publisher} or any inner {@code CompletableSource} and emits them as a {@link CompositeException}
+     *  when all sources terminate. If only one source ever failed, its error is emitted as-is at the end.</dd>
+     * </dl>
+     * @param sources the {@code Publisher} sequence of inner {@code CompletableSource}s to switch between
+     * @return the new {@code Completable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
+     * @since 3.0.0
+     * @see #switchOnNext(Publisher)
+     * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    public static Completable switchOnNextDelayError(@NonNull Publisher<@NonNull ? extends CompletableSource> sources) {
+        Objects.requireNonNull(sources, "sources is null");
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapCompletablePublisher<>(sources, Functions.identity(), true));
+    }
+
+    /**
      * Returns a {@code Completable} instance which manages a resource along
      * with a custom {@link CompletableSource} instance while the subscription is active.
      * <p>
@@ -2328,6 +2393,7 @@ public abstract class Completable implements CompletableSource {
      * @param stop the function that should return {@code true} to stop retrying
      * @return the new {@code Completable} instance
      * @throws NullPointerException if {@code stop} is {@code null}
+     * @since 3.0.0
      */
     @CheckReturnValue
     @NonNull

--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -1019,7 +1019,7 @@ public abstract class Completable implements CompletableSource {
     /**
      * Switches between {@link CompletableSource}s emitted by the source {@link Publisher} whenever
      * a new {@code CompletableSource} is emitted, disposing the previously running {@code CompletableSource},
-     * exposing the success items as a {@code Completable} sequence.
+     * exposing the setup as a {@code Completable} sequence.
      * <p>
      * <img width="640" height="518" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.switchOnNext.png" alt="">
      * <dl>
@@ -1051,7 +1051,7 @@ public abstract class Completable implements CompletableSource {
     /**
      * Switches between {@link CompletableSource}s emitted by the source {@link Publisher} whenever
      * a new {@code CompletableSource} is emitted, disposing the previously running {@code CompletableSource},
-     * exposing the success items as a {@code Completable} sequence and delaying all errors from
+     * exposing the setup as a {@code Completable} sequence and delaying all errors from
      * all of them until all terminate.
      * <p>
      * <img width="640" height="415" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.switchOnNextDelayError.png" alt="">

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -1729,6 +1729,75 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Switches between {@link MaybeSource}s emitted by the source {@link Publisher} whenever
+     * a new {@code MaybeSource} is emitted, disposing the previously running {@code MaybeSource},
+     * exposing the success items as a {@link Flowable} sequence.
+     * <p>
+     * <img width="640" height="521" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.switchOnNext.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The {@code sources} {@code Publisher} is consumed in an unbounded manner (requesting {@link Long#MAX_VALUE}).
+     *  The returned {@code Flowable} respects the backpressure from the downstream.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code switchOnNext} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>The returned sequence fails with the first error signaled by the {@code sources} {@code Publisher}
+     *  or the currently running {@code MaybeSource}, disposing the rest. Late errors are
+     *  forwarded to the global error handler via {@link RxJavaPlugins#onError(Throwable)}.</dd>
+     * </dl>
+     * @param <T> the element type of the {@code MaybeSource}s
+     * @param sources the {@code Publisher} sequence of inner {@code MaybeSource}s to switch between
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
+     * @since 3.0.0
+     * @see #switchOnNextDelayError(Publisher)
+     * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
+     */
+    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> switchOnNext(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources) {
+        Objects.requireNonNull(sources, "sources is null");
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapMaybePublisher<>(sources, Functions.identity(), false));
+    }
+
+    /**
+     * Switches between {@link MaybeSource}s emitted by the source {@link Publisher} whenever
+     * a new {@code MaybeSource} is emitted, disposing the previously running {@code MaybeSource},
+     * exposing the success items as a {@link Flowable} sequence and delaying all errors from
+     * all of them until all terminate.
+     * <p>
+     * <img width="640" height="423" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.switchOnNextDelayError.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The {@code sources} {@code Publisher} is consumed in an unbounded manner (requesting {@link Long#MAX_VALUE}).
+     *  The returned {@code Flowable} respects the backpressure from the downstream.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code switchOnNextDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>The returned {@code Flowable} collects all errors emitted by either the {@code sources}
+     *  {@code Publisher} or any inner {@code MaybeSource} and emits them as a {@link CompositeException}
+     *  when all sources terminate. If only one source ever failed, its error is emitted as-is at the end.</dd>
+     * </dl>
+     * @param <T> the element type of the {@code MaybeSource}s
+     * @param sources the {@code Publisher} sequence of inner {@code MaybeSource}s to switch between
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code sources} is {@code null}
+     * @since 3.0.0
+     * @see #switchOnNext(Publisher)
+     * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static <T> Flowable<T> switchOnNextDelayError(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources) {
+        Objects.requireNonNull(sources, "sources is null");
+        return RxJavaPlugins.onAssembly(new FlowableSwitchMapMaybePublisher<>(sources, Functions.identity(), true));
+    }
+
+    /**
      * Returns a {@code Maybe} that emits {@code 0L} after a specified delay.
      * <p>
      * <img width="640" height="391" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.timer.png" alt="">
@@ -2868,6 +2937,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @throws NullPointerException if {@code unit} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
      * @see #delay(long, TimeUnit, Scheduler, boolean)
+     * @since 3.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
@@ -2922,6 +2992,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * @return the new {@code Maybe} instance
      * @throws NullPointerException if {@code unit} or {@code scheduler} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/delay.html">ReactiveX operators documentation: Delay</a>
+     * @since 3.0.0
      */
     @CheckReturnValue
     @NonNull

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapCompletablePublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapCompletablePublisher.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.mixed;
+
+import org.reactivestreams.Publisher;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.functions.Function;
+
+/**
+ * Switch between subsequent {@link CompletableSource}s emitted by a {@link Publisher}.
+ * Reuses {@link FlowableSwitchMapCompletable} internals.
+ * @param <T> the upstream value type
+ * @since 3.0.0
+ */
+public final class FlowableSwitchMapCompletablePublisher<T> extends Completable {
+
+    final Publisher<T> source;
+
+    final Function<? super T, ? extends CompletableSource> mapper;
+
+    final boolean delayErrors;
+
+    public FlowableSwitchMapCompletablePublisher(Publisher<T> source,
+            Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
+        this.source = source;
+        this.mapper = mapper;
+        this.delayErrors = delayErrors;
+    }
+
+    @Override
+    protected void subscribeActual(CompletableObserver observer) {
+        source.subscribe(new FlowableSwitchMapCompletable.SwitchMapCompletableObserver<>(observer, mapper, delayErrors));
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapMaybePublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapMaybePublisher.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.mixed;
+
+import org.reactivestreams.*;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.functions.Function;
+
+/**
+ * Switch between subsequent {@link MaybeSource}s emitted by a {@link Publisher}.
+ * Reuses {@link FlowableSwitchMapMaybe} internals.
+ * @param <T> the upstream value type
+ * @param <R> the downstream value type
+ * @since 3.0.0
+ */
+public final class FlowableSwitchMapMaybePublisher<T, R> extends Flowable<R> {
+
+    final Publisher<T> source;
+
+    final Function<? super T, ? extends MaybeSource<? extends R>> mapper;
+
+    final boolean delayErrors;
+
+    public FlowableSwitchMapMaybePublisher(Publisher<T> source,
+            Function<? super T, ? extends MaybeSource<? extends R>> mapper,
+            boolean delayErrors) {
+        this.source = source;
+        this.mapper = mapper;
+        this.delayErrors = delayErrors;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        source.subscribe(new FlowableSwitchMapMaybe.SwitchMapMaybeSubscriber<>(s, mapper, delayErrors));
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapSinglePublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableSwitchMapSinglePublisher.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.mixed;
+
+import org.reactivestreams.*;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.functions.Function;
+
+/**
+ * Switch between subsequent {@link SingleSource}s emitted by a {@link Publisher}.
+ * Reuses {@link FlowableSwitchMapSingle} internals.
+ * @param <T> the upstream value type
+ * @param <R> the downstream value type
+ * @since 3.0.0
+ */
+public final class FlowableSwitchMapSinglePublisher<T, R> extends Flowable<R> {
+
+    final Publisher<T> source;
+
+    final Function<? super T, ? extends SingleSource<? extends R>> mapper;
+
+    final boolean delayErrors;
+
+    public FlowableSwitchMapSinglePublisher(Publisher<T> source,
+            Function<? super T, ? extends SingleSource<? extends R>> mapper,
+            boolean delayErrors) {
+        this.source = source;
+        this.mapper = mapper;
+        this.delayErrors = delayErrors;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super R> s) {
+        source.subscribe(new FlowableSwitchMapSingle.SwitchMapSingleSubscriber<>(s, mapper, delayErrors));
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableSwitchOnNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableSwitchOnNextTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.completable;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.subjects.CompletableSubject;
+
+public class CompletableSwitchOnNextTest extends RxJavaTest {
+
+    @Test
+    public void normal() {
+        Runnable run = mock(Runnable.class);
+
+        Completable.switchOnNext(
+                Flowable.range(1, 10)
+                .map(v -> {
+                    if (v % 2 == 0) {
+                        return Completable.fromRunnable(run);
+                    }
+                    return Completable.complete();
+                })
+        )
+        .test()
+        .assertResult();
+
+        verify(run, times(5)).run();
+    }
+
+    @Test
+    public void normalDelayError() {
+        Runnable run = mock(Runnable.class);
+
+        Completable.switchOnNextDelayError(
+                Flowable.range(1, 10)
+                .map(v -> {
+                    if (v % 2 == 0) {
+                        return Completable.fromRunnable(run);
+                    }
+                    return Completable.complete();
+                })
+        )
+        .test()
+        .assertResult();
+
+        verify(run, times(5)).run();
+    }
+
+    @Test
+    public void noDelaySwitch() {
+        PublishProcessor<Completable> pp = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.switchOnNext(pp).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        to.assertEmpty();
+
+        CompletableSubject cs1 = CompletableSubject.create();
+        CompletableSubject cs2 = CompletableSubject.create();
+
+        pp.onNext(cs1);
+
+        assertTrue(cs1.hasObservers());
+
+        pp.onNext(cs2);
+
+        assertFalse(cs1.hasObservers());
+        assertTrue(cs2.hasObservers());
+
+        pp.onComplete();
+
+        assertTrue(cs2.hasObservers());
+
+        cs2.onComplete();
+
+        to.assertResult();
+    }
+
+    @Test
+    public void delaySwitch() {
+        PublishProcessor<Completable> pp = PublishProcessor.create();
+
+        TestObserver<Void> to = Completable.switchOnNextDelayError(pp).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        to.assertEmpty();
+
+        CompletableSubject cs1 = CompletableSubject.create();
+        CompletableSubject cs2 = CompletableSubject.create();
+
+        pp.onNext(cs1);
+
+        assertTrue(cs1.hasObservers());
+
+        pp.onNext(cs2);
+
+        assertFalse(cs1.hasObservers());
+        assertTrue(cs2.hasObservers());
+
+        assertTrue(cs2.hasObservers());
+
+        cs2.onError(new TestException());
+
+        assertTrue(pp.hasSubscribers());
+
+        to.assertEmpty();
+
+        pp.onComplete();
+
+        to.assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeSwitchOnNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeSwitchOnNextTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.subjects.MaybeSubject;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+
+public class MaybeSwitchOnNextTest extends RxJavaTest {
+
+    @Test
+    public void normal() {
+        Maybe.switchOnNext(
+                Flowable.range(1, 10)
+                .map(v -> {
+                    if (v % 2 == 0) {
+                        return Maybe.just(v);
+                    }
+                    return Maybe.empty();
+                })
+        )
+        .test()
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void normalDelayError() {
+        Maybe.switchOnNextDelayError(
+                Flowable.range(1, 10)
+                .map(v -> {
+                    if (v % 2 == 0) {
+                        return Maybe.just(v);
+                    }
+                    return Maybe.empty();
+                })
+        )
+        .test()
+        .assertResult(2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void noDelaySwitch() {
+        PublishProcessor<Maybe<Integer>> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.switchOnNext(pp).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.assertEmpty();
+
+        MaybeSubject<Integer> ms1 = MaybeSubject.create();
+        MaybeSubject<Integer> ms2 = MaybeSubject.create();
+
+        pp.onNext(ms1);
+
+        assertTrue(ms1.hasObservers());
+
+        pp.onNext(ms2);
+
+        assertFalse(ms1.hasObservers());
+        assertTrue(ms2.hasObservers());
+
+        pp.onComplete();
+
+        assertTrue(ms2.hasObservers());
+
+        ms2.onSuccess(1);
+
+        ts.assertResult(1);
+    }
+
+    @Test
+    public void delaySwitch() {
+        PublishProcessor<Maybe<Integer>> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Maybe.switchOnNextDelayError(pp).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.assertEmpty();
+
+        MaybeSubject<Integer> ms1 = MaybeSubject.create();
+        MaybeSubject<Integer> ms2 = MaybeSubject.create();
+
+        pp.onNext(ms1);
+
+        assertTrue(ms1.hasObservers());
+
+        pp.onNext(ms2);
+
+        assertFalse(ms1.hasObservers());
+        assertTrue(ms2.hasObservers());
+
+        assertTrue(ms2.hasObservers());
+
+        ms2.onError(new TestException());
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.assertEmpty();
+
+        pp.onComplete();
+
+        ts.assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleSwitchOnNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleSwitchOnNextTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.single;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.subjects.SingleSubject;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+
+public class SingleSwitchOnNextTest extends RxJavaTest {
+
+    @Test
+    public void normal() {
+        Single.switchOnNext(
+                Flowable.range(1, 5)
+                .map(v -> {
+                    if (v % 2 == 0) {
+                        return Single.just(v);
+                    }
+                    return Single.just(10 + v);
+                })
+        )
+        .test()
+        .assertResult(11, 2, 13, 4, 15);
+    }
+
+    @Test
+    public void normalDelayError() {
+        Single.switchOnNextDelayError(
+                Flowable.range(1, 5)
+                .map(v -> {
+                    if (v % 2 == 0) {
+                        return Single.just(v);
+                    }
+                    return Single.just(10 + v);
+                })
+        )
+        .test()
+        .assertResult(11, 2, 13, 4, 15);
+    }
+
+    @Test
+    public void noDelaySwitch() {
+        PublishProcessor<Single<Integer>> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Single.switchOnNext(pp).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.assertEmpty();
+
+        SingleSubject<Integer> ss1 = SingleSubject.create();
+        SingleSubject<Integer> ss2 = SingleSubject.create();
+
+        pp.onNext(ss1);
+
+        assertTrue(ss1.hasObservers());
+
+        pp.onNext(ss2);
+
+        assertFalse(ss1.hasObservers());
+        assertTrue(ss2.hasObservers());
+
+        pp.onComplete();
+
+        assertTrue(ss2.hasObservers());
+
+        ss2.onSuccess(1);
+
+        ts.assertResult(1);
+    }
+
+    @Test
+    public void delaySwitch() {
+        PublishProcessor<Single<Integer>> pp = PublishProcessor.create();
+
+        TestSubscriber<Integer> ts = Single.switchOnNextDelayError(pp).test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.assertEmpty();
+
+        SingleSubject<Integer> ss1 = SingleSubject.create();
+        SingleSubject<Integer> ss2 = SingleSubject.create();
+
+        pp.onNext(ss1);
+
+        assertTrue(ss1.hasObservers());
+
+        pp.onNext(ss2);
+
+        assertFalse(ss1.hasObservers());
+        assertTrue(ss2.hasObservers());
+
+        assertTrue(ss2.hasObservers());
+
+        ss2.onError(new TestException());
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.assertEmpty();
+
+        pp.onComplete();
+
+        ts.assertFailure(TestException.class);
+    }
+}


### PR DESCRIPTION
Add the missing `switchOnNext` and `switchOnNextDelayError` operators, which are essentially delegated to the respective `Flowable::switchMapX` operators with identity mapping.

Related #6852

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.switchOnNext.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.switchOnNextDelayError.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.switchOnNext.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.switchOnNextDelayError.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.switchOnNext.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.switchOnNextDelayError.png)