### PR TITLE
3.x: Patch out duplicate @NonNull annotation in generated javadocs

### DIFF
--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -30,18 +30,29 @@ def fixJavadocFile(file) {
     fileContents = fileContents.replaceAll("@Nullable</a>\\s{4,}", "@Nullable</a> ");
 
     // javadoc bug: duplicates the link to @NonNull for some reason
-    def nonNullText = "<a href=\"../annotations/NonNull.html\" title=\"annotation in io.reactivex.rxjava3.annotations\">@NonNull</a>";
+    def nonNullText1 = "<a href=\"../annotations/NonNull.html\" title=\"annotation in io.reactivex.rxjava3.annotations\">@NonNull</a>";
     
-    fileContents = fileContents.replace(nonNullText + " " + nonNullText, nonNullText);
-    fileContents = fileContents.replace(nonNullText + "\n " + nonNullText, nonNullText);
-    fileContents = fileContents.replace(nonNullText + "\r\n " + nonNullText, nonNullText);
+    fileContents = fileContents.replace(nonNullText1 + " " + nonNullText1, nonNullText1);
+    fileContents = fileContents.replace(nonNullText1 + "\n " + nonNullText1, nonNullText1);
+    fileContents = fileContents.replace(nonNullText1 + "\r\n " + nonNullText1, nonNullText1);
+
+    def nonNullText2 = "<a href=\"../../../../io/reactivex/rxjava3/annotations/NonNull.html\" title=\"annotation in io.reactivex.rxjava3.annotations\">@NonNull</a>";
+    fileContents = fileContents.replace(nonNullText2 + " " + nonNullText2, nonNullText2);
+    fileContents = fileContents.replace(nonNullText2 + "\n " + nonNullText2, nonNullText2);
+    fileContents = fileContents.replace(nonNullText2 + "\r\n " + nonNullText2, nonNullText2);
 
     // javadoc bug: duplicates the link to @Nullable for some reason
-    def nullableText = "<a href=\"../annotations/Nullable.html\" title=\"annotation in io.reactivex.rxjava3.annotations\">@Nullable</a>";
+    def nullableText1 = "<a href=\"../annotations/Nullable.html\" title=\"annotation in io.reactivex.rxjava3.annotations\">@Nullable</a>";
     
-    fileContents = fileContents.replace(nullableText + " " + nullableText, nullableText);
-    fileContents = fileContents.replace(nullableText + "\n " + nullableText, nullableText);
-    fileContents = fileContents.replace(nullableText + "\r\n " + nullableText, nullableText);
+    fileContents = fileContents.replace(nullableText1 + " " + nullableText1, nullableText1);
+    fileContents = fileContents.replace(nullableText1 + "\n " + nullableText1, nullableText1);
+    fileContents = fileContents.replace(nullableText1 + "\r\n " + nullableText1, nullableText1);
+
+    def nullableText2 = "<a href=\"../../../../io/reactivex/rxjava3/annotations/Nullable.html\" title=\"annotation in io.reactivex.rxjava3.annotations\">@Nullable</a>";
+    
+    fileContents = fileContents.replace(nullableText2 + " " + nullableText2, nullableText2);
+    fileContents = fileContents.replace(nullableText2 + "\n " + nullableText2, nullableText2);
+    fileContents = fileContents.replace(nullableText2 + "\r\n " + nullableText2, nullableText2);
 
     file.setText(fileContents, 'UTF-8');
 }

--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -29,6 +29,20 @@ def fixJavadocFile(file) {
     // lots of spaces after the @Nullable annotations
     fileContents = fileContents.replaceAll("@Nullable</a>\\s{4,}", "@Nullable</a> ");
 
+    // javadoc bug: duplicates the link to @NonNull for some reason
+    def nonNullText = "<a href=\"../annotations/NonNull.html\" title=\"annotation in io.reactivex.rxjava3.annotations\">@NonNull</a>";
+    
+    fileContents = fileContents.replace(nonNullText + " " + nonNullText, nonNullText);
+    fileContents = fileContents.replace(nonNullText + "\n " + nonNullText, nonNullText);
+    fileContents = fileContents.replace(nonNullText + "\r\n " + nonNullText, nonNullText);
+
+    // javadoc bug: duplicates the link to @Nullable for some reason
+    def nullableText = "<a href=\"../annotations/Nullable.html\" title=\"annotation in io.reactivex.rxjava3.annotations\">@Nullable</a>";
+    
+    fileContents = fileContents.replace(nullableText + " " + nullableText, nullableText);
+    fileContents = fileContents.replace(nullableText + "\n " + nullableText, nullableText);
+    fileContents = fileContents.replace(nullableText + "\r\n " + nullableText, nullableText);
+
     file.setText(fileContents, 'UTF-8');
 }
 


### PR DESCRIPTION
There is a long-standing bug in either javac or javadocs that results in certain annotations to be put into the HTML twice:

![image](https://user-images.githubusercontent.com/1269832/92935641-568b9680-f449-11ea-9f2b-75264f641292.png)

https://bugs.openjdk.java.net/browse/JDK-8175533

Looks like it happens with certain `@Documented` annotations, but not others. The issue persists up to JDK 16 preview.

This PR adds a workaround to the existing HTML patching gradle task which removes such duplicates:

![image](https://user-images.githubusercontent.com/1269832/92936752-c8b0ab00-f44a-11ea-9069-e454cd4d7740.png)

*Sidenote: yes, the method return also duplicates `@NonNull`, but that's across HTML elements and is much harder to fix.*