### PR TITLE
3.x: Add Completable.onErrorReturn[Item]

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -2324,6 +2324,64 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
+     * Ends the flow with a success item returned by a function for the {@link Throwable} error signaled by the current
+     * {@code Completable} instead of signaling the error via {@code onError}.
+     * <p>
+     * <img width="640" height="567" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.onErrorReturn.png" alt="">
+     * <p>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorReturn} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the item type to return on error
+     * @param itemSupplier
+     *            a function that returns a single value that will be emitted as success value
+     *            the current {@code Completable} signals an {@code onError} event
+     * @return the new {@link Maybe} instance
+     * @throws NullPointerException if {@code itemSupplier} is {@code null}
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     * @since 3.0.0
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <T> Maybe<T> onErrorReturn(@NonNull Function<? super Throwable, ? extends T> itemSupplier) {
+        Objects.requireNonNull(itemSupplier, "itemSupplier is null");
+        return RxJavaPlugins.onAssembly(new CompletableOnErrorReturn<>(this, itemSupplier));
+    }
+
+    /**
+     * Ends the flow with the given success item when the current {@code Completable}
+     * fails instead of signaling the error via {@code onError}.
+     * <p>
+     * <img width="640" height="567" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.onErrorReturnItem.png" alt="">
+     * <p>
+     * You can use this to prevent errors from propagating or to supply fallback data should errors be
+     * encountered.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code onErrorReturnItem} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <T> the item type to return on error
+     * @param item
+     *            the value that is emitted as {@code onSuccess} in case the current {@code Completable} signals an {@code onError}
+     * @return the new {@link Maybe} instance
+     * @throws NullPointerException if {@code item} is {@code null}
+     * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>
+     */
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <T> Maybe<T> onErrorReturnItem(@NonNull T item) {
+        Objects.requireNonNull(item, "item is null");
+        return onErrorReturn(Functions.justFunction(item));
+    }
+
+    /**
      * Nulls out references to the upstream producer and downstream {@link CompletableObserver} if
      * the sequence is terminated or downstream calls {@code dispose()}.
      * <p>

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -4467,7 +4467,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * Ends the flow with a success item returned by a function for the {@link Throwable} error signaled by the current
      * {@code Maybe} instead of signaling the error via {@code onError}.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorReturn.png" alt="">
+     * <img width="640" height="377" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorReturn.png" alt="">
      * <p>
      * You can use this to prevent errors from propagating or to supply fallback data should errors be
      * encountered.
@@ -4494,7 +4494,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     /**
      * Ends the flow with the given success item when the current {@code Maybe} fails instead of signaling the error via {@code onError}.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorReturn.png" alt="">
+     * <img width="640" height="377" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorReturnItem.png" alt="">
      * <p>
      * You can use this to prevent errors from propagating or to supply fallback data should errors be
      * encountered.
@@ -4504,7 +4504,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
      * </dl>
      *
      * @param item
-     *            the value that is emitted as {@code onSuccess} in case this {@code Maybe} signals an {@code onError}
+     *            the value that is emitted as {@code onSuccess} in case the current {@code Maybe} signals an {@code onError}
      * @return the new {@code Maybe} instance
      * @throws NullPointerException if {@code item} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/catch.html">ReactiveX operators documentation: Catch</a>

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorReturn.java
@@ -11,7 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-package io.reactivex.rxjava3.internal.operators.maybe;
+package io.reactivex.rxjava3.internal.operators.completable;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -24,23 +24,26 @@ import java.util.Objects;
 /**
  * Returns a value generated via a function if the main source signals an onError.
  * @param <T> the value type
+ * @since 3.0.0
  */
-public final class MaybeOnErrorReturn<T> extends AbstractMaybeWithUpstream<T, T> {
+public final class CompletableOnErrorReturn<T> extends Maybe<T> {
 
-    final Function<? super Throwable, ? extends T> itemSupplier;
+    final CompletableSource source;
 
-    public MaybeOnErrorReturn(MaybeSource<T> source,
-            Function<? super Throwable, ? extends T> itemSupplier) {
-        super(source);
-        this.itemSupplier = itemSupplier;
+    final Function<? super Throwable, ? extends T> valueSupplier;
+
+    public CompletableOnErrorReturn(CompletableSource source,
+            Function<? super Throwable, ? extends T> valueSupplier) {
+        this.source = source;
+        this.valueSupplier = valueSupplier;
     }
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new OnErrorReturnMaybeObserver<>(observer, itemSupplier));
+        source.subscribe(new OnErrorReturnMaybeObserver<>(observer, valueSupplier));
     }
 
-    static final class OnErrorReturnMaybeObserver<T> implements MaybeObserver<T>, Disposable {
+    static final class OnErrorReturnMaybeObserver<T> implements CompletableObserver, Disposable {
 
         final MaybeObserver<? super T> downstream;
 
@@ -49,9 +52,9 @@ public final class MaybeOnErrorReturn<T> extends AbstractMaybeWithUpstream<T, T>
         Disposable upstream;
 
         OnErrorReturnMaybeObserver(MaybeObserver<? super T> actual,
-                Function<? super Throwable, ? extends T> valueSupplier) {
+                Function<? super Throwable, ? extends T> itemSupplier) {
             this.downstream = actual;
-            this.itemSupplier = valueSupplier;
+            this.itemSupplier = itemSupplier;
         }
 
         @Override
@@ -71,11 +74,6 @@ public final class MaybeOnErrorReturn<T> extends AbstractMaybeWithUpstream<T, T>
 
                 downstream.onSubscribe(this);
             }
-        }
-
-        @Override
-        public void onSuccess(T value) {
-            downstream.onSuccess(value);
         }
 
         @Override


### PR DESCRIPTION
The operators were already available elsewhere.

Related #6852

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.onErrorReturn.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.onErrorReturnItem.png)

In addition, the `Maybe` variants have received updated marbles as well:

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorReturn.png)
![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.onErrorReturnItem.png)

Related #5806 