### PR TITLE
3.x: Rename workflow tasks

### DIFF
--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -26,9 +26,9 @@ jobs:
         restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build branch without snapshot
+    - name: Build RxJava
       run: ./gradlew build --stacktrace
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
-    - name: Generate Javadocs
+    - name: Generate Javadoc
       run: ./gradlew javadoc --stacktrace

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -28,7 +28,7 @@ jobs:
         restore-keys: ${{ runner.os }}-gradle-1-
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build PR
+    - name: Build RxJava
       run: ./gradlew build --stacktrace
-    - name: Generate Javadocs
+    - name: Generate Javadoc
       run: ./gradlew javadoc --stacktrace

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -26,9 +26,9 @@ jobs:
         restore-keys: ${{ runner.os }}-gradle-1-
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build PR
+    - name: Build RxJava
       run: ./gradlew build --stacktrace
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
-    - name: Generate Javadocs
+    - name: Generate Javadoc
       run: ./gradlew javadoc --stacktrace

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -35,8 +35,8 @@ jobs:
       run: chmod +x push_javadoc.sh
     - name: Extract version tag
       run: echo "BUILD_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
-    - name: Build and Release
-      run: ./gradlew -PreleaseMode=full build --stacktrace --no-daemon
+    - name: Build RxJava
+      run: ./gradlew build --stacktrace --no-daemon
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
     - name: Upload release
@@ -55,7 +55,7 @@ jobs:
         # ------------------------------------------------------------------------------ 
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USER }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
-    - name: Push Javadocs
+    - name: Push Javadoc
       run: ./push_javadoc.sh
       env:
         # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -31,8 +31,8 @@ jobs:
       run: chmod +x gradlew
     - name: Grant execute permission for push
       run: chmod +x push_javadoc.sh
-    - name: Build and Snapshot branch
-      run: ./gradlew -PreleaseMode=branch build --stacktrace --no-daemon
+    - name: Build RxJava
+      run: ./gradlew build --stacktrace --no-daemon
     - name: Upload Snapshot
       run: ./gradlew -PreleaseMode=branch uploadArchives --no-daemon --no-parallel --stacktrace
       env:
@@ -42,7 +42,7 @@ jobs:
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
     - name: Upload to Codecov  
       uses: codecov/codecov-action@v1
-    - name: Push Javadocs
+    - name: Push Javadoc
       run: ./push_javadoc.sh
         # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
         # ------------------------------------------------------------------------------


### PR DESCRIPTION
Change 'build' tasks name to Build RxJava. Update Javadoc task names.
