### PR TITLE
Code cleanup

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -9346,7 +9346,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Flowable<T> distinct() {
-        return distinct((Function)Functions.identity(), Functions.<T>createHashSet());
+        return distinct(Functions.identity(), Functions.createHashSet());
     }
 
     /**
@@ -15534,7 +15534,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     public final Flowable<T> startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), this);
+        return Flowable.concat(Completable.wrap(other).toFlowable(), this);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -5112,7 +5112,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     public final Flowable<T> startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), toFlowable());
+        return Flowable.concat(Completable.wrap(other).toFlowable(), toFlowable());
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -12885,7 +12885,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return Observable.concat(Completable.wrap(other).<T>toObservable(), this);
+        return Observable.concat(Completable.wrap(other).toObservable(), this);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -4589,7 +4589,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     public final Flowable<T> startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), toFlowable());
+        return Flowable.concat(Completable.wrap(other).toFlowable(), toFlowable());
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/functions/Functions.java
@@ -516,7 +516,7 @@ public final class Functions {
 
         @Override
         public List<T> apply(List<T> v) {
-            Collections.sort(v, comparator);
+            v.sort(comparator);
             return v;
         }
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsFlowable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsFlowable.java
@@ -98,11 +98,10 @@ public final class MaybeFlattenStreamAsFlowable<T, R> extends Flowable<R> {
             try {
                 Stream<? extends R> stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
                 Iterator<? extends R> iterator = stream.iterator();
-                AutoCloseable c = stream;
 
-                if (!iterator.hasNext()) {
+              if (!iterator.hasNext()) {
                     downstream.onComplete();
-                    close(c);
+                    close(stream);
                     return;
                 }
                 this.iterator = iterator;

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsObservable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/MaybeFlattenStreamAsObservable.java
@@ -91,11 +91,10 @@ public final class MaybeFlattenStreamAsObservable<T, R> extends Observable<R> {
             try {
                 Stream<? extends R> stream = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Stream");
                 Iterator<? extends R> iterator = stream.iterator();
-                AutoCloseable c = stream;
 
-                if (!iterator.hasNext()) {
+              if (!iterator.hasNext()) {
                     downstream.onComplete();
-                    close(c);
+                    close(stream);
                     return;
                 }
                 this.iterator = iterator;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCache.java
@@ -225,7 +225,6 @@ implements FlowableSubscriber<T> {
         Node<T> node = consumer.node;
         AtomicLong requested = consumer.requested;
         Subscriber<? super T> downstream = consumer.downstream;
-        int capacity = capacityHint;
 
         for (;;) {
             // first see if the source has terminated, read order matters!
@@ -261,7 +260,7 @@ implements FlowableSubscriber<T> {
                 if (consumerRequested != index) {
 
                     // if the offset in the current node has reached the node capacity
-                    if (offset == capacity) {
+                    if (offset == capacityHint) {
                         // switch to the subsequent node
                         node = node.next;
                         // reset the in-node offset

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCombineLatest.java
@@ -179,13 +179,12 @@ extends Flowable<R> {
         }
 
         void subscribe(Publisher<? extends T>[] sources, int n) {
-            CombineLatestInnerSubscriber<T>[] a = subscribers;
 
             for (int i = 0; i < n; i++) {
                 if (done || cancelled) {
                     return;
                 }
-                sources[i].subscribe(a[i]);
+                sources[i].subscribe(subscribers[i]);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCreate.java
@@ -514,8 +514,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
             }
 
             int missed = 1;
-            final Subscriber<? super T> a = downstream;
-            final SpscLinkedArrayQueue<T> q = queue;
+          final SpscLinkedArrayQueue<T> q = queue;
 
             for (;;) {
                 long r = get();
@@ -547,7 +546,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
                         break;
                     }
 
-                    a.onNext(o);
+                    downstream.onNext(o);
 
                     e++;
                 }
@@ -651,8 +650,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
             }
 
             int missed = 1;
-            final Subscriber<? super T> a = downstream;
-            final AtomicReference<T> q = queue;
+          final AtomicReference<T> q = queue;
 
             for (;;) {
                 long r = get();
@@ -684,7 +682,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
                         break;
                     }
 
-                    a.onNext(o);
+                    downstream.onNext(o);
 
                     e++;
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFilter.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFilter.java
@@ -85,7 +85,6 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
         @Override
         public T poll() throws Throwable {
             QueueSubscription<T> qs = this.qs;
-            Predicate<? super T> f = filter;
 
             for (;;) {
                 T t = qs.poll();
@@ -93,7 +92,7 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
                     return null;
                 }
 
-                if (f.test(t)) {
+                if (filter.test(t)) {
                     return t;
                 }
 
@@ -148,7 +147,6 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
         @Override
         public T poll() throws Throwable {
             QueueSubscription<T> qs = this.qs;
-            Predicate<? super T> f = filter;
 
             for (;;) {
                 T t = qs.poll();
@@ -156,7 +154,7 @@ public final class FlowableFilter<T> extends AbstractFlowableWithUpstream<T, T> 
                     return null;
                 }
 
-                if (f.test(t)) {
+                if (filter.test(t)) {
                     return t;
                 }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -101,8 +101,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
 
                 downstream.onSubscribe(this);
 
-                int m = maxConcurrency;
-                if (m == Integer.MAX_VALUE) {
+              if (maxConcurrency == Integer.MAX_VALUE) {
                     s.request(Long.MAX_VALUE);
                 } else {
                     s.request(maxConcurrency);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -101,8 +101,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
 
                 downstream.onSubscribe(this);
 
-                int m = maxConcurrency;
-                if (m == Integer.MAX_VALUE) {
+              if (maxConcurrency == Integer.MAX_VALUE) {
                     s.request(Long.MAX_VALUE);
                 } else {
                     s.request(maxConcurrency);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGenerate.java
@@ -91,9 +91,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
 
             S s = state;
 
-            final BiFunction<S, ? super Emitter<T>, S> f = generator;
-
-            for (;;) {
+          for (;;) {
                 while (e != n) {
 
                     if (cancelled) {
@@ -105,7 +103,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
                     hasNext = false;
 
                     try {
-                        s = f.apply(s, this);
+                        s = generator.apply(s, this);
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
                         cancelled = true;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -478,7 +478,6 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         void drainFused() {
             int missed = 1;
 
-            final SpscLinkedArrayQueue<T> q = this.queue;
             Subscriber<? super T> a = this.actual.get();
 
             for (;;) {
@@ -492,7 +491,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                     if (d && !delayError) {
                         Throwable ex = error;
                         if (ex != null) {
-                            q.clear();
+                            this.queue.clear();
                             a.onError(ex);
                             return;
                         }
@@ -694,9 +693,8 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
         @Override
         public void clear() {
-            SpscLinkedArrayQueue<T> q = queue;
             // queue.clear() would drop submitted items and not replenish, possibly hanging other groups
-            while (q.poll() != null) {
+            while (queue.poll() != null) {
                 produced++;
             }
             tryReplenish();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRange.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRange.java
@@ -118,10 +118,9 @@ public final class FlowableRange extends Flowable<Integer> {
 
         @Override
         void fastPath() {
-            int f = end;
             Subscriber<? super Integer> a = downstream;
 
-            for (int i = index; i != f; i++) {
+            for (int i = index; i != end; i++) {
                 if (cancelled) {
                     return;
                 }
@@ -186,10 +185,9 @@ public final class FlowableRange extends Flowable<Integer> {
 
         @Override
         void fastPath() {
-            int f = end;
             ConditionalSubscriber<? super Integer> a = downstream;
 
-            for (int i = index; i != f; i++) {
+            for (int i = index; i != end; i++) {
                 if (cancelled) {
                     return;
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRangeLong.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableRangeLong.java
@@ -120,10 +120,9 @@ public final class FlowableRangeLong extends Flowable<Long> {
 
         @Override
         void fastPath() {
-            long f = end;
             Subscriber<? super Long> a = downstream;
 
-            for (long i = index; i != f; i++) {
+            for (long i = index; i != end; i++) {
                 if (cancelled) {
                     return;
                 }
@@ -188,10 +187,9 @@ public final class FlowableRangeLong extends Flowable<Long> {
 
         @Override
         void fastPath() {
-            long f = end;
             ConditionalSubscriber<? super Long> a = downstream;
 
-            for (long i = index; i != f; i++) {
+            for (long i = index; i != end; i++) {
                 if (cancelled) {
                     return;
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZip.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZip.java
@@ -117,12 +117,11 @@ public final class FlowableZip<T, R> extends Flowable<R> {
         }
 
         void subscribe(Publisher<? extends T>[] sources, int n) {
-            ZipSubscriber<T, R>[] a = subscribers;
             for (int i = 0; i < n; i++) {
                 if (cancelled || (!delayErrors && errors.get() != null)) {
                     return;
                 }
-                sources[i].subscribe(a[i]);
+                sources[i].subscribe(subscribers[i]);
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArrayDelayError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeConcatArrayDelayError.java
@@ -121,7 +121,6 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
             }
 
             AtomicReference<Object> c = current;
-            Subscriber<? super T> a = downstream;
             Disposable cancelled = disposables;
 
             for (;;) {
@@ -141,7 +140,7 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
                             c.lazySet(null);
                             goNextSource = true;
 
-                            a.onNext((T)o);
+                            downstream.onNext((T)o);
                         } else {
                             goNextSource = false;
                         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMergeArray.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/maybe/MaybeMergeArray.java
@@ -348,7 +348,6 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
             if (ci == length()) {
                 return null;
             }
-            AtomicInteger pi = producerIndex;
             for (;;) {
                 T v = get(ci);
                 if (v != null) {
@@ -356,7 +355,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
                     lazySet(ci, null);
                     return v;
                 }
-                if (pi.get() == ci) {
+                if (producerIndex.get() == ci) {
                     return null;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCache.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCache.java
@@ -220,7 +220,6 @@ implements Observer<T> {
         int offset = consumer.offset;
         Node<T> node = consumer.node;
         Observer<? super T> downstream = consumer.downstream;
-        int capacity = capacityHint;
 
         for (;;) {
             // if the consumer got disposed, clear the node and quit
@@ -251,7 +250,7 @@ implements Observer<T> {
             // there are still items not sent to the consumer
             if (!empty) {
              // if the offset in the current node has reached the node capacity
-                if (offset == capacity) {
+                if (offset == capacityHint) {
                     // switch to the subsequent node
                     node = node.next;
                     // reset the in-node offset

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -232,10 +232,8 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
         void drainLoop() {
             int missed = 1;
             Observer<? super R> a = downstream;
-            AtomicInteger n = active;
-            AtomicReference<SpscLinkedArrayQueue<R>> qr = queue;
 
-            for (;;) {
+          for (;;) {
                 for (;;) {
                     if (cancelled) {
                         clear();
@@ -251,8 +249,8 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
                         }
                     }
 
-                    boolean d = n.get() == 0;
-                    SpscLinkedArrayQueue<R> q = qr.get();
+                    boolean d = active.get() == 0;
+                    SpscLinkedArrayQueue<R> q = queue.get();
                     R v = q != null ? q.poll() : null;
                     boolean empty = v == null;
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlatMapSingle.java
@@ -211,10 +211,8 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
         void drainLoop() {
             int missed = 1;
             Observer<? super R> a = downstream;
-            AtomicInteger n = active;
-            AtomicReference<SpscLinkedArrayQueue<R>> qr = queue;
 
-            for (;;) {
+          for (;;) {
                 for (;;) {
                     if (cancelled) {
                         clear();
@@ -230,8 +228,8 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
                         }
                     }
 
-                    boolean d = n.get() == 0;
-                    SpscLinkedArrayQueue<R> q = qr.get();
+                    boolean d = active.get() == 0;
+                    SpscLinkedArrayQueue<R> q = queue.get();
                     R v = q != null ? q.poll() : null;
                     boolean empty = v == null;
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlattenIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableFlattenIterable.java
@@ -82,9 +82,7 @@ public final class ObservableFlattenIterable<T, R> extends AbstractObservableWit
                 return;
             }
 
-            Observer<? super R> a = downstream;
-
-            for (;;) {
+          for (;;) {
                 boolean b;
 
                 try {
@@ -108,7 +106,7 @@ public final class ObservableFlattenIterable<T, R> extends AbstractObservableWit
                         return;
                     }
 
-                    a.onNext(v);
+                    downstream.onNext(v);
                 } else {
                     break;
                 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGenerate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGenerate.java
@@ -83,9 +83,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
                 return;
             }
 
-            final BiFunction<S, ? super Emitter<T>, S> f = generator;
-
-            for (;;) {
+          for (;;) {
 
                 if (cancelled) {
                     state = null;
@@ -96,7 +94,7 @@ public final class ObservableGenerate<T, S> extends Observable<T> {
                 hasNext = false;
 
                 try {
-                    s = f.apply(s, this);
+                    s = generator.apply(s, this);
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     state = null;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableGroupBy.java
@@ -307,14 +307,13 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
             }
             int missed = 1;
 
-            final SpscLinkedArrayQueue<T> q = queue;
-            final boolean delayError = this.delayError;
+          final boolean delayError = this.delayError;
             Observer<? super T> a = actual.get();
             for (;;) {
                 if (a != null) {
                     for (;;) {
                         boolean d = done;
-                        T v = q.poll();
+                        T v = queue.poll();
                         boolean empty = v == null;
 
                         if (checkTerminated(d, empty, a, delayError)) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRange.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRange.java
@@ -60,8 +60,7 @@ public final class ObservableRange extends Observable<Integer> {
                 return;
             }
             Observer<? super Integer> actual = this.downstream;
-            long e = end;
-            for (long i = index; i != e && get() == 0; i++) {
+            for (long i = index; i != end && get() == 0; i++) {
                 actual.onNext((int)i);
             }
             if (get() == 0) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRangeLong.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableRangeLong.java
@@ -57,8 +57,7 @@ public final class ObservableRangeLong extends Observable<Long> {
                 return;
             }
             Observer<? super Long> actual = this.downstream;
-            long e = end;
-            for (long i = index; i != e && get() == 0; i++) {
+          for (long i = index; i != end && get() == 0; i++) {
                 actual.onNext(i);
             }
             if (get() == 0) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSkipLastTimed.java
@@ -79,11 +79,10 @@ public final class ObservableSkipLastTimed<T> extends AbstractObservableWithUpst
 
         @Override
         public void onNext(T t) {
-            final SpscLinkedArrayQueue<Object> q = queue;
 
             long now = scheduler.now(unit);
 
-            q.offer(now, t);
+            queue.offer(now, t);
 
             drain();
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZip.java
@@ -151,7 +151,6 @@ public final class ObservableZip<T, R> extends Observable<R> {
 
             int missing = 1;
 
-            final ZipObserver<T, R>[] zs = observers;
             final Observer<? super R> a = downstream;
             final T[] os = row;
             final boolean delayError = this.delayError;
@@ -161,7 +160,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
                 for (;;) {
                     int i = 0;
                     int emptyCount = 0;
-                    for (ZipObserver<T, R> z : zs) {
+                    for (ZipObserver<T, R> z : observers) {
                         if (os[i] == null) {
                             boolean d = z.done;
                             T v = z.queue.poll();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelJoin.java
@@ -238,8 +238,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < s.length; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimplePlainQueue<T> q = inner.queue;
                         if (q != null) {
                             T v = q.poll();
@@ -282,9 +281,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < n; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
-
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimpleQueue<T> q = inner.queue;
                         if (q != null && !q.isEmpty()) {
                             empty = false;
@@ -404,9 +401,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < n; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
-
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimplePlainQueue<T> q = inner.queue;
                         if (q != null) {
                             T v = q.poll();
@@ -442,9 +437,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < n; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
-
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimpleQueue<T> q = inner.queue;
                         if (q != null && !q.isEmpty()) {
                             empty = false;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelRunOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelRunOn.java
@@ -230,7 +230,6 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
             int c = consumed;
             SpscArrayQueue<T> q = queue;
             Subscriber<? super T> a = downstream;
-            int lim = limit;
 
             for (;;) {
 
@@ -277,7 +276,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
                     e++;
 
                     int p = ++c;
-                    if (p == lim) {
+                    if (p == limit) {
                         c = 0;
                         upstream.request(p);
                     }
@@ -354,7 +353,6 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
             int c = consumed;
             SpscArrayQueue<T> q = queue;
             ConditionalSubscriber<? super T> a = downstream;
-            int lim = limit;
 
             for (;;) {
 
@@ -401,7 +399,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
                     }
 
                     int p = ++c;
-                    if (p == lim) {
+                    if (p == limit) {
                         c = 0;
                         upstream.request(p);
                     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleOnErrorComplete.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava3.internal.operators.single;
 
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.functions.Predicate;
 import io.reactivex.rxjava3.internal.operators.maybe.MaybeOnErrorComplete;
@@ -37,7 +38,7 @@ public final class SingleOnErrorComplete<T> extends Maybe<T> {
     }
 
     @Override
-    protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new MaybeOnErrorComplete.OnErrorCompleteMultiObserver<T>(observer, predicate));
+    protected void subscribeActual(@NonNull MaybeObserver<? super T> observer) {
+        source.subscribe(new MaybeOnErrorComplete.OnErrorCompleteMultiObserver<>(observer, predicate));
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerWhen.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/SchedulerWhen.java
@@ -102,7 +102,7 @@ import io.reactivex.rxjava3.processors.*;
 public class SchedulerWhen extends Scheduler implements Disposable {
     private final Scheduler actualScheduler;
     private final FlowableProcessor<Flowable<Completable>> workerProcessor;
-    private Disposable disposable;
+    private final Disposable disposable;
 
     public SchedulerWhen(Function<Flowable<Flowable<Completable>>, Completable> combine, Scheduler actualScheduler) {
         this.actualScheduler = actualScheduler;

--- a/src/main/java/io/reactivex/rxjava3/internal/util/SorterFunction.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/SorterFunction.java
@@ -27,7 +27,7 @@ public final class SorterFunction<T> implements Function<List<T>, List<T>> {
 
     @Override
     public List<T> apply(List<T> t) {
-        Collections.sort(t, comparator);
+        t.sort(comparator);
         return t;
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
@@ -243,7 +243,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @NonNull
     public final U assertError(@NonNull Class<? extends Throwable> errorClass) {
-        return (U)assertError((Predicate)Functions.isInstanceOf(errorClass), true);
+        return assertError(Functions.isInstanceOf(errorClass), true);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/ReplayProcessor.java
@@ -705,13 +705,12 @@ public final class ReplayProcessor<@NonNull T> extends FlowableProcessor<T> {
                 }
                 return array;
             }
-            List<T> b = buffer;
 
             if (array.length < s) {
                 array = (T[])Array.newInstance(array.getClass().getComponentType(), s);
             }
             for (int i = 0; i < s; i++) {
-                array[i] = b.get(i);
+                array[i] = buffer.get(i);
             }
             if (array.length > s) {
                 array[s] = null;
@@ -727,7 +726,6 @@ public final class ReplayProcessor<@NonNull T> extends FlowableProcessor<T> {
             }
 
             int missed = 1;
-            final List<T> b = buffer;
             final Subscriber<? super T> a = rs.downstream;
 
             Integer indexObject = (Integer)rs.index;
@@ -769,7 +767,7 @@ public final class ReplayProcessor<@NonNull T> extends FlowableProcessor<T> {
                         break;
                     }
 
-                    a.onNext(b.get(index));
+                    a.onNext(buffer.get(index));
 
                     index++;
                     e++;

--- a/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/UnicastProcessor.java
@@ -329,8 +329,7 @@ public final class UnicastProcessor<@NonNull T> extends FlowableProcessor<T> {
     void drainFused(Subscriber<? super T> a) {
         int missed = 1;
 
-        final SpscLinkedArrayQueue<T> q = queue;
-        final boolean failFast = !delayError;
+      final boolean failFast = !delayError;
         for (;;) {
 
             if (cancelled) {
@@ -341,7 +340,7 @@ public final class UnicastProcessor<@NonNull T> extends FlowableProcessor<T> {
             boolean d = done;
 
             if (failFast && d && error != null) {
-                q.clear();
+                queue.clear();
                 downstream.lazySet(null);
                 a.onError(error);
                 return;

--- a/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
@@ -742,7 +742,6 @@ public final class ReplaySubject<T> extends Subject<T> {
             }
 
             int missed = 1;
-            final List<Object> b = buffer;
             final Observer<? super T> a = rs.downstream;
 
             Integer indexObject = (Integer)rs.index;
@@ -770,7 +769,7 @@ public final class ReplaySubject<T> extends Subject<T> {
                         return;
                     }
 
-                    Object o = b.get(index);
+                    Object o = buffer.get(index);
 
                     if (done) {
                         if (index + 1 == s) {

--- a/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/UnicastSubject.java
@@ -396,8 +396,7 @@ public final class UnicastSubject<T> extends Subject<T> {
     void drainFused(Observer<? super T> a) {
         int missed = 1;
 
-        final SpscLinkedArrayQueue<T> q = queue;
-        final boolean failFast = !delayError;
+      final boolean failFast = !delayError;
 
         for (;;) {
 
@@ -408,7 +407,7 @@ public final class UnicastSubject<T> extends Subject<T> {
             boolean d = done;
 
             if (failFast && d) {
-                if (failedFast(q, a)) {
+                if (failedFast(queue, a)) {
                     return;
                 }
             }


### PR DESCRIPTION
- Remove redundant cast and type.
- Replace `for i` with `for in`.
- Inline variables.
