### PR TITLE
Add NonNull annotations to parameters which are null checked

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
@@ -368,7 +368,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
 
         if (done) {
@@ -385,7 +385,7 @@ public final class ReplayProcessor<T> extends FlowableProcessor<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
 
         if (done) {

--- a/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
@@ -433,7 +433,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
 
         if (done || cancelled) {
@@ -445,7 +445,7 @@ public final class UnicastProcessor<T> extends FlowableProcessor<T> {
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
 
         if (done || cancelled) {

--- a/src/main/java/io/reactivex/rxjava3/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/AsyncSubject.java
@@ -149,7 +149,7 @@ public final class AsyncSubject<T> extends Subject<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         if (subscribers.get() == TERMINATED) {
             return;
@@ -159,7 +159,7 @@ public final class AsyncSubject<T> extends Subject<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (subscribers.get() == TERMINATED) {
             RxJavaPlugins.onError(t);

--- a/src/main/java/io/reactivex/rxjava3/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/BehaviorSubject.java
@@ -241,7 +241,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
 
         if (terminalEvent.get() != null) {
@@ -255,7 +255,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (!terminalEvent.compareAndSet(null, t)) {
             RxJavaPlugins.onError(t);

--- a/src/main/java/io/reactivex/rxjava3/subjects/CompletableSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/CompletableSubject.java
@@ -118,7 +118,7 @@ public final class CompletableSubject extends Completable implements Completable
     }
 
     @Override
-    public void onError(Throwable e) {
+    public void onError(@NonNull Throwable e) {
         ExceptionHelper.nullCheck(e, "onError called with a null Throwable.");
         if (once.compareAndSet(false, true)) {
             this.error = e;

--- a/src/main/java/io/reactivex/rxjava3/subjects/MaybeSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/MaybeSubject.java
@@ -149,7 +149,7 @@ public final class MaybeSubject<T> extends Maybe<T> implements MaybeObserver<T> 
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onSuccess(T value) {
+    public void onSuccess(@NonNull T value) {
         ExceptionHelper.nullCheck(value, "onSuccess called with a null value.");
         if (once.compareAndSet(false, true)) {
             this.value = value;
@@ -161,7 +161,7 @@ public final class MaybeSubject<T> extends Maybe<T> implements MaybeObserver<T> 
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onError(Throwable e) {
+    public void onError(@NonNull Throwable e) {
         ExceptionHelper.nullCheck(e, "onError called with a null Throwable.");
         if (once.compareAndSet(false, true)) {
             this.error = e;

--- a/src/main/java/io/reactivex/rxjava3/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/PublishSubject.java
@@ -220,7 +220,7 @@ public final class PublishSubject<T> extends Subject<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         for (PublishDisposable<T> pd : subscribers.get()) {
             pd.onNext(t);
@@ -229,7 +229,7 @@ public final class PublishSubject<T> extends Subject<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (subscribers.get() == TERMINATED) {
             RxJavaPlugins.onError(t);

--- a/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
@@ -352,7 +352,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         if (done) {
             return;
@@ -367,7 +367,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (done) {
             RxJavaPlugins.onError(t);

--- a/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
@@ -310,7 +310,7 @@ public final class UnicastSubject<T> extends Subject<T> {
     }
 
     @Override
-    public void onNext(T t) {
+    public void onNext(@NonNull T t) {
         ExceptionHelper.nullCheck(t, "onNext called with a null value.");
         if (done || disposed) {
             return;
@@ -320,7 +320,7 @@ public final class UnicastSubject<T> extends Subject<T> {
     }
 
     @Override
-    public void onError(Throwable t) {
+    public void onError(@NonNull Throwable t) {
         ExceptionHelper.nullCheck(t, "onError called with a null Throwable.");
         if (done || disposed) {
             RxJavaPlugins.onError(t);


### PR DESCRIPTION
This PR is adding NonNull annotations to method parameters that are null checked.
It will help Kotlin compiler to recognize code that might produce a NullPointerException.
