### PR TITLE
3.x: Upgrade setup-java GitHub actions to v2

### DIFF
--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -13,10 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.4
       with:

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'adopt'
+        java-version: '11'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.4
       with:

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -13,10 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.4
       with:

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -26,10 +26,11 @@ jobs:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.4
       with:

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -23,10 +23,11 @@ jobs:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.4
       with:


### PR DESCRIPTION
There are two [breaking changes](https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md) between "setup-java" GitHub actions v1 and v2.
v2 requires a java distribution be specified. 'adopt' for AdoptOpenJDK has been
selected. v2 has also dropped support for legacy Java version syntax, so
'1.8' must become '8'.
