### PR TITLE
3.x: onReduceBackpressure internals cleanup

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureReduceTest.java
@@ -110,6 +110,30 @@ public class FlowableOnBackpressureReduceTest extends RxJavaTest {
         ts.assertTerminated();
     }
 
+    @Test
+    public void reduceBackpressuredSync() {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
+
+        source.onBackpressureReduce((a, b) -> a + b).subscribe(ts);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+
+        ts.request(1);
+
+        ts.assertValuesOnly(6);
+
+        source.onNext(4);
+        source.onComplete();
+
+        ts.assertValuesOnly(6);
+
+        ts.request(1);
+        ts.assertResult(6, 4);
+    }
+
     private <T> TestSubscriberEx<T> createDelayedSubscriber() {
         return new TestSubscriberEx<T>(1L) {
             final Random rnd = new Random();

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureReduceTest.java
@@ -115,7 +115,7 @@ public class FlowableOnBackpressureReduceTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
 
-        source.onBackpressureReduce((a, b) -> a + b).subscribe(ts);
+        source.onBackpressureReduce(Integer::sum).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureReduceWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureReduceWithTest.java
@@ -95,7 +95,7 @@ public class FlowableOnBackpressureReduceWithTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
 
-        source.onBackpressureReduce(() -> 0, (a, b) -> a + b).subscribe(ts);
+        source.onBackpressureReduce(() -> 0, Integer::sum).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureReduceWithTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureReduceWithTest.java
@@ -91,6 +91,30 @@ public class FlowableOnBackpressureReduceWithTest extends RxJavaTest {
     }
 
     @Test
+    public void reduceBackpressuredSync() {
+        PublishProcessor<Integer> source = PublishProcessor.create();
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(0L);
+
+        source.onBackpressureReduce(() -> 0, (a, b) -> a + b).subscribe(ts);
+
+        source.onNext(1);
+        source.onNext(2);
+        source.onNext(3);
+
+        ts.request(1);
+
+        ts.assertValuesOnly(6);
+
+        source.onNext(4);
+        source.onComplete();
+
+        ts.assertValuesOnly(6);
+
+        ts.request(1);
+        ts.assertResult(6, 4);
+    }
+
+    @Test
     public void synchronousDrop() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         TestSubscriberEx<List<Integer>> ts = new TestSubscriberEx<>(0L);


### PR DESCRIPTION
- Simplify empty/non-empty cases.
- Fix cancellation order and wrong fall-through.
- Add deterministic test to cover the reduction cases.