### PR TITLE
3.x: Separate GitHub Action for JavaDocs pushback for releases

### DIFF
--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -21,7 +21,6 @@ jobs:
       bintrayKey: ${{ secrets.BINTRAY_KEY }}
       sonatypeUsername: ${{ secrets.SONATYPE_USER }}
       sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-      JAVADOCS_TOKEN: ${{ secrets.JAVADOCS_TOKEN }}
       # ------------------------------------------------------------------------------ 
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
@@ -38,8 +37,6 @@ jobs:
         restore-keys: ${{ runner.os }}-gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Grant execute permission for push
-      run: chmod +x push_javadoc.sh
     - name: Extract version tag
       run: echo "BUILD_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
     - name: Build and Release

--- a/.github/workflows/gradle_release_docs.yml
+++ b/.github/workflows/gradle_release_docs.yml
@@ -38,7 +38,7 @@ jobs:
       run: chmod +x push_javadoc.sh
     - name: Extract version tag
       run: echo "BUILD_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
-    - name: Build and Release
+    - name: Assemble and Generate JavaDocs
       run: ./gradlew assemble javadoc --stacktrace
     - name: Push Javadocs
       run: ./push_javadoc.sh

--- a/.github/workflows/gradle_release_docs.yml
+++ b/.github/workflows/gradle_release_docs.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Release
+name: Release JavaDocs
 
 on:
   release:
@@ -17,10 +17,6 @@ jobs:
     env:
       # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
       # ------------------------------------------------------------------------------ 
-      bintrayUser: ${{ secrets.BINTRAY_USER }}
-      bintrayKey: ${{ secrets.BINTRAY_KEY }}
-      sonatypeUsername: ${{ secrets.SONATYPE_USER }}
-      sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
       JAVADOCS_TOKEN: ${{ secrets.JAVADOCS_TOKEN }}
       # ------------------------------------------------------------------------------ 
       CI_BUILD_NUMBER: ${{ github.run_number }}
@@ -43,6 +39,6 @@ jobs:
     - name: Extract version tag
       run: echo "BUILD_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
     - name: Build and Release
-      run: ./gradlew -PreleaseMode=full -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build --stacktrace
-    - name: Upload to Codecov  
-      uses: codecov/codecov-action@v1
+      run: ./gradlew assemble javadoc --stacktrace
+    - name: Push Javadocs
+      run: ./push_javadoc.sh

--- a/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
@@ -91,7 +91,7 @@ import io.reactivex.rxjava3.schedulers.SchedulerRunnableIntrospection;
 public abstract class Scheduler {
     /**
      * Value representing whether to use {@link System#nanoTime()}, or default as clock for {@link #now(TimeUnit)}
-     * and {@link Scheduler.Worker#now(TimeUnit)}
+     * and {@link Scheduler.Worker#now(TimeUnit)}.
      * <p>
      * Associated system parameter:
      * <ul>
@@ -111,7 +111,7 @@ public abstract class Scheduler {
      * @throws NullPointerException if {@code unit} is {@code null}
      */
     static long computeNow(TimeUnit unit) {
-        if(!IS_DRIFT_USE_NANOTIME) {
+        if (!IS_DRIFT_USE_NANOTIME) {
             return unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
         }
         return unit.convert(System.nanoTime(), TimeUnit.NANOSECONDS);


### PR DESCRIPTION
As of late, releases tend to get stuck between BinTray and Sonatype with Validation Failure. This freezes out the bintray plugin and the release process stops progressing to the codecov & JavaDocs pushbacks.

This PR adds a separate GitHub Action (GHA) to generate and push back the JavaDocs in parallel with the BinTray release process so when it hangs, there is no extra work needed to manually generate and upload the Javadocs to the gh-pages branch.

Unfortunately, since the release does reach BinTray but not Sonatype, simply restarting the Release GHA would then fail with duplicate release on BinTray itself. There are currently [no options](https://github.com/bintray/gradle-bintray-plugin/issues/317) to timeout or ignore errors with the bintray plugin.

Also unfortunate that there is no good way to test this action outside of a full or pre-release triggered from GH so the next release for RxJava has to do release-candidates (RC1,...) first.