### PR TITLE
2.x: Fix Observable.flatMap with maxConcurrency hangs (#6947)

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableFlatMap.java
@@ -334,6 +334,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                 if (checkTerminate()) {
                     return;
                 }
+                int innerCompleted = 0;
                 SimplePlainQueue<U> svq = queue;
 
                 if (svq != null) {
@@ -349,7 +350,16 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                         }
 
                         child.onNext(o);
+                        innerCompleted++;
                     }
+                }
+
+                if (innerCompleted != 0) {
+                    if (maxConcurrency != Integer.MAX_VALUE) {
+                        subscribeMore(innerCompleted);
+                        innerCompleted = 0;
+                    }
+                    continue;
                 }
 
                 boolean d = done;
@@ -376,7 +386,6 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
                     return;
                 }
 
-                int innerCompleted = 0;
                 if (n != 0) {
                     long startId = lastId;
                     int index = lastIndex;
@@ -463,24 +472,30 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
 
                 if (innerCompleted != 0) {
                     if (maxConcurrency != Integer.MAX_VALUE) {
-                        while (innerCompleted-- != 0) {
-                            ObservableSource<? extends U> p;
-                            synchronized (this) {
-                                p = sources.poll();
-                                if (p == null) {
-                                    wip--;
-                                    continue;
-                                }
-                            }
-                            subscribeInner(p);
-                        }
+                        subscribeMore(innerCompleted);
+                        innerCompleted = 0;
                     }
                     continue;
                 }
+
                 missed = addAndGet(-missed);
                 if (missed == 0) {
                     break;
                 }
+            }
+        }
+
+        void subscribeMore(int innerCompleted) {
+            while (innerCompleted-- != 0) {
+                ObservableSource<? extends U> p;
+                synchronized (this) {
+                    p = sources.poll();
+                    if (p == null) {
+                        wip--;
+                        continue;
+                    }
+                }
+                subscribeInner(p);
             }
         }
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableFlatMapTest.java
@@ -1157,4 +1157,27 @@ public class FlowableFlatMapTest {
 
         assertFalse("Has subscribers?", pp1.hasSubscribers());
     }
+
+    @Test(timeout = 5000)
+    public void mixedScalarAsync() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            Flowable
+            .range(0, 20)
+            .flatMap(new Function<Integer, Publisher<?>>() {
+                @Override
+                public Publisher<?> apply(Integer integer) throws Exception {
+                    if (integer % 5 != 0) {
+                        return Flowable
+                                .just(integer);
+                    }
+
+                    return Flowable
+                            .just(-integer)
+                            .observeOn(Schedulers.computation());
+                }
+            }, false, 1)
+            .ignoreElements()
+            .blockingAwait();
+        }
+    }
 }

--- a/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/observable/ObservableFlatMapTest.java
@@ -1118,4 +1118,27 @@ public class ObservableFlatMapTest {
 
         assertFalse("Has subscribers?", ps1.hasObservers());
     }
+
+    @Test(timeout = 5000)
+    public void mixedScalarAsync() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            Observable
+            .range(0, 20)
+            .flatMap(new Function<Integer, ObservableSource<?>>() {
+                @Override
+                public ObservableSource<?> apply(Integer integer) throws Exception {
+                    if (integer % 5 != 0) {
+                        return Observable
+                                .just(integer);
+                    }
+
+                    return Observable
+                            .just(-integer)
+                            .observeOn(Schedulers.computation());
+                }
+            }, false, 1)
+            .ignoreElements()
+            .blockingAwait();
+        }
+    }
 }


### PR DESCRIPTION
Just a backport to 2.x of the fix for the scalar-queue max-concurrency issue already fixed for 3.x in #6946

The code for the fix has been added and also the test for it.

In addition, as was also done for #6946, the corresponding test for `FlowableFlatMap` has been added.

Resolves #6947