### PR TITLE
Fix that exceptions will be swallowed by schedulers (#6954)

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/CompleteFutureTasks.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/CompleteFutureTasks.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.schedulers;
+
+import java.util.concurrent.*;
+
+/**
+ *  Factory of FutureTasks which will call CompleteHandler on complete.
+ */
+public class CompleteFutureTasks {
+    /**
+     * Builds a future task that calls completeHandle on complete.
+     **/
+    public static <V> RunnableFuture<V> newCompleteFutureTask(
+            RunnableFuture<V> base, CompleteScheduledExecutorService.CompleteHandler<V> completeHandler) {
+        return new CompleteFutureTask<>(base, completeHandler);
+    }
+
+    /**
+     * Builds a scheduled future task that calls completeHandle on complete.
+     */
+    public static <V> RunnableScheduledFuture<V> newCompleteScheduledFutureTask(
+            RunnableScheduledFuture<V> base, CompleteScheduledExecutorService.CompleteHandler<V> completeHandler) {
+        return new CompleteScheduledFutureTask<>(base, completeHandler);
+    }
+
+    public static class CallableWithCompleteHandler<V> implements Callable<V> {
+        public CallableWithCompleteHandler(
+                Callable<V> base, CompleteScheduledExecutorService.CompleteHandler<V> completeHandler) {
+            this.base = base;
+            this.completeHandler = completeHandler;
+        }
+
+        public CallableWithCompleteHandler(
+                Runnable runnable, V result, CompleteScheduledExecutorService.CompleteHandler<V> completeHandler) {
+            this.base = () -> {
+                runnable.run();
+                return result;
+            };
+            this.completeHandler = completeHandler;
+        }
+
+        @Override
+        public V call() throws Exception {
+            return base.call();
+        }
+
+        public CompleteScheduledExecutorService.CompleteHandler<V> getCompleteHandler() {
+            return completeHandler;
+        }
+
+        private final Callable<V> base;
+        private final CompleteScheduledExecutorService.CompleteHandler<V> completeHandler;
+    }
+
+    public static class RunnableWithCompleteHandler implements Runnable {
+        public RunnableWithCompleteHandler(
+                Runnable base, CompleteScheduledExecutorService.CompleteHandler<Void> completeHandler) {
+            this.base = base;
+            this.completeHandler = completeHandler;
+        }
+
+        @Override
+        public void run() {
+            base.run();
+        }
+
+        public CompleteScheduledExecutorService.CompleteHandler<Void> getCompleteHandler() {
+            return completeHandler;
+        }
+
+        private final Runnable base;
+        private final CompleteScheduledExecutorService.CompleteHandler<Void> completeHandler;
+    }
+
+    private static class CompleteFutureTask<V> implements RunnableFuture<V> {
+        public CompleteFutureTask(
+                RunnableFuture<V> base, CompleteScheduledExecutorService.CompleteHandler<V> completeHandler) {
+            this.base = base;
+            this.completeHandler = completeHandler;
+
+            this.seq = 0;
+        }
+
+        @Override
+        public void run() {
+            long s = ++seq;
+
+            try {
+                base.run();
+            } finally {
+                if (!base.isDone()) {
+                    return;
+                }
+
+                // interesting case:
+                // We may get the done state of next run if base is a periodic task and posted to another thread for
+                // its next run.
+                // A simple seq test will solve that. We even don't have to make seq volatile, because it is correctly
+                // synchronized by isDone() and re-schedule locks!
+                if (seq != s) {
+                    return;
+                }
+
+                if (base.isCancelled()) {
+                    return;
+                }
+
+                completeHandler.onComplete(this);
+            }
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return base.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return base.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return base.isDone();
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return base.get();
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return base.get(timeout, unit);
+        }
+
+        private long seq;
+
+        private final RunnableFuture<V> base;
+        private final CompleteScheduledExecutorService.CompleteHandler<V> completeHandler;
+    }
+
+    private static class CompleteScheduledFutureTask<V> extends CompleteFutureTask<V>
+            implements RunnableScheduledFuture<V> {
+        public CompleteScheduledFutureTask(
+                RunnableScheduledFuture<V> base, CompleteScheduledExecutorService.CompleteHandler<V> completeHandler) {
+            super(base, completeHandler);
+            this.base = base;
+        }
+
+        private final RunnableScheduledFuture<V> base;
+
+        @Override
+        public boolean isPeriodic() {
+            return base.isPeriodic();
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return base.getDelay(unit);
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            return base.compareTo(o);
+        }
+    }
+
+    /** Utility class. */
+    private CompleteFutureTasks() {
+        throw new IllegalStateException("No instances!");
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledExecutorService.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledExecutorService.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.schedulers;
+
+import java.util.concurrent.*;
+
+/**
+ *  A ScheduledExecutorService that supports setting a complete handler that
+ *  will receive the Future of the submitted job once it completes.
+ */
+public interface CompleteScheduledExecutorService extends ScheduledExecutorService {
+
+    interface CompleteHandler<V> {
+        void onComplete(Future<V> task);
+    }
+
+    <V> Future<V> submit(Callable<V> task,
+                         CompleteHandler<V> completeHandler);
+
+    <V> Future<V> submit(Runnable task,
+                         V result,
+                         CompleteHandler<V> completeHandler);
+
+    <V> ScheduledFuture<V> schedule(Callable<V> callable,
+                                    long delay,
+                                    TimeUnit unit,
+                                    CompleteHandler<V> completeHandler);
+
+    <V> ScheduledFuture<V> schedule(Runnable command,
+                                    V result,
+                                    long delay,
+                                    TimeUnit unit,
+                                    CompleteHandler<V> completeHandler);
+
+    ScheduledFuture<Void> scheduleAtFixedRate(Runnable command,
+                                              long initialDelay,
+                                              long period,
+                                              TimeUnit unit,
+                                              CompleteHandler<Void> completeHandler);
+
+    ScheduledFuture<Void> scheduleWithFixedDelay(Runnable command,
+                                                 long initialDelay,
+                                                 long delay,
+                                                 TimeUnit unit,
+                                                 CompleteHandler<Void> completeHandler);
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledExecutors.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledExecutors.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.schedulers;
+
+import java.util.concurrent.*;
+
+/**
+ * {@link CompleteScheduledExecutorService} factory.
+ */
+public class CompleteScheduledExecutors {
+    public static CompleteScheduledExecutorService newSingleThreadExecutor() {
+        return new CompleteScheduledThreadPoolExecutor(1);
+    }
+
+    public static CompleteScheduledExecutorService newSingleThreadExecutor(ThreadFactory threadFactory) {
+        return new CompleteScheduledThreadPoolExecutor(1, threadFactory);
+    }
+
+    public static CompleteScheduledExecutorService newSingleThreadExecutor(RejectedExecutionHandler handler) {
+        return new CompleteScheduledThreadPoolExecutor(1, handler);
+    }
+
+    public static CompleteScheduledExecutorService newSingleThreadExecutor(ThreadFactory threadFactory,
+                                                                           RejectedExecutionHandler handler) {
+        return new CompleteScheduledThreadPoolExecutor(1, threadFactory, handler);
+    }
+
+    public static CompleteScheduledExecutorService newThreadPoolExecutor(int corePoolSize) {
+        return new CompleteScheduledThreadPoolExecutor(corePoolSize);
+    }
+
+    public static CompleteScheduledExecutorService newThreadPoolExecutor(int corePoolSize,
+                                                                         ThreadFactory threadFactory) {
+        return new CompleteScheduledThreadPoolExecutor(corePoolSize, threadFactory);
+    }
+
+    public static CompleteScheduledExecutorService newThreadPoolExecutor(int corePoolSize,
+                                                                         RejectedExecutionHandler handler) {
+        return new CompleteScheduledThreadPoolExecutor(corePoolSize, handler);
+    }
+
+    public static CompleteScheduledExecutorService newThreadPoolExecutor(int corePoolSize,
+                                                                         ThreadFactory threadFactory,
+                                                                         RejectedExecutionHandler handler) {
+        return new CompleteScheduledThreadPoolExecutor(corePoolSize, threadFactory, handler);
+    }
+
+    /** Utility class. */
+    private CompleteScheduledExecutors() {
+        throw new IllegalStateException("No instances!");
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledThreadPoolExecutor.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledThreadPoolExecutor.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.schedulers;
+
+import java.util.concurrent.*;
+
+/**
+ * Thread pool implementation of {@link CompleteScheduledExecutorService}.
+ */
+public class CompleteScheduledThreadPoolExecutor
+        extends ScheduledThreadPoolExecutor implements CompleteScheduledExecutorService {
+
+    public CompleteScheduledThreadPoolExecutor(int corePoolSize) {
+        super(corePoolSize);
+    }
+
+    public CompleteScheduledThreadPoolExecutor(int corePoolSize,
+                                               ThreadFactory threadFactory) {
+        super(corePoolSize, threadFactory);
+    }
+
+    public CompleteScheduledThreadPoolExecutor(int corePoolSize,
+                                               RejectedExecutionHandler handler) {
+        super(corePoolSize, handler);
+    }
+
+    public CompleteScheduledThreadPoolExecutor(int corePoolSize,
+                                               ThreadFactory threadFactory,
+                                               RejectedExecutionHandler handler) {
+        super(corePoolSize, threadFactory, handler);
+    }
+
+    @Override
+    public <V> Future<V> submit(Callable<V> task,
+                                CompleteHandler<V> completeHandler) {
+        return super.submit(
+                new CompleteFutureTasks.CallableWithCompleteHandler<>(task, completeHandler));
+    }
+
+    @Override
+    public <V> Future<V> submit(Runnable task, V result,
+                                CompleteHandler<V> completeHandler) {
+        return super.submit(
+                new CompleteFutureTasks.CallableWithCompleteHandler<>(task ,result, completeHandler));
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit,
+                                           CompleteHandler<V> completeHandler) {
+        return super.schedule(
+                new CompleteFutureTasks.CallableWithCompleteHandler<>(callable, completeHandler), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Runnable command, V result, long delay, TimeUnit unit,
+                                           CompleteHandler<V> completeHandler) {
+        return super.schedule(
+                new CompleteFutureTasks.CallableWithCompleteHandler<>(command, result, completeHandler), delay, unit);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ScheduledFuture<Void> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit,
+                                                     CompleteHandler<Void> completeHandler) {
+        return (ScheduledFuture<Void>) super.scheduleAtFixedRate(
+                new CompleteFutureTasks.RunnableWithCompleteHandler(command, completeHandler), initialDelay, period, unit);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ScheduledFuture<Void> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit,
+                                                        CompleteHandler<Void> completeHandler) {
+        return (ScheduledFuture<Void>) super.scheduleWithFixedDelay(
+                new CompleteFutureTasks.RunnableWithCompleteHandler(command, completeHandler), initialDelay, delay, unit);
+    }
+
+    @Override
+    protected <V> RunnableScheduledFuture<V> decorateTask(Callable<V> callable, RunnableScheduledFuture<V> task) {
+        if (callable instanceof CompleteFutureTasks.CallableWithCompleteHandler) {
+            return CompleteFutureTasks.newCompleteScheduledFutureTask(
+                    task,
+                    ((CompleteFutureTasks.CallableWithCompleteHandler<V>) callable).getCompleteHandler());
+        }
+
+        return super.decorateTask(callable, task);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <V> RunnableScheduledFuture<V> decorateTask(Runnable runnable, RunnableScheduledFuture<V> task) {
+        if (runnable instanceof CompleteFutureTasks.RunnableWithCompleteHandler) {
+            return (RunnableScheduledFuture<V>) CompleteFutureTasks.newCompleteScheduledFutureTask(
+                    (RunnableScheduledFuture<Void>) task,
+                    ((CompleteFutureTasks.RunnableWithCompleteHandler) runnable).getCompleteHandler());
+        }
+
+        return super.decorateTask(runnable, task);
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
@@ -27,7 +27,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  *
  */
 public class NewThreadWorker extends Scheduler.Worker implements Disposable {
-    private final ScheduledExecutorService executor;
+    private final CompleteScheduledExecutorService executor;
 
     volatile boolean disposed;
 
@@ -63,9 +63,9 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
         try {
             Future<?> f;
             if (delayTime <= 0L) {
-                f = executor.submit(task);
+                f = RxExecutors.submit(executor, task);
             } else {
-                f = executor.schedule(task, delayTime, unit);
+                f = RxExecutors.schedule(executor, task, delayTime, unit);
             }
             task.setFuture(f);
             return task;
@@ -92,9 +92,9 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
             try {
                 Future<?> f;
                 if (initialDelay <= 0L) {
-                    f = executor.submit(periodicWrapper);
+                    f = RxExecutors.submit(executor, periodicWrapper);
                 } else {
-                    f = executor.schedule(periodicWrapper, initialDelay, unit);
+                    f = RxExecutors.schedule(executor, periodicWrapper, initialDelay, unit);
                 }
                 periodicWrapper.setFirst(f);
             } catch (RejectedExecutionException ex) {
@@ -106,7 +106,7 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
         }
         ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(decoratedRun);
         try {
-            Future<?> f = executor.scheduleAtFixedRate(task, initialDelay, period, unit);
+            Future<?> f = RxExecutors.scheduleAtFixedRate(executor, task, initialDelay, period, unit);
             task.setFuture(f);
             return task;
         } catch (RejectedExecutionException ex) {
@@ -141,9 +141,9 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
         Future<?> f;
         try {
             if (delayTime <= 0) {
-                f = executor.submit((Callable<Object>)sr);
+                f = RxExecutors.submit(executor, sr);
             } else {
-                f = executor.schedule((Callable<Object>)sr, delayTime, unit);
+                f = RxExecutors.schedule(executor, sr, delayTime, unit);
             }
             sr.setFuture(f);
         } catch (RejectedExecutionException ex) {

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/RxExecutors.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/RxExecutors.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.schedulers;
+
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+import java.util.concurrent.*;
+
+/**
+ * Utility class of common Executor operations in RxJava.
+ */
+public final class RxExecutors {
+    public static Future<Void> submit(Executor executor, Runnable runnable) {
+        RunnableFuture<Void> futureTask = new FutureTask<>(runnable, null);
+        futureTask = CompleteFutureTasks.newCompleteFutureTask(futureTask, EXECUTE_ERROR_HANDLER);
+        executor.execute(futureTask);
+        return futureTask;
+    }
+
+    public static Future<Void> submit(CompleteScheduledExecutorService executor, Runnable runnable) {
+        return executor.submit(runnable, null, EXECUTE_ERROR_HANDLER);
+    }
+
+    public static Future<Void> schedule(CompleteScheduledExecutorService executor,
+                                     Runnable runnable, long delay, TimeUnit unit) {
+        return executor.schedule(runnable, null, delay, unit, EXECUTE_ERROR_HANDLER);
+    }
+
+    public static Future<Void> scheduleAtFixedRate(CompleteScheduledExecutorService executor,
+                                                Runnable runnable, long initialDelay, long period, TimeUnit unit) {
+        return executor.scheduleAtFixedRate(runnable, initialDelay, period, unit, EXECUTE_ERROR_HANDLER);
+    }
+
+    public static RunnableFuture<Void> makeFutureTask(Runnable runnable) {
+        RunnableFuture<Void> futureTask = new FutureTask<>(runnable, null);
+        futureTask = CompleteFutureTasks.newCompleteFutureTask(futureTask, EXECUTE_ERROR_HANDLER);
+        return futureTask;
+    }
+
+    private static CompleteScheduledExecutorService.CompleteHandler<Void> EXECUTE_ERROR_HANDLER = future -> {
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("won't happen, already completed");
+        } catch (ExecutionException e) {
+            Throwable ex = e.getCause();
+
+            Exceptions.throwIfFatal(ex);
+            RxJavaPlugins.onError(ex);
+        }
+    };
+
+    /** Utility class. */
+    private RxExecutors() {
+        throw new IllegalStateException("No instances!");
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Callable;
  * action and manages completion/cancellation.
  * @since 2.0.8
  */
-public final class ScheduledDirectTask extends AbstractDirectTask implements Callable<Void> {
+public final class ScheduledDirectTask extends AbstractDirectTask implements Runnable {
 
     private static final long serialVersionUID = 1811839108042568751L;
 
@@ -32,7 +32,7 @@ public final class ScheduledDirectTask extends AbstractDirectTask implements Cal
     }
 
     @Override
-    public Void call() {
+    public void run() {
         runner = Thread.currentThread();
         try {
             runnable.run();
@@ -40,6 +40,5 @@ public final class ScheduledDirectTask extends AbstractDirectTask implements Cal
             lazySet(FINISHED);
             runner = null;
         }
-        return null;
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java
@@ -20,7 +20,7 @@ import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class ScheduledRunnable extends AtomicReferenceArray<Object>
-implements Runnable, Callable<Object>, Disposable {
+implements Runnable, Disposable {
 
     private static final long serialVersionUID = -6120223772001106981L;
     final Runnable actual;
@@ -48,13 +48,6 @@ implements Runnable, Callable<Object>, Disposable {
         super(3);
         this.actual = actual;
         this.lazySet(0, parent);
-    }
-
-    @Override
-    public Object call() {
-        // Being Callable saves an allocation in ThreadPoolExecutor
-        run();
-        return null;
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
@@ -51,7 +51,7 @@ public final class SchedulerPoolFactory {
 
     // Upcast to the Map interface here to avoid 8.x compatibility issues.
     // See http://stackoverflow.com/a/32955708/61158
-    static final Map<ScheduledThreadPoolExecutor, Object> POOLS =
+    static final Map<ThreadPoolExecutor, Object> POOLS =
             new ConcurrentHashMap<>();
 
     /**
@@ -140,19 +140,20 @@ public final class SchedulerPoolFactory {
     }
 
     /**
-     * Creates a ScheduledExecutorService with the given factory.
+     * Creates a {@link CompleteScheduledExecutorService} with the given factory.
      * @param factory the thread factory
-     * @return the ScheduledExecutorService
+     * @return the {@link CompleteScheduledExecutorService}
      */
-    public static ScheduledExecutorService create(ThreadFactory factory) {
-        final ScheduledExecutorService exec = Executors.newScheduledThreadPool(1, factory);
+    public static CompleteScheduledExecutorService create(ThreadFactory factory) {
+        final CompleteScheduledExecutorService exec =
+                CompleteScheduledExecutors.newThreadPoolExecutor(1, factory);
         tryPutIntoPool(PURGE_ENABLED, exec);
         return exec;
     }
 
-    static void tryPutIntoPool(boolean purgeEnabled, ScheduledExecutorService exec) {
-        if (purgeEnabled && exec instanceof ScheduledThreadPoolExecutor) {
-            ScheduledThreadPoolExecutor e = (ScheduledThreadPoolExecutor) exec;
+    static void tryPutIntoPool(boolean purgeEnabled, CompleteScheduledExecutorService exec) {
+        if (purgeEnabled && exec instanceof ThreadPoolExecutor) {
+            ThreadPoolExecutor e = (ThreadPoolExecutor) exec;
             POOLS.put(e, exec);
         }
     }
@@ -160,7 +161,7 @@ public final class SchedulerPoolFactory {
     static final class ScheduledTask implements Runnable {
         @Override
         public void run() {
-            for (ScheduledThreadPoolExecutor e : new ArrayList<>(POOLS.keySet())) {
+            for (ThreadPoolExecutor e : new ArrayList<>(POOLS.keySet())) {
                 if (e.isShutdown()) {
                     POOLS.remove(e);
                 } else {

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledExecutorsTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledExecutorsTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.schedulers;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.reactivex.rxjava3.core.RxJavaTest;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+import org.junit.Test;
+
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class CompleteScheduledExecutorsTest extends RxJavaTest {
+
+    @Test
+    public void constructorShouldBePrivate() {
+        TestHelper.checkUtilityClass(CompleteScheduledExecutors.class);
+    }
+
+    @Test
+    public void newExecutorTest() {
+        ThreadFactory threadFactory = (r) -> new Thread(r);
+        RejectedExecutionHandler rejectedHandler = (r, e) -> {
+        };
+
+        assertExecutorAndParam(
+                CompleteScheduledExecutors.newSingleThreadExecutor(),
+                1, null, null);
+
+        assertExecutorAndParam(
+                CompleteScheduledExecutors.newSingleThreadExecutor(threadFactory),
+                1, threadFactory, null);
+
+        assertExecutorAndParam(
+                CompleteScheduledExecutors.newSingleThreadExecutor(rejectedHandler),
+                1, null, rejectedHandler);
+
+        assertExecutorAndParam(
+                CompleteScheduledExecutors.newSingleThreadExecutor(threadFactory, rejectedHandler),
+                1, threadFactory, rejectedHandler);
+
+        assertExecutorAndParam(
+                CompleteScheduledExecutors.newThreadPoolExecutor(6),
+                6, null, null);
+
+        assertExecutorAndParam(
+                CompleteScheduledExecutors.newThreadPoolExecutor(6, threadFactory),
+                6, threadFactory, null);
+
+        assertExecutorAndParam(
+                CompleteScheduledExecutors.newThreadPoolExecutor(6, rejectedHandler),
+                6, null, rejectedHandler);
+
+        assertExecutorAndParam(
+                CompleteScheduledExecutors.newThreadPoolExecutor(6, threadFactory, rejectedHandler),
+                6, threadFactory, rejectedHandler);
+    }
+
+    private void assertExecutorAndParam(CompleteScheduledExecutorService executor,
+                                        int corePoolSize,
+                                        ThreadFactory threadFactory,
+                                        RejectedExecutionHandler rejectHandler) {
+        assertNotNull(executor);
+
+        if (executor instanceof ThreadPoolExecutor) {
+            ThreadPoolExecutor ex = (ThreadPoolExecutor) executor;
+
+            assertEquals(corePoolSize, ex.getCorePoolSize());
+
+            if (null != threadFactory) {
+                assertEquals(threadFactory, ex.getThreadFactory());
+            }
+
+            if (null != rejectHandler) {
+                assertEquals(rejectHandler, ex.getRejectedExecutionHandler());
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledThreadPoolTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/CompleteScheduledThreadPoolTest.java
@@ -1,0 +1,327 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.rxjava3.internal.schedulers;
+
+import io.reactivex.rxjava3.core.RxJavaTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class CompleteScheduledThreadPoolTest extends RxJavaTest {
+
+    @Test
+    public void executeImmediately() throws Exception {
+        CompleteScheduledThreadPoolExecutor executor = new CompleteScheduledThreadPoolExecutor(1);
+        try {
+            CountDownLatch latch = new CountDownLatch(4);
+
+            executor.submit(
+                    new Callable<String>() {
+                        @Override
+                        public String call() throws Exception {
+                            latch.countDown();
+                            return "t";
+                        }
+                    }, new CompleteScheduledExecutorService.CompleteHandler<String>() {
+                        @Override
+                        public void onComplete(Future<String> task) {
+                            try {
+                                if ("t".equals(task.get())) {
+                                    latch.countDown();
+                                }
+                            } catch (InterruptedException e) {
+                            } catch (ExecutionException e) {
+                            }
+                        }
+                    });
+
+            executor.submit(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            latch.countDown();
+                        }
+                    },
+                    "t",
+                    new CompleteScheduledExecutorService.CompleteHandler<String>() {
+                        @Override
+                        public void onComplete(Future task) {
+                            try {
+                                if ("t".equals(task.get())) {
+                                    latch.countDown();
+                                }
+                            } catch (InterruptedException e) {
+                            } catch (ExecutionException e) {
+                            }
+                        }
+                    });
+
+            assertTrue(latch.await(2, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void executeDelay() throws Exception {
+        CompleteScheduledThreadPoolExecutor executor = new CompleteScheduledThreadPoolExecutor(1);
+        try {
+            CountDownLatch latch = new CountDownLatch(4);
+            long startTime = System.nanoTime();
+            long[] delay1 = new long[1];
+            long[] delay2 = new long[1];
+
+            executor.schedule(
+                    new Callable<String>() {
+                        @Override
+                        public String call() throws Exception {
+                            delay1[0] = System.nanoTime() - startTime;
+                            latch.countDown();
+                            return "t";
+                        }
+                    },
+                    1,
+                    TimeUnit.SECONDS,
+                    new CompleteScheduledExecutorService.CompleteHandler<String>() {
+                        @Override
+                        public void onComplete(Future<String> task) {
+                            try {
+                                if ("t".equals(task.get())) {
+                                    latch.countDown();
+                                }
+                            } catch (InterruptedException e) {
+                            } catch (ExecutionException e) {
+                            }
+                        }
+                    });
+
+            executor.schedule(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            delay2[0] = System.nanoTime() - startTime;
+                            latch.countDown();
+                        }
+                    },
+                    "t",
+                    1,
+                    TimeUnit.SECONDS,
+                    new CompleteScheduledExecutorService.CompleteHandler<String>() {
+                        @Override
+                        public void onComplete(Future task) {
+                            try {
+                                if ("t".equals(task.get())) {
+                                    latch.countDown();
+                                }
+                            } catch (InterruptedException e) {
+                            } catch (ExecutionException e) {
+                            }
+                        }
+                    });
+
+            assertTrue(latch.await(3, TimeUnit.SECONDS));
+            assertTrue(delay1[0] >= TimeUnit.SECONDS.toNanos(1));
+            assertTrue(delay2[0] >= TimeUnit.SECONDS.toNanos(1));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void executeAtFixedRate() throws Exception {
+        CompleteScheduledThreadPoolExecutor executor = new CompleteScheduledThreadPoolExecutor(1);
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+
+            long startTime = System.nanoTime();
+            List<Long> delays = new ArrayList<>();
+
+            final RuntimeException endException = new RuntimeException();
+
+            executor.scheduleAtFixedRate(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                Thread.sleep(300);
+                            } catch (InterruptedException e) {
+                            }
+                            delays.add(delays.isEmpty() ?
+                                    System.nanoTime() - startTime : System.nanoTime() - delays.get(delays.size() - 1));
+                            if (delays.size() >= 5) {
+                                throw endException;
+                            }
+                        }
+                    },
+                    100,
+                    500,
+                    TimeUnit.MILLISECONDS,
+                    new CompleteScheduledExecutorService.CompleteHandler<Void>() {
+                        @Override
+                        public void onComplete(Future<Void> task) {
+                            try {
+                                task.get();
+                            } catch (InterruptedException e) {
+                            } catch (ExecutionException e) {
+                                if (endException == e.getCause()) {
+                                    latch.countDown();
+                                }
+                            }
+                        }
+                    });
+
+            assertTrue(latch.await(4, TimeUnit.SECONDS));
+            for (int i = 0; i < delays.size(); ++i) {
+                if (i == 0) { assertTrue(delays.get(i) >= TimeUnit.MICROSECONDS.toNanos(100)); }
+                else { assertTrue(delays.get(i) >= TimeUnit.MICROSECONDS.toNanos(500)); }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void executeAtFixedDelay() throws Exception {
+        CompleteScheduledThreadPoolExecutor executor = new CompleteScheduledThreadPoolExecutor(1);
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+
+            long startTime = System.nanoTime();
+            List<Long> delays = new ArrayList<>();
+
+            final RuntimeException endException = new RuntimeException();
+
+            executor.scheduleWithFixedDelay(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                Thread.sleep(300);
+                            } catch (InterruptedException e) {
+                            }
+                            delays.add(delays.isEmpty() ?
+                                    System.nanoTime() - startTime : System.nanoTime() - delays.get(delays.size() - 1));
+                            if (delays.size() >= 5) {
+                                throw endException;
+                            }
+                        }
+                    },
+                    100,
+                    200,
+                    TimeUnit.MILLISECONDS,
+                    new CompleteScheduledExecutorService.CompleteHandler<Void>() {
+                        @Override
+                        public void onComplete(Future<Void> task) {
+                            try {
+                                task.get();
+                            } catch (InterruptedException e) {
+                            } catch (ExecutionException e) {
+                                if (endException == e.getCause()) {
+                                    latch.countDown();
+                                }
+                            }
+                        }
+                    });
+
+            assertTrue(latch.await(4, TimeUnit.SECONDS));
+            for (int i = 0; i < delays.size(); ++i) {
+                if (i == 0) { assertTrue(delays.get(i) >= TimeUnit.MICROSECONDS.toNanos(100)); }
+                else { assertTrue(delays.get(i) >= TimeUnit.MICROSECONDS.toNanos(500)); }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void wouldNotCallCompleteHandlerForCanceledTask() throws Exception {
+        CompleteScheduledThreadPoolExecutor executor = new CompleteScheduledThreadPoolExecutor(1);
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+
+            Future<?> future = executor.scheduleAtFixedRate(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                        }
+                    },
+                    10,
+                    100,
+                    TimeUnit.MILLISECONDS,
+                    new CompleteScheduledExecutorService.CompleteHandler<Void>() {
+                        @Override
+                        public void onComplete(Future<Void> task) {
+                            latch.countDown();
+                        }
+                    });
+
+            future.cancel(true);
+
+            assertFalse(latch.await(3, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void multiThreadPeriodicTaskCompleteTestRace() throws Exception {
+        CompleteScheduledThreadPoolExecutor executor = new CompleteScheduledThreadPoolExecutor(6);
+        try {
+            int total = 1000;
+
+            CountDownLatch latch = new CountDownLatch(total);
+            AtomicInteger completeCallCount = new AtomicInteger();
+
+            for (int i = 0; i < total; ++i) {
+                Future<?> future = executor.scheduleAtFixedRate(
+                        new Runnable() {
+                            private int runCount = 0;
+
+                            @Override
+                            public void run() {
+                                try {
+                                    Thread.sleep(1);
+                                } catch (InterruptedException e) {
+                                }
+                                if (6 == runCount++) {
+                                    throw new RuntimeException();
+                                }
+                            }
+                        },
+                        0,
+                        1,
+                        TimeUnit.MILLISECONDS,
+                        new CompleteScheduledExecutorService.CompleteHandler<Void>() {
+                            @Override
+                            public void onComplete(Future<Void> task) {
+                                latch.countDown();
+                                completeCallCount.incrementAndGet();
+                            }
+                        });
+            }
+
+            assertTrue(latch.await(3, TimeUnit.SECONDS));
+            assertEquals(total, completeCallCount.get());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTaskTest.java
@@ -33,7 +33,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
     @Test
     public void taskCrash() throws Exception {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
+        CompleteScheduledExecutorService exec = CompleteScheduledExecutors.newSingleThreadExecutor();
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
@@ -44,7 +44,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
                 }
             }, exec);
 
-            assertNull(task.call());
+            task.run();
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
@@ -55,7 +55,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
     @Test
     public void dispose() throws Exception {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
+        CompleteScheduledExecutorService exec = CompleteScheduledExecutors.newSingleThreadExecutor();
         try {
 
             InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
@@ -82,7 +82,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
     @Test
     public void dispose2() throws Exception {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
+        CompleteScheduledExecutorService exec = CompleteScheduledExecutors.newSingleThreadExecutor();
         try {
 
             InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
@@ -112,7 +112,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
     @Test
     public void dispose2CurrentThread() throws Exception {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
+        CompleteScheduledExecutorService exec = CompleteScheduledExecutors.newSingleThreadExecutor();
         try {
 
             InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
@@ -144,7 +144,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
     @Test
     public void dispose3() throws Exception {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
+        CompleteScheduledExecutorService exec = CompleteScheduledExecutors.newSingleThreadExecutor();
         try {
 
             InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
@@ -173,7 +173,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
     @Test
     public void disposeOnCurrentThread() throws Exception {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
+        CompleteScheduledExecutorService exec = CompleteScheduledExecutors.newSingleThreadExecutor();
         try {
 
             InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
@@ -204,7 +204,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
     @Test
     public void firstCancelRace() throws Exception {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
+        CompleteScheduledExecutorService exec = CompleteScheduledExecutors.newSingleThreadExecutor();
         try {
             for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
                 final InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
@@ -241,7 +241,7 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
 
     @Test
     public void restCancelRace() throws Exception {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
+        CompleteScheduledExecutorService exec = CompleteScheduledExecutors.newSingleThreadExecutor();
         try {
             for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
                 final InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnableTest.java
@@ -146,7 +146,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    run.call();
+                    run.run();
                 }
             };
 
@@ -224,14 +224,14 @@ public class ScheduledRunnableTest extends RxJavaTest {
     public void withoutParentDisposed() {
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         run.dispose();
-        run.call();
+        run.run();
     }
 
     @Test
     public void withParentDisposed() {
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, new CompositeDisposable());
         run.dispose();
-        run.call();
+        run.run();
     }
 
     @Test
@@ -239,7 +239,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         run.setFuture(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
         run.dispose();
-        run.call();
+        run.run();
     }
 
     @Test
@@ -247,7 +247,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         run.dispose();
         run.setFuture(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
-        run.call();
+        run.run();
     }
 
     @Test
@@ -256,7 +256,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
         run.dispose();
         run.set(2, Thread.currentThread());
         run.setFuture(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
-        run.call();
+        run.run();
     }
 
     @Test
@@ -271,7 +271,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
             Runnable r1 = new Runnable() {
                 @Override
                 public void run() {
-                    run.call();
+                    run.run();
                 }
             };
 


### PR DESCRIPTION
Fix that RxJava will miss exceptions in Future thrown by tasks executed by
executors

Signed-off-by: jiaoxiaodong <milestonejxd@gmail.com>

In general, exceptions should never be swallowed and should be handled somewhere, eg., catch clause or uncaught exception handlers of threads.

As to RxJava, exceptions are expected to be handled at:
- observer's onError(), or
- RxJava exception handler (RxJavaPlugins.onError()), or
- thread's uncaught exception handler (eg., exceptions thrown by Exceptions.throwIfFatal()), 

and not to be magically swallowed somewhere.

This is true in most situations, but is broken when schedulers are involved. That is, the following tests will fail:

**(Test 1) Exceptions from observables are swallowed:**

    @Test
    public void exceptionFromObservableShouldNotBeSwallowed() throws Exception {
        // Exceptions, fatal or not, should be handled by
        // #1 observer's onError(), or
        // #2 RxJava exception handler, or
        // #3 thread's uncaught exception handler,
        // and should not be swallowed.
        try {
            CountDownLatch latch = new CountDownLatch(1);

            // #3 thread's uncaught exception handler
            Scheduler computationScheduler = new ComputationScheduler(new ThreadFactory() {
                @Override
                public Thread newThread(Runnable r) {
                    Thread t = new Thread(r);
                    t.setUncaughtExceptionHandler((thread, throwable) -> {
                        latch.countDown();
                    });
                    return t;
                }
            });

            // #2 RxJava exception handler
            RxJavaPlugins.setErrorHandler(h -> {
                latch.countDown();
            });

            // #1 observer's onError()
            Observable.create(s -> {

                s.onNext(1);

                if (true) {
                    throw new OutOfMemoryError();
                }

                s.onComplete();

            }).subscribeOn(computationScheduler)
            .subscribe(v -> {
            }, e -> {
                latch.countDown();
            });

            assertTrue(latch.await(2, TimeUnit.SECONDS));
        } finally {
            RxJavaPlugins.reset();
        }
    }

**(Test 2) Exceptions from observers are swallowed:**

    @Test
    public void exceptionFromObserverShouldNotBeSwallowed() throws Exception {
        // Exceptions, fatal or not, should be handled by
        // #1 observer's onError(), or
        // #2 RxJava exception handler, or
        // #3 thread's uncaught exception handler,
        // and should not be swallowed.
        try {
            CountDownLatch latch = new CountDownLatch(1);

            // #3 thread's uncaught exception handler
            Scheduler computationScheduler = new ComputationScheduler(new ThreadFactory() {
                @Override
                public Thread newThread(Runnable r) {
                    Thread t = new Thread(r);
                    t.setUncaughtExceptionHandler((thread, throwable) -> {
                        latch.countDown();
                    });
                    return t;
                }
            });

            // #2 RxJava exception handler
            RxJavaPlugins.setErrorHandler(h -> {
                latch.countDown();
            });

            // #1 observer's onError()
            Flowable.interval(500, TimeUnit.MILLISECONDS, computationScheduler)
                    .subscribe(v -> {
                        throw new OutOfMemoryError();
                    }, e -> {
                        latch.countDown();
                    });

            assertTrue(latch.await(2, TimeUnit.SECONDS));
        } finally {
            RxJavaPlugins.reset();
        }
    }

Sometimes these broken cases matter in certain situation or on certain platform, eg.,
- As Test 1, when out-of-memory occurs before emitter.onComplete(), the application may block forever waiting for onComplete(), because no one in the whole application could possibly known about this exception.
- On Android, on which I code a lot, the exception handing contract implies that any runtime exception or error in any thread should throw to the uncaught exception handler, which will terminate the application. Almost all async tools, including the built in AsyncTask, conform to this contract. Setting an error handler that always throws runtime exceptions and errors via RxJavaPlugins.setErrorHandler() on Android almost makes it. But it doesn't work when schedulers are involved.

The cause is clear. Internal to Scheduler implementation, RxJava only uses Future of a task submitted to Executor as a cancel-handle and never check exceptions inside the Future while any exception thrown by the submitted task will go into the Future.

But the fix is not as easy, there is no chance to check the Future for exception since RxJava pushes task result instead of pulls it.

Pulling results is the design intent of Future. When we won't, I think we should customize the FutureTask which runs the task in Executor and provides the Future function to give us a chance to handle the result(including the exception).  

Actually, JDK has given us all we need to do this via ThreadPoolExecutor#newTaskFor, ScheduledThreadPoolExecutor#decorateTask, RunnableFuture, RunnableScheduledFuture, etc. And Android did something similar in its AsyncTask implementation.

I'll propose a PR that:
- Implements a CompleteScheduledExecutorService which is a ScheduledExecutorService that supports setting a complete handler that will receive the Future(and handle the task result) of the submitted task once it completes in the executing thread.
- Modifies executor based schedulers to use CompleteScheduledExecutorService and check the Future for exceptions(and route it to RxJavaPlugins.onError() or throw it using Exceptions.throwIfFatal()) of submitted tasks in their complete handlers.
- With test cases cover CompleteScheduledExecutorService related code and the above Test 1 & Test 2.