### PR TITLE
3.x: Add Maybe/Completable toFuture

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -2898,7 +2898,7 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * <img width="640" height="433" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Completable.toFuture.png" alt="">
      * <p>
-     * Cancelling the {@code Future} will cancel the subscription to the current {@code Maybe}.
+     * Cancelling the {@code Future} will cancel the subscription to the current {@code Completable}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -2892,6 +2892,28 @@ public abstract class Completable implements CompletableSource {
         }
         return RxJavaPlugins.onAssembly(new CompletableToFlowable<>(this));
     }
+    /**
+     * Returns a {@link Future} representing the termination of the current {@code Completable}
+     * via a {@code null} value.
+     * <p>
+     * <img width="640" height="433" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Completable.toFuture.png" alt="">
+     * <p>
+     * Cancelling the {@code Future} will cancel the subscription to the current {@code Maybe}.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @return the new {@code Future} instance
+     * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
+    public final Future<Void> toFuture() {
+        return subscribeWith(new FutureMultiObserver<>());
+    }
 
     /**
      * Converts this {@code Completable} into a {@link Maybe}.

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -6249,7 +6249,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     /**
      * Returns a {@link Future} representing the only value emitted by this {@code Flowable}.
      * <p>
-     * <img width="640" height="324" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Flowable.toFuture.png" alt="">
+     * <img width="640" height="311" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Flowable.toFuture.png" alt="">
      * <p>
      * If the {@code Flowable} emits more than one item, {@link java.util.concurrent.Future} will receive an
      * {@link java.lang.IndexOutOfBoundsException}. If the {@code Flowable} is empty, {@link java.util.concurrent.Future}

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -4167,6 +4167,29 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
+     * Returns a {@link Future} representing the single value emitted by the current {@code Maybe}
+     * or {@code null} if the current {@code Maybe} is empty.
+     * <p>
+     * <img width="640" height="292" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Maybe.toFuture.png" alt="">
+     * <p>
+     * Cancelling the {@code Future} will cancel the subscription to the current {@code Maybe}.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @return the new {@code Future} instance
+     * @see <a href="http://reactivex.io/documentation/operators/to.html">ReactiveX documentation: To</a>
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
+    public final Future<T> toFuture() {
+        return subscribeWith(new FutureMultiObserver<>());
+    }
+
+    /**
      * Converts this {@code Maybe} into an {@link Observable} instance composing disposal
      * through.
      * <dl>

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -5654,7 +5654,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     /**
      * Returns a {@link Future} representing the only value emitted by the current {@code Observable}.
      * <p>
-     * <img width="640" height="312" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/toFuture.o.png" alt="">
+     * <img width="640" height="299" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/toFuture.o.png" alt="">
      * <p>
      * If the {@code Observable} emits more than one item, {@code Future} will receive an
      * {@link IndexOutOfBoundsException}. If the {@code Observable} is empty, {@code Future}

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -4626,7 +4626,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="467" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Single.toFuture.png" alt="">
      * <p>
-     * Cancelling the {@code Future} will cancel the subscription to the current {@code Maybe}.
+     * Cancelling the {@code Future} will cancel the subscription to the current {@code Single}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -4625,6 +4625,8 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * Returns a {@link Future} representing the single value emitted by this {@code Single}.
      * <p>
      * <img width="640" height="467" src="https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Single.toFuture.png" alt="">
+     * <p>
+     * Cancelling the {@code Future} will cancel the subscription to the current {@code Maybe}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toFuture} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -4637,7 +4639,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Future<T> toFuture() {
-        return subscribeWith(new FutureSingleObserver<>());
+        return subscribeWith(new FutureMultiObserver<>());
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableToFutureTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.completable;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.subjects.CompletableSubject;
+
+public class CompletableToFutureTest extends RxJavaTest {
+
+    @Test
+    public void empty() throws Exception {
+        assertNull(Completable.complete()
+        .subscribeOn(Schedulers.computation())
+        .toFuture()
+        .get());
+    }
+
+    @Test
+    public void error() throws InterruptedException {
+        try {
+            Completable.error(new TestException())
+            .subscribeOn(Schedulers.computation())
+            .toFuture()
+            .get();
+
+            fail("Should have thrown!");
+        } catch (ExecutionException ex) {
+            assertTrue("" + ex.getCause(), ex.getCause() instanceof TestException);
+        }
+    }
+
+    @Test
+    public void cancel() {
+        CompletableSubject cs = CompletableSubject.create();
+
+        Future<Void> f = cs.toFuture();
+
+        assertTrue(cs.hasObservers());
+
+        f.cancel(true);
+
+        assertFalse(cs.hasObservers());
+    }
+
+    @Test
+    public void cancel2() {
+        CompletableSubject cs = CompletableSubject.create();
+
+        Future<Void> f = cs.toFuture();
+
+        assertTrue(cs.hasObservers());
+
+        f.cancel(false);
+
+        assertFalse(cs.hasObservers());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeToFutureTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.maybe;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.subjects.MaybeSubject;
+
+public class MaybeToFutureTest extends RxJavaTest {
+
+    @Test
+    public void success() throws Exception {
+        assertEquals((Integer)1, Maybe.just(1)
+        .subscribeOn(Schedulers.computation())
+        .toFuture()
+        .get());
+    }
+
+    @Test
+    public void empty() throws Exception {
+        assertNull(Maybe.empty()
+        .subscribeOn(Schedulers.computation())
+        .toFuture()
+        .get());
+    }
+
+    @Test
+    public void error() throws InterruptedException {
+        try {
+            Maybe.error(new TestException())
+            .subscribeOn(Schedulers.computation())
+            .toFuture()
+            .get();
+
+            fail("Should have thrown!");
+        } catch (ExecutionException ex) {
+            assertTrue("" + ex.getCause(), ex.getCause() instanceof TestException);
+        }
+    }
+
+    @Test
+    public void cancel() {
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        Future<Integer> f = ms.toFuture();
+
+        assertTrue(ms.hasObservers());
+
+        f.cancel(true);
+
+        assertFalse(ms.hasObservers());
+    }
+
+    @Test
+    public void cancel2() {
+        MaybeSubject<Integer> ms = MaybeSubject.create();
+
+        Future<Integer> f = ms.toFuture();
+
+        assertTrue(ms.hasObservers());
+
+        f.cancel(false);
+
+        assertFalse(ms.hasObservers());
+    }
+}


### PR DESCRIPTION
Add `toFuture` to `Maybe` and `Completable`.

Related #6852 

![image](https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Maybe.toFuture.png)
![image](https://github.com/ReactiveX/RxJava/wiki/images/rx-operators/Completable.toFuture.png)