### PR TITLE
3.x: Fix Observable.flatMap with maxConcurrency hangs

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapTest.java
@@ -1478,4 +1478,28 @@ public class FlowableFlatMapTest extends RxJavaTest {
         .requestMore(1)
         .assertValuesOnly(1);
     }
+
+    @Test(timeout = 5000)
+    public void mixedScalarAsync() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            Flowable
+            .range(0, 20)
+            .flatMap(
+                    integer -> {
+                        if (integer % 5 != 0) {
+                            return Flowable
+                                    .just(integer);
+                        }
+
+                        return Flowable
+                                .just(-integer)
+                                .observeOn(Schedulers.computation());
+                    },
+                    false,
+                    1
+            )
+            .ignoreElements()
+            .blockingAwait();
+        }
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapTest.java
@@ -1240,4 +1240,28 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
         to.assertFailure(TestException.class, 1, 2);
     }
+
+    @Test(timeout = 5000)
+    public void mixedScalarAsync() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            Observable
+            .range(0, 20)
+            .flatMap(
+                    integer -> {
+                        if (integer % 5 != 0) {
+                            return Observable
+                                    .just(integer);
+                        }
+
+                        return Observable
+                                .just(-integer)
+                                .observeOn(Schedulers.computation());
+                    },
+                    false,
+                    1
+            )
+            .ignoreElements()
+            .blockingAwait();
+        }
+    }
 }


### PR DESCRIPTION
Queued up scalar values were not counted as completed, thus the subsequent sources where not subscribed to to fill up the allowed concurrency level.

Fixes #6945