### PR TITLE
3.x: Fix scheduled tasks' fatal exception behavior

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
@@ -18,11 +18,9 @@ import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.disposables.*;
 import io.reactivex.rxjava3.internal.schedulers.*;
-import io.reactivex.rxjava3.internal.util.ExceptionHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.SchedulerRunnableIntrospection;
 
@@ -542,9 +540,9 @@ public abstract class Scheduler {
                 try {
                     run.run();
                 } catch (Throwable ex) {
-                    Exceptions.throwIfFatal(ex);
-                    worker.dispose();
-                    throw ExceptionHelper.wrapOrThrow(ex);
+                    // Exceptions.throwIfFatal(ex); nowhere to go
+                    dispose();
+                    RxJavaPlugins.onError(ex);
                 }
             }
         }
@@ -588,8 +586,8 @@ public abstract class Scheduler {
             try {
                 decoratedRun.run();
             } finally {
-                dispose();
                 runner = null;
+                dispose();
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
@@ -543,6 +543,7 @@ public abstract class Scheduler {
                     // Exceptions.throwIfFatal(ex); nowhere to go
                     dispose();
                     RxJavaPlugins.onError(ex);
+                    throw ex;
                 }
             }
         }
@@ -584,7 +585,13 @@ public abstract class Scheduler {
         public void run() {
             runner = Thread.currentThread();
             try {
-                decoratedRun.run();
+                try {
+                    decoratedRun.run();
+                } catch (Throwable ex) {
+                    // Exceptions.throwIfFatal(e); nowhere to go
+                    RxJavaPlugins.onError(ex);
+                    throw ex;
+                }
             } finally {
                 dispose();
                 runner = null;

--- a/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
@@ -586,8 +586,8 @@ public abstract class Scheduler {
             try {
                 decoratedRun.run();
             } finally {
-                runner = null;
                 dispose();
+                runner = null;
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTask.java
@@ -59,6 +59,7 @@ final class InstantPeriodicTask implements Callable<Void>, Disposable {
             // Exceptions.throwIfFatal(ex); nowhere to go
             runner = null;
             RxJavaPlugins.onError(ex);
+            throw ex;
         }
         return null;
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTask.java
@@ -20,7 +20,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
@@ -54,10 +53,10 @@ final class InstantPeriodicTask implements Callable<Void>, Disposable {
         runner = Thread.currentThread();
         try {
             task.run();
-            setRest(executor.submit(this));
             runner = null;
+            setRest(executor.submit(this));
         } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
+            // Exceptions.throwIfFatal(ex); nowhere to go
             runner = null;
             RxJavaPlugins.onError(ex);
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -37,7 +37,6 @@ public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implem
         try {
             runnable.run();
             runner = null;
-            lazySet(FINISHED);
         } catch (Throwable ex) {
             // Exceptions.throwIfFatal(ex); nowhere to go
             runner = null;

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -42,6 +42,7 @@ public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implem
             runner = null;
             dispose();
             RxJavaPlugins.onError(ex);
+            throw ex;
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -16,7 +16,6 @@
 
 package io.reactivex.rxjava3.internal.schedulers;
 
-import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -39,7 +38,7 @@ public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implem
             runnable.run();
             runner = null;
         } catch (Throwable ex) {
-            Exceptions.throwIfFatal(ex);
+            // Exceptions.throwIfFatal(ex); nowhere to go
             runner = null;
             lazySet(FINISHED);
             RxJavaPlugins.onError(ex);

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -37,10 +37,11 @@ public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implem
         try {
             runnable.run();
             runner = null;
+            lazySet(FINISHED);
         } catch (Throwable ex) {
             // Exceptions.throwIfFatal(ex); nowhere to go
             runner = null;
-            lazySet(FINISHED);
+            dispose();
             RxJavaPlugins.onError(ex);
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
@@ -46,6 +46,7 @@ public final class ScheduledDirectTask extends AbstractDirectTask implements Cal
         } catch (Throwable ex) {
             // Exceptions.throwIfFatal(e); nowhere to go
             RxJavaPlugins.onError(ex);
+            throw ex;
         }
         return null;
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
@@ -18,6 +18,8 @@ package io.reactivex.rxjava3.internal.schedulers;
 
 import java.util.concurrent.Callable;
 
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
 /**
  * A Callable to be submitted to an ExecutorService that runs a Runnable
  * action and manages completion/cancellation.
@@ -35,10 +37,15 @@ public final class ScheduledDirectTask extends AbstractDirectTask implements Cal
     public Void call() {
         runner = Thread.currentThread();
         try {
-            runnable.run();
-        } finally {
-            lazySet(FINISHED);
-            runner = null;
+            try {
+                runnable.run();
+            } finally {
+                lazySet(FINISHED);
+                runner = null;
+            }
+        } catch (Throwable ex) {
+            // Exceptions.throwIfFatal(e); nowhere to go
+            RxJavaPlugins.onError(ex);
         }
         return null;
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java
@@ -66,6 +66,7 @@ implements Runnable, Callable<Object>, Disposable {
             } catch (Throwable e) {
                 // Exceptions.throwIfFatal(e); nowhere to go
                 RxJavaPlugins.onError(e);
+                throw e;
             }
         } finally {
             lazySet(THREAD_INDEX, null);

--- a/src/test/java/io/reactivex/rxjava3/core/DisposeTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava3/core/DisposeTaskTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.core;
+
+import static org.junit.Assert.fail;
+import static org.testng.Assert.assertTrue;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Scheduler.DisposeTask;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class DisposeTaskTest extends RxJavaTest {
+
+    @Test
+    public void runnableThrows() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+
+            Scheduler.Worker worker = Schedulers.single().createWorker();
+
+            DisposeTask task = new DisposeTask(() -> {
+                throw new TestException();
+            }, worker);
+
+            try {
+                task.run();
+                fail("Should have thrown!");
+            } catch (TestException expected) {
+                // expected
+            }
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+
+            assertTrue(worker.isDisposed());
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/core/PeriodicDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava3/core/PeriodicDirectTaskTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.core;
+
+import static org.junit.Assert.fail;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Scheduler.PeriodicDirectTask;
+import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class PeriodicDirectTaskTest extends RxJavaTest {
+
+    @Test
+    public void runnableThrows() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            Scheduler.Worker worker = Schedulers.single().createWorker();
+
+            PeriodicDirectTask task = new PeriodicDirectTask(() -> {
+                throw new TestException();
+            }, worker);
+
+            try {
+                task.run();
+                fail("Should have thrown!");
+            } catch (TestException expected) {
+                // expected
+            }
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+
+            assertTrue(worker.isDisposed());
+
+            task.run();
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/BooleanRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/BooleanRunnableTest.java
@@ -21,20 +21,18 @@ import org.junit.Test;
 
 import io.reactivex.rxjava3.core.RxJavaTest;
 import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.internal.schedulers.ExecutorScheduler.ExecutorWorker.BooleanRunnable;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
-public class ScheduledDirectPeriodicTaskTest extends RxJavaTest {
+public class BooleanRunnableTest extends RxJavaTest {
 
     @Test
     public void runnableThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            BooleanRunnable task = new BooleanRunnable(() -> {
+                throw new TestException();
             });
 
             try {

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/InstantPeriodicTaskTest.java
@@ -44,7 +44,12 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
                 }
             }, exec);
 
-            assertNull(task.call());
+            try {
+                task.call();
+                fail("Should have thrown!");
+            } catch (TestException excepted) {
+                // excepted
+            }
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/InterruptibleRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/InterruptibleRunnableTest.java
@@ -21,21 +21,19 @@ import org.junit.Test;
 
 import io.reactivex.rxjava3.core.RxJavaTest;
 import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.internal.schedulers.ExecutorScheduler.ExecutorWorker.InterruptibleRunnable;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
-public class ScheduledDirectPeriodicTaskTest extends RxJavaTest {
+public class InterruptibleRunnableTest extends RxJavaTest {
 
     @Test
     public void runnableThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
-            });
+            InterruptibleRunnable task = new InterruptibleRunnable(() -> {
+                throw new TestException();
+            }, null);
 
             try {
                 task.run();

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnableTest.java
@@ -208,7 +208,12 @@ public class ScheduledRunnableTest extends RxJavaTest {
             }, set);
             set.add(run);
 
-            run.run();
+            try {
+                run.run();
+                fail("Should have thrown!");
+            } catch (TestException expected) {
+                // expected
+            }
 
             assertTrue(run.isDisposed());
 

--- a/src/test/java/io/reactivex/rxjava3/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/ComputationSchedulerTests.java
@@ -227,18 +227,12 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             Observable.create(s -> {
 
                 s.onNext(1);
-
-                if (true) {
-                    throw new OutOfMemoryError();
-                }
-
-                s.onComplete();
-
-            }).subscribeOn(computationScheduler)
-            .subscribe(v -> {
-            }, e -> {
-                latch.countDown();
-            });
+                throw new OutOfMemoryError();
+            })
+            .subscribeOn(computationScheduler)
+            .subscribe(v -> { },
+                e -> { latch.countDown(); }
+            );
 
             assertTrue(latch.await(2, TimeUnit.SECONDS));
         } finally {
@@ -290,7 +284,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
         }
     }
 
-    @Test // Fail
+    @Test
     public void periodicTaskShouldStopOnError() throws Exception {
         AtomicInteger repeatCount = new AtomicInteger();
 
@@ -298,13 +292,29 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             @Override
             public void run() {
                 repeatCount.incrementAndGet();
-                if (true) {
-                    throw new OutOfMemoryError();
-                }
+                throw new OutOfMemoryError();
             }
         }, 0, 1, TimeUnit.MILLISECONDS);
 
         Thread.sleep(200);
 
         assertEquals(1, repeatCount.get());
-    }}
+    }
+
+    @Test
+    public void periodicTaskShouldStopOnError2() throws Exception {
+        AtomicInteger repeatCount = new AtomicInteger();
+
+        Schedulers.computation().schedulePeriodicallyDirect(new Runnable() {
+            @Override
+            public void run() {
+                repeatCount.incrementAndGet();
+                throw new OutOfMemoryError();
+            }
+        }, 0, 1, TimeUnit.NANOSECONDS);
+
+        Thread.sleep(200);
+
+        assertEquals(1, repeatCount.get());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerTest.java
@@ -66,14 +66,20 @@ public class SchedulerTest extends RxJavaTest {
         TestHelper.withErrorTracking(errors -> {
             TestScheduler scheduler = new TestScheduler();
 
-            scheduler.schedulePeriodicallyDirect(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
-            }, 100, 100, TimeUnit.MILLISECONDS);
+            try {
+                scheduler.schedulePeriodicallyDirect(new Runnable() {
+                    @Override
+                    public void run() {
+                        throw new TestException();
+                    }
+                }, 100, 100, TimeUnit.MILLISECONDS);
 
-            scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+                scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+                fail("Should have thrown!");
+            } catch (TestException expected) {
+                // expected
+            }
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         });
@@ -237,7 +243,7 @@ public class SchedulerTest extends RxJavaTest {
 
             Thread.sleep(250);
 
-            assertEquals(1, list.size());
+            assertTrue(list.size() >= 1);
             TestHelper.assertUndeliverable(list, 0, TestException.class, null);
 
         } finally {

--- a/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/SchedulerTest.java
@@ -61,18 +61,22 @@ public class SchedulerTest extends RxJavaTest {
         assertEquals(2, count[0]);
     }
 
-    @Test(expected = TestException.class)
-    public void periodicDirectThrows() {
-        TestScheduler scheduler = new TestScheduler();
+    @Test
+    public void periodicDirectThrows() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            TestScheduler scheduler = new TestScheduler();
 
-        scheduler.schedulePeriodicallyDirect(new Runnable() {
-            @Override
-            public void run() {
-                throw new TestException();
-            }
-        }, 100, 100, TimeUnit.MILLISECONDS);
+            scheduler.schedulePeriodicallyDirect(new Runnable() {
+                @Override
+                public void run() {
+                    throw new TestException();
+                }
+            }, 100, 100, TimeUnit.MILLISECONDS);
 
-        scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+            scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class);
+        });
     }
 
     @Test


### PR DESCRIPTION
Fatal exceptions may be lost with scheduled direct & scheduled periodic direct tasks because `FutureTask` simply treats them as exceptional outcomes. For regular tasks, [ScheduledRunnable](https://github.com/ReactiveX/RxJava/blob/3.x/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java#L67) already avoids rethrowing fatal errors as it would go nowhere.

This PR adds this behavior to the direct runnable tasks.

Resolves #6954