### PR TITLE
3.x: Specify proper OSGi unique bundle symbolic name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,12 +89,13 @@ jar {
     bnd(
             "Bundle-Name": "rxjava",
             "Bundle-Vendor": "RxJava Contributors",
-            "Bundle-Description": "Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.",
+            "Bundle-Description": "Reactive Extensions for the JVM - a library for composing asynchronous and event-based programs using observable sequences for the Java VM.",
             "Import-Package": "!org.junit,!junit.framework,!org.mockito.*,!org.testng.*,*",
             "Bundle-DocURL": "https://github.com/ReactiveX/RxJava",
             "Eclipse-ExtensibleAPI": "true",
             "Automatic-Module-Name": "io.reactivex.rxjava3",
-            "Export-Package": "!io.reactivex.rxjava3.internal.*, io.reactivex.rxjava3.*"
+            "Export-Package": "!io.reactivex.rxjava3.internal.*, io.reactivex.rxjava3.*",
+            "Bundle-SymbolicName": "io.reactivex.rxjava3.rxjava"
     )
 }
 


### PR DESCRIPTION
The default was just the ArtifactID of "rxjava" which could become a problem in future major versions.

In addition, in the description, the unicode dash is now replaced with the ASCII dash to avoid encoding problems.

Related: #7318