### PR TITLE
Modernize gradle plugin block, change maven to maven-publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
     testNgVersion = "7.3.0"
     mockitoVersion = "3.8.0"
     jmhLibVersion = "1.21"
-    guavaVersion = "30.1-jre"
+    guavaVersion = "30.1.1-jre"
     jacocoVersion = "0.8.4"
     checkstyleVersion = "8.41"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,72 +1,47 @@
-buildscript {
+plugins {
+    id("java-library")
+    id("checkstyle")
+    id("eclipse")
+    id("jacoco")
+    id("maven-publish")
+    id("ru.vyarus.animalsniffer") version "1.5.3"
+    id("me.champeau.gradle.jmh") version "0.5.3"
+    id("com.github.hierynomus.license") version "0.15.0"
+    id("com.jfrog.artifactory") version "4.21.0"
+    id("biz.aQute.bnd.builder") version "5.3.0"
+    id("com.vanniktech.maven.publish") version "0.14.2"
+}
 
-  // Dependency versions
-  // ---------------------------------------
-  ext {
+ext {
     reactiveStreamsVersion = "1.0.3"
     junitVersion = "4.13.2"
     testNgVersion = "7.3.0"
     mockitoVersion = "3.8.0"
     jmhLibVersion = "1.21"
-    jmhGradleVersion = "0.5.3"
-    guavaVersion = "30.1.1-jre"
+    guavaVersion = "30.1-jre"
     jacocoVersion = "0.8.4"
-    animalSnifferVersion = "1.5.3"
-    licenseVersion = "0.15.0"
-    jfrogExtractorVersion = "4.21.0"
-    bndVersion = "5.3.0"
     checkstyleVersion = "8.41"
-    vanniktechPublishPlugin = "0.14.2"
-  }
+}
 
-  // --------------------------------------
+def releaseTag = System.getenv("BUILD_TAG")
+if (releaseTag != null && !releaseTag.isEmpty()) {
+    if (releaseTag.startsWith("v")) {
+        releaseTag = releaseTag.substring(1)
+    }
+    project.setProperty("VERSION_NAME" , releaseTag)
 
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
-  dependencies {
-    classpath "ru.vyarus:gradle-animalsniffer-plugin:$animalSnifferVersion"
-    classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:$licenseVersion"
-    classpath "me.champeau.gradle:jmh-gradle-plugin:$jmhGradleVersion"
-    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:$jfrogExtractorVersion"
-    classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:$bndVersion"
-    classpath "com.vanniktech:gradle-maven-publish-plugin:$vanniktechPublishPlugin"
-  }
+    logger.info("Releasing with version: {}", version)
 }
 
 group = "io.reactivex.rxjava3"
-ext.githubProjectName = "rxjava"
-
-def releaseTag = System.getenv("BUILD_TAG");
-if (releaseTag != null && !releaseTag.isEmpty()) {
-    if (releaseTag.startsWith("v")) {
-        releaseTag = releaseTag.substring(1);
-    }
-    project.setProperty("VERSION_NAME" , releaseTag);
-
-    println("Releasing with version " + version);
-}
-
 version = project.properties["VERSION_NAME"]
-
 description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
-
-apply plugin: "java-library"
-apply plugin: "checkstyle"
-apply plugin: "jacoco"
-apply plugin: "ru.vyarus.animalsniffer"
-apply plugin: "maven"
-apply plugin: "me.champeau.gradle.jmh"
-apply plugin: "com.github.hierynomus.license"
-apply plugin: "com.jfrog.artifactory"
-apply plugin: "eclipse"
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
-  mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
@@ -84,7 +59,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs << "-parameters";
+    options.compilerArgs << "-parameters"
 }
 
 javadoc {
@@ -100,7 +75,7 @@ javadoc {
     options.addStringOption("top").value = ""
     options.addStringOption("doctitle").value = ""
     options.addStringOption("header").value = ""
-    options.stylesheetFile = new File(projectDir, "gradle/stylesheet.css");
+    options.stylesheetFile = rootProject.file("gradle/stylesheet.css")
 
     options.links(
         "https://docs.oracle.com/javase/8/docs/api/",
@@ -112,19 +87,16 @@ animalsniffer {
     annotation = "io.reactivex.rxjava3.internal.util.SuppressAnimalSniffer"
 }
 
-apply plugin: 'maven'
-
-apply plugin: 'biz.aQute.bnd.builder'
-
 jar {
-    bnd ('Bundle-Name': 'rxjava',
-            'Bundle-Vendor': 'RxJava Contributors',
-            'Bundle-Description': 'Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.',
-            'Import-Package': '!org.junit,!junit.framework,!org.mockito.*,!org.testng.*,*',
-            'Bundle-DocURL': 'https://github.com/ReactiveX/RxJava',
-            'Eclipse-ExtensibleAPI': 'true',
-            'Automatic-Module-Name': 'io.reactivex.rxjava3',
-            'Export-Package': '!io.reactivex.rxjava3.internal.*, io.reactivex.rxjava3.*'
+    bnd (
+            "Bundle-Name": "rxjava",
+            "Bundle-Vendor": "RxJava Contributors",
+            "Bundle-Description": "Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.",
+            "Import-Package": "!org.junit,!junit.framework,!org.mockito.*,!org.testng.*,*",
+            "Bundle-DocURL": "https://github.com/ReactiveX/RxJava",
+            "Eclipse-ExtensibleAPI": "true",
+            "Automatic-Module-Name": "io.reactivex.rxjava3",
+            "Export-Package": "!io.reactivex.rxjava3.internal.*, io.reactivex.rxjava3.*"
     )
 }
 
@@ -144,14 +116,13 @@ jmh {
     jvmArgsAppend = ["-Djmh.separateClasspathJAR=true"]
 
     if (project.hasProperty("jmh")) {
-        include = ".*" + project.jmh + ".*"
-        println("JMH: " + include);
+        include = [".*" + project.jmh + ".*"]
+        logger.info("JMH: {}", include)
     }
-
 }
 
 plugins.withType(EclipsePlugin) {
-    project.eclipse.classpath.plusConfigurations += [ configurations.jmh ]
+    project.eclipse.classpath.plusConfigurations += [configurations.jmh]
 }
 
 test {
@@ -199,25 +170,21 @@ task testng(type: Test) {
 check.dependsOn testng 
 
 jacoco {
-    toolVersion = jacocoVersion // See http://www.eclemma.org/jacoco/.
+    toolVersion = jacocoVersion
 }
 
 task GCandMem(dependsOn: "check") doLast {
-    print("Memory usage before: ")
-    println(java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
+    logger.lifecycle("Memory usage before: {}", java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
     System.gc()
     Thread.sleep(200)
-    print("Memory usage: ")
-    println(java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
+    logger.lifecycle("Memory usage: {}", java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
 }
 
 task GCandMem2(dependsOn: "test") doLast {
-    print("Memory usage before: ")
-    println(java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
+    logger.lifecycle("Memory usage before: {}", java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
     System.gc()
     Thread.sleep(200)
-    print("Memory usage: ")
-    println(java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
+    logger.lifecycle("Memory usage: {}", java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0)
 }
 
 testng.dependsOn GCandMem2
@@ -258,12 +225,10 @@ def fixPom() {
 }
 
 if (rootProject.hasProperty("releaseMode")) {
+    logger.lifecycle("ReleaseMode: {}", rootProject.releaseMode)
 
   if ("branch".equals(rootProject.releaseMode)) {
     // From https://github.com/ReactiveX/RxAndroid/blob/2.x/rxandroid/build.gradle#L94
-  
-    println("ReleaseMode: " + rootProject.releaseMode);
-
     artifactory {
         contextUrl = "https://oss.jfrog.org"
     
@@ -287,13 +252,11 @@ if (rootProject.hasProperty("releaseMode")) {
   }
 
   if ("full".equals(rootProject.releaseMode)) {
-    apply plugin: "com.vanniktech.maven.publish"
-
     fixPom()
 
     signing {
-      if (project.hasProperty('SIGNING_PRIVATE_KEY') && project.hasProperty('SIGNING_PASSWORD')) {
-         useInMemoryPgpKeys(project.getProperty('SIGNING_PRIVATE_KEY'), project.getProperty('SIGNING_PASSWORD'))
+      if (project.hasProperty("SIGNING_PRIVATE_KEY") && project.hasProperty("SIGNING_PASSWORD")) {
+         useInMemoryPgpKeys(project.getProperty("SIGNING_PRIVATE_KEY"), project.getProperty("SIGNING_PASSWORD"))
       }
     }
     mavenPublish {


### PR DESCRIPTION
Move gradle plugins to block at top of file per gradle recommendations.
Change deprecated maven plugin to maven-publish as in Gradle 7.0 it will
be removed. Several other minor updates to gradle file including, removing
semi-colons, changing println to use built-in logger.
