### PR TITLE
3.x: Fix recent groupBy tests sometimes failing with MBE

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -2719,10 +2719,9 @@ public class FlowableGroupByTest extends RxJavaTest {
                      // .take(10)
                      .take(10, TimeUnit.MILLISECONDS)
             , flatMapMaxConcurrency)
-        .test()
+        .subscribeWith(new TestSubscriberEx<>())
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertNoErrors()
-        .assertComplete();
+        .assertTerminated(); // MBE is possible if the async group closing is slow
     }
 
     @Test
@@ -2746,10 +2745,9 @@ public class FlowableGroupByTest extends RxJavaTest {
                      // .take(10)
                      .take(10, TimeUnit.MILLISECONDS)
             , flatMapMaxConcurrency)
-        .test()
+        .subscribeWith(new TestSubscriberEx<>())
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertNoErrors()
-        .assertComplete();
+        .assertTerminated(); // MBE is possible if the async group closing is slow
     }
 
     @Test
@@ -2834,10 +2832,9 @@ public class FlowableGroupByTest extends RxJavaTest {
                      // .take(10)
                      .take(10, TimeUnit.MILLISECONDS)
             , flatMapMaxConcurrency)
-        .test()
+        .subscribeWith(new TestSubscriberEx<>())
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertNoErrors()
-        .assertComplete();
+        .assertTerminated(); // MBE is possible if the async group closing is slow
     }
 
     @Test
@@ -2862,10 +2859,9 @@ public class FlowableGroupByTest extends RxJavaTest {
                      // .take(10)
                      .take(10, TimeUnit.MILLISECONDS)
             , flatMapMaxConcurrency)
-        .test()
+        .subscribeWith(new TestSubscriberEx<>())
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertNoErrors()
-        .assertComplete();
+        .assertTerminated(); // MBE is possible if the async group closing is slow
     }
 
     /*


### PR DESCRIPTION
These tests can fail with `MissingBackpressureException` because groups may not complete fast enough so `flatMap` can request more groups in time. This doesn't happen consistently but could fail the test on CI. The workaround is to allow any termination, not just normal completion. The reasoning is that the aim of the tests were to verify the operator doesn't hang.

The underlying complication is that whenever there is an item replenishment, any subsequent item can result in a fresh group being created. If the concurrency level of `flatMap` is not high enough, this will result in a MBE and the sequence terminates.