### PR TITLE
3.x: Disable fusion on the groups of Flowable.groupBy

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -642,10 +642,13 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
         @Override
         public int requestFusion(int mode) {
+            // FIXME fusion mode causes hangs
+            /*
             if ((mode & ASYNC) != 0) {
                 outputFused = true;
                 return ASYNC;
             }
+            */
             return NONE;
         }
 


### PR DESCRIPTION
This PR disables the async fusion capability of the groups emitted by `Flowable.groupBy` as it appears to lead to hangs due to cancellation and/or lack of requests in certain async scenarios.

By disabling fusion, the groups will manage the items they queue and cancellation will (hopefully) properly trigger replenishment requests for the unclaimed items.

This is more of a workaround than a comprehensible fix for the underlying issues. The main problem is that with `groupBy` and backpressure, each group itself and the items passing through them now count as **resources** and Reactive Streams can't cope well with items requiring their own lifecycle.

Related: #6982