### PR TITLE
3.x: Project Loom support in standard schedulers via hooks

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 /**
  * Manages the creating of ScheduledExecutorServices and sets up purging.
@@ -142,7 +143,8 @@ public final class SchedulerPoolFactory {
      * @return the ScheduledExecutorService
      */
     public static ScheduledExecutorService create(ThreadFactory factory) {
-        final ScheduledExecutorService exec = Executors.newScheduledThreadPool(1, factory);
+        ScheduledExecutorService exec = Executors.newScheduledThreadPool(1, factory);
+        exec = RxJavaPlugins.onCreateExecutor(exec);
         tryPutIntoPool(PURGE_ENABLED, exec);
         return exec;
     }


### PR DESCRIPTION
This PR adds a hook point for when the underlying `ScheduledExecutorService`s are created for the standard `Scheduler` implementations. This could support the upcoming Project Loom features without RxJava 3 to go beyond Java 8.

In Project Loom, to be able to cheaply suspend in code, that code has to run in a Virtual Thread. Such virtual threads can have a backing carrier thread, i.e., via a regular threaded `ExecutorService`. In order for RxJava to allow any suspending function in any scheduler, one has to override the underlying default `ScheduledExecutorService` with one that has the virtual thread intermediate layer:

```java
// Requires JDK 17 Loom build
var factory = Thread.ofVirtual().scheduler(executor).factory();
var newExecutor = Executors.newSingleThreadScheduledExecutor(1, factory);
```

However, shutting down this `newExecutor` would not have any effect on the original executor thus one needs to intercept the `shutdown` methods and forward those calls to the original `executor` too:

```java
return new ScheduledExecutorService() {
   // ...
   @Override
   public List<Runnable> shutdownNow() {
        var list = newExecutor.shutdownNow();
        executor.shutdownNow();
        return list;
   }
   @Override
   public void shutdown() {
        newExecutor.shutdown();
        executor.shutdown();
   }
};
```

Some caveats:
- The hook has to be set early before any Scheduler get initialized.
- I'm not 100% sure the above use of a virtual factory actually works. In the [Loom API](https://download.java.net/java/early_access/loom/docs/api/java.base/java/util/concurrent/Executors.html), the new virtual and unowned factory methods return `ExecutorService` which doesn't support timed scheduling.
- This can't be tested in RxJava without significant hacks to the CI (i.e., hack in the Loom runtime, enable jdk-dependent inclusion of unit test classes). The closest place to test this would be in https://github.com/akarnokd/RxJavaFiberInterop .