### PR TITLE
3.x: Fix Flowable.groupBy eviction logic double decrement and hang

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -270,9 +270,10 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
         public void cancel(K key) {
             Object mapKey = key != null ? key : NULL_KEY;
-            groups.remove(mapKey);
-            if (groupCount.decrementAndGet() == 0) {
-                upstream.cancel();
+            if (groups.remove(mapKey) != null) {
+                if (groupCount.decrementAndGet() == 0) {
+                    upstream.cancel();
+                }
             }
         }
 


### PR DESCRIPTION
When a group is evicted, the group is synchronously `onComplete`d during an `onNext`. If a cancellation happened during this time (for example, when a `publish` cancels its upstream because its output completes), the cancellation would unconditionally decrement the group counter even though the `groups` map had no longer the group (because it was evicted before). Then once the eviction logic finishes, it decremented the group counter again, leading to invalid internal state and hangs.

The fix is to only decrement if there was a group actually removed from the map.

Fixes #6974