### PR TITLE
3.x: Add Single.mergeArray & mergeArrayDelayError

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -1415,7 +1415,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Merges an array sequence of {@link MaybeSource} instances into a single {@link Flowable} sequence,
+     * Merges an array of {@link MaybeSource} instances into a single {@link Flowable} sequence,
      * running all {@code MaybeSource}s at once.
      * <p>
      * <img width="640" height="272" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.mergeArray.png" alt="">
@@ -1470,10 +1470,10 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * <img width="640" height="422" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.mergeArrayDelayError.png" alt="">
      * <p>
      * This behaves like {@link #merge(Publisher)} except that if any of the merged {@code MaybeSource}s notify of an
-     * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
+     * error via {@link Subscriber#onError onError}, {@code mergeArrayDelayError} will refrain from propagating that
      * error notification until all of the merged {@code MaybeSource}s have finished emitting items.
      * <p>
-     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
+     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeArrayDelayError} will only
      * invoke the {@code onError} method of its subscribers once.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -1395,10 +1395,6 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @SafeVarargs
     @NonNull
     public static <T> Flowable<T> mergeArrayDelayError(@NonNull SingleSource<? extends T>... sources) {
-        Objects.requireNonNull(sources, "sources is null");
-        if (sources.length == 0) {
-            return Flowable.empty();
-        }
         return Flowable.fromArray(sources).flatMapSingle(Functions.identity(), true, sources.length);
     }
 

--- a/src/test/java/io/reactivex/rxjava3/internal/fuseable/CancellableQueueFuseableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/fuseable/CancellableQueueFuseableTest.java
@@ -57,7 +57,7 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void cancel2() {
-        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() {};
+        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() { };
 
         assertFalse(qs.isDisposed());
 
@@ -66,7 +66,7 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void dispose2() {
-        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() {};
+        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() { };
 
         assertFalse(qs.isDisposed());
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleMergeArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleMergeArrayTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+
+public class SingleMergeArrayTest extends RxJavaTest {
+
+    @Test
+    public void normal() {
+        Single.mergeArray(Single.just(1), Single.just(2), Single.just(3))
+        .test()
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void error() {
+        Single.mergeArray(Single.just(1), Single.error(new TestException()), Single.just(3))
+        .test()
+        .assertFailure(TestException.class, 1);
+    }
+
+    @Test
+    public void normalDelayError() {
+        Single.mergeArrayDelayError(Single.just(1), Single.just(2), Single.just(3))
+        .test()
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void errorDelayError() {
+        Single.mergeArrayDelayError(Single.just(1), Single.error(new TestException()), Single.just(3))
+        .test()
+        .assertFailure(TestException.class, 1, 3);
+    }
+}


### PR DESCRIPTION
`Single` was missing the `mergeArray` and `mergeArrayDelayError` operators already present in the other classes.

Related #6852

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.mergeArray.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.mergeArrayDelayError.png)