### PR TITLE
3.x: Add RxJavaPlugins.createExecutorScheduler

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
@@ -15,7 +15,7 @@ package io.reactivex.rxjava3.plugins;
 
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Objects;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.*;
 
 import org.reactivestreams.Subscriber;
 
@@ -1302,6 +1302,25 @@ public final class RxJavaPlugins {
         return new SingleScheduler(Objects.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
+    /**
+     * Create an instance of a {@link Scheduler} by wrapping an existing {@link Executor}.
+     * <p>
+     * This method allows creating an {@code Executor}-backed {@code Scheduler} before the {@link Schedulers} class
+     * would initialize the standard {@code Scheduler}s.
+     *
+     * @param executor the {@code Executor} to wrap and turn into a {@code Scheduler}.
+     * @param interruptibleWorker if {@code true}, the tasks submitted to the {@link io.reactivex.rxjava3.core.Scheduler.Worker Scheduler.Worker} will
+     * be interrupted when the task is disposed.
+     * @param fair if {@code true}, tasks submitted to the {@code Scheduler} or {@code Worker} will be executed by the underlying {@code Executor} one after the other, still
+     * in a FIFO and non-overlapping manner, but allows interleaving with other tasks submitted to the underlying {@code Executor}.
+     * If {@code false}, the underlying FIFO scheme will execute as many tasks as it can before giving up the underlying {@code Executor} thread.
+     * @return the new {@code Scheduler} wrapping the {@code Executor}
+     * @since 3.1.0
+     */
+    @NonNull
+    public static Scheduler createExecutorScheduler(@NonNull Executor executor, boolean interruptibleWorker, boolean fair) {
+        return new ExecutorScheduler(executor, interruptibleWorker, fair);
+    }
     /**
      * Wraps the call to the function in try-catch and propagates thrown
      * checked exceptions as RuntimeException.

--- a/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
@@ -1321,6 +1321,7 @@ public final class RxJavaPlugins {
     public static Scheduler createExecutorScheduler(@NonNull Executor executor, boolean interruptibleWorker, boolean fair) {
         return new ExecutorScheduler(executor, interruptibleWorker, fair);
     }
+
     /**
      * Wraps the call to the function in try-catch and propagates thrown
      * checked exceptions as RuntimeException.

--- a/src/main/java/io/reactivex/rxjava3/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/rxjava3/schedulers/Schedulers.java
@@ -378,6 +378,10 @@ public final class Schedulers {
      * execute those tasks "unexpectedly".
      * <p>
      * Note that this method returns a new {@code Scheduler} instance, even for the same {@code Executor} instance.
+     * <p>
+     * It is possible to wrap an {@code Executor} into a {@code Scheduler} without triggering the initialization of all the
+     * standard schedulers by using the {@link RxJavaPlugins#createExecutorScheduler(Executor, boolean, boolean)} method
+     * before the {@code Schedulers} class itself is accessed.
      * @param executor
      *          the executor to wrap
      * @return the new {@code Scheduler} wrapping the {@code Executor}
@@ -385,7 +389,7 @@ public final class Schedulers {
      */
     @NonNull
     public static Scheduler from(@NonNull Executor executor) {
-        return new ExecutorScheduler(executor, false, false);
+        return from(executor, false, false);
     }
 
     /**
@@ -452,6 +456,10 @@ public final class Schedulers {
      * execute those tasks "unexpectedly".
      * <p>
      * Note that this method returns a new {@code Scheduler} instance, even for the same {@code Executor} instance.
+     * <p>
+     * It is possible to wrap an {@code Executor} into a {@code Scheduler} without triggering the initialization of all the
+     * standard schedulers by using the {@link RxJavaPlugins#createExecutorScheduler(Executor, boolean, boolean)} method
+     * before the {@code Schedulers} class itself is accessed.
      * <p>History: 2.2.6 - experimental
      * @param executor
      *          the executor to wrap
@@ -463,7 +471,7 @@ public final class Schedulers {
      */
     @NonNull
     public static Scheduler from(@NonNull Executor executor, boolean interruptibleWorker) {
-        return new ExecutorScheduler(executor, interruptibleWorker, false);
+        return from(executor, interruptibleWorker, false);
     }
 
     /**
@@ -532,6 +540,11 @@ public final class Schedulers {
      * execute those tasks "unexpectedly".
      * <p>
      * Note that this method returns a new {@code Scheduler} instance, even for the same {@code Executor} instance.
+     * <p>
+     * It is possible to wrap an {@code Executor} into a {@code Scheduler} without triggering the initialization of all the
+     * standard schedulers by using the {@link RxJavaPlugins#createExecutorScheduler(Executor, boolean, boolean)} method
+     * before the {@code Schedulers} class itself is accessed.
+     *
      * @param executor
      *          the executor to wrap
      * @param interruptibleWorker if {@code true}, the tasks submitted to the {@link io.reactivex.rxjava3.core.Scheduler.Worker Scheduler.Worker} will
@@ -544,7 +557,7 @@ public final class Schedulers {
      */
     @NonNull
     public static Scheduler from(@NonNull Executor executor, boolean interruptibleWorker, boolean fair) {
-        return new ExecutorScheduler(executor, interruptibleWorker, fair);
+        return RxJavaPlugins.createExecutorScheduler(executor, interruptibleWorker, fair);
     }
 
     /**


### PR DESCRIPTION
This PR adds the `RxJavaPlugins.createExecutorScheduler` that instantiates the already existing `ExecutorScheduler` independent of the `Schedulers` class. The `from` methods in the `Schedulers` class are now pointing to this new method.

Resolves #7305
Related #7300