### PR TITLE
3.x: Action cache clear, limit environmental variables

### DIFF
--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -22,8 +22,8 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        key: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build branch without snapshot

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -24,8 +24,8 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        key: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build PR

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -24,8 +24,8 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
+        key: ${{ runner.os }}-gradle-1-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle-1-
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build PR

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -22,8 +22,8 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
+        key: ${{ runner.os }}-gradle-1-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle-1-
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build PR

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -22,8 +22,8 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        key: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build PR

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -15,14 +15,6 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
-      # ------------------------------------------------------------------------------ 
-      JAVADOCS_TOKEN: ${{ secrets.JAVADOCS_TOKEN }}
-      ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_USER }}
-      ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
-      ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-      # ------------------------------------------------------------------------------ 
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@v2
@@ -35,8 +27,8 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        key: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Grant execute permission for push
@@ -49,7 +41,18 @@ jobs:
       uses: codecov/codecov-action@v1
     - name: Upload release
       run: ./gradlew -PreleaseMode=full javadocCleanup uploadArchives --no-daemon --no-parallel --stacktrace
+      env:
+        # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
+        # ------------------------------------------------------------------------------ 
+        ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_USER }}
+        ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
+        ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
     - name: Publish release
       run: ./gradlew -PreleaseMode=full closeAndReleaseRepository --no-daemon --no-parallel --stacktrace
     - name: Push Javadocs
       run: ./push_javadoc.sh
+      env:
+        # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
+        # ------------------------------------------------------------------------------ 
+        JAVADOCS_TOKEN: ${{ secrets.JAVADOCS_TOKEN }}

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -12,13 +12,6 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
-      # ------------------------------------------------------------------------------ 
-      bintrayUser: ${{ secrets.BINTRAY_USER }}
-      bintrayKey: ${{ secrets.BINTRAY_KEY }}
-      sonatypeUsername: ${{ secrets.SONATYPE_USER }}
-      sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-      JAVADOCS_TOKEN: ${{ secrets.JAVADOCS_TOKEN }}
       # ------------------------------------------------------------------------------ 
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
@@ -32,15 +25,27 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        key: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Grant execute permission for push
       run: chmod +x push_javadoc.sh
     - name: Build and Snapshot branch
       run: ./gradlew -PreleaseMode=branch -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build --stacktrace
+      env:
+        # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
+        # ------------------------------------------------------------------------------ 
+        bintrayUser: ${{ secrets.BINTRAY_USER }}
+        bintrayKey: ${{ secrets.BINTRAY_KEY }}
+        sonatypeUsername: ${{ secrets.SONATYPE_USER }}
+        sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
     - name: Push Javadocs
       run: ./push_javadoc.sh
+        # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
+        # ------------------------------------------------------------------------------
+      env:
+        JAVADOCS_TOKEN: ${{ secrets.JAVADOCS_TOKEN }}
+ 


### PR DESCRIPTION
GitHub Actions don't support clearing the cache so the [suggested workaround](https://github.community/t/how-to-clear-cache-in-github-actions/129038/4) is to key it with a version number from a secret that can be updated without changing the yml.

In addition, secrets are now scoped to their run block which should prevent them from leaking across unrelated steps.
