### PR TITLE
3.x: Allow MBE in FlowableGroupByTest.issue6974RunPart2NoEvict

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -2667,19 +2667,17 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     static void issue6974RunPart2NoEvict(int groupByBufferSize, int flatMapMaxConcurrency, int groups,
             boolean notifyOnExplicitEviction) {
-        TestSubscriber<Integer> ts = Flowable
+    	
+        Flowable
         .range(1, 500_000)
         .map(i -> i % groups)
         .groupBy(i -> i)
         .flatMap(gf -> gf
                 .take(10, TimeUnit.MILLISECONDS)
                 , flatMapMaxConcurrency)
-        .test();
-
-        ts
+        .subscribeWith(new TestSubscriberEx<>())
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertNoErrors()
-        .assertComplete();
+        .assertTerminated(); // MBE is possible if the async group closing is slow
     }
 
     @Test


### PR DESCRIPTION
Issue #7001
https://github.com/ReactiveX/RxJava/blob/98acac218cdb04d279b5ac49bb1afc65bc6ec4fe/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java#L2668-L2669

The above test can probabilistically throw an exception, thus:

https://github.com/ReactiveX/RxJava/blob/98acac218cdb04d279b5ac49bb1afc65bc6ec4fe/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java#L2681

The above assertion would be invalid. I have removed the invalid assertion.

Fixes #7001