### PR TITLE
3.x: Improve error messages in the test consumers

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
@@ -228,7 +228,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      */
     @NonNull
     public final U assertError(@NonNull Throwable error) {
-        return assertError(Functions.equalsWith(error));
+        return assertError(Functions.equalsWith(error), true);
     }
 
     /**
@@ -240,7 +240,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @NonNull
     public final U assertError(@NonNull Class<? extends Throwable> errorClass) {
-        return (U)assertError((Predicate)Functions.isInstanceOf(errorClass));
+        return (U)assertError((Predicate)Functions.isInstanceOf(errorClass), true);
     }
 
     /**
@@ -251,9 +251,14 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      *            and should return {@code true} for expected errors.
      * @return this
      */
-    @SuppressWarnings("unchecked")
     @NonNull
     public final U assertError(@NonNull Predicate<Throwable> errorPredicate) {
+        return assertError(errorPredicate, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    @NonNull
+    private U assertError(@NonNull Predicate<Throwable> errorPredicate, boolean exact) {
         int s = errors.size();
         if (s == 0) {
             throw fail("No errors");
@@ -274,10 +279,16 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
 
         if (found) {
             if (s != 1) {
-                throw fail("Error present but other errors as well");
+                if (exact) {
+                    throw fail("Error present but other errors as well");
+                }
+                throw fail("One error passed the predicate but other errors are present as well");
             }
         } else {
-            throw fail("Error not present");
+            if (exact) {
+                throw fail("Error not present");
+            }
+            throw fail("No error(s) passed the predicate");
         }
         return (U)this;
     }
@@ -316,7 +327,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
         assertValueAt(0, valuePredicate);
 
         if (values.size() > 1) {
-            throw fail("Value present but other values as well");
+            throw fail("The first value passed the predicate but this consumer received more than one value");
         }
 
         return (U)this;
@@ -339,13 +350,13 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
             throw fail("No values");
         }
 
-        if (index >= s) {
-            throw fail("Invalid index: " + index);
+        if (index < 0 || index >= s) {
+            throw fail("Index " + index + " is out of range [0, " + s + ")");
         }
 
         T v = values.get(index);
         if (!Objects.equals(value, v)) {
-            throw fail("expected: " + valueAndClass(value) + " but was: " + valueAndClass(v));
+            throw fail("expected: " + valueAndClass(value) + " but was: " + valueAndClass(v) + " at position " + index);
         }
         return (U)this;
     }
@@ -367,14 +378,15 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
             throw fail("No values");
         }
 
-        if (index >= values.size()) {
-            throw fail("Invalid index: " + index);
+        if (index < 0 || index >= s) {
+            throw fail("Index " + index + " is out of range [0, " + s + ")");
         }
 
         boolean found = false;
 
+        T v = values.get(index);
         try {
-            if (valuePredicate.test(values.get(index))) {
+            if (valuePredicate.test(v)) {
                 found = true;
             }
         } catch (Throwable ex) {
@@ -382,7 +394,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
         }
 
         if (!found) {
-            throw fail("Value not present");
+            throw fail("Value " + valueAndClass(v) + " at position " + index + " did not pass the predicate");
         }
         return (U)this;
     }

--- a/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
@@ -963,6 +963,21 @@ public class TestObserverTest extends RxJavaTest {
     }
 
     @Test
+    public void assertValueAtInvalidIndexNegative() {
+        assertThrowsWithMessage("Index -2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<Integer> to = new TestObserver<>();
+
+            Observable.just(1, 2).subscribe(to);
+
+            to.assertValueAt(-2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
+        });
+    }
+
+    @Test
     public void assertValueAtIndexEmpty() {
         assertThrowsWithMessage("No values (latch = 0, values = 0, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Object> to = new TestObserver<>();
@@ -1001,6 +1016,17 @@ public class TestObserverTest extends RxJavaTest {
             Observable.just("a", "b").subscribe(to);
 
             to.assertValueAt(2, "c");
+        });
+    }
+
+    @Test
+    public void assertValueAtIndexInvalidIndexNegative() {
+        assertThrowsWithMessage("Index -2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b").subscribe(to);
+
+            to.assertValueAt(-2, "c");
         });
     }
 

--- a/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.mockito.InOrder;
 import org.reactivestreams.Subscriber;
 
