### PR TITLE
3.x: Fix Observable.window (size, skip, overlap) dispose behavior

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
@@ -720,5 +721,95 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         .doOnNext(w -> w.test())
         .test(3)
         .cancel();
+    }
+
+    @Test
+    public void cancelWithoutWindowSize() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Flowable<Integer>> ts = pp.window(10)
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse("Subject still has subscribers!", pp.hasSubscribers());
+    }
+
+    @Test
+    public void cancelAfterAbandonmentSize() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Flowable<Integer>> ts = pp.window(10)
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onNext(1);
+
+        ts.cancel();
+
+        assertFalse("Subject still has subscribers!", pp.hasSubscribers());
+    }
+
+    @Test
+    public void cancelWithoutWindowSkip() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Flowable<Integer>> ts = pp.window(10, 15)
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse("Subject still has subscribers!", pp.hasSubscribers());
+    }
+
+    @Test
+    public void cancelAfterAbandonmentSkip() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Flowable<Integer>> ts = pp.window(10, 15)
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onNext(1);
+
+        ts.cancel();
+
+        assertFalse("Subject still has subscribers!", pp.hasSubscribers());
+    }
+
+    @Test
+    public void cancelWithoutWindowOverlap() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Flowable<Integer>> ts = pp.window(10, 5)
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        ts.cancel();
+
+        assertFalse("Subject still has subscribers!", pp.hasSubscribers());
+    }
+
+    @Test
+    public void cancelAfterAbandonmentOverlap() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+
+        TestSubscriber<Flowable<Integer>> ts = pp.window(10, 5)
+        .test();
+
+        assertTrue(pp.hasSubscribers());
+
+        pp.onNext(1);
+
+        ts.cancel();
+
+        assertFalse("Subject still has subscribers!", pp.hasSubscribers());
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -535,4 +535,94 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
 
         inner.get().test().assertResult(1);
     }
+
+    @Test
+    public void cancelWithoutWindowSize() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Observable<Integer>> to = ps.window(10)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Subject still has observers!", ps.hasObservers());
+    }
+
+    @Test
+    public void cancelAfterAbandonmentSize() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Observable<Integer>> to = ps.window(10)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        to.dispose();
+
+        assertFalse("Subject still has observers!", ps.hasObservers());
+    }
+
+    @Test
+    public void cancelWithoutWindowSkip() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Observable<Integer>> to = ps.window(10, 15)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Subject still has observers!", ps.hasObservers());
+    }
+
+    @Test
+    public void cancelAfterAbandonmentSkip() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Observable<Integer>> to = ps.window(10, 15)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        to.dispose();
+
+        assertFalse("Subject still has observers!", ps.hasObservers());
+    }
+
+    @Test
+    public void cancelWithoutWindowOverlap() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Observable<Integer>> to = ps.window(10, 5)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        to.dispose();
+
+        assertFalse("Subject still has observers!", ps.hasObservers());
+    }
+
+    @Test
+    public void cancelAfterAbandonmentOverlap() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestObserver<Observable<Integer>> to = ps.window(10, 5)
+        .test();
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        to.dispose();
+
+        assertFalse("Subject still has observers!", ps.hasObservers());
+    }
 }


### PR DESCRIPTION
Disposing the main output of the `Observable.window` operator did not properly propagate the dispose call under certain circumstances, such as no current active window or the window(s) were abandoned immediately.

Fixes #7048