### PR TITLE
3.x: Add subscribe with disposable container

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/observers/AbstractDisposableAutoRelease.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/observers/AbstractDisposableAutoRelease.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.observers;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.internal.functions.Functions;
+import io.reactivex.rxjava3.observers.LambdaConsumerIntrospection;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Wraps lambda callbacks and when the upstream terminates or the observer gets disposed,
+ * removes itself from a {@link io.reactivex.rxjava3.disposables.CompositeDisposable}.
+ * <p>History: 0.18.0 @ RxJavaExtensions
+ * @since 3.1.0
+ */
+abstract class AbstractDisposableAutoRelease
+extends AtomicReference<Disposable>
+implements Disposable, LambdaConsumerIntrospection {
+
+    private static final long serialVersionUID = 8924480688481408726L;
+
+    final AtomicReference<DisposableContainer> composite;
+
+    final Consumer<? super Throwable> onError;
+
+    final Action onComplete;
+
+    AbstractDisposableAutoRelease(
+            DisposableContainer composite,
+            Consumer<? super Throwable> onError,
+            Action onComplete
+    ) {
+        this.onError = onError;
+        this.onComplete = onComplete;
+        this.composite = new AtomicReference<>(composite);
+    }
+
+    public final void onError(Throwable t) {
+        if (get() != DisposableHelper.DISPOSED) {
+            lazySet(DisposableHelper.DISPOSED);
+            try {
+                onError.accept(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                RxJavaPlugins.onError(new CompositeException(t, e));
+            }
+        } else {
+            RxJavaPlugins.onError(t);
+        }
+        removeSelf();
+    }
+
+    public final void onComplete() {
+        if (get() != DisposableHelper.DISPOSED) {
+            lazySet(DisposableHelper.DISPOSED);
+            try {
+                onComplete.run();
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                RxJavaPlugins.onError(e);
+            }
+        }
+        removeSelf();
+    }
+
+    @Override
+    public final void dispose() {
+        DisposableHelper.dispose(this);
+        removeSelf();
+    }
+
+    final void removeSelf() {
+        DisposableContainer c = composite.getAndSet(null);
+        if (c != null) {
+            c.delete(this);
+        }
+    }
+
+    @Override
+    public final boolean isDisposed() {
+        return DisposableHelper.isDisposed(get());
+    }
+
+    public final void onSubscribe(Disposable d) {
+        DisposableHelper.setOnce(this, d);
+    }
+
+    @Override
+    public final boolean hasCustomOnError() {
+        return onError != Functions.ON_ERROR_MISSING;
+    }
+
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/observers/DisposableAutoReleaseMultiObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/observers/DisposableAutoReleaseMultiObserver.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.observers;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Wraps lambda callbacks and when the upstream terminates or this (Single | Maybe | Completable)
+ * observer gets disposed, removes itself from a {@link io.reactivex.rxjava3.disposables.CompositeDisposable}.
+ * <p>History: 0.18.0 @ RxJavaExtensions
+ * @param <T> the element type consumed
+ * @since 3.1.0
+ */
+public final class DisposableAutoReleaseMultiObserver<T>
+extends AbstractDisposableAutoRelease
+implements SingleObserver<T>, MaybeObserver<T>, CompletableObserver {
+
+    private static final long serialVersionUID = 8924480688481408726L;
+
+    final Consumer<? super T> onSuccess;
+
+    public DisposableAutoReleaseMultiObserver(
+            DisposableContainer composite,
+            Consumer<? super T> onSuccess,
+            Consumer<? super Throwable> onError,
+            Action onComplete
+    ) {
+        super(composite, onError, onComplete);
+        this.onSuccess = onSuccess;
+    }
+
+    @Override
+    public void onSuccess(T t) {
+        if (get() != DisposableHelper.DISPOSED) {
+            lazySet(DisposableHelper.DISPOSED);
+            try {
+                onSuccess.accept(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                RxJavaPlugins.onError(e);
+            }
+        }
+        removeSelf();
+    }
+
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/observers/DisposableAutoReleaseObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/observers/DisposableAutoReleaseObserver.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.observers;
+
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+
+/**
+ * Wraps lambda callbacks and when the upstream terminates or this observer gets disposed,
+ * removes itself from a {@link io.reactivex.rxjava3.disposables.CompositeDisposable}.
+ * <p>History: 0.18.0 @ RxJavaExtensions
+ * @param <T> the element type consumed
+ * @since 3.1.0
+ */
+public final class DisposableAutoReleaseObserver<T>
+extends AbstractDisposableAutoRelease
+implements Observer<T> {
+
+    private static final long serialVersionUID = 8924480688481408726L;
+
+    final Consumer<? super T> onNext;
+
+    public DisposableAutoReleaseObserver(
+            DisposableContainer composite,
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Action onComplete
+    ) {
+        super(composite, onError, onComplete);
+        this.onNext = onNext;
+    }
+
+    @Override
+    public void onNext(T t) {
+        if (get() != DisposableHelper.DISPOSED) {
+            try {
+                onNext.accept(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                get().dispose();
+                onError(e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/subscribers/DisposableAutoReleaseSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/subscribers/DisposableAutoReleaseSubscriber.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.subscribers;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscription;
+
+import io.reactivex.rxjava3.core.FlowableSubscriber;
+import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.functions.Functions;
+import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.observers.LambdaConsumerIntrospection;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Wraps lambda callbacks and when the upstream terminates or this subscriber gets disposed,
+ * removes itself from a {@link io.reactivex.rxjava3.disposables.CompositeDisposable}.
+ * <p>History: 0.18.0 @ RxJavaExtensions
+ * @param <T> the element type consumed
+ * @since 3.1.0
+ */
+public final class DisposableAutoReleaseSubscriber<T>
+extends AtomicReference<Subscription>
+implements FlowableSubscriber<T>, Disposable, LambdaConsumerIntrospection {
+
+    private static final long serialVersionUID = 8924480688481408726L;
+
+    final AtomicReference<DisposableContainer> composite;
+
+    final Consumer<? super T> onNext;
+
+    final Consumer<? super Throwable> onError;
+
+    final Action onComplete;
+
+    public DisposableAutoReleaseSubscriber(
+            DisposableContainer composite,
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Action onComplete
+    ) {
+        this.onNext = onNext;
+        this.onError = onError;
+        this.onComplete = onComplete;
+        this.composite = new AtomicReference<>(composite);
+    }
+
+    @Override
+    public void onNext(T t) {
+        if (get() != SubscriptionHelper.CANCELLED) {
+            try {
+                onNext.accept(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                get().cancel();
+                onError(e);
+            }
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        if (get() != SubscriptionHelper.CANCELLED) {
+            lazySet(SubscriptionHelper.CANCELLED);
+            try {
+                onError.accept(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                RxJavaPlugins.onError(new CompositeException(t, e));
+            }
+        } else {
+            RxJavaPlugins.onError(t);
+        }
+        removeSelf();
+    }
+
+    @Override
+    public void onComplete() {
+        if (get() != SubscriptionHelper.CANCELLED) {
+            lazySet(SubscriptionHelper.CANCELLED);
+            try {
+                onComplete.run();
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                RxJavaPlugins.onError(e);
+            }
+        }
+        removeSelf();
+    }
+
+    @Override
+    public void dispose() {
+        SubscriptionHelper.cancel(this);
+        removeSelf();
+    }
+
+    void removeSelf() {
+        DisposableContainer c = composite.getAndSet(null);
+        if (c != null) {
+            c.delete(this);
+        }
+    }
+
+    @Override
+    public boolean isDisposed() {
+        return SubscriptionHelper.CANCELLED == get();
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (SubscriptionHelper.setOnce(this, s)) {
+            s.request(Long.MAX_VALUE);
+        }
+    }
+
+    @Override
+    public boolean hasCustomOnError() {
+        return onError != Functions.ON_ERROR_MISSING;
+    }
+
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/CompletableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/CompletableConsumersTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.observers;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.exceptions.CompositeException;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.observers.LambdaConsumerIntrospection;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.subjects.CompletableSubject;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class CompletableConsumersTest implements Consumer<Object>, Action {
+
+    final CompositeDisposable composite = new CompositeDisposable();
+
+    final CompletableSubject processor = CompletableSubject.create();
+
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void run() throws Exception {
+        events.add("OnComplete");
+    }
+
+    @Override
+    public void accept(Object t) throws Exception {
+        events.add(t);
+    }
+
+    @Test
+    public void onErrorNormal() {
+
+        processor.subscribe(this, this, composite);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onComplete();
+
+        assertEquals(0, composite.size());
+
+        assertEquals(Arrays.<Object>asList("OnComplete"), events);
+
+    }
+
+    @Test
+    public void onErrorError() {
+
+        Disposable d = processor.subscribe(this, this, composite);
+
+        assertTrue(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onError(new IOException());
+
+        assertTrue(events.toString(), events.get(0) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteNormal() {
+
+        processor.subscribe(this, this, composite);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onComplete();
+
+        assertEquals(0, composite.size());
+
+        assertEquals(Arrays.<Object>asList("OnComplete"), events);
+
+    }
+
+    @Test
+    public void onCompleteError() {
+
+        processor.subscribe(this, this, composite);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onError(new IOException());
+
+        assertTrue(events.toString(), events.get(0) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteDispose() {
+
+        Disposable d = processor.subscribe(this, this, composite);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        assertFalse(d.isDisposed());
+
+        d.dispose();
+        d.dispose();
+
+        assertTrue(d.isDisposed());
+
+        assertEquals(0, composite.size());
+
+        assertFalse(processor.hasObservers());
+    }
+
+    @Test
+    public void onErrorCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            processor.subscribe(this, t -> {
+                throw new IOException(t);
+            }, composite);
+
+            processor.onError(new IllegalArgumentException());
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertError(errors, 0, CompositeException.class);
+            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            TestHelper.assertError(inners, 0, IllegalArgumentException.class);
+            TestHelper.assertError(inners, 1, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            processor.subscribe(new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new IOException();
+                }
+            }, this, composite);
+
+            processor.onComplete();
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            new Completable() {
+                @Override
+                protected void subscribeActual(
+                        CompletableObserver observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onComplete();
+
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onComplete();
+                    observer.onError(new IOException());
+                }
+            }.subscribe(this, this, composite);
+
+            assertEquals(Arrays.<Object>asList("OnComplete"), events);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/MaybeConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/MaybeConsumersTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.observers;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.exceptions.CompositeException;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.functions.Functions;
+import io.reactivex.rxjava3.observers.LambdaConsumerIntrospection;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.subjects.MaybeSubject;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class MaybeConsumersTest implements Consumer<Object>, Action {
+
+    final CompositeDisposable composite = new CompositeDisposable();
+
+    final MaybeSubject<Integer> processor = MaybeSubject.create();
+
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void run() throws Exception {
+        events.add("OnComplete");
+    }
+
+    @Override
+    public void accept(Object t) throws Exception {
+        events.add(t);
+    }
+
+    static <T> Disposable subscribeAutoDispose(Maybe<T> source, CompositeDisposable composite,
+            Consumer<? super T> onSuccess, Consumer<? super Throwable> onError, Action onComplete) {
+        return source.subscribe(onSuccess, onError, onComplete, composite);
+    }
+
+    @Test
+    public void onSuccessNormal() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, Functions.ON_ERROR_MISSING, () -> { });
+
+        assertFalse(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onSuccess(1);
+
+        assertEquals(0, composite.size());
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+    }
+
+    @Test
+    public void onErrorNormal() {
+
+        subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onSuccess(1);
+
+        assertEquals(0, composite.size());
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+    }
+
+    @Test
+    public void onErrorError() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onError(new IOException());
+
+        assertTrue(events.toString(), events.get(0) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteNormal() {
+
+        subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onComplete();
+
+        assertEquals(0, composite.size());
+
+        assertEquals(Arrays.<Object>asList("OnComplete"), events);
+
+    }
+
+    @Test
+    public void onCompleteError() {
+
+        subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onError(new IOException());
+
+        assertTrue(events.toString(), events.get(0) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteDispose() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        assertFalse(d.isDisposed());
+
+        d.dispose();
+        d.dispose();
+
+        assertTrue(d.isDisposed());
+
+        assertEquals(0, composite.size());
+
+        assertFalse(processor.hasObservers());
+    }
+
+    @Test
+    public void onSuccessCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, new Consumer<Object>() {
+                @Override
+                public void accept(Object t) throws Exception {
+                    throw new IOException();
+                }
+            }, this, this);
+
+            processor.onSuccess(1);
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, this, new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable t) throws Exception {
+                    throw new IOException(t);
+                }
+            }, this);
+
+            processor.onError(new IllegalArgumentException());
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertError(errors, 0, CompositeException.class);
+            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            TestHelper.assertError(inners, 0, IllegalArgumentException.class);
+            TestHelper.assertError(inners, 1, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, this, this, new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new IOException();
+                }
+            });
+
+            processor.onComplete();
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(
+                    new Maybe<Integer>() {
+                        @Override
+                        protected void subscribeActual(
+                                MaybeObserver<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
+                            observer.onComplete();
+
+                            observer.onSubscribe(Disposable.empty());
+                            observer.onSuccess(2);
+                            observer.onComplete();
+                            observer.onError(new IOException());
+                        }
+                    }, composite, this, this, this
+                );
+
+            assertEquals(Arrays.<Object>asList("OnComplete"), events);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/ObservableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/ObservableConsumersTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.observers;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.functions.Functions;
+import io.reactivex.rxjava3.observers.LambdaConsumerIntrospection;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.subjects.PublishSubject;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class ObservableConsumersTest implements Consumer<Object>, Action {
+
+    final CompositeDisposable composite = new CompositeDisposable();
+
+    final PublishSubject<Integer> processor = PublishSubject.create();
+
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void run() throws Exception {
+        events.add("OnComplete");
+    }
+
+    @Override
+    public void accept(Object t) throws Exception {
+        events.add(t);
+    }
+
+    static <T> Disposable subscribeAutoDispose(Observable<T> source, CompositeDisposable composite,
+            Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete) {
+        return source.subscribe(onNext, onError, onComplete, composite);
+    }
+
+    @Test
+    public void onNextNormal() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, Functions.ON_ERROR_MISSING, () -> { });
+
+        assertFalse(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onComplete();
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onErrorNormal() {
+
+        subscribeAutoDispose(processor, composite, this, Functions.ON_ERROR_MISSING, () -> { });
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onComplete();
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onErrorError() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onError(new IOException());
+
+        assertEquals(events.toString(), 1, events.get(0));
+        assertTrue(events.toString(), events.get(1) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteNormal() {
+
+        subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onComplete();
+
+        assertEquals(Arrays.<Object>asList(1, "OnComplete"), events);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteError() {
+
+        subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onError(new IOException());
+
+        assertEquals(events.toString(), 1, events.get(0));
+        assertTrue(events.toString(), events.get(1) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteDispose() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        assertFalse(d.isDisposed());
+
+        d.dispose();
+        d.dispose();
+
+        assertTrue(d.isDisposed());
+
+        assertEquals(0, composite.size());
+
+        assertFalse(processor.hasObservers());
+    }
+
+    @Test
+    public void onNextCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, new Consumer<Object>() {
+                @Override
+                public void accept(Object t) throws Exception {
+                    throw new IOException();
+                }
+            }, this, this);
+
+            processor.onNext(1);
+
+            assertTrue(errors.toString(), errors.isEmpty());
+
+            assertTrue(events.toString(), events.get(0) instanceof IOException);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextCrashOnError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, this, new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable t) throws Exception {
+                    throw new IOException(t);
+                }
+            }, this);
+
+            processor.onError(new IllegalArgumentException());
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertError(errors, 0, CompositeException.class);
+            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            TestHelper.assertError(inners, 0, IllegalArgumentException.class);
+            TestHelper.assertError(inners, 1, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextCrashNoError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, t -> {
+                throw new IOException();
+            }, Functions.ON_ERROR_MISSING, () -> { });
+
+            processor.onNext(1);
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
+            assertTrue(errors.get(0).getCause() instanceof IOException);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, this, this, new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new IOException();
+                }
+            });
+
+            processor.onNext(1);
+            processor.onComplete();
+
+            assertEquals(Arrays.asList(1), events);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(
+                    new Observable<Integer>() {
+                        @Override
+                        protected void subscribeActual(
+                                Observer<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
+                            observer.onNext(1);
+                            observer.onComplete();
+
+                            observer.onSubscribe(Disposable.empty());
+                            observer.onNext(2);
+                            observer.onComplete();
+                            observer.onError(new IOException());
+                        }
+                    }, composite, this, this, this
+                );
+
+            assertEquals(Arrays.<Object>asList(1, "OnComplete"), events);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/SingleConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/SingleConsumersTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.observers;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.exceptions.CompositeException;
+import io.reactivex.rxjava3.functions.Consumer;
+import io.reactivex.rxjava3.internal.functions.Functions;
+import io.reactivex.rxjava3.observers.LambdaConsumerIntrospection;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.subjects.SingleSubject;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class SingleConsumersTest implements Consumer<Object> {
+
+    final CompositeDisposable composite = new CompositeDisposable();
+
+    final SingleSubject<Integer> processor = SingleSubject.create();
+
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void accept(Object t) throws Exception {
+        events.add(t);
+    }
+
+    static <T> Disposable subscribeAutoDispose(Single<T> source, CompositeDisposable composite,
+            Consumer<? super T> onSuccess, Consumer<? super Throwable> onError) {
+        return source.subscribe(onSuccess, onError, composite);
+    }
+
+    @Test
+    public void onSuccessNormal() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, Functions.ON_ERROR_MISSING);
+
+        assertFalse(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onSuccess(1);
+
+        assertEquals(0, composite.size());
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+    }
+
+    @Test
+    public void onErrorNormal() {
+
+        subscribeAutoDispose(processor, composite, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onSuccess(1);
+
+        assertEquals(0, composite.size());
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+    }
+
+    @Test
+    public void onErrorError() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, this);
+
+        assertTrue(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onError(new IOException());
+
+        assertTrue(events.toString(), events.get(0) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onSuccessCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, new Consumer<Object>() {
+                @Override
+                public void accept(Object t) throws Exception {
+                    throw new IOException();
+                }
+            }, this);
+
+            processor.onSuccess(1);
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onErrorCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, this, new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable t) throws Exception {
+                    throw new IOException(t);
+                }
+            });
+
+            processor.onError(new IllegalArgumentException());
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertError(errors, 0, CompositeException.class);
+            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            TestHelper.assertError(inners, 0, IllegalArgumentException.class);
+            TestHelper.assertError(inners, 1, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(
+                    new Single<Integer>() {
+                        @Override
+                        protected void subscribeActual(
+                                SingleObserver<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
+                            observer.onSuccess(1);
+
+                            observer.onSubscribe(Disposable.empty());
+                            observer.onSuccess(2);
+                            observer.onError(new IOException());
+                        }
+                    }, composite, this, this
+                );
+
+            assertEquals(Arrays.<Object>asList(1), events);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/internal/subscribers/FlowableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/subscribers/FlowableConsumersTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2016-2019 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.subscribers;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.internal.functions.Functions;
+import io.reactivex.rxjava3.internal.subscriptions.BooleanSubscription;
+import io.reactivex.rxjava3.observers.LambdaConsumerIntrospection;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.testsupport.TestHelper;
+
+public class FlowableConsumersTest implements Consumer<Object>, Action {
+
+    final CompositeDisposable composite = new CompositeDisposable();
+
+    final PublishProcessor<Integer> processor = PublishProcessor.create();
+
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void run() throws Exception {
+        events.add("OnComplete");
+    }
+
+    @Override
+    public void accept(Object t) throws Exception {
+        events.add(t);
+    }
+
+    static <T> Disposable subscribeAutoDispose(Flowable<T> source, CompositeDisposable composite,
+            Consumer<? super T> onNext, Consumer<? super Throwable> onError, Action onComplete) {
+        return source.subscribe(onNext, onError, onComplete, composite);
+    }
+
+    @Test
+    public void onNextNormal() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, Functions.ON_ERROR_MISSING, () -> { });
+
+        assertFalse(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onComplete();
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onErrorNormal() {
+
+        subscribeAutoDispose(processor, composite, this, this, () -> { });
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onComplete();
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onErrorError() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(d.getClass().toString(), ((LambdaConsumerIntrospection)d).hasCustomOnError());
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onError(new IOException());
+
+        assertEquals(events.toString(), 1, events.get(0));
+        assertTrue(events.toString(), events.get(1) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteNormal() {
+
+        subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onComplete();
+
+        assertEquals(Arrays.<Object>asList(1, "OnComplete"), events);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteError() {
+
+        subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        processor.onNext(1);
+
+        assertTrue(composite.size() > 0);
+
+        assertEquals(Arrays.<Object>asList(1), events);
+
+        processor.onError(new IOException());
+
+        assertEquals(events.toString(), 1, events.get(0));
+        assertTrue(events.toString(), events.get(1) instanceof IOException);
+
+        assertEquals(0, composite.size());
+    }
+
+    @Test
+    public void onCompleteDispose() {
+
+        Disposable d = subscribeAutoDispose(processor, composite, this, this, this);
+
+        assertTrue(composite.size() > 0);
+
+        assertTrue(events.toString(), events.isEmpty());
+
+        assertFalse(d.isDisposed());
+
+        d.dispose();
+        d.dispose();
+
+        assertTrue(d.isDisposed());
+
+        assertEquals(0, composite.size());
+
+        assertFalse(processor.hasSubscribers());
+    }
+
+    @Test
+    public void onNextCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, new Consumer<Object>() {
+                @Override
+                public void accept(Object t) throws Exception {
+                    throw new IOException();
+                }
+            }, this, this);
+
+            processor.onNext(1);
+
+            assertTrue(errors.toString(), errors.isEmpty());
+
+            assertTrue(events.toString(), events.get(0) instanceof IOException);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextCrashOnError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, this, new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable t) throws Exception {
+                    throw new IOException(t);
+                }
+            }, this);
+
+            processor.onError(new IllegalArgumentException());
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertError(errors, 0, CompositeException.class);
+            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            TestHelper.assertError(inners, 0, IllegalArgumentException.class);
+            TestHelper.assertError(inners, 1, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onNextCrashNoError() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, new Consumer<Object>() {
+                @Override
+                public void accept(Object t) throws Exception {
+                    throw new IOException();
+                }
+            }, Functions.ON_ERROR_MISSING, () -> { });
+
+            processor.onNext(1);
+
+            assertTrue(events.toString(), events.isEmpty());
+
+            TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
+            assertTrue(errors.get(0).getCause() instanceof IOException);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void onCompleteCrash() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(processor, composite, this, this, new Action() {
+                @Override
+                public void run() throws Exception {
+                    throw new IOException();
+                }
+            });
+
+            processor.onNext(1);
+            processor.onComplete();
+
+            assertEquals(Arrays.asList(1), events);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    public void badSource() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            subscribeAutoDispose(
+                    new Flowable<Integer>() {
+                        @Override
+                        protected void subscribeActual(
+                                Subscriber<? super Integer> s) {
+                            s.onSubscribe(new BooleanSubscription());
+                            s.onNext(1);
+                            s.onComplete();
+
+                            s.onSubscribe(new BooleanSubscription());
+                            s.onNext(2);
+                            s.onComplete();
+                            s.onError(new IOException());
+                        }
+                    }, composite, this, this, this
+                );
+
+            assertEquals(Arrays.<Object>asList(1, "OnComplete"), events);
+
+            TestHelper.assertUndeliverable(errors, 0, IOException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava3/validators/BaseTypeAnnotations.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/BaseTypeAnnotations.java
@@ -22,6 +22,7 @@ import org.reactivestreams.Publisher;
 
 import io.reactivex.rxjava3.annotations.*;
 import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import io.reactivex.rxjava3.flowables.ConnectableFlowable;
 import io.reactivex.rxjava3.observables.ConnectableObservable;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
@@ -44,7 +45,8 @@ public class BaseTypeAnnotations {
 
         for (Method m : clazz.getMethods()) {
             if (m.getDeclaringClass() == clazz) {
-                boolean isSubscribeMethod = "subscribe".equals(m.getName()) && m.getParameterTypes().length == 0;
+                boolean isSubscribeMethod = "subscribe".equals(m.getName()) &&
+                        (m.getParameterTypes().length == 0 || m.getParameterTypes()[m.getParameterCount() - 1] == DisposableContainer.class);
                 boolean isConnectMethod = "connect".equals(m.getName()) && m.getParameterTypes().length == 0;
                 boolean isAnnotationPresent = m.isAnnotationPresent(CheckReturnValue.class);
 

--- a/src/test/java/io/reactivex/rxjava3/validators/JavadocForAnnotations.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/JavadocForAnnotations.java
@@ -95,7 +95,7 @@ public class JavadocForAnnotations {
                     ;
                     int lc = lineNumber(sourceCode, idx);
 
-                    e.append(" at io.reactivex.").append(baseClassName)
+                    e.append(" at io.reactivex.rxjava3.core.").append(baseClassName)
                     .append(" (").append(baseClassName).append(".java:")
                     .append(lc).append(")").append("\r\n\r\n");
                 }

--- a/src/test/java/io/reactivex/rxjava3/validators/JavadocWording.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/JavadocWording.java
@@ -309,6 +309,7 @@ public class JavadocWording {
                                 && !m.signature.contains("Maybe")
                                 && !m.signature.contains("MaybeSource")
                                 && !m.signature.contains("Disposable")
+                                && !m.signature.contains("void subscribe")
                         ) {
                             CharSequence subSequence = m.javadoc.subSequence(idx - 6, idx + 11);
                             if (idx < 6 || !subSequence.equals("{@link Disposable")) {

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -25,7 +25,7 @@ import org.reactivestreams.*;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Observer;
-import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.*;
 import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.functions.Functions;
@@ -579,6 +579,8 @@ public class ParamValidationCheckerTest {
         defaultValues.put(Subscriber[].class, new Subscriber[] { new AllFunctionals() });
 
         defaultValues.put(ParallelFailureHandling.class, ParallelFailureHandling.ERROR);
+
+        defaultValues.put(DisposableContainer.class, new CompositeDisposable());
 
         // JDK 8 types
 


### PR DESCRIPTION
### Purpose

With the existing lambda-subscribe methods, the returned `Disposable` is often added to a `CompositeDisposable` but generally is not removed right when the source terminates but when the parent context calls `clear()` on the composite. This can lead to unintended retention of resources captured by the lambdas as well as the composite growing and growing with now dead consumers.

These new overloads will interact with the container by adding themselves and removing themselves during the consumer's lifecycle.

Resolves #7295 

### Description

Wraps the given `onXXX` callbacks into a `Disposable` `Subscriber`/`Observer`/etc.,
adds it to the given `DisposableContainer` (such as `CompositeDisposable`) and ensures, that if the upstream
terminates or this particular `Disposable` is disposed, the `Subscriber`/`Observer`/etc. is removed
from the given composite.

The `Subscriber`/`Observer`/etc. will be removed *after* the callback for the terminal event has been invoked.

### Example

```java
CompositeDisposable composite = new CompositeDisposable();

Disposable d = Flowable.just(1).subscribe(
    System.out::println, 
     Throwable::printStackTrace, 
     () -> System.out.println("Done"),
     composite
);

assertEquals(0, composite.size());

// --------------------------

Disposable d2 = Flowable.never().subscribe(
    System.out::println, 
    Throwable::printStackTrace, 
    () -> System.out.println("Done"),
    composite
);

assertEquals(1, composite.size());

d2.dispose();

assertEquals(0, composite.size());
```

### Credits

This code was uplifted and adapted from the RxJavaExtensions project of mine: https://github.com/akarnokd/RxJavaExtensions#subscribeautodispose