### PR TITLE
3x: Add full module descriptor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id("com.github.hierynomus.license") version "0.16.1"
     id("biz.aQute.bnd.builder") version "5.3.0"
     id("com.vanniktech.maven.publish") version "0.17.0"
+    id("org.beryx.jar") version "1.2.0"
 }
 
 ext {
@@ -29,6 +30,10 @@ if (releaseTag != null && !releaseTag.isEmpty()) {
 
     logger.lifecycle("Releasing with version: " + project.version)
 }
+
+group = "io.reactivex.rxjava3"
+version = project.properties["VERSION_NAME"]
+description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
 
 repositories {
     mavenCentral()
@@ -52,6 +57,7 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
+ext.javaCompatibility = JavaVersion.VERSION_1_8
 
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-parameters"
@@ -86,6 +92,8 @@ animalsniffer {
 }
 
 jar {
+    // Cover for bnd still not supporting MR Jars: https://github.com/bndtools/bnd/issues/2227
+    bnd('-fixupmessages': '^Classes found in the wrong directory: \\\\{META-INF/versions/9/module-info\\\\.class=module-info}$')
     bnd(
             "Bundle-Name": "rxjava",
             "Bundle-Vendor": "RxJava Contributors",
@@ -93,10 +101,12 @@ jar {
             "Import-Package": "!org.junit,!junit.framework,!org.mockito.*,!org.testng.*,*",
             "Bundle-DocURL": "https://github.com/ReactiveX/RxJava",
             "Eclipse-ExtensibleAPI": "true",
-            "Automatic-Module-Name": "io.reactivex.rxjava3",
             "Export-Package": "!io.reactivex.rxjava3.internal.*, io.reactivex.rxjava3.*",
-            "Bundle-SymbolicName": "io.reactivex.rxjava3.rxjava"
+            "Bundle-SymbolicName": "io.reactivex.rxjava3.rxjava",
+            "Multi-Release": "true"
     )
+
+    moduleInfoPath = 'src/main/module/module-info.java'
 }
 
 license {

--- a/src/main/module/module-info.java
+++ b/src/main/module/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+module io.reactivex.rxjava3 {
+    exports io.reactivex.rxjava3.annotations;
+    exports io.reactivex.rxjava3.core;
+    exports io.reactivex.rxjava3.disposables;
+    exports io.reactivex.rxjava3.exceptions;
+    exports io.reactivex.rxjava3.functions;
+    exports io.reactivex.rxjava3.observables;
+    exports io.reactivex.rxjava3.observers;
+    exports io.reactivex.rxjava3.parallel;
+    exports io.reactivex.rxjava3.plugins;
+    exports io.reactivex.rxjava3.processors;
+    exports io.reactivex.rxjava3.schedulers;
+    exports io.reactivex.rxjava3.subjects;
+    exports io.reactivex.rxjava3.subscribers;
+
+    requires org.reactivestreams;
+}


### PR DESCRIPTION
As described at https://github.com/ReactiveX/RxJava/issues/7240, add a full Java module descriptor to version 3.x.

This setup lets the 3.x series remain Java 8 compatible while the `module-info.class` is compiled with Java 9+ and stored inside the jar at `/META-INF/versions/9`.

Resolves #7240.