### PR TITLE
3.x: Update withLatestFrom doc about upstream early complete

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -19233,6 +19233,13 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     /**
      * Merges the specified {@link Publisher} into the current {@code Flowable} sequence by using the {@code resultSelector}
      * function only when the current {@code Flowable} (this instance) emits an item.
+     *
+     * <p>Note that this operator doesn't emit anything until the other source has produced at
+     * least one value. The resulting emission only happens when the current {@code Flowable} emits (and
+     * not when any of the other sources emit, unlike combineLatest).
+     * If the other source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before the other source has produced at least one value, the sequence completes
+     * without emission.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/withLatestFrom.v3.png" alt="">
      *
@@ -19277,6 +19284,8 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * least one value. The resulting emission only happens when the current {@code Flowable} emits (and
      * not when any of the other sources emit, unlike combineLatest).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -19317,6 +19326,8 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * least one value. The resulting emission only happens when the current {@code Flowable} emits (and
      * not when any of the other sources emit, unlike combineLatest).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -19362,6 +19373,8 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * least one value. The resulting emission only happens when the current {@code Flowable} emits (and
      * not when any of the other sources emit, unlike combineLatest).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -19411,6 +19424,8 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * least one value. The resulting emission only happens when the current {@code Flowable} emits (and
      * not when any of the other sources emit, unlike combineLatest).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -19445,6 +19460,8 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * least one value. The resulting emission only happens when the current {@code Flowable} emits (and
      * not when any of the other sources emit, unlike combineLatest).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      *
      * <dl>
      *  <dt><b>Backpressure:</b></dt>

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -19236,7 +19236,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      *
      * <p>Note that this operator doesn't emit anything until the other source has produced at
      * least one value. The resulting emission only happens when the current {@code Flowable} emits (and
-     * not when any of the other sources emit, unlike combineLatest).
+     * not when the other source emits, unlike combineLatest).
      * If the other source doesn't produce any value and just completes, the sequence is completed immediately.
      * If the upstream completes before the other source has produced at least one value, the sequence completes
      * without emission.

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -16074,6 +16074,13 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     /**
      * Merges the specified {@link ObservableSource} into the current {@code Observable} sequence by using the {@code resultSelector}
      * function only when the current {@code Observable} emits an item.
+     *
+     * <p>Note that this operator doesn't emit anything until the other source has produced at
+     * least one value. The resulting emission only happens when the current {@code Observable} emits (and
+     * not when any of the other sources emit, unlike combineLatest).
+     * If the other source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before the other source has produced at least one value, the sequence completes
+     * without emission.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/withLatestFrom.v3.png" alt="">
      *
@@ -16112,6 +16119,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * least one value. The resulting emission only happens when the current {@code Observable} emits (and
      * not when any of the other sources emit, unlike {@code combineLatest}).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/withLatestFrom.v3.png" alt="">
      * <dl>
@@ -16150,6 +16159,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * least one value. The resulting emission only happens when the current {@code Observable} emits (and
      * not when any of the other sources emit, unlike combineLatest).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/withLatestFrom.v3.png" alt="">
      * <dl>
@@ -16192,6 +16203,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * least one value. The resulting emission only happens when the current {@code Observable} emits (and
      * not when any of the other sources emit, unlike combineLatest).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/withLatestFrom.v3.png" alt="">
      * <dl>
@@ -16238,6 +16251,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * least one value. The resulting emission only happens when the current {@code Observable} emits (and
      * not when any of the other sources emit, unlike combineLatest).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/withLatestFrom.v3.png" alt="">
      * <dl>
@@ -16269,6 +16284,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * least one value. The resulting emission only happens when the current {@code Observable} emits (and
      * not when any of the other sources emit, unlike {@code combineLatest}).
      * If a source doesn't produce any value and just completes, the sequence is completed immediately.
+     * If the upstream completes before all other sources have produced at least one value, the sequence completes
+     * without emission.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/withLatestFrom.v3.png" alt="">
      * <dl>

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -16077,7 +16077,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *
      * <p>Note that this operator doesn't emit anything until the other source has produced at
      * least one value. The resulting emission only happens when the current {@code Observable} emits (and
-     * not when any of the other sources emit, unlike combineLatest).
+     * not when the other source emits, unlike combineLatest).
      * If the other source doesn't produce any value and just completes, the sequence is completed immediately.
      * If the upstream completes before the other source has produced at least one value, the sequence completes
      * without emission.


### PR DESCRIPTION
- Add missing note to the one-source `withLatestFrom` methods.
- Add a sentence about the case when the upstream completes early and thus no emission happens as no tuple can be formed for the callback.

Resolves #7288