### PR TITLE
3.x: Add onSubscribe hook to ParallelFlowable operators

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Scheduler.java
@@ -91,7 +91,7 @@ import io.reactivex.rxjava3.schedulers.SchedulerRunnableIntrospection;
 public abstract class Scheduler {
     /**
      * Value representing whether to use {@link System#nanoTime()}, or default as clock for {@link #now(TimeUnit)}
-     * and {@link Scheduler.Worker#now(TimeUnit)}
+     * and {@link Scheduler.Worker#now(TimeUnit)}.
      * <p>
      * Associated system parameter:
      * <ul>
@@ -111,7 +111,7 @@ public abstract class Scheduler {
      * @throws NullPointerException if {@code unit} is {@code null}
      */
     static long computeNow(TimeUnit unit) {
-        if(!IS_DRIFT_USE_NANOTIME) {
+        if (!IS_DRIFT_USE_NANOTIME) {
             return unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
         }
         return unit.convert(System.nanoTime(), TimeUnit.NANOSECONDS);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelCollect.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelCollect.java
@@ -47,6 +47,8 @@ public final class ParallelCollect<T, C> extends ParallelFlowable<C> {
 
     @Override
     public void subscribe(Subscriber<? super C>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelConcatMap.java
@@ -19,6 +19,7 @@ import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMap;
 import io.reactivex.rxjava3.internal.util.ErrorMode;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 import java.util.Objects;
 
@@ -55,6 +56,8 @@ public final class ParallelConcatMap<T, R> extends ParallelFlowable<R> {
 
     @Override
     public void subscribe(Subscriber<? super R>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelDoOnNextTry.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelDoOnNextTry.java
@@ -48,6 +48,8 @@ public final class ParallelDoOnNextTry<T> extends ParallelFlowable<T> {
 
     @Override
     public void subscribe(Subscriber<? super T>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFilter.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFilter.java
@@ -40,6 +40,8 @@ public final class ParallelFilter<T> extends ParallelFlowable<T> {
 
     @Override
     public void subscribe(Subscriber<? super T>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFilterTry.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFilterTry.java
@@ -46,6 +46,8 @@ public final class ParallelFilterTry<T> extends ParallelFlowable<T> {
 
     @Override
     public void subscribe(Subscriber<? super T>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFlatMap.java
@@ -18,6 +18,7 @@ import org.reactivestreams.*;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.operators.flowable.FlowableFlatMap;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Flattens the generated Publishers on each rail.
@@ -57,6 +58,8 @@ public final class ParallelFlatMap<T, R> extends ParallelFlowable<R> {
 
     @Override
     public void subscribe(Subscriber<? super R>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFlatMapIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFlatMapIterable.java
@@ -18,6 +18,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.operators.flowable.FlowableFlattenIterable;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Flattens the generated {@link Iterable}s on each rail.
@@ -50,6 +51,8 @@ public final class ParallelFlatMapIterable<T, R> extends ParallelFlowable<R> {
 
     @Override
     public void subscribe(Subscriber<? super R>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFromArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFromArray.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava3.internal.operators.parallel;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Wraps multiple Publishers into a ParallelFlowable which runs them
@@ -37,6 +38,8 @@ public final class ParallelFromArray<T> extends ParallelFlowable<T> {
 
     @Override
     public void subscribe(Subscriber<? super T>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFromPublisher.java
@@ -24,6 +24,7 @@ import io.reactivex.rxjava3.internal.queue.SpscArrayQueue;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.BackpressureHelper;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Dispatches the values from upstream in a round robin fashion to subscribers which are
@@ -51,6 +52,8 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
 
     @Override
     public void subscribe(Subscriber<? super T>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelMap.java
@@ -44,6 +44,8 @@ public final class ParallelMap<T, R> extends ParallelFlowable<R> {
 
     @Override
     public void subscribe(Subscriber<? super R>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelMapTry.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelMapTry.java
@@ -49,6 +49,8 @@ public final class ParallelMapTry<T, R> extends ParallelFlowable<R> {
 
     @Override
     public void subscribe(Subscriber<? super R>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelPeek.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelPeek.java
@@ -66,6 +66,8 @@ public final class ParallelPeek<T> extends ParallelFlowable<T> {
 
     @Override
     public void subscribe(Subscriber<? super T>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelReduce.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelReduce.java
@@ -46,6 +46,8 @@ public final class ParallelReduce<T, R> extends ParallelFlowable<R> {
 
     @Override
     public void subscribe(Subscriber<? super R>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelRunOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelRunOn.java
@@ -49,7 +49,9 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
     }
 
     @Override
-    public void subscribe(final Subscriber<? super T>[] subscribers) {
+    public void subscribe(Subscriber<? super T>[] subscribers) {
+        subscribers = RxJavaPlugins.onSubscribe(this, subscribers);
+
         if (!validate(subscribers)) {
             return;
         }

--- a/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
@@ -112,6 +112,10 @@ public final class RxJavaPlugins {
     @Nullable
     static volatile BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> onCompletableSubscribe;
 
+    @SuppressWarnings("rawtypes")
+    @Nullable
+    static volatile BiFunction<? super ParallelFlowable, ? super Subscriber[], ? extends Subscriber[]> onParallelSubscribe;
+
     @Nullable
     static volatile BooleanSupplier onBeforeBlocking;
 
@@ -525,6 +529,7 @@ public final class RxJavaPlugins {
         setOnMaybeSubscribe(null);
 
         setOnParallelAssembly(null);
+        setOnParallelSubscribe(null);
 
         setFailOnNonBlockingScheduler(false);
         setOnBeforeBlocking(null);
@@ -996,6 +1001,23 @@ public final class RxJavaPlugins {
      * Calls the associated hook function.
      * @param <T> the value type
      * @param source the hook's input value
+     * @param subscribers the array of subscribers
+     * @return the value returned by the hook
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @NonNull
+    public static <T> Subscriber<@NonNull ? super T>[] onSubscribe(@NonNull ParallelFlowable<T> source, @NonNull Subscriber<@NonNull ? super T>[] subscribers) {
+        BiFunction<? super ParallelFlowable, ? super Subscriber[], ? extends Subscriber[]> f = onParallelSubscribe;
+        if (f != null) {
+            return apply(f, source, subscribers);
+        }
+        return subscribers;
+    }
+
+    /**
+     * Calls the associated hook function.
+     * @param <T> the value type
+     * @param source the hook's input value
      * @return the value returned by the hook
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1126,6 +1148,32 @@ public final class RxJavaPlugins {
     @Nullable
     public static Function<? super ParallelFlowable, ? extends ParallelFlowable> getOnParallelAssembly() {
         return onParallelAssembly;
+    }
+
+    /**
+     * Sets the specific hook function.
+     * @param handler the hook function to set, null allowed
+     * @since 3.0.11 - experimental
+     */
+    @SuppressWarnings("rawtypes")
+    @Experimental
+    public static void setOnParallelSubscribe(@Nullable BiFunction<? super ParallelFlowable, ? super Subscriber[], ? extends Subscriber[]> handler) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        onParallelSubscribe = handler;
+    }
+
+    /**
+     * Returns the current hook function.
+     * @return the hook function, may be null
+     * @since 3.0.11 - experimental
+     */
+    @SuppressWarnings("rawtypes")
+    @Experimental
+    @Nullable
+    public static BiFunction<? super ParallelFlowable, ? super Subscriber[], ? extends Subscriber[]> getOnParallelSubscribe() {
+        return onParallelSubscribe;
     }
 
     /**


### PR DESCRIPTION
Parallel operators were missing an `RxJavaPlugins.onSubscribe` hook.

Resolves #7190