### PR TITLE
3.x: Fix ExecutorScheduler initializing Schedulers prematurely

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
@@ -38,7 +38,9 @@ public final class ExecutorScheduler extends Scheduler {
     @NonNull
     final Executor executor;
 
-    static final Scheduler HELPER = Schedulers.single();
+    static final class SingleHolder {
+        static final Scheduler HELPER = Schedulers.single();
+    }
 
     public ExecutorScheduler(@NonNull Executor executor, boolean interruptibleWorker, boolean fair) {
         this.executor = executor;
@@ -97,7 +99,7 @@ public final class ExecutorScheduler extends Scheduler {
 
         final DelayedRunnable dr = new DelayedRunnable(decoratedRun);
 
-        Disposable delayed = HELPER.scheduleDirect(new DelayedDispose(dr), delay, unit);
+        Disposable delayed = SingleHolder.HELPER.scheduleDirect(new DelayedDispose(dr), delay, unit);
 
         dr.timed.replace(delayed);
 
@@ -215,7 +217,7 @@ public final class ExecutorScheduler extends Scheduler {
                     return EmptyDisposable.INSTANCE;
                 }
             } else {
-                final Disposable d = HELPER.scheduleDirect(sr, delay, unit);
+                final Disposable d = SingleHolder.HELPER.scheduleDirect(sr, delay, unit);
                 sr.setFuture(new DisposeOnCancel(d));
             }
 

--- a/src/test/java/io/reactivex/rxjava3/internal/schedulers/ExecutorSchedulerInternalTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/schedulers/ExecutorSchedulerInternalTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.internal.schedulers;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class ExecutorSchedulerInternalTest {
+
+    @Test
+    public void helperHolder() {
+        assertNotNull(new ExecutorScheduler.SingleHolder());
+    }
+
+}


### PR DESCRIPTION
`ExecutorScheduler` had a static field referencing `Schedulers` thus when using `RxJavaPlugins.createExecutorScheduler`, it would still initialize the standard schedulers despite the intention of the create method. Using the static inner holder class idiom can prevent this, similar to how `Schedulers` does it.

Related: https://github.com/ReactiveX/RxJava/pull/7306#issuecomment-905405129