### PR TITLE
3.x: Update Gradle task dependencies to remove dependsOn 'build' task

### DIFF
--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build branch without snapshot
-      run: ./gradlew -PreleaseMode=pr build --stacktrace
+      run: ./gradlew build --stacktrace
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
+    - name: Generate Javadocs
+      run: ./gradlew javadoc --stacktrace

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build PR
-      run: ./gradlew -PreleaseMode=pr build --stacktrace
-    #- name: Upload to Codecov  
-    #  uses: codecov/codecov-action@v1
+      run: ./gradlew build --stacktrace
+    - name: Generate Javadocs
+      run: ./gradlew javadoc --stacktrace

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: PR
+name: Pull Request
 
 on:
   pull_request:
@@ -27,6 +27,8 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build PR
-      run: ./gradlew -PreleaseMode=pr build --stacktrace
+      run: ./gradlew build --stacktrace
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
+    - name: Generate Javadocs
+      run: ./gradlew javadoc --stacktrace

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
     - name: Upload release
-      run: ./gradlew -PreleaseMode=full javadocCleanup uploadArchives --no-daemon --no-parallel --stacktrace
+      run: ./gradlew -PreleaseMode=full uploadArchives --no-daemon --no-parallel --stacktrace
       env:
         # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
         # ------------------------------------------------------------------------------ 

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build and Snapshot branch
       run: ./gradlew -PreleaseMode=branch build --stacktrace --no-daemon
     - name: Upload Snapshot
-      run: ./gradlew -PreleaseMode=branch javadocCleanup uploadArchives --no-daemon --no-parallel --stacktrace
+      run: ./gradlew -PreleaseMode=branch uploadArchives --no-daemon --no-parallel --stacktrace
       env:
         # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
         # ------------------------------------------------------------------------------ 
@@ -48,4 +48,3 @@ jobs:
         # ------------------------------------------------------------------------------
       env:
         JAVADOCS_TOKEN: ${{ secrets.JAVADOCS_TOKEN }}
- 

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ group = "io.reactivex.rxjava3"
 version = project.properties["VERSION_NAME"]
 description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 repositories {
     mavenCentral()
 }
@@ -57,9 +54,16 @@ dependencies {
     testImplementation "com.google.guava:guava:$guavaVersion"
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-parameters"
 }
+
+apply from: file("gradle/javadoc_cleanup.gradle")
 
 javadoc {
     failOnError = false
@@ -80,6 +84,8 @@ javadoc {
         "https://docs.oracle.com/javase/8/docs/api/",
         "http://www.reactive-streams.org/reactive-streams-${reactiveStreamsVersion}-javadoc/"
     )
+
+    finalizedBy javadocCleanup
 }
 
 animalsniffer {
@@ -172,13 +178,16 @@ jacoco {
 }
 
 jacocoTestReport {
+    dependsOn test
+    dependsOn testng
+
     reports {
         xml.enabled = true
         html.enabled = true
     }
 }
 
-build.dependsOn jacocoTestReport
+check.dependsOn jacocoTestReport
 
 checkstyle {
     configFile = rootProject.file("config/checkstyle/checkstyle.xml")
@@ -188,8 +197,6 @@ checkstyle {
             "checkstyle.header.file": rootProject.file("config/license/HEADER_JAVA")
     ]
 }
-
-apply from: file("gradle/javadoc_cleanup.gradle")
 
 if (rootProject.hasProperty("releaseMode")) {
     logger.lifecycle("ReleaseMode: {}", rootProject.releaseMode)

--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -57,4 +57,3 @@ def fixJavadocFile(file) {
     file.setText(fileContents, 'UTF-8');
 }
 
-build.dependsOn javadocCleanup 


### PR DESCRIPTION
It is generally discouraged to add dependencies on 'build', so 'javadocCleanup'
and 'jacocoTestReport' have been removed and put on better tasks. Also,
'jacocoTestReport' needs input from the test results.

Updated task dependencies:
- Gradle 'javadoc' task is finalized by 'javadocCleanup', and 'javadocCleanup'
  no longer directly invoked by 'build'
- Gradle 'jacocoTestReport' task run by 'check' instead of 'build', and
  'jacocoTestReport' depends on 'test' and 'testng'

Changes due to dependency updates:
- Add 'javadoc' generation task on Github actions that only 'build'
- Remove 'javadocCleanup' task from Github action as 'publish...' tasks
  already dependent on 'javadoc'

Miscellaneous tangential cleanup:
- Remove "pr" parameter on command line in Github workflow as parameter
  is no longer functional
- Enclose source/target compatibility in Gradle java block
