### PR TITLE
3.x: Migrate Gradle to Java Toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,15 @@ group = "io.reactivex.rxjava3"
 version = project.properties["VERSION_NAME"]
 description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-parameters"
+}
 
 repositories {
     mavenCentral()
@@ -56,10 +63,6 @@ dependencies {
     testImplementation "org.reactivestreams:reactive-streams-tck:$reactiveStreamsVersion"
     testImplementation "org.testng:testng:$testNgVersion"
     testImplementation "com.google.guava:guava:$guavaVersion"
-}
-
-tasks.withType(JavaCompile) {
-    options.compilerArgs << "-parameters"
 }
 
 javadoc {


### PR DESCRIPTION
Use Java 8 as toolchain for Java tasks, instead of using JAVA_HOME and
removing need to cross-compile.