### PR TITLE
Add missing `@Test` annotation

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectTest.java
@@ -797,6 +797,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
     }
 
+    @Test
     public void createInvalidCapacity() {
         try {
             ReplaySubject.create(-99);


### PR DESCRIPTION
There was a missing `@Test` annotation in `ReplaySubjectTest`. This PR fix that.