### PR TITLE
Suppress UndeliverableException handling in tests (#6987)

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
@@ -32,6 +32,15 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
  * Utility class to inject handlers to certain standard RxJava operations.
  */
 public final class RxJavaPlugins {
+    @NonNull
+    private static final java.util.function.Consumer<? super Throwable> defaultErrorHandler = new java.util.function.Consumer<Throwable>() {
+        @Override
+        public void accept(Throwable throwable) {
+            throwable.printStackTrace(); // NOPMD
+            uncaught(throwable);
+        }
+    };
+
     @Nullable
     static volatile Consumer<? super Throwable> errorHandler;
 
@@ -175,6 +184,15 @@ public final class RxJavaPlugins {
     @Nullable
     public static Function<? super Scheduler, ? extends Scheduler> getComputationSchedulerHandler() {
         return onComputationHandler;
+    }
+
+    /**
+     * Returns the default error handler.
+     * @return the default error handler
+     */
+    @NonNull
+    public static java.util.function.Consumer<? super Throwable> getDefaultErrorHandler() {
+        return defaultErrorHandler;
     }
 
     /**
@@ -374,13 +392,11 @@ public final class RxJavaPlugins {
                 return;
             } catch (Throwable e) {
                 // Exceptions.throwIfFatal(e); TODO decide
-                e.printStackTrace(); // NOPMD
-                uncaught(e);
+                defaultErrorHandler.accept(e);
             }
         }
 
-        error.printStackTrace(); // NOPMD
-        uncaught(error);
+        defaultErrorHandler.accept(error);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
@@ -32,15 +32,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
  * Utility class to inject handlers to certain standard RxJava operations.
  */
 public final class RxJavaPlugins {
-    @NonNull
-    private static final java.util.function.Consumer<? super Throwable> defaultErrorHandler = new java.util.function.Consumer<Throwable>() {
-        @Override
-        public void accept(Throwable throwable) {
-            throwable.printStackTrace(); // NOPMD
-            uncaught(throwable);
-        }
-    };
-
     @Nullable
     static volatile Consumer<? super Throwable> errorHandler;
 
@@ -184,15 +175,6 @@ public final class RxJavaPlugins {
     @Nullable
     public static Function<? super Scheduler, ? extends Scheduler> getComputationSchedulerHandler() {
         return onComputationHandler;
-    }
-
-    /**
-     * Returns the default error handler.
-     * @return the default error handler
-     */
-    @NonNull
-    public static java.util.function.Consumer<? super Throwable> getDefaultErrorHandler() {
-        return defaultErrorHandler;
     }
 
     /**
@@ -392,11 +374,13 @@ public final class RxJavaPlugins {
                 return;
             } catch (Throwable e) {
                 // Exceptions.throwIfFatal(e); TODO decide
-                defaultErrorHandler.accept(e);
+                e.printStackTrace(); // NOPMD
+                uncaught(e);
             }
         }
 
-        defaultErrorHandler.accept(error);
+        error.printStackTrace(); // NOPMD
+        uncaught(error);
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava3/core/RxJavaTest.java
+++ b/src/test/java/io/reactivex/rxjava3/core/RxJavaTest.java
@@ -20,9 +20,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.*;
 import org.junit.rules.Timeout;
 
+import io.reactivex.rxjava3.testsupport.SuppressUndeliverableRule;
+
 public abstract class RxJavaTest {
     @Rule
     public Timeout globalTimeout = new Timeout(5, TimeUnit.MINUTES);
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     /**
      * Announce creates a log print preventing Travis CI from killing the build.

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ParallelCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ParallelCollectorTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.*;
 import java.util.stream.*;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.TestException;
@@ -32,6 +32,9 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ParallelCollectorTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     static Set<Integer> set(int count) {
         return IntStream.rangeClosed(1, count)
@@ -148,6 +151,7 @@ public class ParallelCollectorTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void collectorCombinerCrash() {
         Flowable.range(1, 5)
         .parallel()

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/ParallelCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/ParallelCollectorTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.*;
 import java.util.stream.*;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.TestException;
@@ -32,9 +32,6 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ParallelCollectorTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     static Set<Integer> set(int count) {
         return IntStream.rangeClosed(1, count)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromCallableTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -29,9 +29,13 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class CompletableFromCallableTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     @Test
     public void fromCallable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
@@ -161,6 +165,7 @@ public class CompletableFromCallableTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void fromActionErrorsDisposed() {
         final AtomicInteger calls = new AtomicInteger();
         Completable.fromCallable(new Callable<Object>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromCallableTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -32,9 +32,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class CompletableFromCallableTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void fromCallable() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromSupplierTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -30,9 +30,12 @@ import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.Supplier;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class CompletableFromSupplierTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void fromSupplier() {
@@ -163,6 +166,7 @@ public class CompletableFromSupplierTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void fromActionErrorsDisposed() {
         final AtomicInteger calls = new AtomicInteger();
         Completable.fromSupplier(new Supplier<Object>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableFromSupplierTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -33,9 +33,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class CompletableFromSupplierTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void fromSupplier() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -23,7 +23,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
 
@@ -45,9 +45,6 @@ import io.reactivex.rxjava3.subscribers.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableGroupByTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     static Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>> FLATTEN_INTEGER = new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -23,7 +23,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
 
@@ -45,6 +45,9 @@ import io.reactivex.rxjava3.subscribers.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableGroupByTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     static Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>> FLATTEN_INTEGER = new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
 
@@ -112,6 +115,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error() {
         Flowable<String> sourceStrings = Flowable.just("one", "two", "three", "four", "five", "six");
         Flowable<String> errorSource = Flowable.error(new TestException("forced failure"));
@@ -1196,6 +1200,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void valueSelectorThrows() {
         Flowable<Integer> source = Flowable.just(0, 1, 2, 3, 4, 5, 6);
 
@@ -1251,6 +1256,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error2() {
         Flowable<Integer> source = Flowable.concat(Flowable.just(0),
                 Flowable.<Integer> error(new TestException("Forced failure")));
@@ -1686,6 +1692,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void keySelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .groupBy(Functions.<Integer>identity(), true)
@@ -1700,6 +1707,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void keyAndValueSelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true)
@@ -1853,6 +1861,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void groupError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .groupBy(Functions.justFunction(1), true)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -35,6 +35,9 @@ import io.reactivex.rxjava3.subscribers.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableWindowWithFlowableTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void windowViaFlowableNormal1() {
@@ -623,6 +626,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void disposeMainBoundaryErrorRace() {
         final TestException ex = new TestException();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -35,9 +35,6 @@ import io.reactivex.rxjava3.subscribers.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableWindowWithFlowableTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void windowViaFlowableNormal1() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -36,9 +36,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -32,9 +32,12 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.processors.*;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.reactivex.rxjava3.subscribers.*;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
@@ -324,6 +327,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void endError() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> start = PublishProcessor.create();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -31,9 +31,12 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.processors.*;
 import io.reactivex.rxjava3.schedulers.*;
 import io.reactivex.rxjava3.subscribers.*;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableWindowWithTimeTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
@@ -556,6 +559,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void exactBoundaryError() {
         Flowable.error(new TestException())
         .window(1, TimeUnit.DAYS, Schedulers.single(), 2, true)
@@ -973,6 +977,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void exactTimeBoundNoInterruptWindowOutputOnError() throws Exception {
         final AtomicBoolean isInterrupted = new AtomicBoolean();
 
@@ -1053,6 +1058,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void exactTimeAndSizeBoundNoInterruptWindowOutputOnError() throws Exception {
         final AtomicBoolean isInterrupted = new AtomicBoolean();
 
@@ -1133,6 +1139,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void skipTimeAndSizeBoundNoInterruptWindowOutputOnError() throws Exception {
         final AtomicBoolean isInterrupted = new AtomicBoolean();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -35,9 +35,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableWindowWithTimeTest extends RxJavaTest {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeUsingTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -30,9 +30,6 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class MaybeUsingTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void resourceSupplierThrows() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeUsingTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -30,6 +30,9 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class MaybeUsingTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void resourceSupplierThrows() {
@@ -481,6 +484,7 @@ public class MaybeUsingTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void errorDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCreateTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -32,7 +32,11 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableCreateTest extends RxJavaTest {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     @Test
+    @SuppressUndeliverable
     public void basic() {
         final Disposable d = Disposable.empty();
 
@@ -58,6 +62,7 @@ public class ObservableCreateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void basicWithCancellable() {
         final Disposable d1 = Disposable.empty();
         final Disposable d2 = Disposable.empty();
@@ -91,6 +96,7 @@ public class ObservableCreateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void basicWithError() {
         final Disposable d = Disposable.empty();
 
@@ -115,6 +121,7 @@ public class ObservableCreateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void basicSerialized() {
         final Disposable d = Disposable.empty();
 
@@ -142,6 +149,7 @@ public class ObservableCreateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void basicWithErrorSerialized() {
         final Disposable d = Disposable.empty();
 
@@ -209,6 +217,7 @@ public class ObservableCreateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void createNullValue() {
         final Throwable[] error = { null };
 
@@ -232,6 +241,7 @@ public class ObservableCreateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void createNullValueSerialized() {
         final Throwable[] error = { null };
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCreateTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -31,9 +31,6 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableCreateTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     @SuppressUndeliverable

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.Mockito;
 
 import io.reactivex.rxjava3.core.*;
@@ -38,9 +38,6 @@ import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableGroupByTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     final Function<String, Integer> length = new Function<String, Integer>() {
         @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupByTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mockito;
 
 import io.reactivex.rxjava3.core.*;
@@ -38,6 +38,9 @@ import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableGroupByTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     final Function<String, Integer> length = new Function<String, Integer>() {
         @Override
@@ -96,6 +99,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error() {
         Observable<String> sourceStrings = Observable.just("one", "two", "three", "four", "five", "six");
         Observable<String> errorSource = Observable.error(new RuntimeException("forced failure"));
@@ -1178,6 +1182,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void valueSelectorThrows() {
         Observable<Integer> source = Observable.just(0, 1, 2, 3, 4, 5, 6);
 
@@ -1233,6 +1238,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error2() {
         Observable<Integer> source = Observable.concat(Observable.just(0),
                 Observable.<Integer> error(new TestException("Forced failure")));
@@ -1446,6 +1452,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void keySelectorAndDelayError() {
         Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
         .groupBy(Functions.<Integer>identity(), true)
@@ -1460,6 +1467,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void keyAndValueSelectorAndDelayError() {
         Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
         .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupJoinTest.java
@@ -39,9 +39,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableGroupJoinTest extends RxJavaTest {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     Observer<Object> observer = TestHelper.mockObserver();
 
     BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupJoinTest.java
@@ -39,6 +39,9 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableGroupJoinTest extends RxJavaTest {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     Observer<Object> observer = TestHelper.mockObserver();
 
     BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {
@@ -479,6 +482,7 @@ public class ObservableGroupJoinTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void innerErrorRight() {
         Observable.just(1)
         .groupJoin(

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableLiftTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableLiftTest.java
@@ -15,16 +15,13 @@ package io.reactivex.rxjava3.internal.operators.observable;
 
 import static org.junit.Assert.*;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.TestException;
-import io.reactivex.rxjava3.testsupport.*;
+import io.reactivex.rxjava3.testsupport.SuppressUndeliverable;
 
 public class ObservableLiftTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     @SuppressUndeliverable

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableLiftTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableLiftTest.java
@@ -15,14 +15,19 @@ package io.reactivex.rxjava3.internal.operators.observable;
 
 import static org.junit.Assert.*;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.TestException;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableLiftTest extends RxJavaTest {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     @Test
+    @SuppressUndeliverable
     public void callbackCrash() {
         try {
             Observable.just(1)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
@@ -23,7 +23,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava3.core.*;
@@ -43,6 +43,9 @@ import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableRefCountTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void refCountAsync() throws InterruptedException {
@@ -855,6 +858,7 @@ public class ObservableRefCountTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void badSourceSubscribe() {
         BadObservableSubscribe bo = new BadObservableSubscribe();
 
@@ -881,6 +885,7 @@ public class ObservableRefCountTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void badSourceConnect() {
         BadObservableConnect bo = new BadObservableConnect();
 
@@ -922,6 +927,7 @@ public class ObservableRefCountTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void badSourceSubscribe2() {
         BadObservableSubscribe2 bo = new BadObservableSubscribe2();
 
@@ -959,6 +965,7 @@ public class ObservableRefCountTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void badSourceCompleteDisconnect() {
         BadObservableConnect2 bo = new BadObservableConnect2();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRefCountTest.java
@@ -23,7 +23,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava3.core.*;
@@ -43,9 +43,6 @@ import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableRefCountTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void refCountAsync() throws InterruptedException {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -22,7 +22,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava3.core.*;
@@ -37,9 +37,6 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableRetryWithPredicateTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     BiPredicate<Integer, Throwable> retryTwice = new BiPredicate<Integer, Throwable>() {
         @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -22,7 +22,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava3.core.*;
@@ -37,6 +37,10 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableRetryWithPredicateTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     BiPredicate<Integer, Throwable> retryTwice = new BiPredicate<Integer, Throwable>() {
         @Override
         public boolean test(Integer t1, Throwable t2) {
@@ -390,6 +394,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void retryDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
@@ -438,6 +443,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void retryBiPredicateDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava3.core.*;
@@ -34,9 +34,12 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.PublishSubject;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableTakeTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void take1() {
@@ -111,6 +114,7 @@ public class ObservableTakeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void takeDoesntLeakErrors() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava3.core.*;
@@ -37,9 +37,6 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableTakeTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void take1() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeWhileTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -29,9 +29,6 @@ import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableTakeWhileTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void takeWhile1() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTakeWhileTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -29,6 +29,9 @@ import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableTakeWhileTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void takeWhile1() {
@@ -100,6 +103,7 @@ public class ObservableTakeWhileTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void takeWhileDoesntLeakErrors() {
         Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -40,6 +40,10 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     @Test
     public void timeoutSelectorNormal1() {
         PublishSubject<Integer> source = PublishSubject.create();
@@ -493,6 +497,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void badSourceTimeout() {
         new Observable<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -40,9 +40,6 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void timeoutSelectorNormal1() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Observable;
@@ -36,9 +36,6 @@ import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableWindowWithObservableTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void windowViaObservableNormal1() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Observable;
@@ -36,6 +36,9 @@ import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableWindowWithObservableTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void windowViaObservableNormal1() {
@@ -586,6 +589,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void disposeMainBoundaryErrorRace() {
         final TestException ex = new TestException();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -37,9 +37,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -33,9 +33,12 @@ import io.reactivex.rxjava3.observers.*;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.reactivex.rxjava3.subjects.*;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
@@ -290,6 +293,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void endError() {
         PublishSubject<Integer> source = PublishSubject.create();
         PublishSubject<Integer> start = PublishSubject.create();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -19,21 +19,24 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.rxjava3.disposables.Disposable;
 import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.observers.*;
 import io.reactivex.rxjava3.schedulers.*;
 import io.reactivex.rxjava3.subjects.*;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableWindowWithTimeTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
@@ -368,6 +371,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void exactOnError() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -383,6 +387,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void overlappingOnError() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -398,6 +403,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void skipOnError() {
         TestScheduler scheduler = new TestScheduler();
 
@@ -434,6 +440,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void exactBoundaryError() {
         Observable.error(new TestException())
         .window(1, TimeUnit.DAYS, Schedulers.single(), 2, true)
@@ -751,6 +758,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void exactTimeBoundNoInterruptWindowOutputOnError() throws Exception {
         final AtomicBoolean isInterrupted = new AtomicBoolean();
 
@@ -831,6 +839,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void exactTimeAndSizeBoundNoInterruptWindowOutputOnError() throws Exception {
         final AtomicBoolean isInterrupted = new AtomicBoolean();
 
@@ -911,6 +920,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void skipTimeAndSizeBoundNoInterruptWindowOutputOnError() throws Exception {
         final AtomicBoolean isInterrupted = new AtomicBoolean();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -35,9 +35,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableWindowWithTimeTest extends RxJavaTest {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     private TestScheduler scheduler;
     private Scheduler.Worker innerScheduler;
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleCreateTest.java
@@ -18,18 +18,22 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.Cancellable;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class SingleCreateTest extends RxJavaTest {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     @Test
+    @SuppressUndeliverable
     public void basic() {
         final Disposable d = Disposable.empty();
 
@@ -51,6 +55,7 @@ public class SingleCreateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void basicWithCancellable() {
         final Disposable d1 = Disposable.empty();
         final Disposable d2 = Disposable.empty();
@@ -80,6 +85,7 @@ public class SingleCreateTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void basicWithError() {
         final Disposable d = Disposable.empty();
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleCreateTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -28,9 +28,6 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class SingleCreateTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     @SuppressUndeliverable

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleUsingTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -30,9 +30,6 @@ import io.reactivex.rxjava3.processors.PublishProcessor;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class SingleUsingTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     Function<Disposable, Single<Integer>> mapper = new Function<Disposable, Single<Integer>>() {
         @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleUsingTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -30,6 +30,9 @@ import io.reactivex.rxjava3.processors.PublishProcessor;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class SingleUsingTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     Function<Disposable, Single<Integer>> mapper = new Function<Disposable, Single<Integer>>() {
         @Override
@@ -293,6 +296,7 @@ public class SingleUsingTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void errorDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp = PublishProcessor.create();

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
@@ -17,15 +17,20 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.RxJavaTest;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.internal.schedulers.ExecutorScheduler.DelayedRunnable;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class ExecutorSchedulerDelayedRunnableTest extends RxJavaTest {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     @Test(expected = TestException.class)
+    @SuppressUndeliverable
     public void delayedRunnableCrash() {
         DelayedRunnable dl = new DelayedRunnable(new Runnable() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
@@ -17,17 +17,14 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.RxJavaTest;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.internal.schedulers.ExecutorScheduler.DelayedRunnable;
-import io.reactivex.rxjava3.testsupport.*;
+import io.reactivex.rxjava3.testsupport.SuppressUndeliverable;
 
 public class ExecutorSchedulerDelayedRunnableTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test(expected = TestException.class)
     @SuppressUndeliverable

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/SingleSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/SingleSchedulerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.concurrent.*;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
@@ -30,9 +30,6 @@ import io.reactivex.rxjava3.schedulers.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class SingleSchedulerTest extends AbstractSchedulerTests {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     @SuppressUndeliverable

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/SingleSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/SingleSchedulerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.concurrent.*;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
@@ -27,11 +27,15 @@ import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.internal.schedulers.SingleScheduler.ScheduledWorker;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.*;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class SingleSchedulerTest extends AbstractSchedulerTests {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     @Test
+    @SuppressUndeliverable
     public void shutdownRejects() {
         final int[] calls = { 0 };
 

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/TrampolineSchedulerInternalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/TrampolineSchedulerInternalTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
@@ -34,9 +34,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class TrampolineSchedulerInternalTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     @SuppressUndeliverable

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/TrampolineSchedulerInternalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/TrampolineSchedulerInternalTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
@@ -31,11 +31,15 @@ import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.internal.schedulers.TrampolineScheduler.*;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class TrampolineSchedulerInternalTest extends RxJavaTest {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     @Test
+    @SuppressUndeliverable
     public void scheduleDirectInterrupt() {
         Thread.currentThread().interrupt();
 
@@ -147,6 +151,7 @@ public class TrampolineSchedulerInternalTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void reentrantScheduleInterrupt() {
         final Worker w = Schedulers.trampoline().createWorker();
         try {

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/BoundedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/BoundedSubscriberTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -30,9 +30,6 @@ import io.reactivex.rxjava3.processors.PublishProcessor;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class BoundedSubscriberTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void onSubscribeThrows() {

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/BoundedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/BoundedSubscriberTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -27,9 +27,12 @@ import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.processors.PublishProcessor;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class BoundedSubscriberTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void onSubscribeThrows() {
@@ -315,6 +318,7 @@ public class BoundedSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void badSourceEmitAfterDone() {
         Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/FutureSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/FutureSubscriberTest.java
@@ -30,9 +30,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class FutureSubscriberTest extends RxJavaTest {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     FutureSubscriber<Integer> fs;
 
     @Before

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/FutureSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/FutureSubscriberTest.java
@@ -26,9 +26,12 @@ import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class FutureSubscriberTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     FutureSubscriber<Integer> fs;
 
@@ -155,6 +158,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FutureSubscriber<Integer> fs = new FutureSubscriber<>();
@@ -180,6 +184,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onCompleteCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FutureSubscriber<Integer> fs = new FutureSubscriber<>();
@@ -211,6 +216,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorOnComplete() throws Exception {
         fs.onError(new TestException("One"));
         fs.onComplete();
@@ -224,6 +230,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onCompleteOnError() throws Exception {
         fs.onComplete();
         fs.onError(new TestException("One"));
@@ -236,6 +243,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void cancelOnError() throws Exception {
         fs.cancel(true);
         fs.onError(new TestException("One"));
@@ -249,6 +257,7 @@ public class FutureSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void cancelOnComplete() throws Exception {
         fs.cancel(true);
         fs.onComplete();

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/LambdaSubscriberTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
-import org.junit.*;
+import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -31,9 +31,6 @@ import io.reactivex.rxjava3.processors.PublishProcessor;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class LambdaSubscriberTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void onSubscribeThrows() {

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/LambdaSubscriberTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
-import org.junit.Test;
+import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -28,9 +28,12 @@ import io.reactivex.rxjava3.internal.operators.flowable.FlowableInternalHelper;
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.processors.PublishProcessor;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class LambdaSubscriberTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void onSubscribeThrows() {
@@ -246,6 +249,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void badSourceEmitAfterDone() {
         Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerObserverTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -26,6 +26,9 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class HalfSerializerObserverTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -160,6 +163,7 @@ public class HalfSerializerObserverTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void reentrantErrorOnError() {
         final AtomicInteger wip = new AtomicInteger();
@@ -234,6 +238,7 @@ public class HalfSerializerObserverTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorOnCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerObserverTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -26,9 +26,6 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class HalfSerializerObserverTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerSubscriberTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -27,6 +27,9 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class HalfSerializerSubscriberTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void utilityClass() {
@@ -166,6 +169,7 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void reentrantErrorOnError() {
         final AtomicInteger wip = new AtomicInteger();
@@ -240,6 +244,7 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorOnCompleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/util/HalfSerializerSubscriberTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -27,9 +27,6 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class HalfSerializerSubscriberTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void utilityClass() {

--- a/src/test/java/io/reactivex/rxjava3/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SafeObserverTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -27,9 +27,6 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class SafeObserverTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void onNextFailure() {

--- a/src/test/java/io/reactivex/rxjava3/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SafeObserverTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.*;
@@ -27,6 +27,9 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class SafeObserverTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void onNextFailure() {
@@ -221,6 +224,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onNextAfterComplete() {
         TestObserver<Integer> to = new TestObserver<>();
 

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -33,9 +33,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class SerializedObserverTest extends RxJavaTest {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     Observer<String> observer;
 
     @Before

--- a/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/SerializedObserverTest.java
@@ -33,6 +33,9 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class SerializedObserverTest extends RxJavaTest {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     Observer<String> observer;
 
     @Before
@@ -1144,6 +1147,7 @@ public class SerializedObserverTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorQueuedUp() {
         AtomicReference<SerializedObserver<Integer>> soRef = new AtomicReference<>();
         TestObserverEx<Integer> to = new TestObserverEx<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelPeekTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelPeekTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.*;
+import org.junit.Test;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.rxjava3.core.*;
@@ -29,9 +29,6 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class ParallelPeekTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void subscriberCount() {

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelPeekTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelPeekTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.*;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.rxjava3.core.*;
@@ -26,9 +26,12 @@ import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class ParallelPeekTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Test
     public void subscriberCount() {
@@ -37,6 +40,7 @@ public class ParallelPeekTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onSubscribeCrash() {
         Flowable.range(1, 5)
         .parallel()
@@ -125,6 +129,7 @@ public class ParallelPeekTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onCompleteCrash() {
         Flowable.just(1)
         .parallel()

--- a/src/test/java/io/reactivex/rxjava3/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/AsyncProcessorTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.*;
 import org.reactivestreams.Subscriber;
 
@@ -32,6 +32,9 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     private final Throwable testException = new Throwable();
 
@@ -112,6 +115,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error() {
         AsyncProcessor<String> processor = AsyncProcessor.create();
 
@@ -424,6 +428,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorCancelRace() {
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -481,6 +486,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorCrossCancel() {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava3/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/AsyncProcessorTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.*;
 import org.reactivestreams.Subscriber;
 
@@ -32,9 +32,6 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     private final Throwable testException = new Throwable();
 

--- a/src/test/java/io/reactivex/rxjava3/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/PublishProcessorTest.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.*;
 import org.reactivestreams.*;
 
@@ -33,9 +33,6 @@ import io.reactivex.rxjava3.subscribers.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class PublishProcessorTest extends FlowableProcessorTest<Object> {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected FlowableProcessor<Object> create() {

--- a/src/test/java/io/reactivex/rxjava3/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/PublishProcessorTest.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.*;
 import org.reactivestreams.*;
 
@@ -30,9 +30,12 @@ import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subscribers.*;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class PublishProcessorTest extends FlowableProcessorTest<Object> {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected FlowableProcessor<Object> create() {
@@ -40,6 +43,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void completed() {
         PublishProcessor<String> processor = PublishProcessor.create();
 
@@ -113,6 +117,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error() {
         PublishProcessor<String> processor = PublishProcessor.create();
 
@@ -434,6 +439,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void crossCancelOnError() {
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
         TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorTest.java
@@ -39,9 +39,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     private final Throwable testException = new Throwable();
 
     @Override

--- a/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorTest.java
@@ -39,6 +39,9 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     private final Throwable testException = new Throwable();
 
     @Override
@@ -47,6 +50,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void completed() {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 
@@ -71,6 +75,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void completedStopsEmittingData() {
         ReplayProcessor<Integer> channel = ReplayProcessor.create();
         Subscriber<Object> observerA = TestHelper.mockSubscriber();
@@ -140,6 +145,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void completedAfterError() {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 
@@ -170,6 +176,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error() {
         ReplayProcessor<String> processor = ReplayProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava3/schedulers/CachedThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/CachedThreadSchedulerTest.java
@@ -17,15 +17,19 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
 import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.schedulers.IoScheduler;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected Scheduler getScheduler() {
@@ -91,6 +95,7 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
     }
 
     @Test
+    @SuppressUndeliverable
     public void shutdownRejects() {
         final int[] calls = { 0 };
 

--- a/src/test/java/io/reactivex/rxjava3/schedulers/CachedThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/CachedThreadSchedulerTest.java
@@ -17,19 +17,16 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
 import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.schedulers.IoScheduler;
-import io.reactivex.rxjava3.testsupport.*;
+import io.reactivex.rxjava3.testsupport.SuppressUndeliverable;
 
 public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected Scheduler getScheduler() {

--- a/src/test/java/io/reactivex/rxjava3/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/ComputationSchedulerTests.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
@@ -27,12 +27,9 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.schedulers.ComputationScheduler;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
-import io.reactivex.rxjava3.testsupport.*;
+import io.reactivex.rxjava3.testsupport.SuppressUndeliverable;
 
 public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected Scheduler getScheduler() {

--- a/src/test/java/io/reactivex/rxjava3/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/ComputationSchedulerTests.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
@@ -27,8 +27,12 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.schedulers.ComputationScheduler;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected Scheduler getScheduler() {
@@ -161,6 +165,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     }
 
     @Test
+    @SuppressUndeliverable
     public void shutdownRejects() {
         final int[] calls = { 0 };
 
@@ -285,6 +290,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     }
 
     @Test
+    @SuppressUndeliverable
     public void periodicTaskShouldStopOnError() throws Exception {
         AtomicInteger repeatCount = new AtomicInteger();
 
@@ -302,6 +308,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     }
 
     @Test
+    @SuppressUndeliverable
     public void periodicTaskShouldStopOnError2() throws Exception {
         AtomicInteger repeatCount = new AtomicInteger();
 

--- a/src/test/java/io/reactivex/rxjava3/schedulers/NewThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/NewThreadSchedulerTest.java
@@ -17,18 +17,15 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.*;
+import org.junit.Test;
 
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
 import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.internal.schedulers.NewThreadWorker;
-import io.reactivex.rxjava3.testsupport.*;
+import io.reactivex.rxjava3.testsupport.SuppressUndeliverable;
 
 public class NewThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected Scheduler getScheduler() {

--- a/src/test/java/io/reactivex/rxjava3/schedulers/NewThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/NewThreadSchedulerTest.java
@@ -17,14 +17,18 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
 import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.internal.schedulers.NewThreadWorker;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class NewThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected Scheduler getScheduler() {
@@ -37,6 +41,7 @@ public class NewThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
     }
 
     @Test
+    @SuppressUndeliverable
     public void shutdownRejects() {
         final int[] calls = { 0 };
 
@@ -75,6 +80,7 @@ public class NewThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
      * @throws Exception on error
      */
     @Test
+    @SuppressUndeliverable
     public void npeRegression() throws Exception {
         Scheduler s = getScheduler();
         NewThreadWorker w = (NewThreadWorker) s.createWorker();

--- a/src/test/java/io/reactivex/rxjava3/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/AsyncSubjectTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.*;
 
 import io.reactivex.rxjava3.core.Observer;
@@ -32,9 +32,6 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class AsyncSubjectTest extends SubjectTest<Integer> {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     private final Throwable testException = new Throwable();
 

--- a/src/test/java/io/reactivex/rxjava3/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/AsyncSubjectTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.*;
 
 import io.reactivex.rxjava3.core.Observer;
@@ -32,6 +32,9 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class AsyncSubjectTest extends SubjectTest<Integer> {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     private final Throwable testException = new Throwable();
 
@@ -112,6 +115,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error() {
         AsyncSubject<String> subject = AsyncSubject.create();
 
@@ -418,6 +422,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorCancelRace() {
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -475,6 +480,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorCrossCancel() {
         AsyncSubject<Object> p = AsyncSubject.create();
 

--- a/src/test/java/io/reactivex/rxjava3/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/PublishSubjectTest.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -32,9 +32,6 @@ import io.reactivex.rxjava3.observers.*;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class PublishSubjectTest extends SubjectTest<Integer> {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected Subject<Integer> create() {

--- a/src/test/java/io/reactivex/rxjava3/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/PublishSubjectTest.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.*;
 
 import io.reactivex.rxjava3.core.*;
@@ -29,9 +29,12 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.observers.*;
-import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class PublishSubjectTest extends SubjectTest<Integer> {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     @Override
     protected Subject<Integer> create() {
@@ -39,6 +42,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void completed() {
         PublishSubject<String> subject = PublishSubject.create();
 
@@ -112,6 +116,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error() {
         PublishSubject<String> subject = PublishSubject.create();
 
@@ -414,6 +419,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void crossCancelOnError() {
         final TestObserver<Integer> to1 = new TestObserver<>();
         TestObserver<Integer> to2 = new TestObserver<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectTest.java
@@ -36,9 +36,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ReplaySubjectTest extends SubjectTest<Integer> {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     private final Throwable testException = new Throwable();
 
     @Override

--- a/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/ReplaySubjectTest.java
@@ -36,6 +36,9 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class ReplaySubjectTest extends SubjectTest<Integer> {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     private final Throwable testException = new Throwable();
 
     @Override
@@ -44,6 +47,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void completed() {
         ReplaySubject<String> subject = ReplaySubject.create();
 
@@ -68,6 +72,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void completedStopsEmittingData() {
         ReplaySubject<Integer> channel = ReplaySubject.create();
         Observer<Object> observerA = TestHelper.mockObserver();
@@ -137,6 +142,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void completedAfterError() {
         ReplaySubject<String> subject = ReplaySubject.create();
 
@@ -167,6 +173,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
+    @SuppressUndeliverable
     public void error() {
         ReplaySubject<String> subject = ReplaySubject.create();
 

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SafeSubscriberTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
 
@@ -31,6 +31,9 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class SafeSubscriberTest extends RxJavaTest {
+
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     /**
      * Ensure onNext can not be called after onError.
@@ -98,6 +101,7 @@ public class SafeSubscriberTest extends RxJavaTest {
      * Ensure onError can not be called after onComplete.
      */
     @Test
+    @SuppressUndeliverable
     public void onErrorAfterOnCompleted() {
         TestObservable t = new TestObservable();
         Flowable<String> st = Flowable.unsafeCreate(t);
@@ -364,6 +368,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onNextAfterComplete() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SafeSubscriberTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.*;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.*;
 
@@ -31,9 +31,6 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.testsupport.*;
 
 public class SafeSubscriberTest extends RxJavaTest {
-
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
 
     /**
      * Ensure onNext can not be called after onError.

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
@@ -34,9 +34,6 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class SerializedSubscriberTest extends RxJavaTest {
 
-    @Rule
-    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
-
     Subscriber<String> subscriber;
 
     @Before

--- a/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/SerializedSubscriberTest.java
@@ -34,6 +34,9 @@ import io.reactivex.rxjava3.testsupport.*;
 
 public class SerializedSubscriberTest extends RxJavaTest {
 
+    @Rule
+    public final SuppressUndeliverableRule suppressUndeliverableRule = new SuppressUndeliverableRule();
+
     Subscriber<String> subscriber;
 
     @Before
@@ -1136,6 +1139,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    @SuppressUndeliverable
     public void onErrorQueuedUp() {
         AtomicReference<SerializedSubscriber<Integer>> ssRef = new AtomicReference<>();
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {

--- a/src/test/java/io/reactivex/rxjava3/testsupport/SuppressUndeliverable.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/SuppressUndeliverable.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.rxjava3.testsupport;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SuppressUndeliverable {
+}

--- a/src/test/java/io/reactivex/rxjava3/testsupport/SuppressUndeliverableRule.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/SuppressUndeliverableRule.java
@@ -20,7 +20,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import io.reactivex.rxjava3.exceptions.UndeliverableException;
-import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
@@ -38,12 +37,11 @@ public class SuppressUndeliverableRule implements TestRule {
                 @Override
                 public void evaluate() throws Throwable {
                     try {
-                        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-                            @Override
-                            public void accept(Throwable throwable) throws Throwable {
-                                if (!(throwable instanceof UndeliverableException)) {
-                                    RxJavaPlugins.getDefaultErrorHandler().accept(throwable);
-                                }
+                        RxJavaPlugins.setErrorHandler(throwable -> {
+                            if (!(throwable instanceof UndeliverableException)) {
+                                throwable.printStackTrace();
+                                Thread currentThread = Thread.currentThread();
+                                currentThread.getUncaughtExceptionHandler().uncaughtException(currentThread, throwable);
                             }
                         });
                         base.evaluate();

--- a/src/test/java/io/reactivex/rxjava3/testsupport/SuppressUndeliverableRule.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/SuppressUndeliverableRule.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.rxjava3.testsupport;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import io.reactivex.rxjava3.exceptions.UndeliverableException;
+import io.reactivex.rxjava3.functions.Consumer;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * A rule for suppressing UndeliverableException handling.
+ *
+ * <p>Test classes that use this rule can suppress UndeliverableException
+ * handling by annotating the test method with SuppressUndeliverable.
+ */
+public class SuppressUndeliverableRule implements TestRule {
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        if (description.getAnnotation(SuppressUndeliverable.class) != null) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    try {
+                        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable throwable) throws Throwable {
+                                if (!(throwable instanceof UndeliverableException)) {
+                                    RxJavaPlugins.getDefaultErrorHandler().accept(throwable);
+                                }
+                            }
+                        });
+                        base.evaluate();
+                    } finally {
+                        RxJavaPlugins.setErrorHandler(null);
+                    }
+                }
+            };
+        } else {
+            return base;
+        }
+    }
+}


### PR DESCRIPTION
I used a JUnit TestRule to suppress handling of UndeliverableException for test methods annotated with @SuppressUndeliverable. This approach is coarser than the suggested approach (it suppresses the handling of all UndeliverableExceptions for the entire annotated test method).
I thought this approach was clean but I can switch to the suggested approach if preferred.

I added @SuppressUndeliverable to most tests that were logging UndeliverableExceptions with the test method in the stack trace. This may be more suppression than was required so just let me know.

Fixes #6987 