### PR TITLE
Switch to travis-ci.com as the org goes away

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RxJava: Reactive Extensions for the JVM
 
-<a href='https://travis-ci.org/ReactiveX/RxJava/builds'><img src='https://travis-ci.org/ReactiveX/RxJava.svg?branch=3.x'></a>
+<a href='https://travis-ci.com/ReactiveX/RxJava/builds'><img src='https://travis-ci.com/ReactiveX/RxJava.svg?branch=3.x'></a>
 [![codecov.io](http://codecov.io/github/ReactiveX/RxJava/coverage.svg?branch=3.x)](https://codecov.io/gh/ReactiveX/RxJava/branch/3.x)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.reactivex.rxjava3/rxjava/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.reactivex.rxjava3/rxjava)
 


### PR DESCRIPTION
travis-ci.org will go defunct and the backend has been migrated to travis-ci.com. This PR updates the badge links and triggers the first build(s) there.