### PR TITLE
Change a method name to make consistent with PR#6801

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipIterable.java
@@ -112,7 +112,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
                 u = Objects.requireNonNull(iterator.next(), "The iterator returned a null value");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                error(e);
+                fail(e);
                 return;
             }
 
@@ -121,7 +121,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
                 v = Objects.requireNonNull(zipper.apply(t, u), "The zipper function returned a null value");
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                error(e);
+                fail(e);
                 return;
             }
 
@@ -133,7 +133,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
                 b = iterator.hasNext();
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                error(e);
+                fail(e);
                 return;
             }
 
@@ -144,7 +144,7 @@ public final class ObservableZipIterable<T, U, V> extends Observable<V> {
             }
         }
 
-        void error(Throwable e) {
+        void fail(Throwable e) {
             done = true;
             upstream.dispose();
             downstream.onError(e);


### PR DESCRIPTION
Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [x] Please give a description about what and why you are contributing, even if it's trivial.

In #6801, a method name, `FlowableZipIterable#error` is changed to `fail`, but its similar class, `ObservableZipIterable` was not changed.
I changed it for consistency.

  - [x] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

This PR is related to #6801

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.

This change will not affect external behavior.
