### PR TITLE
3.x: Add missing startWith overloads

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -2592,7 +2592,7 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns a {@code Flowable} which first runs the other {@link SingleSource}
+     * Returns a {@link Flowable} which first runs the other {@link SingleSource}
      * then the current {@code Completable} if the other succeeded normally.
      * <p>
      * <img width="640" height="388" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.s.png" alt="">
@@ -2618,7 +2618,7 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Returns a {@code Flowable} which first runs the other {@link MaybeSource}
+     * Returns a {@link Flowable} which first runs the other {@link MaybeSource}
      * then the current {@code Completable} if the other succeeded or completed normally.
      * <p>
      * <img width="640" height="266" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.m.png" alt="">

--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -2572,7 +2572,7 @@ public abstract class Completable implements CompletableSource {
 
     /**
      * Returns a {@code Completable} which first runs the other {@link CompletableSource}
-     * then this {@code Completable} if the other completed normally.
+     * then the current {@code Completable} if the other completed normally.
      * <p>
      * <img width="640" height="437" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.c.png" alt="">
      * <dl>
@@ -2592,8 +2592,60 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
+     * Returns a {@code Flowable} which first runs the other {@link SingleSource}
+     * then the current {@code Completable} if the other succeeded normally.
+     * <p>
+     * <img width="640" height="388" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.s.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the element type of the {@code other} {@code SingleSource}.
+     * @param other the other {@code SingleSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final <T> Flowable<T> startWith(@NonNull SingleSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Single.wrap(other).toFlowable(), toFlowable());
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link MaybeSource}
+     * then the current {@code Completable} if the other succeeded or completed normally.
+     * <p>
+     * <img width="640" height="266" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.m.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param <T> the element type of the {@code other} {@code MaybeSource}.
+     * @param other the other {@code MaybeSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final <T> Flowable<T> startWith(@NonNull MaybeSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Maybe.wrap(other).toFlowable(), toFlowable());
+    }
+
+    /**
      * Returns an {@link Observable} which first delivers the events
-     * of the other {@link ObservableSource} then runs this {@code Completable}.
+     * of the other {@link ObservableSource} then runs the current {@code Completable}.
      * <p>
      * <img width="640" height="289" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.o.png" alt="">
      * <dl>
@@ -2612,9 +2664,10 @@ public abstract class Completable implements CompletableSource {
         Objects.requireNonNull(other, "other is null");
         return Observable.wrap(other).concatWith(this.toObservable());
     }
+
     /**
      * Returns a {@link Flowable} which first delivers the events
-     * of the other {@link Publisher} then runs this {@code Completable}.
+     * of the other {@link Publisher} then runs the current {@code Completable}.
      * <p>
      * <img width="640" height="250" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.p.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -15239,6 +15239,81 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     }
 
     /**
+     * Returns a {@code Flowable} which first runs the other {@link CompletableSource}
+     * then the current {@code Flowable} if the other completed normally.
+     * <p>
+     * <img width="640" height="268" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.startWith.c.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code CompletableSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull CompletableSource other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), this);
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link SingleSource}
+     * then the current {@code Flowable} if the other succeeded normally.
+     * <p>
+     * <img width="640" height="248" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.startWith.s.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code SingleSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull SingleSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Single.wrap(other).toFlowable(), this);
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link MaybeSource}
+     * then the current {@code Flowable} if the other succeeded or completed normally.
+     * <p>
+     * <img width="640" height="168" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.startWith.m.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code MaybeSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull MaybeSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Maybe.wrap(other).toFlowable(), this);
+    }
+
+    /**
      * Returns a {@code Flowable} that emits the items in a specified {@link Publisher} before it begins to emit
      * items emitted by the current {@code Flowable}.
      * <p>

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -4861,7 +4861,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a {@code Flowable} which first runs the other {@link CompletableSource}
+     * Returns a {@link Flowable} which first runs the other {@link CompletableSource}
      * then the current {@code Maybe} if the other completed normally.
      * <p>
      * <img width="640" height="268" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.c.png" alt="">
@@ -4886,7 +4886,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a {@code Flowable} which first runs the other {@link SingleSource}
+     * Returns a {@link Flowable} which first runs the other {@link SingleSource}
      * then the current {@code Maybe} if the other succeeded normally.
      * <p>
      * <img width="640" height="237" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.s.png" alt="">
@@ -4911,7 +4911,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a {@code Flowable} which first runs the other {@link MaybeSource}
+     * Returns a {@link Flowable} which first runs the other {@link MaybeSource}
      * then the current {@code Maybe} if the other succeeded or completed normally.
      * <p>
      * <img width="640" height="178" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.m.png" alt="">

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -20,6 +20,7 @@ import java.util.stream.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
@@ -4857,6 +4858,129 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     public final Maybe<T> retryWhen(
             @NonNull Function<? super Flowable<Throwable>, ? extends Publisher<@NonNull ?>> handler) {
         return toFlowable().retryWhen(handler).singleElement();
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link CompletableSource}
+     * then the current {@code Maybe} if the other completed normally.
+     * <p>
+     * <img width="640" height="268" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.c.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code CompletableSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull CompletableSource other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), toFlowable());
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link SingleSource}
+     * then the current {@code Maybe} if the other succeeded normally.
+     * <p>
+     * <img width="640" height="237" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.s.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code SingleSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull SingleSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Single.wrap(other).toFlowable(), toFlowable());
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link MaybeSource}
+     * then the current {@code Maybe} if the other succeeded or completed normally.
+     * <p>
+     * <img width="640" height="178" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.m.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code MaybeSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull MaybeSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Maybe.wrap(other).toFlowable(), toFlowable());
+    }
+
+    /**
+     * Returns an {@link Observable} which first delivers the events
+     * of the other {@link ObservableSource} then runs the current {@code Maybe}.
+     * <p>
+     * <img width="640" height="179" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.o.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code ObservableSource} to run first
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Observable<T> startWith(@NonNull ObservableSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Observable.wrap(other).concatWith(this.toObservable());
+    }
+
+    /**
+     * Returns a {@link Flowable} which first delivers the events
+     * of the other {@link Publisher} then runs the current {@code Maybe}.
+     * <p>
+     * <img width="640" height="179" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.p.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code Publisher} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Flowable<T> startWith(@NonNull Publisher<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return toFlowable().startWith(other);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -12705,7 +12705,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a {@code Observable} which first runs the other {@link CompletableSource}
+     * Returns an {@code Observable} which first runs the other {@link CompletableSource}
      * then the current {@code Observable} if the other completed normally.
      * <p>
      * <img width="640" height="437" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.c.png" alt="">
@@ -12727,7 +12727,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns a {@code Observable} which first runs the other {@link SingleSource}
+     * Returns an {@code Observable} which first runs the other {@link SingleSource}
      * then the current {@code Observable} if the other succeeded normally.
      * <p>
      * <img width="640" height="248" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.s.png" alt="">
@@ -12743,20 +12743,17 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @BackpressureSupport(BackpressureKind.FULL)
     public final Observable<T> startWith(@NonNull SingleSource<T> other) {
         Objects.requireNonNull(other, "other is null");
         return Observable.concat(Single.wrap(other).toObservable(), this);
     }
 
     /**
-     * Returns a {@code Observable} which first runs the other {@link MaybeSource}
+     * Returns an {@code Observable} which first runs the other {@link MaybeSource}
      * then the current {@code Observable} if the other succeeded or completed normally.
      * <p>
      * <img width="640" height="168" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.m.png" alt="">
      * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -12768,7 +12765,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @BackpressureSupport(BackpressureKind.FULL)
     public final Observable<T> startWith(@NonNull MaybeSource<T> other) {
         Objects.requireNonNull(other, "other is null");
         return Observable.concat(Maybe.wrap(other).toObservable(), this);

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -12705,6 +12705,76 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     }
 
     /**
+     * Returns a {@code Observable} which first runs the other {@link CompletableSource}
+     * then the current {@code Observable} if the other completed normally.
+     * <p>
+     * <img width="640" height="437" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.c.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code CompletableSource} to run first
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Observable<T> startWith(@NonNull CompletableSource other) {
+        Objects.requireNonNull(other, "other is null");
+        return Observable.concat(Completable.wrap(other).<T>toObservable(), this);
+    }
+
+    /**
+     * Returns a {@code Observable} which first runs the other {@link SingleSource}
+     * then the current {@code Observable} if the other succeeded normally.
+     * <p>
+     * <img width="640" height="248" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.s.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code SingleSource} to run first
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Observable<T> startWith(@NonNull SingleSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Observable.concat(Single.wrap(other).toObservable(), this);
+    }
+
+    /**
+     * Returns a {@code Observable} which first runs the other {@link MaybeSource}
+     * then the current {@code Observable} if the other succeeded or completed normally.
+     * <p>
+     * <img width="640" height="168" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.m.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code MaybeSource} to run first
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Observable<T> startWith(@NonNull MaybeSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Observable.concat(Maybe.wrap(other).toObservable(), this);
+    }
+
+    /**
      * Returns an {@code Observable} that emits the items in a specified {@link ObservableSource} before it begins to emit
      * items emitted by the current {@code Observable}.
      * <p>

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -4288,7 +4288,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     }
 
     /**
-     * Returns a {@code Flowable} which first runs the other {@link CompletableSource}
+     * Returns a {@link Flowable} which first runs the other {@link CompletableSource}
      * then the current {@code Single} if the other completed normally.
      * <p>
      * <img width="640" height="360" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.c.png" alt="">
@@ -4313,7 +4313,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     }
 
     /**
-     * Returns a {@code Flowable} which first runs the other {@link SingleSource}
+     * Returns a {@link Flowable} which first runs the other {@link SingleSource}
      * then the current {@code Single} if the other succeeded normally.
      * <p>
      * <img width="640" height="341" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.s.png" alt="">
@@ -4338,7 +4338,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     }
 
     /**
-     * Returns a {@code Flowable} which first runs the other {@link MaybeSource}
+     * Returns a {@link Flowable} which first runs the other {@link MaybeSource}
      * then the current {@code Single} if the other succeeded or completed normally.
      * <p>
      * <img width="640" height="232" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.m.png" alt="">

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -20,6 +20,7 @@ import java.util.stream.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
@@ -4284,6 +4285,129 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @NonNull
     public final Single<T> retryWhen(@NonNull Function<? super Flowable<Throwable>, ? extends Publisher<@NonNull ?>> handler) {
         return toSingle(toFlowable().retryWhen(handler));
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link CompletableSource}
+     * then the current {@code Single} if the other completed normally.
+     * <p>
+     * <img width="640" height="360" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.c.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code CompletableSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull CompletableSource other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), toFlowable());
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link SingleSource}
+     * then the current {@code Single} if the other succeeded normally.
+     * <p>
+     * <img width="640" height="341" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.s.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code SingleSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull SingleSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Single.wrap(other).toFlowable(), toFlowable());
+    }
+
+    /**
+     * Returns a {@code Flowable} which first runs the other {@link MaybeSource}
+     * then the current {@code Single} if the other succeeded or completed normally.
+     * <p>
+     * <img width="640" height="232" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.m.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code MaybeSource} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    public final Flowable<T> startWith(@NonNull MaybeSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Flowable.concat(Maybe.wrap(other).toFlowable(), toFlowable());
+    }
+
+    /**
+     * Returns an {@link Observable} which first delivers the events
+     * of the other {@link ObservableSource} then runs the current {@code Single}.
+     * <p>
+     * <img width="640" height="175" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.o.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code ObservableSource} to run first
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Observable<T> startWith(@NonNull ObservableSource<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return Observable.wrap(other).concatWith(this.toObservable());
+    }
+
+    /**
+     * Returns a {@link Flowable} which first delivers the events
+     * of the other {@link Publisher} then runs the current {@code Single}.
+     * <p>
+     * <img width="640" height="175" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.p.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer
+     *  and expects the other {@code Publisher} to honor it as well.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code startWith} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     * @param other the other {@code Publisher} to run first
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final Flowable<T> startWith(@NonNull Publisher<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return toFlowable().startWith(other);
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableStartWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableStartWithTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.completable;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+
+public class CompletableStartWithTest {
+
+    @Test
+    public void singleNormal() {
+        Completable.complete().startWith(Single.just(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void singleError() {
+        Runnable run = mock(Runnable.class);
+
+        Completable.fromRunnable(run).startWith(Single.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void maybeNormal() {
+        Completable.complete().startWith(Maybe.just(1))
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void maybeEmptyNormal() {
+        Completable.complete().startWith(Maybe.empty())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void maybeError() {
+        Runnable run = mock(Runnable.class);
+
+        Completable.fromRunnable(run).startWith(Maybe.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableStartWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableStartWithTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.flowable;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+
+public class FlowableStartWithTest {
+
+    @Test
+    public void justCompletableComplete() {
+        Flowable.just(1).startWith(Completable.complete())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void emptyCompletableComplete() {
+        Flowable.empty().startWith(Completable.complete())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void runCompletableError() {
+        Runnable run = mock(Runnable.class);
+
+        Flowable.fromRunnable(run).startWith(Completable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justSingleJust() {
+        Flowable.just(1).startWith(Single.just(2))
+        .test()
+        .assertResult(2, 1);
+    }
+
+    @Test
+    public void emptySingleJust() {
+        Runnable run = mock(Runnable.class);
+
+        Flowable.fromRunnable(run)
+        .startWith(Single.just(2))
+        .test()
+        .assertResult(2);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void runSingleError() {
+        Runnable run = mock(Runnable.class);
+
+        Flowable.fromRunnable(run).startWith(Single.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justMaybeJust() {
+        Flowable.just(1).startWith(Maybe.just(2))
+        .test()
+        .assertResult(2, 1);
+    }
+
+    @Test
+    public void emptyMaybeJust() {
+        Runnable run = mock(Runnable.class);
+
+        Flowable.fromRunnable(run)
+        .startWith(Maybe.just(2))
+        .test()
+        .assertResult(2);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void runMaybeError() {
+        Runnable run = mock(Runnable.class);
+
+        Flowable.fromRunnable(run).startWith(Maybe.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justFlowableJust() {
+        Flowable.just(1).startWith(Flowable.just(2, 3, 4, 5))
+        .test()
+        .assertResult(2, 3, 4, 5, 1);
+    }
+
+    @Test
+    public void emptyFlowableJust() {
+        Runnable run = mock(Runnable.class);
+
+        Flowable.fromRunnable(run)
+        .startWith(Flowable.just(2, 3, 4, 5))
+        .test()
+        .assertResult(2, 3, 4, 5);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void emptyFlowableEmpty() {
+        Runnable run = mock(Runnable.class);
+        Runnable run2 = mock(Runnable.class);
+
+        Flowable.fromRunnable(run)
+        .startWith(Flowable.fromRunnable(run2))
+        .test()
+        .assertResult();
+
+        verify(run).run();
+        verify(run2).run();
+    }
+
+    @Test
+    public void runFlowableError() {
+        Runnable run = mock(Runnable.class);
+
+        Flowable.fromRunnable(run).startWith(Flowable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeStartWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeStartWithTest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.maybe;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+
+public class MaybeStartWithTest {
+
+    @Test
+    public void justCompletableComplete() {
+        Maybe.just(1).startWith(Completable.complete())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void emptyCompletableComplete() {
+        Maybe.empty().startWith(Completable.complete())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void runCompletableError() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run).startWith(Completable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justSingleJust() {
+        Maybe.just(1).startWith(Single.just(2))
+        .test()
+        .assertResult(2, 1);
+    }
+
+    @Test
+    public void emptySingleJust() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run)
+        .startWith(Single.just(2))
+        .test()
+        .assertResult(2);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void runSingleError() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run).startWith(Single.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justMaybeJust() {
+        Maybe.just(1).startWith(Maybe.just(2))
+        .test()
+        .assertResult(2, 1);
+    }
+
+    @Test
+    public void emptyMaybeJust() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run)
+        .startWith(Maybe.just(2))
+        .test()
+        .assertResult(2);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void runMaybeError() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run).startWith(Maybe.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justObservableJust() {
+        Maybe.just(1).startWith(Observable.just(2, 3, 4, 5))
+        .test()
+        .assertResult(2, 3, 4, 5, 1);
+    }
+
+    @Test
+    public void emptyObservableJust() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run)
+        .startWith(Observable.just(2, 3, 4, 5))
+        .test()
+        .assertResult(2, 3, 4, 5);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void emptyObservableEmpty() {
+        Runnable run = mock(Runnable.class);
+        Runnable run2 = mock(Runnable.class);
+
+        Maybe.fromRunnable(run)
+        .startWith(Observable.fromRunnable(run2))
+        .test()
+        .assertResult();
+
+        verify(run).run();
+        verify(run2).run();
+    }
+
+    @Test
+    public void runObservableError() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run).startWith(Observable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justFlowableJust() {
+        Maybe.just(1).startWith(Flowable.just(2, 3, 4, 5))
+        .test()
+        .assertResult(2, 3, 4, 5, 1);
+    }
+
+    @Test
+    public void emptyFlowableJust() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run)
+        .startWith(Flowable.just(2, 3, 4, 5))
+        .test()
+        .assertResult(2, 3, 4, 5);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void emptyFlowableEmpty() {
+        Runnable run = mock(Runnable.class);
+        Runnable run2 = mock(Runnable.class);
+
+        Maybe.fromRunnable(run)
+        .startWith(Flowable.fromRunnable(run2))
+        .test()
+        .assertResult();
+
+        verify(run).run();
+        verify(run2).run();
+    }
+
+    @Test
+    public void runFlowableError() {
+        Runnable run = mock(Runnable.class);
+
+        Maybe.fromRunnable(run).startWith(Flowable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableStartWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableStartWithTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.observable;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+
+public class ObservableStartWithTest {
+
+    @Test
+    public void justCompletableComplete() {
+        Observable.just(1).startWith(Completable.complete())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void emptyCompletableComplete() {
+        Observable.empty().startWith(Completable.complete())
+        .test()
+        .assertResult();
+    }
+
+    @Test
+    public void runCompletableError() {
+        Runnable run = mock(Runnable.class);
+
+        Observable.fromRunnable(run).startWith(Completable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justSingleJust() {
+        Observable.just(1).startWith(Single.just(2))
+        .test()
+        .assertResult(2, 1);
+    }
+
+    @Test
+    public void emptySingleJust() {
+        Runnable run = mock(Runnable.class);
+
+        Observable.fromRunnable(run)
+        .startWith(Single.just(2))
+        .test()
+        .assertResult(2);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void runSingleError() {
+        Runnable run = mock(Runnable.class);
+
+        Observable.fromRunnable(run).startWith(Single.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justMaybeJust() {
+        Observable.just(1).startWith(Maybe.just(2))
+        .test()
+        .assertResult(2, 1);
+    }
+
+    @Test
+    public void emptyMaybeJust() {
+        Runnable run = mock(Runnable.class);
+
+        Observable.fromRunnable(run)
+        .startWith(Maybe.just(2))
+        .test()
+        .assertResult(2);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void runMaybeError() {
+        Runnable run = mock(Runnable.class);
+
+        Observable.fromRunnable(run).startWith(Maybe.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+
+    @Test
+    public void justObservableJust() {
+        Observable.just(1).startWith(Observable.just(2, 3, 4, 5))
+        .test()
+        .assertResult(2, 3, 4, 5, 1);
+    }
+
+    @Test
+    public void emptyObservableJust() {
+        Runnable run = mock(Runnable.class);
+
+        Observable.fromRunnable(run)
+        .startWith(Observable.just(2, 3, 4, 5))
+        .test()
+        .assertResult(2, 3, 4, 5);
+
+        verify(run).run();
+    }
+
+    @Test
+    public void emptyObservableEmpty() {
+        Runnable run = mock(Runnable.class);
+        Runnable run2 = mock(Runnable.class);
+
+        Observable.fromRunnable(run)
+        .startWith(Observable.fromRunnable(run2))
+        .test()
+        .assertResult();
+
+        verify(run).run();
+        verify(run2).run();
+    }
+
+    @Test
+    public void runObservableError() {
+        Runnable run = mock(Runnable.class);
+
+        Observable.fromRunnable(run).startWith(Observable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+
+        verify(run, never()).run();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleStartWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleStartWithTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.single;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.TestException;
+
+public class SingleStartWithTest {
+
+    @Test
+    public void justCompletableComplete() {
+        Single.just(1)
+        .startWith(Completable.complete())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void justCompletableError() {
+        Single.just(1)
+        .startWith(Completable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void justSingleJust() {
+        Single.just(1)
+        .startWith(Single.just(0))
+        .test()
+        .assertResult(0, 1);
+    }
+
+    @Test
+    public void justSingleError() {
+        Single.just(1)
+        .startWith(Single.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void justMaybeJust() {
+        Single.just(1)
+        .startWith(Maybe.just(0))
+        .test()
+        .assertResult(0, 1);
+    }
+
+    @Test
+    public void justMaybeEmpty() {
+        Single.just(1)
+        .startWith(Maybe.empty())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void justMaybeError() {
+        Single.just(1)
+        .startWith(Maybe.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void justObservableJust() {
+        Single.just(1)
+        .startWith(Observable.just(-1, 0))
+        .test()
+        .assertResult(-1, 0, 1);
+    }
+
+    @Test
+    public void justObservableEmpty() {
+        Single.just(1)
+        .startWith(Observable.empty())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void justObservableError() {
+        Single.just(1)
+        .startWith(Observable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void justFlowableJust() {
+        Single.just(1)
+        .startWith(Flowable.just(-1, 0))
+        .test()
+        .assertResult(-1, 0, 1);
+    }
+
+    @Test
+    public void justFlowableEmpty() {
+        Single.just(1)
+        .startWith(Observable.empty())
+        .test()
+        .assertResult(1);
+    }
+
+    @Test
+    public void justFlowableError() {
+        Single.just(1)
+        .startWith(Flowable.error(new TestException()))
+        .test()
+        .assertFailure(TestException.class);
+    }
+}


### PR DESCRIPTION
Add missing ( ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) ) `startWith` overloads 

source \ other | F | O | M | S | C |
--|--|--|--|--|--|
Flowable | ![present](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | ![absent](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png)
Observable | ![absent](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_off.png) | ![present](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png)| ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png)
Maybe | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png)
Single | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png)
Completable | ![present](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | ![present](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![add](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_half.png) | ![present](https://raw.github.com/wiki/ReactiveX/RxJava/images/checkmark_on.png)

Related #6852

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.startWith.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.startWith.s.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.startWith.c.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.s.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.startWith.c.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.p.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.o.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.s.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.startWith.c.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.p.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.o.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.s.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.startWith.c.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.m.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.startWith.s.png)