### PR TITLE
3.x: Document Schedulers.from's RejectedExecutionException handling

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/rxjava3/schedulers/Schedulers.java
@@ -340,6 +340,16 @@ public final class Schedulers {
      * }
      * </code></pre>
      * <p>
+     * Note that the provided {@code Executor} should avoid throwing a {@link RejectedExecutionException}
+     * (for example, by shutting it down prematurely or using a bounded-queue {@code ExecutorService})
+     * because such circumstances prevent RxJava from progressing flow-related activities correctly.
+     * If the {@link Executor#execute(Runnable)} or {@link ExecutorService#submit(Callable)} throws,
+     * the {@code RejectedExecutionException} is routed to the global error handler via
+     * {@link RxJavaPlugins#onError(Throwable)}. To avoid shutdown-reladed problems, it is recommended
+     * all flows using the returned {@code Scheduler} to be canceled/disposed before the underlying
+     * {@code Executor} is shut down. To avoid problems due to the {@code Executor} having a bounded-queue,
+     * it is recommended to rephrase the flow to utilize backpressure as the means to limit outstanding work.
+     * <p>
      * This type of scheduler is less sensitive to leaking {@link io.reactivex.rxjava3.core.Scheduler.Worker Scheduler.Worker} instances, although
      * not disposing a worker that has timed/delayed tasks not cancelled by other means may leak resources and/or
      * execute those tasks "unexpectedly".
@@ -403,6 +413,16 @@ public final class Schedulers {
      *     exec.shutdown();
      * }
      * </code></pre>
+     * <p>
+     * Note that the provided {@code Executor} should avoid throwing a {@link RejectedExecutionException}
+     * (for example, by shutting it down prematurely or using a bounded-queue {@code ExecutorService})
+     * because such circumstances prevent RxJava from progressing flow-related activities correctly.
+     * If the {@link Executor#execute(Runnable)} or {@link ExecutorService#submit(Callable)} throws,
+     * the {@code RejectedExecutionException} is routed to the global error handler via
+     * {@link RxJavaPlugins#onError(Throwable)}. To avoid shutdown-reladed problems, it is recommended
+     * all flows using the returned {@code Scheduler} to be canceled/disposed before the underlying
+     * {@code Executor} is shut down. To avoid problems due to the {@code Executor} having a bounded-queue,
+     * it is recommended to rephrase the flow to utilize backpressure as the means to limit outstanding work.
      * <p>
      * This type of scheduler is less sensitive to leaking {@link io.reactivex.rxjava3.core.Scheduler.Worker Scheduler.Worker} instances, although
      * not disposing a worker that has timed/delayed tasks not cancelled by other means may leak resources and/or
@@ -473,6 +493,16 @@ public final class Schedulers {
      *     exec.shutdown();
      * }
      * </code></pre>
+     * <p>
+     * Note that the provided {@code Executor} should avoid throwing a {@link RejectedExecutionException}
+     * (for example, by shutting it down prematurely or using a bounded-queue {@code ExecutorService})
+     * because such circumstances prevent RxJava from progressing flow-related activities correctly.
+     * If the {@link Executor#execute(Runnable)} or {@link ExecutorService#submit(Callable)} throws,
+     * the {@code RejectedExecutionException} is routed to the global error handler via
+     * {@link RxJavaPlugins#onError(Throwable)}. To avoid shutdown-reladed problems, it is recommended
+     * all flows using the returned {@code Scheduler} to be canceled/disposed before the underlying
+     * {@code Executor} is shut down. To avoid problems due to the {@code Executor} having a bounded-queue,
+     * it is recommended to rephrase the flow to utilize backpressure as the means to limit outstanding work.
      * <p>
      * This type of scheduler is less sensitive to leaking {@link io.reactivex.rxjava3.core.Scheduler.Worker Scheduler.Worker} instances, although
      * not disposing a worker that has timed/delayed tasks not cancelled by other means may leak resources and/or


### PR DESCRIPTION
Updates the 3 overloads of `Schedulers.from` to describe (in a concise manner) the cases when the `Executor` would throw a `RejectedExecutionException`. Such exceptions can't be reasonably handled from within RxJava.

There are typically two cases when such exception would occur:

1) **The underlying Executor is shut down.** 

Operators such as `observeOn` guarantee worker-confinement when calling `onNext`, `onError` and `onComplete`. A failure to schedule would at best bypass this confinement, notifying the downstream on the current thread, at worst cause overlapping execution downstream.

The recommended workaround is to cancel all flows using the particular `Scheduler` after which the Executor can be shut down safely.

2) **The underlying Executor temporarily rejects more work.**

Such temporary rejections are often used in traditional `Executor` usages to drop work or pause the submission of work. In RxJava though, there is often no 1:1 correspondence to signals (`onNext`, `onError` or `onComplete`). Some work may be correlated to several `onNext`s, other work may be due to downstream requests. Dropping any such work may lead to inconsistent flow state or livelocks.

The recommended workaround is to express limits on the execution via backpressure (e.g., `Flowable`s).    

Resolves #7149