### PR TITLE
3.x: Fix Flowable.switchMap not canceling properly during onNext-cancel races

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
@@ -198,7 +198,6 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
             for (;;) {
 
                 if (cancelled) {
-                    active.lazySet(null);
                     return;
                 }
 


### PR DESCRIPTION
There was an unnecessary `active.lazySet(null)` which prevented cancellation of the inner source under some circumstances.

More specifically, when one thread issued a `cancel`, the cancelled flag was set, then another thread in `drain` would loop around, see the `cancelled` flag and clear the reference. Back in the cancelling thread, the `disposeInner` would only see `null` and do nothing.

Observable.switchMap did not have this mistake. Both received unit tests to verify the correct behavior.

2.x will be fixed in a separate PR.

Resolves #6914