### PR TITLE
adding 1.x 2.x 3.x javadoc to wiki sidebar

### DIFF
--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -27,6 +27,6 @@
 * [Writing operators](https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0)
 * [Backpressure](https://github.com/ReactiveX/RxJava/wiki/Backpressure-(2.0))
   * [another explanation](https://github.com/ReactiveX/RxJava/wiki/Backpressure)
-* [JavaDoc](http://reactivex.io/RxJava/2.x/javadoc)
+* [JavaDoc](http://reactivex.io/RxJava/3.x/javadoc)
 * [Coming from RxJava 1](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0)
 * [Additional Reading](https://github.com/ReactiveX/RxJava/wiki/Additional-Reading)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -27,6 +27,6 @@
 * [Writing operators](https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0)
 * [Backpressure](https://github.com/ReactiveX/RxJava/wiki/Backpressure-(2.0))
   * [another explanation](https://github.com/ReactiveX/RxJava/wiki/Backpressure)
-* [JavaDoc](http://reactivex.io/RxJava/3.x/javadoc)
+* JavaDoc: [1.x](http://reactivex.io/RxJava/1.x/javadoc), [2.x](http://reactivex.io/RxJava/2.x/javadoc), [3.x](http://reactivex.io/RxJava/3.x/javadoc)
 * [Coming from RxJava 1](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0)
 * [Additional Reading](https://github.com/ReactiveX/RxJava/wiki/Additional-Reading)


### PR DESCRIPTION
This is a fix of the url located in the sidebar of the wiki, linking to the JavaDoc.  
The current url links to the 2.x documentation.  The fix links to the 1.x 2.x and 3.x documentations.