### PR TITLE
3.x: Javadoc: Fix wording of *OnSubscribe interfaces

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/CompletableOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/CompletableOnSubscribe.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
  * A functional interface that has a {@code subscribe()} method that receives
- * an instance of a {@link CompletableEmitter} instance that allows pushing
+ * a {@link CompletableEmitter} instance that allows pushing
  * an event in a cancellation-safe manner.
  */
 @FunctionalInterface

--- a/src/main/java/io/reactivex/rxjava3/core/FlowableOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/FlowableOnSubscribe.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
  * A functional interface that has a {@code subscribe()} method that receives
- * an instance of a {@link FlowableEmitter} instance that allows pushing
+ * a {@link FlowableEmitter} instance that allows pushing
  * events in a backpressure-safe and cancellation-safe manner.
  *
  * @param <T> the value type pushed

--- a/src/main/java/io/reactivex/rxjava3/core/MaybeOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/MaybeOnSubscribe.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
  * A functional interface that has a {@code subscribe()} method that receives
- * an instance of a {@link MaybeEmitter} instance that allows pushing
+ * a {@link MaybeEmitter} instance that allows pushing
  * an event in a cancellation-safe manner.
  *
  * @param <T> the value type pushed

--- a/src/main/java/io/reactivex/rxjava3/core/ObservableOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/ObservableOnSubscribe.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
  * A functional interface that has a {@code subscribe()} method that receives
- * an instance of an {@link ObservableEmitter} instance that allows pushing
+ * an {@link ObservableEmitter} instance that allows pushing
  * events in a cancellation-safe manner.
  *
  * @param <T> the value type pushed

--- a/src/main/java/io/reactivex/rxjava3/core/SingleOnSubscribe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/SingleOnSubscribe.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
  * A functional interface that has a {@code subscribe()} method that receives
- * an instance of a {@link SingleEmitter} instance that allows pushing
+ * a {@link SingleEmitter} instance that allows pushing
  * an event in a cancellation-safe manner.
  *
  * @param <T> the value type pushed


### PR DESCRIPTION
Bad wording: "an instance of a(n) X instance".