### PR TITLE
3.x: Allow reruns of release actions by enabling bintray.override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -349,6 +349,7 @@ if (rootProject.hasProperty("releaseMode")) {
          key = rootProject.bintrayKey
          configurations = ["archives"]
          publish = true
+         override = true // Allows re-running the GHA upon release hangs
          pkg {
            repo = "RxJava"
            name = "RxJava"


### PR DESCRIPTION
By default, the bintray plugin only uploads a particular release version once. However, if the maven release fails afterwards, re-running the GitHub Action (GHA) would now fail with duplicate release error.

This setting of the bintray plugin allows overriding existing releases thus the GHA could be rerun and hopefully succeed next time.

Note to test this, a release or pre-release has to be issued so the next release for RxJava has to do release-candidates (RC1,...) first.