### PR TITLE
3.x: Remove redundant addition of JMH to classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,10 +126,6 @@ jmh {
     }
 }
 
-plugins.withType(EclipsePlugin) {
-    project.eclipse.classpath.plusConfigurations += [configurations.jmh]
-}
-
 test {
     testLogging  {
         // showing skipped occasionally should prevent CI timeout due to lack of standard output


### PR DESCRIPTION
Remove manual addition of JMH classpath in build file. Gradle adds classpath
for all sourceSets to Eclipse by default as fixed in Gradle 6.8 by PR
[14534](https://github.com/gradle/gradle/pull/14534). The JMH sourceSet is added by the JMH Plugin.

Tested by running 'eclipse' task in Eclipse 2021-03 (4.19.0). Then refreshing,
and JMH still on classpath and viewable in Eclipse. Then removed project from
Eclipse, ran 'cleanEclipse', and re-imported project to Eclipse. All successful.
