### PR TITLE
Removed unnecessary upstream.cancel() call for casually finished upstream sequences.

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticast.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
-import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.fuseable.*;
@@ -124,7 +123,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
         }
     }
 
-    static final class MulticastProcessor<T> extends Flowable<T> implements FlowableSubscriber<T>, Disposable {
+    static final class MulticastProcessor<T> extends Flowable<T> implements FlowableSubscriber<T> {
 
         @SuppressWarnings("rawtypes")
         static final MulticastSubscription[] EMPTY = new MulticastSubscription[0];
@@ -192,18 +191,18 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             }
         }
 
-        @Override
         public void dispose() {
-            SubscriptionHelper.cancel(upstream);
-            if (wip.getAndIncrement() == 0) {
-                SimpleQueue<T> q = queue;
-                if (q != null) {
-                    q.clear();
+            if (!done) {
+                SubscriptionHelper.cancel(upstream);
+                if (wip.getAndIncrement() == 0) {
+                    SimpleQueue<T> q = queue;
+                    if (q != null) {
+                        q.clear();
+                    }
                 }
             }
         }
 
-        @Override
         public boolean isDisposed() {
             return upstream.get() == SubscriptionHelper.CANCELLED;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticast.java
@@ -191,7 +191,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             }
         }
 
-        public void dispose() {
+        void dispose() {
             if (!done) {
                 SubscriptionHelper.cancel(upstream);
                 if (wip.getAndIncrement() == 0) {
@@ -203,7 +203,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             }
         }
 
-        public boolean isDisposed() {
+        boolean isDisposed() {
             return upstream.get() == SubscriptionHelper.CANCELLED;
         }
 


### PR DESCRIPTION
- no upstream.cancel() in FlowablePublishMulticast when the sequence is finished normally via onComplete/onError from upstream;
- minor code cleanup - unnecessary Disposable implementation to avoid method name clash
- Fixes https://github.com/ReactiveX/RxJava/issues/6989
- FlowablePublishFunctionTest.java  refactored to use lambdas