### PR TITLE
3.x: Remove fixPom method from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,27 +191,12 @@ checkstyle {
 
 apply from: file("gradle/javadoc_cleanup.gradle")
 
-def fixPom() {
-    // Reactive-Streams as compile dependency
-    publishing.publications.all {
-      pom.withXml {
-        asNode().dependencies."*".findAll() {
-          it.scope.text() == "runtime" && project.configurations.compile.allDependencies.find { dep ->
-            dep.name == it.artifactId.text()
-          }
-        }.each { it.scope*.value = "compile"}
-      }
-    }
-}
-
 if (rootProject.hasProperty("releaseMode")) {
     logger.lifecycle("ReleaseMode: {}", rootProject.releaseMode)
 
   if ("branch".equals(rootProject.releaseMode)) {
   
     if (version.endsWith("-SNAPSHOT")) {
-      fixPom()
-      
       publishing {
         repositories {
           maven {
@@ -229,8 +214,6 @@ if (rootProject.hasProperty("releaseMode")) {
   }
 
   if ("full".equals(rootProject.releaseMode)) {
-    fixPom()
-
     signing {
       if (project.hasProperty("SIGNING_PRIVATE_KEY") && project.hasProperty("SIGNING_PASSWORD")) {
          useInMemoryPgpKeys(project.getProperty("SIGNING_PRIVATE_KEY"), project.getProperty("SIGNING_PASSWORD"))


### PR DESCRIPTION
The pom is generated with the reactive-streams scope set to 'compile' based on it being set to 'api' in dependencies. I'm assuming this was fixed at some point previously, so the fixPom method is no longer needed.

To test that this works, the below gradle tasks were run:
./gradlew -PreleaseMode=full cleanGeneratePomFileForMavenPublication generatePomFileForMavenPublication
./gradlew -PreleaseMode=branch cleanGeneratePomFileForMavenPublication generatePomFileForMavenPublication

Both tasks generated a pom file with the reactive-streams set to
'compile' scope.
