### PR TITLE
Initial commit for dependabot.yml config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This is the third part of converting to the native GitHub Dependabot per Issue #7226.

Note, this should probably not be merged until dependabot-preview has been disabled (first bullet of Issue #7226).

Resolves #7226