### PR TITLE
3.x: Fix take() mentioning the old limit() operator

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -16411,8 +16411,8 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     }
 
     /**
-     * Returns a {@code Flowable} that emits only the first {@code count} items emitted by the current {@code Flowable}. If the source emits fewer than
-     * {@code count} items then all of its items are emitted.
+     * Returns a {@code Flowable} that emits only the first {@code count} items emitted by the current {@code Flowable}.
+     * If the source emits fewer than {@code count} items then all of its items are emitted.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/take.v3.png" alt="">
      * <p>
@@ -16425,15 +16425,15 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * possibly prevent the creation of excess items by the upstream.
      * <p>
      * The operator requests at most the given {@code count} of items from upstream even
-     * if the downstream requests more than that. For example, given a {@code limit(5)},
+     * if the downstream requests more than that. For example, given a {@code take(5)},
      * if the downstream requests 1, a request of 1 is submitted to the upstream
      * and the operator remembers that only 4 items can be requested now on. A request
      * of 5 at this point will request 4 from the upstream and any subsequent requests will
      * be ignored.
      * <p>
-     * Note that requests are negotiated on an operator boundary and {@code limit}'s amount
+     * Note that requests are negotiated on an operator boundary and {@code take}'s amount
      * may not be preserved further upstream. For example,
-     * {@code source.observeOn(Schedulers.computation()).limit(5)} will still request the
+     * {@code source.observeOn(Schedulers.computation()).take(5)} will still request the
      * default (128) elements from the given {@code source}.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>


### PR DESCRIPTION
The Javadocs of `take` still referenced the original `limit` operator.