@@ -38,6 +39,10 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class TestObserverTest extends RxJavaTest {
+
+    static void assertThrowsWithMessage(String message, Class<? extends Throwable> clazz, ThrowingRunnable run) {
+        assertEquals(message, assertThrows(clazz, run).getMessage());
+    }
 
     @Test
     public void assertTestObserver() {
@@ -843,7 +848,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateEmpty() {
-        assertThrows("No values", AssertionError.class, () -> {
+        assertThrowsWithMessage("No values (latch = 0, values = 0, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Object> to = new TestObserver<>();
 
             Observable.empty().subscribe(to);
@@ -871,7 +876,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        assertThrows("Value not present", AssertionError.class, () -> {
+        assertThrowsWithMessage("Value 1 (class: Integer) at position 0 did not pass the predicate (latch = 0, values = 1, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Integer> to = new TestObserver<>();
 
             Observable.just(1).subscribe(to);
@@ -886,7 +891,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        assertThrows("Value present but other values as well", AssertionError.class, () -> {
+        assertThrowsWithMessage("The first value passed the predicate but this consumer received more than one value (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Integer> to = new TestObserver<>();
 
             Observable.just(1, 2).subscribe(to);
@@ -901,7 +906,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        assertThrows("No values", AssertionError.class, () -> {
+        assertThrowsWithMessage("No values (latch = 0, values = 0, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Object> to = new TestObserver<>();
 
             Observable.empty().subscribe(to);
@@ -929,7 +934,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        assertThrows("Value not present", AssertionError.class, () -> {
+        assertThrowsWithMessage("Value 3 (class: Integer) at position 2 did not pass the predicate (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Integer> to = new TestObserver<>();
 
             Observable.just(1, 2, 3).subscribe(to);
@@ -944,7 +949,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtInvalidIndex() {
-        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Index 2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Integer> to = new TestObserver<>();
 
             Observable.just(1, 2).subscribe(to);
@@ -959,7 +964,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexEmpty() {
-        assertThrows("No values", AssertionError.class, () -> {
+        assertThrowsWithMessage("No values (latch = 0, values = 0, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Object> to = new TestObserver<>();
 
             Observable.empty().subscribe(to);
@@ -979,7 +984,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        assertThrows("expected: b (class: String) but was: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("expected: b (class: String) but was: c (class: String) at position 2 (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);
@@ -990,7 +995,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexInvalidIndex() {
-        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Index 2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b").subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
@@ -1485,6 +1485,43 @@ public class TestSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    public void assertValueAtIndexInvalidIndex() {
+        assertThrowsWithMessage("Index 2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+            Flowable.just(1, 2).subscribe(ts);
+
+            ts.assertValueAt(2, 3);
+        });
+    }
+
+    @Test
+    public void assertValueAtIndexInvalidIndexNegative() {
+        assertThrowsWithMessage("Index -2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+            Flowable.just(1, 2).subscribe(ts);
+
+            ts.assertValueAt(-2, 3);
+        });
+    }
+
+    @Test
+    public void assertValueAtInvalidIndexNegative() {
+        assertThrowsWithMessage("Index -2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+            Flowable.just(1, 2).subscribe(ts);
+
+            ts.assertValueAt(-2, new Predicate<Integer>() {
+                @Override public boolean test(final Integer o) throws Exception {
+                    return o == 1;
+                }
+            });
+        });
+    }
+
+    @Test
     public void requestMore() {
         Flowable.range(1, 5)
         .test(0)

--- a/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.mockito.InOrder;
 import org.reactivestreams.*;
 
@@ -1391,9 +1392,13 @@ public class TestSubscriberTest extends RxJavaTest {
         });
     }
 
+    static void assertThrowsWithMessage(String message, Class<? extends Throwable> clazz, ThrowingRunnable run) {
+        assertEquals(message, assertThrows(clazz, run).getMessage());
+    }
+
     @Test
     public void assertValuePredicateNoMatch() {
-        assertThrows("Value not present", AssertionError.class, () -> {
+        assertThrowsWithMessage("Value 1 (class: Integer) at position 0 did not pass the predicate (latch = 0, values = 1, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1).subscribe(ts);
@@ -1408,7 +1413,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        assertThrows("Value present but other values as well", AssertionError.class, () -> {
+        assertThrowsWithMessage("The first value passed the predicate but this consumer received more than one value (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).subscribe(ts);
@@ -1423,7 +1428,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        assertThrows("No values", AssertionError.class, () -> {
+        assertThrowsWithMessage("No values (latch = 0, values = 0, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestSubscriber<Object> ts = new TestSubscriber<>();
 
             Flowable.empty().subscribe(ts);
@@ -1451,7 +1456,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        assertThrows("Value not present", AssertionError.class, () -> {
+        assertThrowsWithMessage("Value 3 (class: Integer) at position 2 did not pass the predicate (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2, 3).subscribe(ts);
@@ -1466,7 +1471,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtInvalidIndex() {
-        assertThrows("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Index 2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).subscribe(ts);


### PR DESCRIPTION
This PR improves the error messages reported in the `TestObserver` and `TestSubscriber`:

- `assertValue(Predicate)` now shows the value that didn't pass the predicate
- `assertValueAt(index, T)`:
  - If the index is out of range, the message includes the valid range
  - the message now includes the index argument where the failure happened
- `assertValueAt(index, Predicate)`:
  - If the index is out of range, the message includes the valid range
  - shows the value at index that didn't pass the predicate
  - the message now includes the index argument where the failure happened
- `assertError(Predicate)` is now worded to indicate the exception did not pass the predicate

In addition, the verification tests for the error messages were not actually testing the error message with `assertThrows` and have been updated.

Resolves #7125 