### PR TITLE
Updating documentation for scheduleActual method

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
@@ -116,10 +116,8 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
     }
 
     /**
-     * Wraps the given runnable into a ScheduledRunnable and schedules it
+     * Wraps and returns the given runnable into a ScheduledRunnable and schedules it
      * on the underlying ScheduledExecutorService.
-     * <p>If the schedule has been rejected, the ScheduledRunnable.wasScheduled will return
-     * false.
      * @param run the runnable instance
      * @param delayTime the time to delay the execution
      * @param unit the time unit


### PR DESCRIPTION
Remove unnecessary sentence from `NewThreadWorker.scheduleActual`.

Resolves #7161