### PR TITLE
Fix intermittently failing unit tests

### DIFF
--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava3.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -355,7 +356,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     }
 
     @Test
-    public void issue2890NoStackoverflow() throws InterruptedException {
+    public void issue2890NoStackoverflow() throws InterruptedException, TimeoutException {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
 
@@ -400,7 +401,11 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             }
         });
 
-        executor.awaitTermination(20000, TimeUnit.MILLISECONDS);
+        Duration awaitTerminationTimeout = Duration.ofSeconds(100);
+        if (!executor.awaitTermination(awaitTerminationTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            throw new TimeoutException("Completed " + counter.get() + "/" + n + " before timed out after "
+                    + awaitTerminationTimeout.toMillis() + " milliseconds.");
+        }
 
         assertEquals(n, counter.get());
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava3.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
-import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -401,10 +400,10 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             }
         });
 
-        Duration awaitTerminationTimeout = Duration.ofSeconds(100);
-        if (!executor.awaitTermination(awaitTerminationTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        long awaitTerminationTimeoutMillis = 100_000;
+        if (!executor.awaitTermination(awaitTerminationTimeoutMillis, TimeUnit.MILLISECONDS)) {
             throw new TimeoutException("Completed " + counter.get() + "/" + n + " before timed out after "
-                    + awaitTerminationTimeout.toMillis() + " milliseconds.");
+                    + awaitTerminationTimeoutMillis + " milliseconds.");
         }
 
         assertEquals(n, counter.get());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -775,10 +774,10 @@ public class FlowableConcatTest {
             }
         });
 
-        Duration awaitTerminationTimeout = Duration.ofSeconds(100);
-        if (!executor.awaitTermination(awaitTerminationTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        long awaitTerminationTimeoutMillis = 100_000;
+        if (!executor.awaitTermination(awaitTerminationTimeoutMillis, TimeUnit.MILLISECONDS)) {
             throw new TimeoutException("Completed " + counter.get() + "/" + n + " before timed out after "
-                    + awaitTerminationTimeout.toMillis() + " milliseconds.");
+                + awaitTerminationTimeoutMillis + " milliseconds.");
         }
 
         assertEquals(n, counter.get());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava3.internal.operators.observable;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -307,7 +308,7 @@ public class ObservableConcatMapSchedulerTest {
     }
 
     @Test
-    public void issue2890NoStackoverflow() throws InterruptedException {
+    public void issue2890NoStackoverflow() throws InterruptedException, TimeoutException {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
 
@@ -352,7 +353,11 @@ public class ObservableConcatMapSchedulerTest {
             }
         });
 
-        executor.awaitTermination(20000, TimeUnit.MILLISECONDS);
+        Duration awaitTerminationTimeout = Duration.ofSeconds(100);
+        if (!executor.awaitTermination(awaitTerminationTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            throw new TimeoutException("Completed " + counter.get() + "/" + n + " before timed out after "
+                    + awaitTerminationTimeout.toMillis() + " milliseconds.");
+        }
 
         assertEquals(n, counter.get());
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava3.internal.operators.observable;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
-import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -353,10 +352,10 @@ public class ObservableConcatMapSchedulerTest {
             }
         });
 
-        Duration awaitTerminationTimeout = Duration.ofSeconds(100);
-        if (!executor.awaitTermination(awaitTerminationTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        long awaitTerminationTimeout = 100_000;
+        if (!executor.awaitTermination(awaitTerminationTimeout, TimeUnit.MILLISECONDS)) {
             throw new TimeoutException("Completed " + counter.get() + "/" + n + " before timed out after "
-                    + awaitTerminationTimeout.toMillis() + " milliseconds.");
+                + awaitTerminationTimeout + " milliseconds.");
         }
 
         assertEquals(n, counter.get());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -729,10 +728,10 @@ public class ObservableConcatTest extends RxJavaTest {
             }
         });
 
-        Duration awaitTerminationTimeout = Duration.ofSeconds(100);
-        if (!executor.awaitTermination(awaitTerminationTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        long awaitTerminationTimeout = 100_000;
+        if (!executor.awaitTermination(awaitTerminationTimeout, TimeUnit.MILLISECONDS)) {
             throw new TimeoutException("Completed " + counter.get() + "/" + n + " before timed out after "
-                    + awaitTerminationTimeout.toMillis() + " milliseconds.");
+                + awaitTerminationTimeout + " milliseconds.");
         }
 
         assertEquals(n, counter.get());

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableConcatTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -683,7 +684,7 @@ public class ObservableConcatTest extends RxJavaTest {
     }
 
     @Test
-    public void issue2890NoStackoverflow() throws InterruptedException {
+    public void issue2890NoStackoverflow() throws InterruptedException, TimeoutException {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
 
@@ -728,7 +729,11 @@ public class ObservableConcatTest extends RxJavaTest {
             }
         });
 
-        executor.awaitTermination(20000, TimeUnit.MILLISECONDS);
+        Duration awaitTerminationTimeout = Duration.ofSeconds(100);
+        if (!executor.awaitTermination(awaitTerminationTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            throw new TimeoutException("Completed " + counter.get() + "/" + n + " before timed out after "
+                    + awaitTerminationTimeout.toMillis() + " milliseconds.");
+        }
 
         assertEquals(n, counter.get());
     }

--- a/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
@@ -471,19 +471,17 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
                 final UnicastSubject<Integer> us = UnicastSubject.create();
 
                 TestObserver<Integer> to = us
-                .observeOn(Schedulers.io())
-                .map(Functions.<Integer>identity())
-                .observeOn(Schedulers.single())
-                .firstOrError()
-                .test();
+                    .observeOn(Schedulers.io())
+                    .map(Functions.identity())
+                    .observeOn(Schedulers.single())
+                    .firstOrError()
+                    .test();
 
                 for (int i = 0; us.hasObservers(); i++) {
                     us.onNext(i);
                 }
 
-                to
-                .awaitDone(5, TimeUnit.SECONDS)
-                ;
+                to.awaitDone(10, TimeUnit.SECONDS);
 
                 if (!errors.isEmpty()) {
                     throw new CompositeException(errors);

--- a/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subjects/UnicastSubjectTest.java
@@ -471,11 +471,11 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
                 final UnicastSubject<Integer> us = UnicastSubject.create();
 
                 TestObserver<Integer> to = us
-                    .observeOn(Schedulers.io())
-                    .map(Functions.identity())
-                    .observeOn(Schedulers.single())
-                    .firstOrError()
-                    .test();
+                .observeOn(Schedulers.io())
+                .map(Functions.<Integer>identity())
+                .observeOn(Schedulers.single())
+                .firstOrError()
+                .test();
 
                 for (int i = 0; us.hasObservers(); i++) {
                     us.onNext(i);


### PR DESCRIPTION
Fix several unit tests that are intermittently failing on slower clients due to timeouts. All fixes
involve increasing timeouts.

All other changes are adjustments to formatting within the updated tests.
