### PR TITLE
3.x: Update marbles of onErrorResume(Next|With) + cleanup

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -12770,7 +12770,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * Resumes the flow with the given {@link Publisher} when the current {@code Flowable} fails instead of
      * signaling the error via {@code onError}.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.v3.png" alt="">
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeWith.v3.png" alt="">
      * <p>
      * By default, when a {@code Publisher} encounters an error that prevents it from emitting the expected item to
      * its {@link Subscriber}, the {@code Publisher} invokes its {@code Subscriber}'s {@code onError} method, and then quits

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -10691,7 +10691,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * Resumes the flow with the given {@link ObservableSource} when the current {@code Observable} fails instead of
      * signaling the error via {@code onError}.
      * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.v3.png" alt="">
+     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeWith.v3.png" alt="">
      * <p>
      * By default, when an {@code ObservableSource} encounters an error that prevents it from emitting the expected item to
      * its {@link Observer}, the {@code ObservableSource} invokes its {@code Observer}'s {@code onError} method, and then quits

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupByTest.java
@@ -2667,7 +2667,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     static void issue6974RunPart2NoEvict(int groupByBufferSize, int flatMapMaxConcurrency, int groups,
             boolean notifyOnExplicitEviction) {
-    	
+
         Flowable
         .range(1, 500_000)
         .map(i -> i % groups)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -79,7 +79,7 @@ public class FlowableGroupJoinTest extends RxJavaTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableJoinTest.java
@@ -55,7 +55,7 @@ public class FlowableJoinTest extends RxJavaTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupJoinTest.java
@@ -81,7 +81,7 @@ public class ObservableGroupJoinTest extends RxJavaTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableJoinTest.java
@@ -54,7 +54,7 @@ public class ObservableJoinTest extends RxJavaTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/testsupport/SuppressUndeliverableRule.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/SuppressUndeliverableRule.java
@@ -30,11 +30,10 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  */
 public class SuppressUndeliverableRule implements TestRule {
 
-    private static class SuppressUndeliverableRuleStatement extends Statement {
+    static final class SuppressUndeliverableRuleStatement extends Statement {
         private Statement base;
 
-        private SuppressUndeliverableRuleStatement(){}
-        public SuppressUndeliverableRuleStatement(Statement base) {
+        SuppressUndeliverableRuleStatement(Statement base) {
             this.base = base;
         }
 


### PR DESCRIPTION
- `onErrorResumeNext` marble now indicates the error and function-callback nature:

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.v3.png)

- `onErrorResumeWith` marble now has the correct name (and retains the original onErrorResumeNext style):

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeWith.v3.png)

- Address now deprecated API usage of Mockito.
- Few other style corrections.

Fixes #7050