### PR TITLE
3.x: Add Completable.sequenceEqual

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -29,7 +29,7 @@ import io.reactivex.rxjava3.internal.observers.*;
 import io.reactivex.rxjava3.internal.operators.completable.*;
 import io.reactivex.rxjava3.internal.operators.maybe.*;
 import io.reactivex.rxjava3.internal.operators.mixed.*;
-import io.reactivex.rxjava3.internal.operators.single.SingleDelayWithCompletable;
+import io.reactivex.rxjava3.internal.operators.single.*;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -412,6 +412,29 @@ public abstract class Completable implements CompletableSource {
     public static Completable create(@NonNull CompletableOnSubscribe source) {
         Objects.requireNonNull(source, "source is null");
         return RxJavaPlugins.onAssembly(new CompletableCreate(source));
+    }
+
+    /**
+     * Compares two {@link CompletableSource}s and emits {@code true} via a {@link Single} if both complete.
+     * <p>
+     * <img width="640" height="187" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.sequenceEqual.png" alt="">
+     * <dl>
+     * <dt><b>Scheduler:</b></dt>
+     * <dd>{@code sequenceEqual} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param source1 the first {@code CompletableSource} instance
+     * @param source2 the second {@code CompletableSource} instance
+     * @return the new {@code Single} instance
+     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public static Single<Boolean> sequenceEqual(@NonNull CompletableSource source1, @NonNull CompletableSource source2) { // NOPMD
+        Objects.requireNonNull(source1, "source1 is null");
+        Objects.requireNonNull(source2, "source2 is null");
+        return mergeArrayDelayError(source1, source2).andThen(Single.just(true));
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableSequenceEqualTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.completable;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.exceptions.TestException;
+
+public class CompletableSequenceEqualTest {
+
+    @Test
+    public void bothComplete() {
+        Completable.sequenceEqual(Completable.complete(), Completable.complete())
+        .test()
+        .assertResult(true);
+    }
+
+    @Test
+    public void firstFails() {
+        Completable.sequenceEqual(Completable.error(new TestException()), Completable.complete())
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void secondFails() {
+        Completable.sequenceEqual(Completable.complete(), Completable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+}


### PR DESCRIPTION
The operator was available in all other classes.

Related #6852 

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.sequenceEqual.png)