### PR TITLE
3.x: Fix Flowable.groupBy cancellation/cleanup/eviction race hangs

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -259,8 +259,9 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                 int count = 0;
                 GroupedUnicast<K, V> evictedGroup;
                 while ((evictedGroup = evictedGroups.poll()) != null) {
-                    evictedGroup.onComplete();
-                    count++;
+                    if (evictedGroup.state.tryComplete()) {
+                        count++;
+                    }
                 }
                 if (count != 0) {
                     groupCount.addAndGet(-count);
@@ -383,6 +384,8 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         static final int ABANDONED = 2;
         static final int ABANDONED_HAS_SUBSCRIBER = ABANDONED | HAS_SUBSCRIBER;
 
+        final AtomicBoolean evictOnce = new AtomicBoolean();
+
         State(int bufferSize, GroupBySubscriber<?, K, T> parent, K key, boolean delayError) {
             this.queue = new SpscLinkedArrayQueue<>(bufferSize);
             this.parent = parent;
@@ -444,9 +447,18 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             drain();
         }
 
+        boolean tryComplete() {
+            boolean canEvict = evictOnce.compareAndSet(false, true);
+            done = true;
+            drain();
+            return canEvict;
+        }
+
         void cancelParent() {
             if ((once.get() & ABANDONED) == 0) {
-                parent.cancel(key);
+                if (evictOnce.compareAndSet(false, true)) {
+                    parent.cancel(key);
+                }
             }
         }
 
@@ -518,37 +530,44 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             final SpscLinkedArrayQueue<T> q = queue;
             final boolean delayError = this.delayError;
             Subscriber<? super T> a = actual.get();
+            final AtomicBoolean cancelled = this.cancelled;
+
+            outer:
             for (;;) {
-                if (a != null) {
-                    long r = requested.get();
-                    long e = 0;
+                if (cancelled.get()) {
+                    cleanupQueue(0, false);
+                } else {
+                    if (a != null) {
+                        long r = requested.get();
+                        long e = 0;
 
-                    while (e != r) {
-                        boolean d = done;
-                        T v = q.poll();
-                        boolean empty = v == null;
+                        while (e != r) {
+                            boolean d = done;
+                            T v = q.poll();
+                            boolean empty = v == null;
 
-                        if (checkTerminated(d, empty, a, delayError, e)) {
-                            return;
+                            if (checkTerminated(d, empty, a, delayError, e, !empty)) {
+                                continue outer;
+                            }
+
+                            if (empty) {
+                                break;
+                            }
+
+                            a.onNext(v);
+
+                            e++;
                         }
 
-                        if (empty) {
-                            break;
+                        if (e == r && checkTerminated(done, q.isEmpty(), a, delayError, e, false)) {
+                            continue outer;
                         }
 
-                        a.onNext(v);
-
-                        e++;
-                    }
-
-                    if (e == r && checkTerminated(done, q.isEmpty(), a, delayError, e)) {
-                        return;
-                    }
-
-                    if (e != 0L) {
-                        BackpressureHelper.produced(requested, e);
-                        // replenish based on this batch run
-                        requestParent(e);
+                        if (e != 0L) {
+                            BackpressureHelper.produced(requested, e);
+                            // replenish based on this batch run
+                            requestParent(e);
+                        }
                     }
                 }
 
@@ -568,23 +587,32 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
             }
         }
 
-        boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a, boolean delayError, long emitted) {
+        void cleanupQueue(long emitted, boolean polled) {
+            // if this group is canceled, all accumulated emissions and
+            // remaining items in the queue should be requested
+            // so that other groups can proceed
+            while (queue.poll() != null) {
+                emitted++;
+            }
+            if (polled) {
+                emitted++;
+            }
+            if (emitted != 0L) {
+                requestParent(emitted);
+            }
+        }
+
+        boolean checkTerminated(boolean d, boolean empty, Subscriber<? super T> a,
+                boolean delayError, long emitted, boolean polled) {
             if (cancelled.get()) {
-                // if this group is canceled, all accumulated emissions and
-                // remaining items in the queue should be requested
-                // so that other groups can proceed
-                while (queue.poll() != null) {
-                    emitted++;
-                }
-                if (emitted != 0L) {
-                    requestParent(emitted);
-                }
+                cleanupQueue(emitted, polled);
                 return true;
             }
 
             if (d) {
                 if (delayError) {
                     if (empty) {
+                        cancelled.lazySet(true);
                         Throwable e = error;
                         if (e != null) {
                             a.onError(e);
@@ -597,10 +625,12 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                     Throwable e = error;
                     if (e != null) {
                         queue.clear();
+                        cancelled.lazySet(true);
                         a.onError(e);
                         return true;
                     } else
                     if (empty) {
+                        cancelled.lazySet(true);
                         a.onComplete();
                         return true;
                     }


### PR DESCRIPTION
This PR fixes three additional race conditions from https://github.com/ReactiveX/RxJava/issues/6974#issuecomment-626319431

1. When a cancellation arrived asynchronously to a group, the drain loop quit and left unconsumed items in the queue and thus prevented the replenishment from the main upstream. **Fix:** change the drain loop to always clean & replenish upon seeing a canceled state.

2. When a cancellation was detected just after the drain loop has polled from the queue, that polled item was ignored and not replenished. **Fix:** Include the non-empty polled item in the replenishment count upon cancellation.

3. When a cancellation happened concurrently with an eviction, both could end up decrementing the group counter into an invalid (negative) number, preventing the operator to function properly. **Fix:** make sure group removal accounting happens at most once.

Fixes: #6974