### PR TITLE
3.x: Workaround flakyness of multiThreadedWithNPE* tests

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSerializeTest.java
@@ -79,7 +79,22 @@ public class FlowableSerializeTest extends RxJavaTest {
     }
 
     @Test
-    public void multiThreadedWithNPE() {
+    public void multiThreadedWithNPEFlaky() throws InterruptedException {
+        int max = 9;
+        for (int i = 0; i <= max; i++) {
+            try {
+                multiThreadedWithNPE();
+                return;
+            } catch (AssertionError ex) {
+                if (i == max) {
+                    throw ex;
+                }
+            }
+            Thread.sleep((long)(1000 * Math.random() + 100));
+        }
+    }
+
+    void multiThreadedWithNPE() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null);
         Flowable<String> w = Flowable.unsafeCreate(onSubscribe);
 
@@ -105,6 +120,22 @@ public class FlowableSerializeTest extends RxJavaTest {
         assertTrue(onSubscribe.maxConcurrentThreads.get() > 1);
         // ... but the onNext execution should be single threaded
         assertEquals(1, busyobserver.maxConcurrentThreads.get());
+    }
+
+    @Test
+    public void multiThreadedWithNPEinMiddleFlaky() throws InterruptedException {
+        int max = 9;
+        for (int i = 0; i <= max; i++) {
+            try {
+                multiThreadedWithNPEinMiddle();
+                return;
+            } catch (AssertionError ex) {
+                if (i == max) {
+                    throw ex;
+                }
+            }
+            Thread.sleep((long)(1000 * Math.random() + 100));
+        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSerializeTest.java
@@ -138,8 +138,7 @@ public class FlowableSerializeTest extends RxJavaTest {
         }
     }
 
-    @Test
-    public void multiThreadedWithNPEinMiddle() {
+    void multiThreadedWithNPEinMiddle() {
         boolean lessThan9 = false;
         for (int i = 0; i < 3; i++) {
             TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null, "four", "five", "six", "seven", "eight", "nine");

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSerializeTest.java
@@ -78,7 +78,22 @@ public class ObservableSerializeTest extends RxJavaTest {
     }
 
     @Test
-    public void multiThreadedWithNPE() {
+    public void multiThreadedWithNPEFlaky() throws InterruptedException {
+        int max = 9;
+        for (int i = 0; i <= max; i++) {
+            try {
+                multiThreadedWithNPE();
+                return;
+            } catch (AssertionError ex) {
+                if (i == max) {
+                    throw ex;
+                }
+            }
+            Thread.sleep((long)(1000 * Math.random() + 100));
+        }
+    }
+
+    void multiThreadedWithNPE() {
         TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null);
         Observable<String> w = Observable.unsafeCreate(onSubscribe);
 
@@ -107,7 +122,22 @@ public class ObservableSerializeTest extends RxJavaTest {
     }
 
     @Test
-    public void multiThreadedWithNPEinMiddle() {
+    public void multiThreadedWithNPEinMiddleFlaky() throws InterruptedException {
+        int max = 9;
+        for (int i = 0; i <= max; i++) {
+            try {
+                multiThreadedWithNPEinMiddle();
+                return;
+            } catch (AssertionError ex) {
+                if (i == max) {
+                    throw ex;
+                }
+            }
+            Thread.sleep((long)(1000 * Math.random() + 100));
+        }
+    }
+
+    void multiThreadedWithNPEinMiddle() {
         boolean lessThan9 = false;
         for (int i = 0; i < 3; i++) {
             TestMultiThreadedObservable onSubscribe = new TestMultiThreadedObservable("one", "two", "three", null, "four", "five", "six", "seven", "eight", "nine");


### PR DESCRIPTION
These tests tend to fail more often with JDK 9 Target 9 builds (but all the others are fine).

Note that an overarching flakyness plugin could hide many of the legitimately incorrect behavior tested via races.