### PR TITLE
3.x: Migrate Gradle to use Java Toolchain

### DIFF
--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -29,6 +29,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build PR
-      run: ./gradlew -PreleaseMode=pr build --stacktrace
-    #- name: Upload to Codecov  
-    #  uses: codecov/codecov-action@v1
+      run: ./gradlew -PreleaseMode=pr -PtoolchainJavaVersion=11 build --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,16 @@ group = "io.reactivex.rxjava3"
 version = project.properties["VERSION_NAME"]
 description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(project.toolchainJavaVersion)
+        vendor = JvmVendorSpec.ADOPTOPENJDK
+    }
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-parameters"
+}
 
 repositories {
     mavenCentral()
@@ -56,10 +64,6 @@ dependencies {
     testImplementation "org.reactivestreams:reactive-streams-tck:$reactiveStreamsVersion"
     testImplementation "org.testng:testng:$testNgVersion"
     testImplementation "com.google.guava:guava:$guavaVersion"
-}
-
-tasks.withType(JavaCompile) {
-    options.compilerArgs << "-parameters"
 }
 
 javadoc {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+toolchainJavaVersion=8
+
 release.scope=patch
 VERSION_NAME=3.0.0-SNAPSHOT
 


### PR DESCRIPTION
Use Gradle java toolchain functionality, instead of relying on JAVA_HOME
version used to run the Gradle instance. Remove target and compatibility
Java versions properties. Make the Java version configurable in gradle.properties
with default version set to 8.

Fix bug where GitHub JDK11 Action was using Java 8 due to hardcoded
target/compatibility properties of 1.8.