### PR TITLE
3.x: Release to Sonatype directly

### DIFF
--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -17,11 +17,11 @@ jobs:
     env:
       # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
       # ------------------------------------------------------------------------------ 
-      bintrayUser: ${{ secrets.BINTRAY_USER }}
-      bintrayKey: ${{ secrets.BINTRAY_KEY }}
-      sonatypeUsername: ${{ secrets.SONATYPE_USER }}
-      sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
       JAVADOCS_TOKEN: ${{ secrets.JAVADOCS_TOKEN }}
+      ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_USER }}
+      ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
+      ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
       # ------------------------------------------------------------------------------ 
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
@@ -43,8 +43,12 @@ jobs:
     - name: Extract version tag
       run: echo "BUILD_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
     - name: Build and Release
-      run: ./gradlew -PreleaseMode=full -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build --stacktrace
+      run: ./gradlew -PreleaseMode=full build --stacktrace --no-daemon
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
+    - name: Upload release
+      run: ./gradlew -PreleaseMode=full javadocCleanup uploadArchives --no-daemon --no-parallel
+    - name: Publish release
+      run: ./gradlew -PreleaseMode=full closeAndReleaseRepository --no-daemon --no-parallel
     - name: Push Javadocs
       run: ./push_javadoc.sh

--- a/build.gradle
+++ b/build.gradle
@@ -13,15 +13,14 @@ buildscript {
   ext.jacocoVersion = "0.8.4"
   ext.animalSnifferVersion = "1.5.2"
   ext.licenseVersion = "0.15.0"
-  ext.bintrayVersion = "1.8.5"
   ext.jfrogExtractorVersion = "4.20.0"
   ext.bndVersion = "5.2.0"
   ext.checkstyleVersion = "8.26"
+  ext.vanniktechPublishPlugin = "0.13.0"
 
   // --------------------------------------
 
   repositories { 
-    jcenter()
     mavenCentral()
     maven {
         url "https://plugins.gradle.org/m2/"
@@ -31,9 +30,9 @@ buildscript {
     classpath "ru.vyarus:gradle-animalsniffer-plugin:$animalSnifferVersion"
     classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:$licenseVersion"
     classpath "me.champeau.gradle:jmh-gradle-plugin:$jmhGradleVersion"
-    classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$bintrayVersion"
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:$jfrogExtractorVersion"
     classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:$bndVersion"
+    classpath "com.vanniktech:gradle-maven-publish-plugin:$vanniktechPublishPlugin"
   }
 }
 
@@ -48,10 +47,13 @@ if (releaseTag != null && !releaseTag.isEmpty()) {
         releaseTag = releaseTag.substring(1);
     }
     version = releaseTag;
-    project.properties.put("release.version", releaseTag);
+    project.setProperty("release.version", releaseTag);
+    project.setProperty("VERSION_NAME" , releaseTag);
 
     println("Releasing with version " + version);
 }
+
+println(project.properties["VERSION_NAME"])
 
 description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
 
@@ -62,7 +64,6 @@ apply plugin: "ru.vyarus.animalsniffer"
 apply plugin: "maven"
 apply plugin: "me.champeau.gradle.jmh"
 apply plugin: "com.github.hierynomus.license"
-apply plugin: "com.jfrog.bintray"
 apply plugin: "com.jfrog.artifactory"
 apply plugin: "eclipse"
 
@@ -116,21 +117,7 @@ animalsniffer {
     annotation = "io.reactivex.rxjava3.internal.util.SuppressAnimalSniffer"
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = "javadoc"
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives jar
-    archives sourcesJar
-    archives javadocJar
-}
+apply plugin: 'maven'
 
 apply plugin: 'biz.aQute.bnd.builder'
 
@@ -154,60 +141,16 @@ license {
     excludes(["**/*.md", "**/*.txt"])
 }
 
-apply plugin: "maven-publish"
-
-install {
-    repositories.mavenInstaller.pom.project {
-        name "RxJava"
-        description "Reactive Extensions for Java"
-        url "https://github.com/ReactiveX/RxJava"
-        licenses {
-            license {
-                name "The Apache Software License, Version 2.0"
-                url "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                distribution "repo"
-            }
-        }
-        developers {
-            developer {
-                id "akarnokd"
-                name "David Karnok"
-                email "akarnokd@gmail.com"
-            }
-        }
-        scm {
-            connection "scm:git:git@github.com:ReactiveX/RxJava.git"
-            url "scm:git:git@github.com:ReactiveX/RxJava.git"
-            developerConnection "scm:git:git@github.com:ReactiveX/RxJava.git"
-        }
-        issueManagement {
-            system "github"
-            url "https://github.com/ReactiveX/RxJava/issues"
-        }
-    }
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-            artifact (sourcesJar) { 
-                classifier = "sources"
-            }
-        }
-    }
-}
-
 // Reactive-Streams as compile dependency
