### PR TITLE
3.x: Remove Javadoc not failing on error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,6 @@ tasks.withType(JavaCompile) {
 apply from: file("gradle/javadoc_cleanup.gradle")
 
 javadoc {
-    failOnError = false
     exclude "**/internal/**"
     exclude "**/test/**"
     exclude "**/perf/**"


### PR DESCRIPTION
The 'javadoc' task should fail when there is an error. The
'javadocCleanup' task failed for PR [7239](https://github.com/ReactiveX/RxJava/pull/7239/checks) due to publish plugin issue [242](https://github.com/vanniktech/gradle-maven-publish-plugin/issues/242),
while it should have been the 'javadoc' task that failed the build.
Also, publishing when javadocs fail is not desired.
