### PR TITLE
3.x: Fix Schedulers.from to honor interruptibleWorker across methods

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
@@ -58,7 +58,7 @@ public final class ExecutorScheduler extends Scheduler {
         Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         try {
             if (executor instanceof ExecutorService) {
-                ScheduledDirectTask task = new ScheduledDirectTask(decoratedRun);
+                ScheduledDirectTask task = new ScheduledDirectTask(decoratedRun, interruptibleWorker);
                 Future<?> f = ((ExecutorService)executor).submit(task);
                 task.setFuture(f);
                 return task;
@@ -85,7 +85,7 @@ public final class ExecutorScheduler extends Scheduler {
         final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
         if (executor instanceof ScheduledExecutorService) {
             try {
-                ScheduledDirectTask task = new ScheduledDirectTask(decoratedRun);
+                ScheduledDirectTask task = new ScheduledDirectTask(decoratedRun, interruptibleWorker);
                 Future<?> f = ((ScheduledExecutorService)executor).schedule(task, delay, unit);
                 task.setFuture(f);
                 return task;
@@ -110,7 +110,7 @@ public final class ExecutorScheduler extends Scheduler {
         if (executor instanceof ScheduledExecutorService) {
             Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
             try {
-                ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(decoratedRun);
+                ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(decoratedRun, interruptibleWorker);
                 Future<?> f = ((ScheduledExecutorService)executor).scheduleAtFixedRate(task, initialDelay, period, unit);
                 task.setFuture(f);
                 return task;

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
@@ -59,7 +59,7 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
      * @return the ScheduledRunnable instance
      */
     public Disposable scheduleDirect(final Runnable run, long delayTime, TimeUnit unit) {
-        ScheduledDirectTask task = new ScheduledDirectTask(RxJavaPlugins.onSchedule(run));
+        ScheduledDirectTask task = new ScheduledDirectTask(RxJavaPlugins.onSchedule(run), true);
         try {
             Future<?> f;
             if (delayTime <= 0L) {
@@ -104,7 +104,7 @@ public class NewThreadWorker extends Scheduler.Worker implements Disposable {
 
             return periodicWrapper;
         }
-        ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(decoratedRun);
+        ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(decoratedRun, true);
         try {
             Future<?> f = executor.scheduleAtFixedRate(task, initialDelay, period, unit);
             task.setFuture(f);

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -27,8 +27,8 @@ public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implem
 
     private static final long serialVersionUID = 1811839108042568751L;
 
-    public ScheduledDirectPeriodicTask(Runnable runnable) {
-        super(runnable);
+    public ScheduledDirectPeriodicTask(Runnable runnable, boolean interruptOnCancel) {
+        super(runnable, interruptOnCancel);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectTask.java
@@ -29,8 +29,8 @@ public final class ScheduledDirectTask extends AbstractDirectTask implements Cal
 
     private static final long serialVersionUID = 1811839108042568751L;
 
-    public ScheduledDirectTask(Runnable runnable) {
-        super(runnable);
+    public ScheduledDirectTask(Runnable runnable, boolean interruptOnCancel) {
+        super(runnable, interruptOnCancel);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SingleScheduler.java
@@ -105,7 +105,7 @@ public final class SingleScheduler extends Scheduler {
     @NonNull
     @Override
     public Disposable scheduleDirect(@NonNull Runnable run, long delay, TimeUnit unit) {
-        ScheduledDirectTask task = new ScheduledDirectTask(RxJavaPlugins.onSchedule(run));
+        ScheduledDirectTask task = new ScheduledDirectTask(RxJavaPlugins.onSchedule(run), true);
         try {
             Future<?> f;
             if (delay <= 0L) {
@@ -145,7 +145,7 @@ public final class SingleScheduler extends Scheduler {
 
             return periodicWrapper;
         }
-        ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(decoratedRun);
+        ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(decoratedRun, true);
         try {
             Future<?> f = executor.get().scheduleAtFixedRate(task, initialDelay, period, unit);
             task.setFuture(f);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableTimerTest.java
@@ -37,7 +37,7 @@ public class CompletableTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Void> to = Completable.timer(1, TimeUnit.MILLISECONDS, s)
                 .doOnComplete(new Action() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimerTest.java
@@ -352,7 +352,7 @@ public class FlowableTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestSubscriber<Long> ts = Flowable.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeTimerTest.java
@@ -37,7 +37,7 @@ public class MaybeTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Long> to = Maybe.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableTimerTest.java
@@ -317,7 +317,7 @@ public class ObservableTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Long> to = Observable.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleTimerTest.java
@@ -37,7 +37,7 @@ public class SingleTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Long> to = Single.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/AbstractDirectTaskTest.java
@@ -27,7 +27,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void cancelSetFuture() {
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -58,7 +58,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void cancelSetFutureCurrentThread() {
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -91,7 +91,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void setFutureCancel() {
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -119,7 +119,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void setFutureCancelSameThread() {
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -148,7 +148,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void finished() {
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -177,7 +177,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void finishedCancel() {
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -211,7 +211,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     @Test
     public void disposeSetFutureRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE) {
+            final AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
                 private static final long serialVersionUID = 208585707945686116L;
             };
 
@@ -246,7 +246,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
         private static final long serialVersionUID = 587679821055711738L;
 
         TestDirectTask() {
-            super(Functions.EMPTY_RUNNABLE);
+            super(Functions.EMPTY_RUNNABLE, true);
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/ScheduledDirectPeriodicTaskTest.java
@@ -35,7 +35,7 @@ public class ScheduledDirectPeriodicTaskTest extends RxJavaTest {
                 public void run() {
                     throw new TestException();
                 }
-            });
+            }, true);
 
             try {
                 task.run();

--- a/src/test/java/io/reactivex/rxjava3/schedulers/ExecutorSchedulerInterruptibleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/schedulers/ExecutorSchedulerInterruptibleTest.java
@@ -505,4 +505,464 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
             worker.dispose();
         }
     }
+
+    @Test
+    public void interruptibleDirectTaskScheduledExecutor() throws Exception {
+        ScheduledExecutorService exec = Executors.newScheduledThreadPool(1);
+        try {
+            Scheduler scheduler = Schedulers.from(exec, true);
+
+            final AtomicInteger sync = new AtomicInteger(2);
+
+            final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+            Disposable d = scheduler.scheduleDirect(new Runnable() {
+                @Override
+                public void run() {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                }
+            });
+
+            if (sync.decrementAndGet() != 0) {
+                while (sync.get() != 0) { }
+            }
+
+            Thread.sleep(500);
+
+            d.dispose();
+
+            int i = 20;
+            while (i-- > 0 && !isInterrupted.get()) {
+                Thread.sleep(50);
+            }
+
+            assertTrue("Interruption did not propagate", isInterrupted.get());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void interruptibleWorkerTaskScheduledExecutor() throws Exception {
+        ScheduledExecutorService exec = Executors.newScheduledThreadPool(1);
+        try {
+            Scheduler scheduler = Schedulers.from(exec, true);
+
+            Worker worker = scheduler.createWorker();
+
+            try {
+                final AtomicInteger sync = new AtomicInteger(2);
+
+                final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+                Disposable d = worker.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (sync.decrementAndGet() != 0) {
+                            while (sync.get() != 0) { }
+                        }
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ex) {
+                            isInterrupted.set(true);
+                        }
+                    }
+                });
+
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+
+                Thread.sleep(500);
+
+                d.dispose();
+
+                int i = 20;
+                while (i-- > 0 && !isInterrupted.get()) {
+                    Thread.sleep(50);
+                }
+
+                assertTrue("Interruption did not propagate", isInterrupted.get());
+            } finally {
+                worker.dispose();
+            }
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void nonInterruptibleDirectTask() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+            Scheduler scheduler = Schedulers.from(exec, false);
+
+            final AtomicInteger sync = new AtomicInteger(2);
+
+            final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+            Disposable d = scheduler.scheduleDirect(new Runnable() {
+                @Override
+                public void run() {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                }
+            });
+
+            if (sync.decrementAndGet() != 0) {
+                while (sync.get() != 0) { }
+            }
+
+            Thread.sleep(500);
+
+            d.dispose();
+
+            int i = 20;
+            while (i-- > 0 && !isInterrupted.get()) {
+                Thread.sleep(50);
+            }
+
+            assertFalse("Interruption happened", isInterrupted.get());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void nonInterruptibleWorkerTask() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+            Scheduler scheduler = Schedulers.from(exec, false);
+
+            Worker worker = scheduler.createWorker();
+
+            try {
+                final AtomicInteger sync = new AtomicInteger(2);
+
+                final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+                Disposable d = worker.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (sync.decrementAndGet() != 0) {
+                            while (sync.get() != 0) { }
+                        }
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ex) {
+                            isInterrupted.set(true);
+                        }
+                    }
+                });
+
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+
+                Thread.sleep(500);
+
+                d.dispose();
+
+                int i = 20;
+                while (i-- > 0 && !isInterrupted.get()) {
+                    Thread.sleep(50);
+                }
+
+                assertFalse("Interruption happened", isInterrupted.get());
+            } finally {
+                worker.dispose();
+            }
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void nonInterruptibleDirectTaskScheduledExecutor() throws Exception {
+        ScheduledExecutorService exec = Executors.newScheduledThreadPool(1);
+        try {
+            Scheduler scheduler = Schedulers.from(exec, false);
+
+            final AtomicInteger sync = new AtomicInteger(2);
+
+            final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+            Disposable d = scheduler.scheduleDirect(new Runnable() {
+                @Override
+                public void run() {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                }
+            });
+
+            if (sync.decrementAndGet() != 0) {
+                while (sync.get() != 0) { }
+            }
+
+            Thread.sleep(500);
+
+            d.dispose();
+
+            int i = 20;
+            while (i-- > 0 && !isInterrupted.get()) {
+                Thread.sleep(50);
+            }
+
+            assertFalse("Interruption happened", isInterrupted.get());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void nonInterruptibleWorkerTaskScheduledExecutor() throws Exception {
+        ScheduledExecutorService exec = Executors.newScheduledThreadPool(1);
+        try {
+            Scheduler scheduler = Schedulers.from(exec, false);
+
+            Worker worker = scheduler.createWorker();
+
+            try {
+                final AtomicInteger sync = new AtomicInteger(2);
+
+                final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+                Disposable d = worker.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (sync.decrementAndGet() != 0) {
+                            while (sync.get() != 0) { }
+                        }
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ex) {
+                            isInterrupted.set(true);
+                        }
+                    }
+                });
+
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+
+                Thread.sleep(500);
+
+                d.dispose();
+
+                int i = 20;
+                while (i-- > 0 && !isInterrupted.get()) {
+                    Thread.sleep(50);
+                }
+
+                assertFalse("Interruption happened", isInterrupted.get());
+            } finally {
+                worker.dispose();
+            }
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void nonInterruptibleDirectTaskTimed() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+            Scheduler scheduler = Schedulers.from(exec, false);
+
+            final AtomicInteger sync = new AtomicInteger(2);
+
+            final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+            Disposable d = scheduler.scheduleDirect(new Runnable() {
+                @Override
+                public void run() {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                }
+            }, 1, TimeUnit.MILLISECONDS);
+
+            if (sync.decrementAndGet() != 0) {
+                while (sync.get() != 0) { }
+            }
+
+            Thread.sleep(500);
+
+            d.dispose();
+
+            int i = 20;
+            while (i-- > 0 && !isInterrupted.get()) {
+                Thread.sleep(50);
+            }
+
+            assertFalse("Interruption happened", isInterrupted.get());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void nonInterruptibleWorkerTaskTimed() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        try {
+            Scheduler scheduler = Schedulers.from(exec, false);
+
+            Worker worker = scheduler.createWorker();
+
+            try {
+                final AtomicInteger sync = new AtomicInteger(2);
+
+                final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+                Disposable d = worker.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (sync.decrementAndGet() != 0) {
+                            while (sync.get() != 0) { }
+                        }
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ex) {
+                            isInterrupted.set(true);
+                        }
+                    }
+                }, 1, TimeUnit.MILLISECONDS);
+
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+
+                Thread.sleep(500);
+
+                d.dispose();
+
+                int i = 20;
+                while (i-- > 0 && !isInterrupted.get()) {
+                    Thread.sleep(50);
+                }
+
+                assertFalse("Interruption happened", isInterrupted.get());
+            } finally {
+                worker.dispose();
+            }
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void nonInterruptibleDirectTaskScheduledExecutorTimed() throws Exception {
+        ScheduledExecutorService exec = Executors.newScheduledThreadPool(1);
+        try {
+            Scheduler scheduler = Schedulers.from(exec, false);
+
+            final AtomicInteger sync = new AtomicInteger(2);
+
+            final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+            Disposable d = scheduler.scheduleDirect(new Runnable() {
+                @Override
+                public void run() {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
+                    }
+                }
+            }, 1, TimeUnit.MILLISECONDS);
+
+            if (sync.decrementAndGet() != 0) {
+                while (sync.get() != 0) { }
+            }
+
+            Thread.sleep(500);
+
+            d.dispose();
+
+            int i = 20;
+            while (i-- > 0 && !isInterrupted.get()) {
+                Thread.sleep(50);
+            }
+
+            assertFalse("Interruption happened", isInterrupted.get());
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    public void nonInterruptibleWorkerTaskScheduledExecutorTimed() throws Exception {
+        ScheduledExecutorService exec = Executors.newScheduledThreadPool(1);
+        try {
+            Scheduler scheduler = Schedulers.from(exec, false);
+
+            Worker worker = scheduler.createWorker();
+
+            try {
+                final AtomicInteger sync = new AtomicInteger(2);
+
+                final AtomicBoolean isInterrupted = new AtomicBoolean();
+
+                Disposable d = worker.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (sync.decrementAndGet() != 0) {
+                            while (sync.get() != 0) { }
+                        }
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ex) {
+                            isInterrupted.set(true);
+                        }
+                    }
+                }, 1, TimeUnit.MILLISECONDS);
+
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+
+                Thread.sleep(500);
+
+                d.dispose();
+
+                int i = 20;
+                while (i-- > 0 && !isInterrupted.get()) {
+                    Thread.sleep(50);
+                }
+
+                assertFalse("Interruption happened", isInterrupted.get());
+            } finally {
+                worker.dispose();
+            }
+        } finally {
+            exec.shutdown();
+        }
+    }
 }


### PR DESCRIPTION
The direct scheduling methods of the `ExecutorScheduler` created via `Schedulers.from(Executor, boolean)` did not fully honor the `interruptibleWorker` settings.

Fixes #7201 