### PR TITLE
2.x: Fix Flowable.concatMap backpressure w/ scalars

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
@@ -109,22 +109,28 @@ public class FlowableConcatMapTest {
 
     @Test
     public void innerScalarRequestRace() {
-        Flowable<Integer> just = Flowable.just(1);
-        int n = 1000;
+        final Flowable<Integer> just = Flowable.just(1);
+        final int n = 1000;
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            PublishProcessor<Flowable<Integer>> source = PublishProcessor.create();
+            final PublishProcessor<Flowable<Integer>> source = PublishProcessor.create();
 
-            TestSubscriber<Integer> ts = source
+            final TestSubscriber<Integer> ts = source
                     .concatMap(Functions.<Flowable<Integer>>identity(), n + 1)
                     .test(1L);
 
-            TestHelper.race(() -> {
-                for (int j = 0; j < n; j++) {
-                    source.onNext(just);
+            TestHelper.race(new Runnable() {
+                @Override
+                public void run() {
+                    for (int j = 0; j < n; j++) {
+                        source.onNext(just);
+                    }
                 }
-            }, () -> {
-                for (int j = 0; j < n; j++) {
-                    ts.request(1);
+            }, new Runnable() {
+                @Override
+                public void run() {
+                    for (int j = 0; j < n; j++) {
+                        ts.request(1);
+                    }
                 }
             });
 
@@ -134,22 +140,28 @@ public class FlowableConcatMapTest {
 
     @Test
     public void innerScalarRequestRaceDelayError() {
-        Flowable<Integer> just = Flowable.just(1);
-        int n = 1000;
+        final Flowable<Integer> just = Flowable.just(1);
+        final int n = 1000;
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            PublishProcessor<Flowable<Integer>> source = PublishProcessor.create();
+            final PublishProcessor<Flowable<Integer>> source = PublishProcessor.create();
 
-            TestSubscriber<Integer> ts = source
+            final TestSubscriber<Integer> ts = source
                     .concatMapDelayError(Functions.<Flowable<Integer>>identity(), n + 1, true)
                     .test(1L);
 
-            TestHelper.race(() -> {
-                for (int j = 0; j < n; j++) {
-                    source.onNext(just);
+            TestHelper.race(new Runnable() {
+                @Override
+                public void run() {
+                    for (int j = 0; j < n; j++) {
+                        source.onNext(just);
+                    }
                 }
-            }, () -> {
-                for (int j = 0; j < n; j++) {
-                    ts.request(1);
+            }, new Runnable() {
+                @Override
+                public void run() {
+                    for (int j = 0; j < n; j++) {
+                        ts.request(1);
+                    }
                 }
             });
 

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableConcatMapTest.java
@@ -24,7 +24,9 @@ import org.reactivestreams.Publisher;
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
-import io.reactivex.internal.operators.flowable.FlowableConcatMap.WeakScalarSubscription;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.operators.flowable.FlowableConcatMap.SimpleScalarSubscription;
+import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -33,7 +35,7 @@ public class FlowableConcatMapTest {
     @Test
     public void weakSubscriptionRequest() {
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0);
-        WeakScalarSubscription<Integer> ws = new WeakScalarSubscription<Integer>(1, ts);
+        SimpleScalarSubscription<Integer> ws = new SimpleScalarSubscription<Integer>(1, ts);
         ts.onSubscribe(ws);
 
         ws.request(0);
@@ -103,6 +105,56 @@ public class FlowableConcatMapTest {
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult("RxSingleScheduler");
+    }
+
+    @Test
+    public void innerScalarRequestRace() {
+        Flowable<Integer> just = Flowable.just(1);
+        int n = 1000;
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            PublishProcessor<Flowable<Integer>> source = PublishProcessor.create();
+
+            TestSubscriber<Integer> ts = source
+                    .concatMap(Functions.<Flowable<Integer>>identity(), n + 1)
+                    .test(1L);
+
+            TestHelper.race(() -> {
+                for (int j = 0; j < n; j++) {
+                    source.onNext(just);
+                }
+            }, () -> {
+                for (int j = 0; j < n; j++) {
+                    ts.request(1);
+                }
+            });
+
+            ts.assertValueCount(n);
+        }
+    }
+
+    @Test
+    public void innerScalarRequestRaceDelayError() {
+        Flowable<Integer> just = Flowable.just(1);
+        int n = 1000;
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            PublishProcessor<Flowable<Integer>> source = PublishProcessor.create();
+
+            TestSubscriber<Integer> ts = source
+                    .concatMapDelayError(Functions.<Flowable<Integer>>identity(), n + 1, true)
+                    .test(1L);
+
+            TestHelper.race(() -> {
+                for (int j = 0; j < n; j++) {
+                    source.onNext(just);
+                }
+            }, () -> {
+                for (int j = 0; j < n; j++) {
+                    ts.request(1);
+                }
+            });
+
+            ts.assertValueCount(n);
+        }
     }
 
     @Test


### PR DESCRIPTION
In `concatMap`, there is a shortcut for when the mapped `Flowable` turns out to be a scalar value and thus the full subscription process can be skipped. This used a so-called weak subscription that expected non-concurrent requesting to emits its single value.

Unfortunately, there is a race condition for when the downstream requests exactly when this weak subscription is activated, resulting in either double emission or no emission at all. The fix is to do the proper `compareAndSet` to ensure the emission happens exactly once.

Backport of #7089