### PR TITLE
3.x: Fix Flowable.concatMap backpressure w/ scalars

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
@@ -345,7 +345,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                                 continue;
                             } else {
                                 active = true;
-                                inner.setSubscription(new WeakScalarSubscription<>(vr, inner));
+                                inner.setSubscription(new SimpleScalarSubscription<>(vr, inner));
                             }
 
                         } else {
@@ -528,7 +528,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
                                 continue;
                             } else {
                                 active = true;
-                                inner.setSubscription(new WeakScalarSubscription<>(vr, inner));
+                                inner.setSubscription(new SimpleScalarSubscription<>(vr, inner));
                             }
                         } else {
                             active = true;

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapTest.java
@@ -24,8 +24,8 @@ import org.reactivestreams.Publisher;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
-import io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMap.WeakScalarSubscription;
-import io.reactivex.rxjava3.processors.UnicastProcessor;
+import io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMap.SimpleScalarSubscription;
+import io.reactivex.rxjava3.processors.*;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.TestHelper;
@@ -33,9 +33,9 @@ import io.reactivex.rxjava3.testsupport.TestHelper;
 public class FlowableConcatMapTest extends RxJavaTest {
 
     @Test
-    public void weakSubscriptionRequest() {
+    public void simpleSubscriptionRequest() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(0);
-        WeakScalarSubscription<Integer> ws = new WeakScalarSubscription<>(1, ts);
+        SimpleScalarSubscription<Integer> ws = new SimpleScalarSubscription<>(1, ts);
         ts.onSubscribe(ws);
 
         ws.request(0);
@@ -77,6 +77,56 @@ public class FlowableConcatMapTest extends RxJavaTest {
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult("RxSingleScheduler");
+    }
+
+    @Test
+    public void innerScalarRequestRace() {
+        Flowable<Integer> just = Flowable.just(1);
+        int n = 1000;
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            PublishProcessor<Flowable<Integer>> source = PublishProcessor.create();
+
+            TestSubscriber<Integer> ts = source
+                    .concatMap(v -> v, n + 1)
+                    .test(1L);
+
+            TestHelper.race(() -> {
+                for (int j = 0; j < n; j++) {
+                    source.onNext(just);
+                }
+            }, () -> {
+                for (int j = 0; j < n; j++) {
+                    ts.request(1);
+                }
+            });
+
+            ts.assertValueCount(n);
+        }
+    }
+
+    @Test
+    public void innerScalarRequestRaceDelayError() {
+        Flowable<Integer> just = Flowable.just(1);
+        int n = 1000;
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            PublishProcessor<Flowable<Integer>> source = PublishProcessor.create();
+
+            TestSubscriber<Integer> ts = source
+                    .concatMapDelayError(v -> v, true, n + 1)
+                    .test(1L);
+
+            TestHelper.race(() -> {
+                for (int j = 0; j < n; j++) {
+                    source.onNext(just);
+                }
+            }, () -> {
+                for (int j = 0; j < n; j++) {
+                    ts.request(1);
+                }
+            });
+
+            ts.assertValueCount(n);
+        }
     }
 
     @Test


### PR DESCRIPTION
In `concatMap`, there is a shortcut for when the mapped `Flowable` turns out to be a scalar value and thus the full subscription process can be skipped. This used a so-called weak subscription that expected non-concurrent requesting to emits its single value.

Unfortunately, there is a race condition for when the downstream requests exactly when this weak subscription is activated, resulting in either double emission or no emission at all. The fix is to do the proper `compareAndSet` to ensure the emission happens exactly once.

Discovered while running the build matrix and a test failed with:

```
io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMapSchedulerTest > boundaryFusionDelayError FAILED
    java.lang.AssertionError: Error(s) present: [io.reactivex.rxjava3.exceptions.MissingBackpressureException: Queue is full?!] (latch = 0, values = 1, errors = 1, completions = 0)
        at io.reactivex.rxjava3.observers.BaseTestConsumer.fail(BaseTestConsumer.java:125)
        at io.reactivex.rxjava3.observers.BaseTestConsumer.assertNoErrors(BaseTestConsumer.java:212)
        at io.reactivex.rxjava3.observers.BaseTestConsumer.assertResult(BaseTestConsumer.java:525)
        at io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMapSchedulerTest.boundaryFusionDelayError(FlowableConcatMapSchedulerTest.java:94)
        Caused by:
        io.reactivex.rxjava3.exceptions.MissingBackpressureException: Queue is full?!
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableObserveOn$BaseObserveOnSubscriber.onNext(FlowableObserveOn.java:114)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMapScheduler$ConcatMapDelayed.innerNext(FlowableConcatMapScheduler.java:396)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMap$ConcatMapInner.onNext(FlowableConcatMap.java:559)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMap$WeakScalarSubscription.request(FlowableConcatMap.java:343)
            at io.reactivex.rxjava3.internal.subscriptions.SubscriptionArbiter.setSubscription(SubscriptionArbiter.java:99)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMapScheduler$ConcatMapDelayed.run(FlowableConcatMapScheduler.java:531)
            at io.reactivex.rxjava3.internal.schedulers.ImmediateThinScheduler$ImmediateThinWorker.schedule(ImmediateThinScheduler.java:89)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMapScheduler$ConcatMapDelayed.schedule(FlowableConcatMapScheduler.java:431)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMapScheduler$BaseConcatMapSubscriber.onNext(FlowableConcatMapScheduler.java:156)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableMap$MapSubscriber.onNext(FlowableMap.java:69)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableObserveOn$ObserveOnSubscriber.runSync(FlowableObserveOn.java:337)
            at io.reactivex.rxjava3.internal.operators.flowable.FlowableObserveOn$BaseObserveOnSubscriber.run(FlowableObserveOn.java:174)
            at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:65)
            at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:56)
            at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
            at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
            at java.base/java.lang.Thread.run(Thread.java:832)
```