### PR TITLE
3.x: Fix toFlowable(ERROR) not cancelling on MBE

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureError.java
@@ -65,6 +65,7 @@ public final class FlowableOnBackpressureError<T> extends AbstractFlowableWithUp
                 downstream.onNext(t);
                 BackpressureHelper.produced(this, 1);
             } else {
+                upstream.cancel();
                 onError(new MissingBackpressureException("could not emit value due to lack of requests"));
             }
         }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureErrorTest.java
@@ -13,11 +13,16 @@
 
 package io.reactivex.rxjava3.internal.operators.flowable;
 
+import static org.junit.Assert.*;
+
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
 import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.subjects.PublishSubject;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class FlowableOnBackpressureErrorTest extends RxJavaTest {
@@ -50,5 +55,21 @@ public class FlowableOnBackpressureErrorTest extends RxJavaTest {
                 return new FlowableOnBackpressureError<>(f);
             }
         }, false, 1, 1, 1);
+    }
+
+    @Test
+    public void overflowCancels() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestSubscriber<Integer> ts = ps.toFlowable(BackpressureStrategy.ERROR)
+        .test(0L);
+
+        assertTrue(ps.hasObservers());
+
+        ps.onNext(1);
+
+        assertFalse(ps.hasObservers());
+
+        ts.assertFailure(MissingBackpressureException.class);
     }
 }


### PR DESCRIPTION
There was a missing `upstream.cancel()` for when the overflow happens.

Fixes #7081