### PR TITLE
adding the google code formatter plugin which will auto correct the s…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -379,3 +379,8 @@ if (rootProject.hasProperty("releaseMode")) {
 }
 
 apply from: file("gradle/javadoc_cleanup.gradle")
+
+tasks.verifyGoogleJavaFormat.ignoreFailures = true
+googleJavaFormat {
+    toolVersion = '1.1'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
   ext.jfrogExtractorVersion = "4.17.2"
   ext.bndVersion = "5.2.0"
   ext.checkstyleVersion = "8.26"
+  ext.googleJavaFromatterVersion = "0.9"
 
   // --------------------------------------
 
@@ -34,6 +35,7 @@ buildscript {
     classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$bintrayVersion"
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:$jfrogExtractorVersion"
     classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:$bndVersion"
+    classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:$googleJavaFromatterVersion"
   }
 }
 
@@ -65,6 +67,7 @@ apply plugin: "com.github.hierynomus.license"
 apply plugin: "com.jfrog.bintray"
 apply plugin: "com.jfrog.artifactory"
 apply plugin: "eclipse"
+apply plugin: "com.github.sherter.google-java-format"
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
…ome syntax.

example:
private final static int version = 1.0
to
private static final int version = 1.0

No need check the sonar basic code errors by using this plugin.

More info available on:
https://medium.com/@alexprut/integrate-google-java-style-guide-in-a-java-project-567abb6d7987

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
