### PR TITLE
3.x: Remove unnecessary cancel/dispose calls from terminating using

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/FlowableSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableSubscriber.java
@@ -18,8 +18,10 @@ import org.reactivestreams.*;
 import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
- * Represents a Reactive-Streams inspired {@link Subscriber} that is RxJava 2 only
- * and weakens rules §1.3 and §3.9 of the specification for gaining performance.
+ * Represents a Reactive-Streams inspired {@link Subscriber} that is RxJava 3 only
+ * and weakens the Reactive Streams rules <a href='https://github.com/reactive-streams/reactive-streams-jvm#1.3'>§1.3</a>
+ * and <a href='https://github.com/reactive-streams/reactive-streams-jvm#3.9'>§3.9</a> of the specification
+ * for gaining performance.
  *
  * <p>History: 2.0.7 - experimental; 2.1 - beta
  * @param <T> the value type

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUsing.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableUsing.java
@@ -117,7 +117,6 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
                     }
                 }
 
-                upstream.cancel();
                 if (innerError != null) {
                     downstream.onError(new CompositeException(t, innerError));
                 } else {
@@ -125,7 +124,6 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
                 }
             } else {
                 downstream.onError(t);
-                upstream.cancel();
                 disposeResource();
             }
         }
@@ -143,11 +141,9 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
                     }
                 }
 
-                upstream.cancel();
                 downstream.onComplete();
             } else {
                 downstream.onComplete();
-                upstream.cancel();
                 disposeResource();
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUsing.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableUsing.java
@@ -115,11 +115,9 @@ public final class ObservableUsing<T, D> extends Observable<T> {
                     }
                 }
 
-                upstream.dispose();
                 downstream.onError(t);
             } else {
                 downstream.onError(t);
-                upstream.dispose();
                 disposeResource();
             }
         }
@@ -137,11 +135,9 @@ public final class ObservableUsing<T, D> extends Observable<T> {
                     }
                 }
 
-                upstream.dispose();
                 downstream.onComplete();
             } else {
                 downstream.onComplete();
-                upstream.dispose();
                 disposeResource();
             }
         }


### PR DESCRIPTION
Following up on a [Gitter.im report](https://gitter.im/ReactiveX/RxJava?at=5fc4fc11226043667c24e3b6), the `onComplete`/`onError` methods of the `using` operators were calling cancel/dispose on the upstream even though there is no reason to do such a thing and is also not allowed by Reactive Streams rule [2.3](https://github.com/reactive-streams/reactive-streams-jvm#2.3).

The original code's side-effect was that given a nested `using` pair, an `onComplete`/`onError` of the inner sequence would trigger a cancellation and resource release in the outer before/while the `onComplete`/`onError` signals propagate downstream and return back on a non-eager setting.

