### PR TITLE
Fix missing NonNull on Observable.map

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -10371,7 +10371,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <R> Observable<R> map(@NonNull Function<? super T, ? extends R> mapper) {
+    public final <R> Observable<@NonNull R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableMap<>(this, mapper));
     }

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -10371,7 +10371,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <R> Observable<@NonNull R> map(@NonNull Function<? super T, ? extends R> mapper) {
+    public final <@NonNull R> Observable<R> map(@NonNull Function<? super T, ? extends R> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return RxJavaPlugins.onAssembly(new ObservableMap<>(this, mapper));
     }


### PR DESCRIPTION
I noticed this while testing the upcoming Kotlin 1.5.30-M1 (which has improved support for type-use nullability annotations) https://youtrack.jetbrains.com/issue/KT-47833. This makes at least match `Single`, but `Maybe.map` is also missing this. I suspect there are others too.