### PR TITLE
3.x: Add fusion support to concatMap{Maybe|Single|Completable}

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ConcatMapXMainObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ConcatMapXMainObserver.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.mixed;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.rxjava3.internal.util.*;
+
+/**
+ * Base class for implementing concatMapX main observers.
+ *
+ * @param <T> the upstream value type
+ * @since 3.0.10
+ */
+public abstract class ConcatMapXMainObserver<T> extends AtomicInteger
+implements Observer<T>, Disposable {
+
+    private static final long serialVersionUID = -3214213361171757852L;
+
+    final AtomicThrowable errors;
+
+    final int prefetch;
+
+    final ErrorMode errorMode;
+
+    SimpleQueue<T> queue;
+
+    Disposable upstream;
+
+    volatile boolean done;
+
+    volatile boolean disposed;
+
+    public ConcatMapXMainObserver(int prefetch, ErrorMode errorMode) {
+        this.errorMode = errorMode;
+        this.errors = new AtomicThrowable();
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    public final void onSubscribe(Disposable d) {
+        if (DisposableHelper.validate(upstream, d)) {
+            upstream = d;
+            if (d instanceof QueueDisposable) {
+                @SuppressWarnings("unchecked")
+                QueueDisposable<T> qd = (QueueDisposable<T>)d;
+                int mode = qd.requestFusion(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
+                if (mode == QueueFuseable.SYNC) {
+                    queue = qd;
+                    done = true;
+
+                    onSubscribeDownstream();
+
+                    drain();
+                    return;
+                }
+                else if (mode == QueueFuseable.ASYNC) {
+                    queue = qd;
+
+                    onSubscribeDownstream();
+
+                    return;
+                }
+            }
+
+            queue = new SpscLinkedArrayQueue<>(prefetch);
+            onSubscribeDownstream();
+        }
+    }
+
+    @Override
+    public final void onNext(T t) {
+        // In async fusion mode, t is a drain indicator
+        if (t != null) {
+            queue.offer(t);
+        }
+        drain();
+    }
+
+    @Override
+    public final void onError(Throwable t) {
+        if (errors.tryAddThrowableOrReport(t)) {
+            if (errorMode == ErrorMode.IMMEDIATE) {
+                disposeInner();
+            }
+            done = true;
+            drain();
+        }
+    }
+
+    @Override
+    public final void onComplete() {
+        done = true;
+        drain();
+    }
+
+    @Override
+    public final void dispose() {
+        disposed = true;
+        upstream.dispose();
+        disposeInner();
+        errors.tryTerminateAndReport();
+        if (getAndIncrement() == 0) {
+            queue.clear();
+            clearValue();
+        }
+    }
+
+    @Override
+    public final boolean isDisposed() {
+        return disposed;
+    }
+
+    /**
+     * Override this to clear values when the downstream disposes.
+     */
+    void clearValue() {
+    }
+
+    /**
+     * Typically, this should be {@code downstream.onSubscribe(this)}.
+     */
+    abstract void onSubscribeDownstream();
+
+    /**
+     * Typically, this should be {@code inner.dispose()}.
+     */
+    abstract void disposeInner();
+
+    /**
+     * Implement the serialized inner subscribing and value emission here.
+     */
+    abstract void drain();
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ConcatMapXMainSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ConcatMapXMainSubscriber.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.operators.mixed;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.Subscription;
+
+import io.reactivex.rxjava3.core.FlowableSubscriber;
+import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.internal.fuseable.*;
+import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
+import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.internal.util.*;
+
+/**
+ * Base class for implementing concatMapX main subscribers.
+ *
+ * @param <T> the upstream value type
+ * @since 3.0.10
+ */
+public abstract class ConcatMapXMainSubscriber<T> extends AtomicInteger
+implements FlowableSubscriber<T> {
+
+    private static final long serialVersionUID = -3214213361171757852L;
+
+    final AtomicThrowable errors;
+
+    final int prefetch;
+
+    final ErrorMode errorMode;
+
+    SimpleQueue<T> queue;
+
+    Subscription upstream;
+
+    volatile boolean done;
+
+    volatile boolean cancelled;
+
+    boolean syncFused;
+
+    public ConcatMapXMainSubscriber(int prefetch, ErrorMode errorMode) {
+        this.errorMode = errorMode;
+        this.errors = new AtomicThrowable();
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    public final void onSubscribe(Subscription s) {
+        if (SubscriptionHelper.validate(upstream, s)) {
+            upstream = s;
+            if (s instanceof QueueSubscription) {
+                @SuppressWarnings("unchecked")
+                QueueSubscription<T> qs = (QueueSubscription<T>)s;
+                int mode = qs.requestFusion(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
+                if (mode == QueueFuseable.SYNC) {
+                    queue = qs;
+                    syncFused = true;
+                    done = true;
+
+                    onSubscribeDownstream();
+
+                    drain();
+                    return;
+                }
+                else if (mode == QueueFuseable.ASYNC) {
+                    queue = qs;
+
+                    onSubscribeDownstream();
+
+                    upstream.request(prefetch);
+                    return;
+                }
+            }
+
+            queue = new SpscArrayQueue<>(prefetch);
+            onSubscribeDownstream();
+            upstream.request(prefetch);
+        }
+    }
+
+    @Override
+    public final void onNext(T t) {
+        // In async fusion mode, t is a drain indicator
+        if (t != null) {
+            if (!queue.offer(t)) {
+                upstream.cancel();
+                onError(new MissingBackpressureException("queue full?!"));
+                return;
+            }
+        }
+        drain();
+    }
+
+    @Override
+    public final void onError(Throwable t) {
+        if (errors.tryAddThrowableOrReport(t)) {
+            if (errorMode == ErrorMode.IMMEDIATE) {
+                disposeInner();
+            }
+            done = true;
+            drain();
+        }
+    }
+
+    @Override
+    public final void onComplete() {
+        done = true;
+        drain();
+    }
+
+    final void stop() {
+        cancelled = true;
+        upstream.cancel();
+        disposeInner();
+        errors.tryTerminateAndReport();
+        if (getAndIncrement() == 0) {
+            queue.clear();
+            clearValue();
+        }
+    }
+
+    /**
+     * Override this to clear values when the downstream disposes.
+     */
+    void clearValue() {
+    }
+
+    /**
+     * Typically, this should be {@code downstream.onSubscribe(this);}.
+     */
+    abstract void onSubscribeDownstream();
+
+    /**
+     * Typically, this should be {@code inner.dispose()}.
+     */
+    abstract void disposeInner();
+
+    /**
+     * Implement the serialized inner subscribing and value emission here.
+     */
+    abstract void drain();
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapCompletable.java
@@ -14,18 +14,14 @@
 package io.reactivex.rxjava3.internal.operators.mixed;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.*;
-
-import org.reactivestreams.Subscription;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
-import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
-import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
-import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.internal.fuseable.SimpleQueue;
 import io.reactivex.rxjava3.internal.util.*;
 
 /**
@@ -61,8 +57,8 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
     }
 
     static final class ConcatMapCompletableObserver<T>
-    extends AtomicInteger
-    implements FlowableSubscriber<T>, Disposable {
+    extends ConcatMapXMainSubscriber<T>
+    implements Disposable {
 
         private static final long serialVersionUID = 3610901111000061034L;
 
@@ -70,93 +66,39 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
 
         final Function<? super T, ? extends CompletableSource> mapper;
 
-        final ErrorMode errorMode;
-
-        final AtomicThrowable errors;
-
         final ConcatMapInnerObserver inner;
 
-        final int prefetch;
-
-        final SimplePlainQueue<T> queue;
-
-        Subscription upstream;
-
         volatile boolean active;
-
-        volatile boolean done;
-
-        volatile boolean disposed;
 
         int consumed;
 
         ConcatMapCompletableObserver(CompletableObserver downstream,
                 Function<? super T, ? extends CompletableSource> mapper,
                 ErrorMode errorMode, int prefetch) {
+            super(prefetch, errorMode);
             this.downstream = downstream;
             this.mapper = mapper;
-            this.errorMode = errorMode;
-            this.prefetch = prefetch;
-            this.errors = new AtomicThrowable();
             this.inner = new ConcatMapInnerObserver(this);
-            this.queue = new SpscArrayQueue<>(prefetch);
         }
 
         @Override
-        public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validate(upstream, s)) {
-                this.upstream = s;
-                downstream.onSubscribe(this);
-                s.request(prefetch);
-            }
+        void onSubscribeDownstream() {
+            downstream.onSubscribe(this);
         }
 
         @Override
-        public void onNext(T t) {
-            if (queue.offer(t)) {
-                drain();
-            } else {
-                upstream.cancel();
-                onError(new MissingBackpressureException("Queue full?!"));
-            }
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            if (errors.tryAddThrowableOrReport(t)) {
-                if (errorMode == ErrorMode.IMMEDIATE) {
-                    inner.dispose();
-                    errors.tryTerminateConsumer(downstream);
-                    if (getAndIncrement() == 0) {
-                        queue.clear();
-                    }
-                } else {
-                    done = true;
-                    drain();
-                }
-            }
-        }
-
-        @Override
-        public void onComplete() {
-            done = true;
-            drain();
+        void disposeInner() {
+            inner.dispose();
         }
 
         @Override
         public void dispose() {
-            disposed = true;
-            upstream.cancel();
-            inner.dispose();
-            errors.tryTerminateAndReport();
-            if (getAndIncrement() == 0) {
-                queue.clear();
-            }
+            stop();
         }
 
         @Override
         public boolean isDisposed() {
-            return disposed;
+            return cancelled;
         }
 
         void innerError(Throwable ex) {
@@ -179,29 +121,45 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
             drain();
         }
 
+        @Override
         void drain() {
             if (getAndIncrement() != 0) {
                 return;
             }
 
+            ErrorMode errorMode = this.errorMode;
+            SimpleQueue<T> queue = this.queue;
+            AtomicThrowable errors = this.errors;
+            boolean syncFused = this.syncFused;
+
             do {
-                if (disposed) {
+                if (cancelled) {
                     queue.clear();
                     return;
                 }
 
+                if (errors.get() != null) {
+                    if (errorMode == ErrorMode.IMMEDIATE
+                            || (errorMode == ErrorMode.BOUNDARY && !active)) {
+                        queue.clear();
+                        errors.tryTerminateConsumer(downstream);
+                        return;
+                    }
+                }
+
                 if (!active) {
 
-                    if (errorMode == ErrorMode.BOUNDARY) {
-                        if (errors.get() != null) {
-                            queue.clear();
-                            errors.tryTerminateConsumer(downstream);
-                            return;
-                        }
-                    }
-
                     boolean d = done;
-                    T v = queue.poll();
+                    T v;
+                    try {
+                        v = queue.poll();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        upstream.cancel();
+                        errors.tryAddThrowableOrReport(ex);
+                        errors.tryTerminateConsumer(downstream);
+                        return;
+                    }
                     boolean empty = v == null;
 
                     if (d && empty) {
@@ -212,12 +170,15 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
                     if (!empty) {
 
                         int limit = prefetch - (prefetch >> 1);
-                        int c = consumed + 1;
-                        if (c == limit) {
-                            consumed = 0;
-                            upstream.request(limit);
-                        } else {
-                            consumed = c;
+
+                        if (!syncFused) {
+                            int c = consumed + 1;
+                            if (c == limit) {
+                                consumed = 0;
+                                upstream.request(limit);
+                            } else {
+                                consumed = c;
+                            }
                         }
 
                         CompletableSource cs;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybe.java
@@ -20,12 +20,10 @@ import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
-import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
-import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
-import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.internal.fuseable.SimpleQueue;
 import io.reactivex.rxjava3.internal.util.*;
 
 /**
@@ -62,8 +60,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
     }
 
     static final class ConcatMapMaybeSubscriber<T, R>
-    extends AtomicInteger
-    implements FlowableSubscriber<T>, Subscription {
+    extends ConcatMapXMainSubscriber<T> implements Subscription {
 
         private static final long serialVersionUID = -9140123220065488293L;
 
@@ -71,23 +68,9 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
 
         final Function<? super T, ? extends MaybeSource<? extends R>> mapper;
 
-        final int prefetch;
-
         final AtomicLong requested;
 
-        final AtomicThrowable errors;
-
         final ConcatMapMaybeObserver<R> inner;
-
-        final SimplePlainQueue<T> queue;
-
-        final ErrorMode errorMode;
-
-        Subscription upstream;
-
-        volatile boolean done;
-
-        volatile boolean cancelled;
 
         long emitted;
 
@@ -107,50 +90,16 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
         ConcatMapMaybeSubscriber(Subscriber<? super R> downstream,
                 Function<? super T, ? extends MaybeSource<? extends R>> mapper,
                         int prefetch, ErrorMode errorMode) {
+            super(prefetch, errorMode);
             this.downstream = downstream;
             this.mapper = mapper;
-            this.prefetch = prefetch;
-            this.errorMode = errorMode;
             this.requested = new AtomicLong();
-            this.errors = new AtomicThrowable();
             this.inner = new ConcatMapMaybeObserver<>(this);
-            this.queue = new SpscArrayQueue<>(prefetch);
         }
 
         @Override
-        public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validate(upstream, s)) {
-                upstream = s;
-                downstream.onSubscribe(this);
-                s.request(prefetch);
-            }
-        }
-
-        @Override
-        public void onNext(T t) {
-            if (!queue.offer(t)) {
-                upstream.cancel();
-                onError(new MissingBackpressureException("queue full?!"));
-                return;
-            }
-            drain();
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            if (errors.tryAddThrowableOrReport(t)) {
-                if (errorMode == ErrorMode.IMMEDIATE) {
-                    inner.dispose();
-                }
-                done = true;
-                drain();
-            }
-        }
-
-        @Override
-        public void onComplete() {
-            done = true;
-            drain();
+        void onSubscribeDownstream() {
+            downstream.onSubscribe(this);
         }
 
         @Override
@@ -161,14 +110,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
 
         @Override
         public void cancel() {
-            cancelled = true;
-            upstream.cancel();
-            inner.dispose();
-            errors.tryTerminateAndReport();
-            if (getAndIncrement() == 0) {
-                queue.clear();
-                item = null;
-            }
+            stop();
         }
 
         void innerSuccess(R item) {
@@ -192,6 +134,17 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
             }
         }
 
+        @Override
+        void clearValue() {
+            item = null;
+        }
+
+        @Override
+        void disposeInner() {
+            inner.dispose();
+        }
+
+        @Override
         void drain() {
             if (getAndIncrement() != 0) {
                 return;
@@ -200,10 +153,11 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
             int missed = 1;
             Subscriber<? super R> downstream = this.downstream;
             ErrorMode errorMode = this.errorMode;
-            SimplePlainQueue<T> queue = this.queue;
+            SimpleQueue<T> queue = this.queue;
             AtomicThrowable errors = this.errors;
             AtomicLong requested = this.requested;
             int limit = prefetch - (prefetch >> 1);
+            boolean syncFused = this.syncFused;
 
             for (;;) {
 
@@ -228,7 +182,16 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
 
                     if (s == STATE_INACTIVE) {
                         boolean d = done;
-                        T v = queue.poll();
+                        T v;
+                        try {
+                            v = queue.poll();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            upstream.cancel();
+                            errors.tryAddThrowableOrReport(ex);
+                            errors.tryTerminateConsumer(downstream);
+                            return;
+                        }
                         boolean empty = v == null;
 
                         if (d && empty) {
@@ -240,12 +203,14 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
                             break;
                         }
 
-                        int c = consumed + 1;
-                        if (c == limit) {
-                            consumed = 0;
-                            upstream.request(limit);
-                        } else {
-                            consumed = c;
+                        if (!syncFused) {
+                            int c = consumed + 1;
+                            if (c == limit) {
+                                consumed = 0;
+                                upstream.request(limit);
+                            } else {
+                                consumed = c;
+                            }
                         }
 
                         MaybeSource<? extends R> ms;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -20,12 +20,10 @@ import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
-import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
-import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
-import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.internal.fuseable.SimpleQueue;
 import io.reactivex.rxjava3.internal.util.*;
 
 /**
@@ -62,8 +60,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
     }
 
     static final class ConcatMapSingleSubscriber<T, R>
-    extends AtomicInteger
-    implements FlowableSubscriber<T>, Subscription {
+    extends ConcatMapXMainSubscriber<T> implements Subscription {
 
         private static final long serialVersionUID = -9140123220065488293L;
 
@@ -71,23 +68,9 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
 
         final Function<? super T, ? extends SingleSource<? extends R>> mapper;
 
-        final int prefetch;
-
         final AtomicLong requested;
 
-        final AtomicThrowable errors;
-
         final ConcatMapSingleObserver<R> inner;
-
-        final SimplePlainQueue<T> queue;
-
-        final ErrorMode errorMode;
-
-        Subscription upstream;
-
-        volatile boolean done;
-
-        volatile boolean cancelled;
 
         long emitted;
 
@@ -107,50 +90,16 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
         ConcatMapSingleSubscriber(Subscriber<? super R> downstream,
                 Function<? super T, ? extends SingleSource<? extends R>> mapper,
                         int prefetch, ErrorMode errorMode) {
+            super(prefetch, errorMode);
             this.downstream = downstream;
             this.mapper = mapper;
-            this.prefetch = prefetch;
-            this.errorMode = errorMode;
             this.requested = new AtomicLong();
-            this.errors = new AtomicThrowable();
             this.inner = new ConcatMapSingleObserver<>(this);
-            this.queue = new SpscArrayQueue<>(prefetch);
         }
 
         @Override
-        public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validate(upstream, s)) {
-                upstream = s;
-                downstream.onSubscribe(this);
-                s.request(prefetch);
-            }
-        }
-
-        @Override
-        public void onNext(T t) {
-            if (!queue.offer(t)) {
-                upstream.cancel();
-                onError(new MissingBackpressureException("queue full?!"));
-                return;
-            }
-            drain();
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            if (errors.tryAddThrowableOrReport(t)) {
-                if (errorMode == ErrorMode.IMMEDIATE) {
-                    inner.dispose();
-                }
-                done = true;
-                drain();
-            }
-        }
-
-        @Override
-        public void onComplete() {
-            done = true;
-            drain();
+        void onSubscribeDownstream() {
+            downstream.onSubscribe(this);
         }
 
         @Override
@@ -161,14 +110,17 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
 
         @Override
         public void cancel() {
-            cancelled = true;
-            upstream.cancel();
+            stop();
+        }
+
+        @Override
+        void clearValue() {
+            item = null;
+        }
+
+        @Override
+        void disposeInner() {
             inner.dispose();
-            errors.tryTerminateAndReport();
-            if (getAndIncrement() == 0) {
-                queue.clear();
-                item = null;
-            }
         }
 
         void innerSuccess(R item) {
@@ -187,6 +139,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
             }
         }
 
+        @Override
         void drain() {
             if (getAndIncrement() != 0) {
                 return;
@@ -195,10 +148,11 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
             int missed = 1;
             Subscriber<? super R> downstream = this.downstream;
             ErrorMode errorMode = this.errorMode;
-            SimplePlainQueue<T> queue = this.queue;
+            SimpleQueue<T> queue = this.queue;
             AtomicThrowable errors = this.errors;
             AtomicLong requested = this.requested;
             int limit = prefetch - (prefetch >> 1);
+            boolean syncFused = this.syncFused;
 
             for (;;) {
 
@@ -223,7 +177,16 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
 
                     if (s == STATE_INACTIVE) {
                         boolean d = done;
-                        T v = queue.poll();
+                        T v;
+                        try {
+                            v = queue.poll();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            upstream.cancel();
+                            errors.tryAddThrowableOrReport(ex);
+                            errors.tryTerminateConsumer(downstream);
+                            return;
+                        }
                         boolean empty = v == null;
 
                         if (d && empty) {
@@ -235,12 +198,14 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
                             break;
                         }
 
-                        int c = consumed + 1;
-                        if (c == limit) {
-                            consumed = 0;
-                            upstream.request(limit);
-                        } else {
-                            consumed = c;
+                        if (!syncFused) {
+                            int c = consumed + 1;
+                            if (c == limit) {
+                                consumed = 0;
+                                upstream.request(limit);
+                            } else {
+                                consumed = c;
+                            }
                         }
 
                         SingleSource<? extends R> ss;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybe.java
@@ -14,15 +14,14 @@
 package io.reactivex.rxjava3.internal.operators.mixed;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
-import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
-import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.rxjava3.internal.fuseable.*;
 import io.reactivex.rxjava3.internal.util.*;
 
 /**
@@ -61,8 +60,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
     }
 
     static final class ConcatMapMaybeMainObserver<T, R>
-    extends AtomicInteger
-    implements Observer<T>, Disposable {
+    extends ConcatMapXMainObserver<T> {
 
         private static final long serialVersionUID = -9140123220065488293L;
 
@@ -70,19 +68,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
 
         final Function<? super T, ? extends MaybeSource<? extends R>> mapper;
 
-        final AtomicThrowable errors;
-
         final ConcatMapMaybeObserver<R> inner;
-
-        final SimplePlainQueue<T> queue;
-
-        final ErrorMode errorMode;
-
-        Disposable upstream;
-
-        volatile boolean done;
-
-        volatile boolean cancelled;
 
         R item;
 
@@ -98,60 +84,20 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
         ConcatMapMaybeMainObserver(Observer<? super R> downstream,
                 Function<? super T, ? extends MaybeSource<? extends R>> mapper,
                         int prefetch, ErrorMode errorMode) {
+            super(prefetch, errorMode);
             this.downstream = downstream;
             this.mapper = mapper;
-            this.errorMode = errorMode;
-            this.errors = new AtomicThrowable();
             this.inner = new ConcatMapMaybeObserver<>(this);
-            this.queue = new SpscLinkedArrayQueue<>(prefetch);
         }
 
         @Override
-        public void onSubscribe(Disposable d) {
-            if (DisposableHelper.validate(upstream, d)) {
-                upstream = d;
-                downstream.onSubscribe(this);
-            }
+        void onSubscribeDownstream() {
+            downstream.onSubscribe(this);
         }
 
         @Override
-        public void onNext(T t) {
-            queue.offer(t);
-            drain();
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            if (errors.tryAddThrowableOrReport(t)) {
-                if (errorMode == ErrorMode.IMMEDIATE) {
-                    inner.dispose();
-                }
-                done = true;
-                drain();
-            }
-        }
-
-        @Override
-        public void onComplete() {
-            done = true;
-            drain();
-        }
-
-        @Override
-        public void dispose() {
-            cancelled = true;
-            upstream.dispose();
-            inner.dispose();
-            errors.tryTerminateAndReport();
-            if (getAndIncrement() == 0) {
-                queue.clear();
-                item = null;
-            }
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return cancelled;
+        void clearValue() {
+            item = null;
         }
 
         void innerSuccess(R item) {
@@ -175,6 +121,12 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
             }
         }
 
+        @Override
+        void disposeInner() {
+            inner.dispose();
+        }
+
+        @Override
         void drain() {
             if (getAndIncrement() != 0) {
                 return;
@@ -183,13 +135,13 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
             int missed = 1;
             Observer<? super R> downstream = this.downstream;
             ErrorMode errorMode = this.errorMode;
-            SimplePlainQueue<T> queue = this.queue;
+            SimpleQueue<T> queue = this.queue;
             AtomicThrowable errors = this.errors;
 
             for (;;) {
 
                 for (;;) {
-                    if (cancelled) {
+                    if (disposed) {
                         queue.clear();
                         item = null;
                         break;
@@ -209,7 +161,18 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
 
                     if (s == STATE_INACTIVE) {
                         boolean d = done;
-                        T v = queue.poll();
+                        T v;
+
+                        try {
+                            v = queue.poll();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            disposed = true;
+                            upstream.dispose();
+                            errors.tryAddThrowableOrReport(ex);
+                            errors.tryTerminateConsumer(downstream);
+                            return;
+                        }
                         boolean empty = v == null;
 
                         if (d && empty) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -14,15 +14,14 @@
 package io.reactivex.rxjava3.internal.operators.mixed;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
-import io.reactivex.rxjava3.internal.fuseable.SimplePlainQueue;
-import io.reactivex.rxjava3.internal.queue.SpscLinkedArrayQueue;
+import io.reactivex.rxjava3.internal.fuseable.SimpleQueue;
 import io.reactivex.rxjava3.internal.util.*;
 
 /**
@@ -61,8 +60,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
     }
 
     static final class ConcatMapSingleMainObserver<T, R>
-    extends AtomicInteger
-    implements Observer<T>, Disposable {
+    extends ConcatMapXMainObserver<T> {
 
         private static final long serialVersionUID = -9140123220065488293L;
 
@@ -70,19 +68,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
 
         final Function<? super T, ? extends SingleSource<? extends R>> mapper;
 
-        final AtomicThrowable errors;
-
         final ConcatMapSingleObserver<R> inner;
-
-        final SimplePlainQueue<T> queue;
-
-        final ErrorMode errorMode;
-
-        Disposable upstream;
-
-        volatile boolean done;
-
-        volatile boolean cancelled;
 
         R item;
 
@@ -98,60 +84,10 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
         ConcatMapSingleMainObserver(Observer<? super R> downstream,
                 Function<? super T, ? extends SingleSource<? extends R>> mapper,
                         int prefetch, ErrorMode errorMode) {
+            super(prefetch, errorMode);
             this.downstream = downstream;
             this.mapper = mapper;
-            this.errorMode = errorMode;
-            this.errors = new AtomicThrowable();
             this.inner = new ConcatMapSingleObserver<>(this);
-            this.queue = new SpscLinkedArrayQueue<>(prefetch);
-        }
-
-        @Override
-        public void onSubscribe(Disposable d) {
-            if (DisposableHelper.validate(upstream, d)) {
-                upstream = d;
-                downstream.onSubscribe(this);
-            }
-        }
-
-        @Override
-        public void onNext(T t) {
-            queue.offer(t);
-            drain();
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            if (errors.tryAddThrowableOrReport(t)) {
-                if (errorMode == ErrorMode.IMMEDIATE) {
-                    inner.dispose();
-                }
-                done = true;
-                drain();
-            }
-        }
-
-        @Override
-        public void onComplete() {
-            done = true;
-            drain();
-        }
-
-        @Override
-        public void dispose() {
-            cancelled = true;
-            upstream.dispose();
-            inner.dispose();
-            errors.tryTerminateAndReport();
-            if (getAndIncrement() == 0) {
-                queue.clear();
-                item = null;
-            }
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return cancelled;
         }
 
         void innerSuccess(R item) {
@@ -170,6 +106,22 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
             }
         }
 
+        @Override
+        void disposeInner() {
+            inner.dispose();
+        }
+
+        @Override
+        void onSubscribeDownstream() {
+            downstream.onSubscribe(this);
+        }
+
+        @Override
+        void clearValue() {
+            item = null;
+        }
+
+        @Override
         void drain() {
             if (getAndIncrement() != 0) {
                 return;
@@ -178,13 +130,13 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
             int missed = 1;
             Observer<? super R> downstream = this.downstream;
             ErrorMode errorMode = this.errorMode;
-            SimplePlainQueue<T> queue = this.queue;
+            SimpleQueue<T> queue = this.queue;
             AtomicThrowable errors = this.errors;
 
             for (;;) {
 
                 for (;;) {
-                    if (cancelled) {
+                    if (disposed) {
                         queue.clear();
                         item = null;
                         break;
@@ -204,7 +156,18 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
 
                     if (s == STATE_INACTIVE) {
                         boolean d = done;
-                        T v = queue.poll();
+                        T v;
+
+                        try {
+                            v = queue.poll();
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            disposed = true;
+                            upstream.dispose();
+                            errors.tryAddThrowableOrReport(ex);
+                            errors.tryTerminateConsumer(downstream);
+                            return;
+                        }
                         boolean empty = v == null;
 
                         if (d && empty) {

--- a/src/main/java/io/reactivex/rxjava3/internal/subscriptions/DeferredScalarSubscription.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/subscriptions/DeferredScalarSubscription.java
@@ -115,7 +115,7 @@ public class DeferredScalarSubscription<T> extends BasicIntQueueSubscription<T> 
                 lazySet(FUSED_READY);
 
                 Subscriber<? super T> a = downstream;
-                a.onNext(v);
+                a.onNext(null);
                 if (get() != CANCELLED) {
                     a.onComplete();
                 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -19,11 +19,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.rxjava3.disposables.Disposable;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.functions.Functions;
@@ -31,7 +31,7 @@ import io.reactivex.rxjava3.internal.operators.mixed.FlowableConcatMapMaybe.Conc
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava3.internal.util.ErrorMode;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
-import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.processors.*;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.MaybeSubject;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
@@ -54,15 +54,19 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     }
 
     @Test
-    public void simpleLong() {
+    public void simpleLongPrefetch() {
         Flowable.range(1, 1024)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        }, 32)
+        .concatMapMaybe(Maybe::just, 32)
+        .test()
+        .assertValueCount(1024)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void simpleLongPrefetchHidden() {
+        Flowable.range(1, 1024).hide()
+        .concatMapMaybe(Maybe::just, 32)
         .test()
         .assertValueCount(1024)
         .assertNoErrors()
@@ -463,5 +467,55 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
                 }, true, 2);
             }
         });
+    }
+
+    @Test
+    public void basicNonFused() {
+        Flowable.range(1, 5).hide()
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicSyncFused() {
+        Flowable.range(1, 5)
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicAsyncFused() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicFusionRejected() {
+        TestHelper.<Integer>rejectFlowableFusion()
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertEmpty();
+    }
+
+    @Test
+    public void fusedPollCrash() {
+        Flowable.range(1, 5)
+        .map(v -> {
+            if (v == 3) {
+                throw new TestException();
+            }
+            return v;
+        })
+        .compose(TestHelper.flowableStripBoundary())
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertFailure(TestException.class, 1, 2);
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.internal.operators.mixed.FlowableConcatMapSingle.Con
 import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava3.internal.util.ErrorMode;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
-import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.processors.*;
 import io.reactivex.rxjava3.subjects.SingleSubject;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.reactivex.rxjava3.testsupport.*;
@@ -52,15 +52,19 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
     }
 
     @Test
-    public void simpleLong() {
+    public void simpleLongPrefetch() {
         Flowable.range(1, 1024)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        }, 32)
+        .concatMapSingle(Single::just, 32)
+        .test()
+        .assertValueCount(1024)
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @Test
+    public void simpleLongPrefetchHidden() {
+        Flowable.range(1, 1024).hide()
+        .concatMapSingle(Single::just, 32)
         .test()
         .assertValueCount(1024)
         .assertNoErrors()
@@ -381,5 +385,55 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
                 }, true, 2);
             }
         });
+    }
+
+    @Test
+    public void basicNonFused() {
+        Flowable.range(1, 5).hide()
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicSyncFused() {
+        Flowable.range(1, 5)
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicAsyncFused() {
+        UnicastProcessor<Integer> up = UnicastProcessor.create();
+        TestHelper.emit(up, 1, 2, 3, 4, 5);
+
+        up
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicFusionRejected() {
+        TestHelper.<Integer>rejectFlowableFusion()
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertEmpty();
+    }
+
+    @Test
+    public void fusedPollCrash() {
+        Flowable.range(1, 5)
+        .map(v -> {
+            if (v == 3) {
+                throw new TestException();
+            }
+            return v;
+        })
+        .compose(TestHelper.flowableStripBoundary())
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertFailure(TestException.class, 1, 2);
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -485,4 +485,54 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
             }
         });
     }
+
+    @Test
+    public void basicNonFused() {
+        Observable.range(1, 5).hide()
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicSyncFused() {
+        Observable.range(1, 5)
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicAsyncFused() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicFusionRejected() {
+        TestHelper.<Integer>rejectObservableFusion()
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertEmpty();
+    }
+
+    @Test
+    public void fusedPollCrash() {
+        Observable.range(1, 5)
+        .map(v -> {
+            if (v == 3) {
+                throw new TestException();
+            }
+            return v;
+        })
+        .compose(TestHelper.observableStripBoundary())
+        .concatMapMaybe(v -> Maybe.just(v).hide())
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -425,4 +425,54 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
             }
         });
     }
+
+    @Test
+    public void basicNonFused() {
+        Observable.range(1, 5).hide()
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicSyncFused() {
+        Observable.range(1, 5)
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicAsyncFused() {
+        UnicastSubject<Integer> us = UnicastSubject.create();
+        TestHelper.emit(us, 1, 2, 3, 4, 5);
+
+        us
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void basicFusionRejected() {
+        TestHelper.<Integer>rejectObservableFusion()
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertEmpty();
+    }
+
+    @Test
+    public void fusedPollCrash() {
+        Observable.range(1, 5)
+        .map(v -> {
+            if (v == 3) {
+                throw new TestException();
+            }
+            return v;
+        })
+        .compose(TestHelper.observableStripBoundary())
+        .concatMapSingle(v -> Single.just(v).hide())
+        .test()
+        .assertFailure(TestException.class, 1, 2);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -3018,6 +3018,12 @@ public enum TestHelper {
         }
     }
 
+    /**
+     * Creates a fuseable Observable that does not emit anything but rejects
+     * fusion requests.
+     * @param <T> the element type
+     * @return the new Observable
+     */
     public static <T> Observable<T> rejectObservableFusion() {
         return new Observable<T>() {
             @Override
@@ -3066,6 +3072,12 @@ public enum TestHelper {
         };
     }
 
+    /**
+     * Creates a fuseable Flowable that does not emit anything but rejects
+     * fusion requests.
+     * @param <T> the element type
+     * @return the new Observable
+     */
     public static <T> Flowable<T> rejectFlowableFusion() {
         return new Flowable<T>() {
             @Override


### PR DESCRIPTION
This PR adds front fusion support to
- `Flowable.concatMapCompletable`
- `Flowable.concatMapMaybe`
- `Flowable.concatMapSingle`
- `Observable.concatMapCompletable`
- `Observable.concatMapMaybe`
- `Observable.concatMapSingle`

The operators have been tidied up by factoring out common code paths.

In addition, the `DeferredScalarSubscription`'s fusion-emission had to be fixed. In async fusion mode, `onNext(null)` is generally expected from the upstream but `DeferredScalarSubscription` sent the value itself. Now it correctly sends `null`. (`DeferredScalarDisposable` already did this correctly).

Resolves #7061