### PR TITLE
3.x: Move Gradle properties into gradle.properties file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,14 +27,10 @@ if (releaseTag != null && !releaseTag.isEmpty()) {
     if (releaseTag.startsWith("v")) {
         releaseTag = releaseTag.substring(1)
     }
-    project.setProperty("VERSION_NAME" , releaseTag)
+    project.version = releaseTag
 
-    logger.info("Releasing with version: {}", version)
+    logger.lifecycle("Releasing with version: " + project.version)
 }
-
-group = "io.reactivex.rxjava3"
-version = project.properties["VERSION_NAME"]
-description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ group=io.reactivex.rxjava3
 version=3.0.0-SNAPSHOT
 description=RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.
 
+POM_ARTIFACT_ID=rxjava
 POM_NAME=RxJava
 POM_PACKAGING=jar
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
-release.scope=patch
-VERSION_NAME=3.0.0-SNAPSHOT
+group=io.reactivex.rxjava3
+version=3.0.0-SNAPSHOT
+description=RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.
 
-GROUP=io.reactivex.rxjava3
-POM_ARTIFACT_ID=rxjava
 POM_NAME=RxJava
 POM_PACKAGING=jar
 


### PR DESCRIPTION
Moved version, group, and description into gradle.properties file.
Removed POM_ARTIFACT property as the 'name' property in the settings file
is used when building the POM. Removed 'release.scope' property as it
does not appear to be used. Removed VERSION_NAME property and references
to it, in favor of 'version' property.
