### PR TITLE
3.x: Fix source locator code to support GitHub Actions folder layout

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -3503,18 +3503,26 @@ public enum TestHelper {
         parentPackage = parentPackage.replace(".", "/");
 //        System.out.println(path);
 
-        int i = path.toLowerCase().indexOf("/rxjava");
-        if (i < 0) {
-            System.out.println("Can't find the base RxJava directory");
-            return null;
+        // Locate the src/main/java directory
+        String p = null;
+        while (true) {
+            int idx = path.lastIndexOf("/");
+            if (idx < 0) {
+                break;
+            }
+            path = path.substring(0, idx);
+            String check = path + "/src/main/java";
+
+            if (new File(check).exists()) {
+                p = check + "/" + parentPackage + "/" + baseClassName + ".java";
+                break;
+            }
         }
 
-        // find end of any potential postfix to /RxJava
-        int j = path.indexOf("/", i + 6);
-
-        String basePackage = path.substring(0, j + 1) + "src/main/java";
-
-        String p = basePackage + "/" + parentPackage + "/" + baseClassName + ".java";
+        if (p == null) {
+            System.err.println("Unable to locate the RxJava sources");
+            return null;
+        }
 
         File f = new File(p);
 


### PR DESCRIPTION
GitHub Action `actions/checkout@v2` downloads the files to a directory that doesn't appear to include the  `rxjava` name anymore and makes the source code tests unable to read the files.

This changes the locator to try for `src/main/java` in each parent directory relative to where the class files are located via `getResource`.

This is a preparation in case we have to bail from Travis CI. They now have a pricing model that in theory would be free for open source projects still but who knows in practice as there are hops apparently to get projects recognized as such.
