### PR TITLE
docs: Quick Javadoc fixes.

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToFlowable.java
@@ -21,8 +21,8 @@ import io.reactivex.rxjava3.core.Flowable;
  * the operator goes from Flowable to some other reactive type and then the sequence calls
  * for toFlowable again:
  * <pre>
- * Single&lt;Integer> single = Flowable.range(1, 10).reduce((a, b) -> a + b);
- * Flowable&lt;Integer> flowable = single.toFlowable();
+ * {@code Single<Integer> single = Flowable.range(1, 10).reduce((a, b) -> a + b);}
+ * {@code Flowable<Integer> flowable = single.toFlowable();}
  * </pre>
  *
  * The {@code Single.toFlowable()} will check for this interface and call the {@link #fuseToFlowable()}

--- a/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToFlowable.java
@@ -21,8 +21,10 @@ import io.reactivex.rxjava3.core.Flowable;
  * the operator goes from Flowable to some other reactive type and then the sequence calls
  * for toFlowable again:
  * <pre>
- * {@code Single<Integer> single = Flowable.range(1, 10).reduce((a, b) -> a + b);}
- * {@code Flowable<Integer> flowable = single.toFlowable();}
+ * {@code 
+ * Single<Integer> single = Flowable.range(1, 10).reduce((a, b) -> a + b);
+ * Flowable<Integer> flowable = single.toFlowable();
+ * }
  * </pre>
  *
  * The {@code Single.toFlowable()} will check for this interface and call the {@link #fuseToFlowable()}

--- a/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToMaybe.java
@@ -21,8 +21,8 @@ import io.reactivex.rxjava3.core.Maybe;
  * the operator goes from Maybe to some other reactive type and then the sequence calls
  * for toMaybe again:
  * <pre>
- * Single&lt;Integer> single = Maybe.just(1).isEmpty();
- * Maybe&lt;Integer> maybe = single.toMaybe();
+ * {@code Single<Integer> single = Maybe.just(1).isEmpty();}
+ * {@code Maybe<Integer> maybe = single.toMaybe();}
  * </pre>
  *
  * The {@code Single.toMaybe()} will check for this interface and call the {@link #fuseToMaybe()}

--- a/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToMaybe.java
@@ -21,8 +21,10 @@ import io.reactivex.rxjava3.core.Maybe;
  * the operator goes from Maybe to some other reactive type and then the sequence calls
  * for toMaybe again:
  * <pre>
- * {@code Single<Integer> single = Maybe.just(1).isEmpty();}
- * {@code Maybe<Integer> maybe = single.toMaybe();}
+ * {@code 
+ * Single<Integer> single = Maybe.just(1).isEmpty();
+ * Maybe<Integer> maybe = single.toMaybe();
+ * }
  * </pre>
  *
  * The {@code Single.toMaybe()} will check for this interface and call the {@link #fuseToMaybe()}

--- a/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToObservable.java
@@ -21,8 +21,10 @@ import io.reactivex.rxjava3.core.Observable;
  * the operator goes from Observable to some other reactive type and then the sequence calls
  * for toObservable again:
  * <pre>
- * {@code Single<Integer> single = Observable.range(1, 10).reduce((a, b) -> a + b);}
- * {@code Observable<Integer> observable = single.toObservable();}
+ * {@code
+ * Single<Integer> single = Observable.range(1, 10).reduce((a, b) -> a + b);
+ * Observable<Integer> observable = single.toObservable();
+ * }
  * </pre>
  *
  * The {@code Single.toObservable()} will check for this interface and call the {@link #fuseToObservable()}

--- a/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/fuseable/FuseToObservable.java
@@ -21,8 +21,8 @@ import io.reactivex.rxjava3.core.Observable;
  * the operator goes from Observable to some other reactive type and then the sequence calls
  * for toObservable again:
  * <pre>
- * Single&lt;Integer> single = Observable.range(1, 10).reduce((a, b) -> a + b);
- * Observable&lt;Integer> observable = single.toObservable();
+ * {@code Single<Integer> single = Observable.range(1, 10).reduce((a, b) -> a + b);}
+ * {@code Observable<Integer> observable = single.toObservable();}
  * </pre>
  *
  * The {@code Single.toObservable()} will check for this interface and call the {@link #fuseToObservable()}

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerWhen.java
@@ -53,7 +53,7 @@ import io.reactivex.rxjava3.processors.*;
  * thread pool:
  *
  * <pre>
- * Scheduler limitScheduler = Schedulers.computation().when(workers -> {
+ * {@code Scheduler limitScheduler = Schedulers.computation().when(workers ->} {
  *  // use merge max concurrent to limit the number of concurrent
  *  // callbacks two at a time
  *  return Completable.merge(Observable.merge(workers), 2);
@@ -71,7 +71,7 @@ import io.reactivex.rxjava3.processors.*;
  * to the second.
  *
  * <pre>
- * Scheduler limitScheduler = Schedulers.computation().when(workers -> {
+ * {@code Scheduler limitScheduler = Schedulers.computation().when(workers ->} {
  *  // use merge max concurrent to limit the number of concurrent
  *  // Observables two at a time
  *  return Completable.merge(Observable.merge(workers, 2));
@@ -84,9 +84,9 @@ import io.reactivex.rxjava3.processors.*;
  * algorithm).
  *
  * <pre>
- * Scheduler slowScheduler = Schedulers.computation().when(workers -> {
+ * {@code Scheduler slowScheduler = Schedulers.computation().when(workers ->} {
  *  // use concatenate to make each worker happen one at a time.
- *  return Completable.concat(workers.map(actions -> {
+ *  {@code return Completable.concat(workers.map(actions ->} {
  *      // delay the starting of the next worker by 1 second.
  *      return Completable.merge(actions.delaySubscription(1, TimeUnit.SECONDS));
  *  }));

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerWhen.java
@@ -91,7 +91,7 @@ import io.reactivex.rxjava3.processors.*;
  * {@code 
  * Scheduler slowScheduler = Schedulers.computation().when(workers -> {
  *  // use concatenate to make each worker happen one at a time.
- *  return Completable.concat(workers.map(actions ->} {
+ *  return Completable.concat(workers.map(actions -> {
  *      // delay the starting of the next worker by 1 second.
  *      return Completable.merge(actions.delaySubscription(1, TimeUnit.SECONDS));
  *  }));

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerWhen.java
@@ -53,11 +53,13 @@ import io.reactivex.rxjava3.processors.*;
  * thread pool:
  *
  * <pre>
- * {@code Scheduler limitScheduler = Schedulers.computation().when(workers ->} {
+ * {@code 
+ * Scheduler limitScheduler = Schedulers.computation().when(workers -> {
  *  // use merge max concurrent to limit the number of concurrent
  *  // callbacks two at a time
  *  return Completable.merge(Observable.merge(workers), 2);
  * });
+ * }
  * </pre>
  * <p>
  * This is a slightly different way to limit the concurrency but it has some
@@ -71,11 +73,13 @@ import io.reactivex.rxjava3.processors.*;
  * to the second.
  *
  * <pre>
- * {@code Scheduler limitScheduler = Schedulers.computation().when(workers ->} {
+ * {@code 
+ * Scheduler limitScheduler = Schedulers.computation().when(workers -> {
  *  // use merge max concurrent to limit the number of concurrent
  *  // Observables two at a time
  *  return Completable.merge(Observable.merge(workers, 2));
  * });
+ * }
  * </pre>
  *
  * Slowing down the rate to no more than than 1 a second. This suffers from the
@@ -84,13 +88,15 @@ import io.reactivex.rxjava3.processors.*;
  * algorithm).
  *
  * <pre>
- * {@code Scheduler slowScheduler = Schedulers.computation().when(workers ->} {
+ * {@code 
+ * Scheduler slowScheduler = Schedulers.computation().when(workers -> {
  *  // use concatenate to make each worker happen one at a time.
- *  {@code return Completable.concat(workers.map(actions ->} {
+ *  return Completable.concat(workers.map(actions ->} {
  *      // delay the starting of the next worker by 1 second.
  *      return Completable.merge(actions.delaySubscription(1, TimeUnit.SECONDS));
  *  }));
  * });
+ * }
  * </pre>
  * <p>History 2.0.1 - experimental
  * @since 2.1

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -223,8 +223,8 @@ public class BlockingFlowableNextTest extends RxJavaTest {
 
     /**
      * Confirm that no buffering or blocking of the Observable onNext calls occurs and it just grabs the next emitted value.
-     * <p/>
-     * This results in output such as => a: 1 b: 2 c: 89
+     * <p>
+     * {@code This results in output such as => a: 1 b: 2 c: 89}
      *
      * @throws Throwable some method call is declared throws
      */

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -224,7 +224,7 @@ public class BlockingFlowableNextTest extends RxJavaTest {
     /**
      * Confirm that no buffering or blocking of the Observable onNext calls occurs and it just grabs the next emitted value.
      * <p>
-     * {@code This results in output such as => a: 1 b: 2 c: 89}
+     * This results in output such as {@code => a: 1 b: 2 c: 89}
      *
      * @throws Throwable some method call is declared throws
      */

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNextTest.java
@@ -228,7 +228,7 @@ public class BlockingObservableNextTest extends RxJavaTest {
     /**
      * Confirm that no buffering or blocking of the Observable onNext calls occurs and it just grabs the next emitted value.
      * <p>
-     * {@code This results in output such as => a: 1 b: 2 c: 89}
+     * This results in output such as {@code => a: 1 b: 2 c: 89}
      *
      * @throws Throwable some method call is declared throws
      */

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/BlockingObservableNextTest.java
@@ -227,8 +227,8 @@ public class BlockingObservableNextTest extends RxJavaTest {
 
     /**
      * Confirm that no buffering or blocking of the Observable onNext calls occurs and it just grabs the next emitted value.
-     * <p/>
-     * This results in output such as => a: 1 b: 2 c: 89
+     * <p>
+     * {@code This results in output such as => a: 1 b: 2 c: 89}
      *
      * @throws Throwable some method call is declared throws
      */

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -340,11 +340,11 @@ public class SerializedObserverTest extends RxJavaTest {
      *
      * When using SynchronizedSubscriber we get this output:
      *
-     * p1: 18 p2: 68 => should be close to each other unless we have thread starvation
+     * {@code p1: 18 p2: 68 => should be close to each other unless we have thread starvation}
      *
      * When using SerializedObserver we get:
      *
-     * p1: 1 p2: 2445261 => should be close to each other unless we have thread starvation
+     * {@code p1: 1 p2: 2445261 => should be close to each other unless we have thread starvation}
      *
      * This demonstrates how SynchronizedSubscriber balances back and forth better, and blocks emission.
      * The real issue in this example is the async buffer-bloat, so we need backpressure.

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -340,11 +340,11 @@ public class SerializedObserverTest extends RxJavaTest {
      *
      * When using SynchronizedSubscriber we get this output:
      *
-     * {@code p1: 18 p2: 68 => should be close to each other unless we have thread starvation}
+     * {@code p1: 18 p2: 68 =>} should be close to each other unless we have thread starvation
      *
      * When using SerializedObserver we get:
      *
-     * {@code p1: 1 p2: 2445261 => should be close to each other unless we have thread starvation}
+     * {@code p1: 1 p2: 2445261 =>} should be close to each other unless we have thread starvation
      *
      * This demonstrates how SynchronizedSubscriber balances back and forth better, and blocks emission.
      * The real issue in this example is the async buffer-bloat, so we need backpressure.
@@ -1043,7 +1043,7 @@ public class SerializedObserverTest extends RxJavaTest {
             };
 
             TestHelper.race(r1, r2);
-
+'';
             to.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
             .assertNotComplete();

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -1043,6 +1043,7 @@ public class SerializedObserverTest extends RxJavaTest {
             };
 
             TestHelper.race(r1, r2);
+            
             to.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
             .assertNotComplete();

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -1043,7 +1043,6 @@ public class SerializedObserverTest extends RxJavaTest {
             };
 
             TestHelper.race(r1, r2);
-'';
             to.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
             .assertNotComplete();

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -1042,8 +1042,7 @@ public class SerializedObserverTest extends RxJavaTest {
                 }
             };
 
-            TestHelper.race(r1, r2);
-            
+            TestHelper.race(r1, r2);       
             to.awaitDone(5, TimeUnit.SECONDS)
             .assertError(ex)
             .assertNotComplete();

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
@@ -341,11 +341,11 @@ public class SerializedSubscriberTest extends RxJavaTest {
      *
      * When using SynchronizedSubscriber we get this output:
      *
-     * {@code p1: 18 p2: 68 => should be close to each other unless we have thread starvation}
+     * {@code p1: 18 p2: 68 =>} should be close to each other unless we have thread starvation
      *
      * When using SerializedSubscriber we get:
      *
-     * {@code p1: 1 p2: 2445261 => should be close to each other unless we have thread starvation}
+     * {@code p1: 1 p2: 2445261 =>} should be close to each other unless we have thread starvation
      *
      * This demonstrates how SynchronizedSubscriber balances back and forth better, and blocks emission.
      * The real issue in this example is the async buffer-bloat, so we need backpressure.

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
@@ -341,11 +341,11 @@ public class SerializedSubscriberTest extends RxJavaTest {
      *
      * When using SynchronizedSubscriber we get this output:
      *
-     * p1: 18 p2: 68 => should be close to each other unless we have thread starvation
+     * {@code p1: 18 p2: 68 => should be close to each other unless we have thread starvation}
      *
      * When using SerializedSubscriber we get:
      *
-     * p1: 1 p2: 2445261 => should be close to each other unless we have thread starvation
+     * {@code p1: 1 p2: 2445261 => should be close to each other unless we have thread starvation}
      *
      * This demonstrates how SynchronizedSubscriber balances back and forth better, and blocks emission.
      * The real issue in this example is the async buffer-bloat, so we need backpressure.

--- a/src/test/java/io/reactivex/rxjava3/tck/BaseTck.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/BaseTck.java
@@ -51,7 +51,7 @@ public abstract class BaseTck<T> extends PublisherVerification<T> {
 
     /**
      * Creates an Iterable with the specified number of elements or an infinite one if
-     * elements > {@link Integer#MAX_VALUE}.
+     * {@code elements > {@link Integer#MAX_VALUE}.}
      * @param elements the number of elements to return, {@link Integer#MAX_VALUE} means an infinite sequence
      * @return the Iterable
      */

--- a/src/test/java/io/reactivex/rxjava3/tck/BaseTck.java
+++ b/src/test/java/io/reactivex/rxjava3/tck/BaseTck.java
@@ -51,7 +51,7 @@ public abstract class BaseTck<T> extends PublisherVerification<T> {
 
     /**
      * Creates an Iterable with the specified number of elements or an infinite one if
-     * {@code elements > {@link Integer#MAX_VALUE}.}
+     * {@code elements >} {@link Integer#MAX_VALUE}.
      * @param elements the number of elements to return, {@link Integer#MAX_VALUE} means an infinite sequence
      * @return the Iterable
      */


### PR DESCRIPTION
Added @code tag wherever < or > were used, also removed a few
self-closing <p> tags. Both of these issues cause errors with the latest
version of Javadoc.

Signed-off-by: Zachary Trant <zach@graalonline.com>