### PR TITLE
3.x: Fix groupBy not requesting more if a group is cancelled w/ items

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -401,6 +401,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         public void cancel() {
             if (cancelled.compareAndSet(false, true)) {
                 cancelParent();
+                drain();
             }
         }
 


### PR DESCRIPTION
If a group is cancelled with unconsumed item in its buffer, the operator stopped requesting more thus hanging other groups. In 3.x the operator was somewhat strenghtened for this case except one case when the cancellation happens outside the drain loop.

The fix is to invoke `drain()` from cancel for it to have the cleanup and replenishment happen.

Fixes #6889