### PR TITLE
Add an overloaded version assertValues that takes predicates

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
@@ -464,8 +464,8 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
-     * Assert that the {@code TestObserver}/{@code TestSubscriber} received only values for which
-     * the provided predicates return {@code true} in the specified order.
+     * Assert that the {@code TestObserver}/{@code TestSubscriber} received only values that when tested with
+     * the provided predicates, in the specified order, they all return {@code true}.
      * @param valuePredicates
      *            the predicates that receives the {@code onNext} values
      *            and should return {@code true} for the expected value.

--- a/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
@@ -464,6 +464,29 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
+     * Assert that the {@code TestObserver}/{@code TestSubscriber} received only values for which
+     * the provided predicates return {@code true} in the specified order.
+     * @param valuePredicates
+     *            the predicates that receives the {@code onNext} values
+     *            and should return {@code true} for the expected value.
+     * @return this
+     */
+    @SuppressWarnings("unchecked")
+    @SafeVarargs
+    @NonNull
+    public final U assertValues(@NonNull Predicate<T>... valuePredicates) {
+        int s = this.values.size();
+        if (s != valuePredicates.length) {
+            throw fail("Value count differs; expected: " + valuePredicates.length
+                    + " but was: " + s + " " + this.values);
+        }
+        for (int i = 0; i < s; i++) {
+            assertValueAt(i, valuePredicates[i]);
+        }
+        return (U)this;
+    }
+
+    /**
      * Assert that the {@code TestObserver}/{@code TestSubscriber} received only the specified values in the specified order without terminating.
      * <p>History: 2.1.4 - experimental
      * @param values the values expected

--- a/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
@@ -56,6 +56,44 @@ public class TestObserverTest extends RxJavaTest {
     }
 
     @Test
+    public void assertValuesWithMorePredicatesThanValuesFails() {
+        assertThrows(AssertionError.class, () -> {
+            TestObserver<Integer> observer = TestObserver.create();
+            Observable.just(1).subscribe(observer);
+
+            observer.assertValues(n -> n == 1, n -> n == 1);
+        });
+    }
+
+    @Test
+    public void assertValuesWithLessPredicatesThanValuesFails() {
+        assertThrows(AssertionError.class, () -> {
+            TestObserver<Integer> observer = TestObserver.create();
+            Observable.just(1, 2, 3).subscribe(observer);
+
+            observer.assertValues(n -> n == 1, n -> n == 2);
+        });
+    }
+
+    @Test
+    public void assertValuesWithPredicatesThatAreMatchingTheValuesSucceed() {
+        TestObserver<Integer> observer = TestObserver.create();
+        Observable.just(1, 2).subscribe(observer);
+
+        observer.assertValues(n -> n == 1, n -> n == 2);
+    }
+
+    @Test
+    public void assertValuesWithSomePredicatesThatAreNotMatchingTheValuesFails() {
+        assertThrows(AssertionError.class, () -> {
+            TestObserver<Integer> observer = TestObserver.create();
+            Observable.just(1, 2).subscribe(observer);
+
+            observer.assertValues(n -> n == 1, n -> n != 2);
+        });
+    }
+
+    @Test
     public void assertNotMatchCount() {
         assertThrows(AssertionError.class, () -> {
             Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));

--- a/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava3/subscribers/TestSubscriberTest.java
@@ -51,6 +51,48 @@ public class TestSubscriberTest extends RxJavaTest {
     }
 
     @Test
+    public void assertValuesWithMorePredicatesThanValuesFails() {
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.just(1);
+            TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+            oi.subscribe(subscriber);
+
+            subscriber.assertValues(n -> n == 1, n -> n == 1);
+        });
+    }
+
+    @Test
+    public void assertValuesWithLessPredicatesThanValuesFails() {
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.just(1, 2, 3);
+            TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+            oi.subscribe(subscriber);
+
+            subscriber.assertValues(n -> n == 1, n -> n == 2);
+        });
+    }
+
+    @Test
+    public void assertValuesWithPredicatesThatAreMatchingTheValuesSucceed() {
+        Flowable<Integer> oi = Flowable.just(1, 2);
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+        oi.subscribe(subscriber);
+
+        subscriber.assertValues(n -> n == 1, n -> n == 2);
+    }
+
+    @Test
+    public void assertValuesWithPredicatesThatAreNotMatchingTheValuesFails() {
+        assertThrows(AssertionError.class, () -> {
+            Flowable<Integer> oi = Flowable.just(1, 2);
+            TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+            oi.subscribe(subscriber);
+
+            subscriber.assertValues(n -> n == 1, n -> n != 2);
+        });
+    }
+
+    @Test
     public void assertNotMatchCount() {
         assertThrows(AssertionError.class, () -> {
             Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));


### PR DESCRIPTION
An overloaded version of assertValues, that takes predicates, has been added to BaseTestConsumer. This is consistent with the other asserts on values (like assertValue and assertValueAt) which are already allowing assertions with predicates.

The same behaviour can already be obtained by using multiple assertValueAt:
```
streamUnderTest.test()  
   .assertValueAt(0, somePredicate)
   .assertValueAt(1, someOtherPredicate);
```
but being able to use assertValues for the same checks makes (imho) the assertion clearer and less cluttered:
```
streamUnderTest.test()
   .assertValues(somePredicate, someOtherPredicate);
```

NOTE: I'm not very fond of the javadoc, I think it can be improved