### PR TITLE
3.x: Workaround for FutureTask.toString + JDK 11 build

### DIFF
--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: JDK 11
+
+on:
+  push:
+    branches: [ 3.x ]
+  pull_request:
+    branches: [ 3.x ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build PR
+      run: ./gradlew -PreleaseMode=pr build --stacktrace
+    #- name: Upload to Codecov  
+    #  uses: codecov/codecov-action@v1

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/AbstractDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/AbstractDirectTask.java
@@ -83,4 +83,24 @@ implements Disposable, SchedulerRunnableIntrospection {
     public Runnable getWrappedRunnable() {
         return runnable;
     }
+
+    @Override
+    public String toString() {
+        String status;
+        Future<?> f = get();
+        if (f == FINISHED) {
+            status = "Finished";
+        } else if (f == DISPOSED) {
+            status = "Disposed";
+        } else {
+            Thread r = runner;
+            if (r != null) {
+                status = "Running on " + runner;
+            } else {
+                status = "Waiting";
+            }
+        }
+
+        return getClass().getSimpleName() + "[" + status + "]";
+    }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -39,8 +39,8 @@ public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implem
             runner = null;
         } catch (Throwable ex) {
             // Exceptions.throwIfFatal(ex); nowhere to go
-            runner = null;
             dispose();
+            runner = null;
             RxJavaPlugins.onError(ex);
             throw ex;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnable.java
@@ -69,7 +69,6 @@ implements Runnable, Callable<Object>, Disposable {
                 throw e;
             }
         } finally {
-            lazySet(THREAD_INDEX, null);
             Object o = get(PARENT_INDEX);
             if (o != PARENT_DISPOSED && compareAndSet(PARENT_INDEX, o, DONE) && o != null) {
                 ((DisposableContainer)o).delete(this);
@@ -81,6 +80,7 @@ implements Runnable, Callable<Object>, Disposable {
                     break;
                 }
             }
+            lazySet(THREAD_INDEX, null);
         }
     }
 
@@ -136,5 +136,27 @@ implements Runnable, Callable<Object>, Disposable {
     public boolean isDisposed() {
         Object o = get(PARENT_INDEX);
         return o == PARENT_DISPOSED || o == DONE;
+    }
+
+    @Override
+    public String toString() {
+        String state;
+        Object o = get(FUTURE_INDEX);
+        if (o == DONE) {
+            state = "Finished";
+        } else if (o == SYNC_DISPOSED) {
+            state = "Disposed(Sync)";
+        } else if (o == ASYNC_DISPOSED) {
+            state = "Disposed(Async)";
+        } else {
+            o = get(THREAD_INDEX);
+            if (o == null) {
+                state = "Waiting";
+            } else {
+                state = "Running on " + o;
+            }
+        }
+
+        return getClass().getSimpleName() + "[" + state + "]";
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/AbstractDirectTaskTest.java
@@ -241,4 +241,31 @@ public class AbstractDirectTaskTest extends RxJavaTest {
             TestHelper.race(r1, r2);
         }
     }
+
+    static class TestDirectTask extends AbstractDirectTask {
+        private static final long serialVersionUID = 587679821055711738L;
+
+        TestDirectTask() {
+            super(Functions.EMPTY_RUNNABLE);
+        }
+    }
+
+    @Test
+    public void toStringStates() {
+        TestDirectTask task = new TestDirectTask();
+
+        assertEquals("TestDirectTask[Waiting]", task.toString());
+
+        task.runner = Thread.currentThread();
+
+        assertEquals("TestDirectTask[Running on " + Thread.currentThread() + "]", task.toString());
+
+        task.dispose();
+
+        assertEquals("TestDirectTask[Disposed]", task.toString());
+
+        task.set(AbstractDirectTask.FINISHED);
+
+        assertEquals("TestDirectTask[Finished]", task.toString());
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledRunnableTest.java
@@ -399,4 +399,29 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
         assertFalse(set.remove(run));
     }
+
+    @Test
+    public void toStringStates() {
+        CompositeDisposable set = new CompositeDisposable();
+        ScheduledRunnable task = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
+
+        assertEquals("ScheduledRunnable[Waiting]", task.toString());
+
+        task.set(ScheduledRunnable.THREAD_INDEX, Thread.currentThread());
+
+        assertEquals("ScheduledRunnable[Running on " + Thread.currentThread() + "]", task.toString());
+
+        task.dispose();
+
+        assertEquals("ScheduledRunnable[Disposed(Sync)]", task.toString());
+
+        task.set(ScheduledRunnable.FUTURE_INDEX, ScheduledRunnable.DONE);
+
+        assertEquals("ScheduledRunnable[Finished]", task.toString());
+
+        task = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
+        task.dispose();
+
+        assertEquals("ScheduledRunnable[Disposed(Async)]", task.toString());
+    }
 }


### PR DESCRIPTION
Starting from JDK 10, the `FutureTask.toString` can now print the inner callable routine, which if somehow references the parent `FutureTask` again, it leads to `StackOverflowError`. This can happen in RxJava because `AbstractDirectTask` and `ScheduledRunnable` store the `Future` object returned by the executor in a reference field that gets accessed by their default `toString` implementation.

The fix is to define custom `toString`s that break this cycle. Note that we can't print the underlying `Runnable` either because that could also reference something in a circular manner. In addition, the release of the `runner` `Thread` marker has been moved closer to the exit of the wrappers which helps with the state determination and self-cancellation.

To verify the fix works, a new GitHub Action has been added, targeting JDK 11 as the issue does not manifest itself under the main target JDK 8.

Resolves #7172