### PR TITLE
Implement Observable.publish with completeOnDisposal

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -10842,6 +10842,29 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     }
 
     /**
+     * Returns a {@link ConnectableObservable}, which is a variety of {@link ObservableSource} that waits until its
+     * {@link ConnectableObservable#connect connect} method is called before it begins emitting items to those
+     * {@link Observer}s that have subscribed to it.
+     * <p>
+     * <img width="640" height="510" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/publishConnect.v3.png" alt="">
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code publish} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param completeOnDisposal
+     *            whether to emit {@code onComplete} to downstream observers when the underlying connection is terminated.
+     * @return the new {@code ConnectableObservable} instance
+     * @see <a href="http://reactivex.io/documentation/operators/publish.html">ReactiveX operators documentation: Publish</a>
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
+    public final ConnectableObservable<T> publish(boolean completeOnDisposal) {
+        return RxJavaPlugins.onAssembly(new ObservablePublish<>(this, completeOnDisposal));
+    }
+
+    /**
      * Returns an {@code Observable} that emits the results of invoking a specified selector on items emitted by a
      * {@link ConnectableObservable} that shares a single subscription to the current {@code Observable} sequence.
      * <p>

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservablePublishTest.java
@@ -893,4 +893,24 @@ public class ObservablePublishTest extends RxJavaTest {
 
         to.assertValuesOnly(2);
     }
+
+    @Test
+    public void completeOnDisposalDisabled() {
+        ConnectableObservable co = Observable.never().publish(false);
+        TestObserver<Integer> to = co.test();
+        to.assertEmpty();
+        Disposable d = co.connect();
+        d.dispose();
+        to.assertNotComplete();
+    }
+
+    @Test
+    public void completeOnDisposal() {
+        ConnectableObservable co = Observable.never().publish(true);
+        TestObserver<Integer> to = co.test();
+        to.assertEmpty();
+        Disposable d = co.connect();
+        d.dispose();
+        to.assertComplete();
+    }
 }


### PR DESCRIPTION
This is a sketch of a feature I'd often find useful. ConnectableObservable.connect returns a Disposable, but disposing it actually leaves the observers in a strange state. They have not been disposed, and no terminal event has been delivered to them either. However, any newly-subscribed observer will actually receive a terminal event.

This PR adds a switch to Observable.publish method, enabling a "more correct" behavior.

This PR is just a draft. I will happily adjust it according to the feedback. I don't want to spend hours of polishing it to just get a rejection in the end. Maybe I miss something important and this change cannot be done, or the solution with the switch is incorrect and we should rather change the behavior of the publish() method.