### PR TITLE
3.x: API promotions for 3.1.0

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -12725,15 +12725,15 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onBackpressureReduce} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 3.0.9 - experimental
      * @param reducer the bi-function to call when there is more than one non-emitted value to downstream,
      *                 the first argument of the bi-function is previous item and the second one is currently
      *                 emitting from upstream
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code reducer} is {@code null}
-     * @since 3.0.9 - experimental
+     * @since 3.1.0
      * @see #onBackpressureReduce(Supplier, BiFunction)
      */
-    @Experimental
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -12764,6 +12764,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code onBackpressureReduce} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
+     * <p>History: 3.0.9 - experimental
      * @param <R> the aggregate type emitted when the downstream requests more items
      * @param supplier the factory to call to create new item of type R to pass it as the first argument to {@code reducer}.
      *                 It is called when previous returned value by {@code reducer} already sent to
@@ -12774,9 +12775,8 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code supplier} or {@code reducer} is {@code null}
      * @see #onBackpressureReduce(BiFunction)
-     * @since 3.0.9 - experimental
+     * @since 3.1.0
      */
-    @Experimental
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactory.java
@@ -13,9 +13,7 @@
 
 package io.reactivex.rxjava3.internal.schedulers;
 
-import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava3.exceptions.Exceptions;
 import io.reactivex.rxjava3.functions.Function;

--- a/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
@@ -1153,11 +1153,11 @@ public final class RxJavaPlugins {
 
     /**
      * Sets the specific hook function.
+     * <p>History: 3.0.11 - experimental
      * @param handler the hook function to set, null allowed
-     * @since 3.0.11 - experimental
+     * @since 3.1.0
      */
     @SuppressWarnings("rawtypes")
-    @Experimental
     public static void setOnParallelSubscribe(@Nullable BiFunction<? super ParallelFlowable, ? super Subscriber[], ? extends Subscriber[]> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
@@ -1167,11 +1167,11 @@ public final class RxJavaPlugins {
 
     /**
      * Returns the current hook function.
+     * <p>History: 3.0.11 - experimental
      * @return the hook function, may be null
-     * @since 3.0.11 - experimental
+     * @since 3.1.0
      */
     @SuppressWarnings("rawtypes")
-    @Experimental
     @Nullable
     public static BiFunction<? super ParallelFlowable, ? super Subscriber[], ? extends Subscriber[]> getOnParallelSubscribe() {
         return onParallelSubscribe;

--- a/src/main/java/io/reactivex/rxjava3/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/schedulers/TestScheduler.java
@@ -52,12 +52,12 @@ public final class TestScheduler extends Scheduler {
     /**
      * Creates a new TestScheduler with the option to use the
      * {@link RxJavaPlugins#onSchedule(Runnable)} hook when scheduling tasks.
+     * <p>History: 3.0.10 - experimental
      * @param useOnScheduleHook if {@code true}, the tasks submitted to this
      *                          TestScheduler is wrapped via the
      *                          {@link RxJavaPlugins#onSchedule(Runnable)} hook
-     * @since 3.0.10 - experimental
+     * @since 3.1.0
      */
-    @Experimental
     public TestScheduler(boolean useOnScheduleHook) {
         this.useOnScheduleHook = useOnScheduleHook;
     }
@@ -78,7 +78,7 @@ public final class TestScheduler extends Scheduler {
      * Creates a new TestScheduler with the specified initial virtual time
      * and with the option to use the
      * {@link RxJavaPlugins#onSchedule(Runnable)} hook when scheduling tasks.
-     *
+     * <p>History: 3.0.10 - experimental
      * @param delayTime
      *          the point in time to move the Scheduler's clock to
      * @param unit
@@ -86,9 +86,8 @@ public final class TestScheduler extends Scheduler {
      * @param useOnScheduleHook if {@code true}, the tasks submitted to this
      *                          TestScheduler is wrapped via the
      *                          {@link RxJavaPlugins#onSchedule(Runnable)} hook
-     * @since 3.0.10 - experimental
+     * @since 3.1.0
      */
-    @Experimental
     public TestScheduler(long delayTime, TimeUnit unit, boolean useOnScheduleHook) {
         time = unit.toNanos(delayTime);
         this.useOnScheduleHook = useOnScheduleHook;

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactoryTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/SchedulerPoolFactoryTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import io.reactivex.rxjava3.core.RxJavaTest;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.internal.functions.Functions;
-import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
 public class SchedulerPoolFactoryTest extends RxJavaTest {


### PR DESCRIPTION
Promote the following methods to standard:

- `Flowable.onBackpressureReduce()` + 1
- `RxJavaPlugins.getOnParallelSubscribe()` and `RxJavaPlugins.setOnParallelSubscribe()`
- `TestScheduler([...] boolean useOnScheduleHook)`