-publishing.publications.all {
-  pom.withXml {
-    asNode().dependencies."*".findAll() {
-      it.scope.text() == "runtime" && project.configurations.compile.allDependencies.find { dep ->
-        dep.name == it.artifactId.text()
-      }
-    }.each { it.scope*.value = "compile"}
-  }
-}
+// publishing.publications.all {
+//   pom.withXml {
+//     asNode().dependencies."*".findAll() {
+//       it.scope.text() == "runtime" && project.configurations.compile.allDependencies.find { dep ->
+//         dep.name == it.artifactId.text()
+//       }
+//     }.each { it.scope*.value = "compile"}
+//   }
+// }
 
 jmh {
     jmhVersion = jmhLibVersion
@@ -312,6 +255,8 @@ checkstyle {
     toolVersion = checkstyleVersion
 }
 
+apply from: file("gradle/javadoc_cleanup.gradle")
+
 if (rootProject.hasProperty("releaseMode")) {
 
   if ("branch".equals(rootProject.releaseMode)) {
@@ -338,42 +283,13 @@ if (rootProject.hasProperty("releaseMode")) {
     build.finalizedBy(artifactoryPublish)
   }
 
-   if ("full".equals(rootProject.releaseMode)) {
-      // based on https://github.com/bintray/gradle-bintray-plugin
-      def rver = version;
+  if ("full".equals(rootProject.releaseMode)) {
+    apply plugin: "com.vanniktech.maven.publish"
 
-      println("ReleaseMode: " + rootProject.releaseMode + " version " + rver);
-
-      bintray {
-         user = rootProject.bintrayUser
-         key = rootProject.bintrayKey
-         configurations = ["archives"]
-         publish = true
-         override = true // Allows re-running the GHA upon release hangs
-         pkg {
-           repo = "RxJava"
-           name = "RxJava"
-           userOrg = "reactivex"
-           labels = ["rxjava", "reactivex"]
-           licenses = ["Apache-2.0"]
-           vcsUrl = "https://github.com/ReactiveX/RxJava.git"
-           version {
-             name = rver
-             gpg {
-                sign = true
-             }
-             mavenCentralSync {
-               sync = true 
-               user = rootProject.sonatypeUsername
-               password = rootProject.sonatypePassword
-               close = "1"
-             }
-           }
-         }
+    signing {
+      if (project.hasProperty('SIGNING_PRIVATE_KEY') && project.hasProperty('SIGNING_PASSWORD')) {
+         useInMemoryPgpKeys(project.getProperty('SIGNING_PRIVATE_KEY'), project.getProperty('SIGNING_PASSWORD'))
       }
-      
-      build.finalizedBy(bintrayUpload)
-   }
+    }
+  }
 }
-
-apply from: file("gradle/javadoc_cleanup.gradle")

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ if (releaseTag != null && !releaseTag.isEmpty()) {
     if (releaseTag.startsWith("v")) {
         releaseTag = releaseTag.substring(1);
     }
-    project.setProperty("release.version", releaseTag);
     project.setProperty("VERSION_NAME" , releaseTag);
 
     println("Releasing with version " + version);
@@ -137,17 +136,6 @@ license {
     ignoreFailures true
     excludes(["**/*.md", "**/*.txt"])
 }
-
-// Reactive-Streams as compile dependency
-// publishing.publications.all {
-//   pom.withXml {
-//     asNode().dependencies."*".findAll() {
-//       it.scope.text() == "runtime" && project.configurations.compile.allDependencies.find { dep ->
-//         dep.name == it.artifactId.text()
-//       }
-//     }.each { it.scope*.value = "compile"}
-//   }
-// }
 
 jmh {
     jmhVersion = jmhLibVersion
@@ -282,6 +270,17 @@ if (rootProject.hasProperty("releaseMode")) {
 
   if ("full".equals(rootProject.releaseMode)) {
     apply plugin: "com.vanniktech.maven.publish"
+
+    // Reactive-Streams as compile dependency
+    publishing.publications.all {
+      pom.withXml {
+        asNode().dependencies."*".findAll() {
+          it.scope.text() == "runtime" && project.configurations.compile.allDependencies.find { dep ->
+            dep.name == it.artifactId.text()
+          }
+        }.each { it.scope*.value = "compile"}
+      }
+    }
 
     signing {
       if (project.hasProperty('SIGNING_PRIVATE_KEY') && project.hasProperty('SIGNING_PASSWORD')) {

--- a/build.gradle
+++ b/build.gradle
@@ -242,12 +242,26 @@ checkstyle {
 
 apply from: file("gradle/javadoc_cleanup.gradle")
 
+def fixPom() {
+    // Reactive-Streams as compile dependency
+    publishing.publications.all {
+      pom.withXml {
+        asNode().dependencies."*".findAll() {
+          it.scope.text() == "runtime" && project.configurations.compile.allDependencies.find { dep ->
+            dep.name == it.artifactId.text()
+          }
+        }.each { it.scope*.value = "compile"}
+      }
+    }
+}
+
 if (rootProject.hasProperty("releaseMode")) {
 
   if ("branch".equals(rootProject.releaseMode)) {
     // From https://github.com/ReactiveX/RxAndroid/blob/2.x/rxandroid/build.gradle#L94
   
     println("ReleaseMode: " + rootProject.releaseMode);
+
     artifactory {
         contextUrl = "https://oss.jfrog.org"
     
@@ -262,6 +276,8 @@ if (rootProject.hasProperty("releaseMode")) {
             defaults {
                 publishConfigs("archives")
             }
+
+            fixPom()
         }
     }
     
@@ -271,16 +287,7 @@ if (rootProject.hasProperty("releaseMode")) {
   if ("full".equals(rootProject.releaseMode)) {
     apply plugin: "com.vanniktech.maven.publish"
 
-    // Reactive-Streams as compile dependency
-    publishing.publications.all {
-      pom.withXml {
-        asNode().dependencies."*".findAll() {
-          it.scope.text() == "runtime" && project.configurations.compile.allDependencies.find { dep ->
-            dep.name == it.artifactId.text()
-          }
-        }.each { it.scope*.value = "compile"}
-      }
-    }
+    fixPom()
 
     signing {
       if (project.hasProperty('SIGNING_PRIVATE_KEY') && project.hasProperty('SIGNING_PASSWORD')) {

--- a/build.gradle
+++ b/build.gradle
@@ -39,21 +39,18 @@ buildscript {
 group = "io.reactivex.rxjava3"
 ext.githubProjectName = "rxjava"
 
-version = project.properties["release.version"]
-
 def releaseTag = System.getenv("BUILD_TAG");
 if (releaseTag != null && !releaseTag.isEmpty()) {
     if (releaseTag.startsWith("v")) {
         releaseTag = releaseTag.substring(1);
     }
-    version = releaseTag;
     project.setProperty("release.version", releaseTag);
     project.setProperty("VERSION_NAME" , releaseTag);
 
     println("Releasing with version " + version);
 }
 
-println(project.properties["VERSION_NAME"])
+version = project.properties["VERSION_NAME"]
 
 description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 release.scope=patch
-release.version=3.0.0-SNAPSHOT
 VERSION_NAME=3.0.0-SNAPSHOT
 
 GROUP=io.reactivex.rxjava3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,25 @@
 release.scope=patch
 release.version=3.0.0-SNAPSHOT
+VERSION_NAME=3.0.0-SNAPSHOT
+
+GROUP=io.reactivex.rxjava3
+POM_ARTIFACT_ID=rxjava
+POM_NAME=RxJava
+POM_PACKAGING=jar
+
+POM_DESCRIPTION=Reactive Extensions for Java
+POM_INCEPTION_YEAR=2013
+
+POM_URL=https://github.com/akarnokd/RxJavaExtensions
+POM_SCM_URL=https://github.com/ReactiveX/RxJava
+POM_SCM_CONNECTION=scm:git:git://github.com/ReactiveX/RxJava.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ReactiveX/RxJava.git
+
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=akarnokd
+POM_DEVELOPER_NAME=David Karnok
+POM_DEVELOPER_URL=https://github.com/akarnokd/
+POM_DEVELOPER_EMAIL=akarnokd@gmail.com

--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -57,5 +57,4 @@ def fixJavadocFile(file) {
     file.setText(fileContents, 'UTF-8');
 }
 
-javadocJar.dependsOn javadocCleanup
 build.dependsOn javadocCleanup 


### PR DESCRIPTION
Update the release process to use Sonatype directly via the help of the `com.vanniktech:gradle-maven-publish-plugin`.

In order for it to work, two secrets has to be set in the [settings](https://github.com/ReactiveX/RxJava/settings/secrets/actions):

 - `SIGNING_PRIVATE_KEY`
- `SIGNING_PASSWORD`

The `SIGNING_PRIVATE_KEY` should be the ascii-armored private key to sign the JAR files and can be generated from a pgp keychain:

```
gpg --export-secret-key --armor ___key_name_here___ > private_key.asc
```

The `SIGNING_PASSWORD` is then the password for that `private_key.asc`.

I tested the process on my local machine as much as I could, but we'll only know if it really works when doing an RxJava release.

Resolves #7179
