### PR TITLE
3.x: Fix replay() not resetting when the connection is disposed

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishTest.java
@@ -1776,4 +1776,31 @@ public class FlowablePublishTest extends RxJavaTest {
 
         ts1.assertEmpty();
     }
+
+    @Test
+    public void disposeNoNeedForReset() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        ConnectableFlowable<Integer> cf = pp.publish();
+
+        TestSubscriber<Integer> ts = cf.test();
+
+        Disposable d = cf.connect();
+
+        pp.onNext(1);
+
+        d.dispose();
+
+        ts = cf.test();
+
+        ts.assertEmpty();
+
+        cf.connect();
+
+        ts.assertEmpty();
+
+        pp.onNext(2);
+
+        ts.assertValuesOnly(2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublishTest.java
@@ -866,4 +866,31 @@ public class ObservablePublishTest extends RxJavaTest {
 
         to.assertValuesOnly(1);
     }
+
+    @Test
+    public void disposeNoNeedForReset() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        ConnectableObservable<Integer> co = ps.publish();
+
+        TestObserver<Integer> to = co.test();
+
+        Disposable d = co.connect();
+
+        ps.onNext(1);
+
+        d.dispose();
+
+        to = co.test();
+
+        to.assertEmpty();
+
+        co.connect();
+
+        to.assertEmpty();
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
-import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
@@ -1975,5 +1975,86 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         .test()
         .assertComplete()
         .assertNoErrors();
+    }
+
+    @Test
+    public void disposeNoNeedForResetSizeBound() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        ConnectableObservable<Integer> co = ps.replay(10, true);
+
+        TestObserver<Integer> to = co.test();
+
+        Disposable d = co.connect();
+
+        ps.onNext(1);
+
+        d.dispose();
+
+        to = co.test();
+
+        to.assertEmpty();
+
+        co.connect();
+
+        to.assertEmpty();
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(2);
+    }
+
+    @Test
+    public void disposeNoNeedForResetTimeBound() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        ConnectableObservable<Integer> co = ps.replay(10, TimeUnit.MINUTES, Schedulers.single(), true);
+
+        TestObserver<Integer> to = co.test();
+
+        Disposable d = co.connect();
+
+        ps.onNext(1);
+
+        d.dispose();
+
+        to = co.test();
+
+        to.assertEmpty();
+
+        co.connect();
+
+        to.assertEmpty();
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(2);
+    }
+
+    @Test
+    public void disposeNoNeedForResetTimeAndSIzeBound() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        ConnectableObservable<Integer> co = ps.replay(10, 10, TimeUnit.MINUTES, Schedulers.single(), true);
+
+        TestObserver<Integer> to = co.test();
+
+        Disposable d = co.connect();
+
+        ps.onNext(1);
+
+        d.dispose();
+
+        to = co.test();
+
+        to.assertEmpty();
+
+        co.connect();
+
+        to.assertEmpty();
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(2);
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableReplayTest.java
@@ -1724,4 +1724,31 @@ public class ObservableReplayTest extends RxJavaTest {
 
         co.reset();
     }
+
+    @Test
+    public void disposeNoNeedForReset() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        ConnectableObservable<Integer> co = ps.replay();
+
+        TestObserver<Integer> to = co.test();
+
+        Disposable d = co.connect();
+
+        ps.onNext(1);
+
+        d.dispose();
+
+        to = co.test();
+
+        to.assertEmpty();
+
+        co.connect();
+
+        to.assertEmpty();
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(2);
+    }
 }


### PR DESCRIPTION
Disposing a `replay()`-based connectable should reset the operator to its fresh state. This was supposed to happen but the relevant code changes were not enabled. The PR fixes this for both `Flowable` and `Observable`-based implementations.

The `publish`-based connectables work as intended.

Fixes #6920