### PR TITLE
Align hasCustomOnError behavior of CallbackCompletableObserver with L…

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -2996,11 +2996,7 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Disposable subscribe(@NonNull Action onComplete) {
-        Objects.requireNonNull(onComplete, "onComplete is null");
-
-        CallbackCompletableObserver observer = new CallbackCompletableObserver(onComplete);
-        subscribe(observer);
-        return observer;
+        return subscribe(onComplete, Functions.ON_ERROR_MISSING);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/internal/observers/CallbackCompletableObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/observers/CallbackCompletableObserver.java
@@ -20,31 +20,22 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava3.internal.functions.Functions;
 import io.reactivex.rxjava3.observers.LambdaConsumerIntrospection;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 
 public final class CallbackCompletableObserver
 extends AtomicReference<Disposable>
-        implements CompletableObserver, Disposable, Consumer<Throwable>, LambdaConsumerIntrospection {
+        implements CompletableObserver, Disposable, LambdaConsumerIntrospection {
 
     private static final long serialVersionUID = -4361286194466301354L;
 
     final Consumer<? super Throwable> onError;
     final Action onComplete;
 
-    public CallbackCompletableObserver(Action onComplete) {
-        this.onError = this;
-        this.onComplete = onComplete;
-    }
-
     public CallbackCompletableObserver(Consumer<? super Throwable> onError, Action onComplete) {
         this.onError = onError;
         this.onComplete = onComplete;
-    }
-
-    @Override
-    public void accept(Throwable e) {
-        RxJavaPlugins.onError(new OnErrorNotImplementedException(e));
     }
 
     @Override
@@ -86,6 +77,6 @@ extends AtomicReference<Disposable>
 
     @Override
     public boolean hasCustomOnError() {
-        return onError != this;
+        return onError != Functions.ON_ERROR_MISSING;
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/CallbackCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/CallbackCompletableObserverTest.java
@@ -24,7 +24,7 @@ public final class CallbackCompletableObserverTest extends RxJavaTest {
 
     @Test
     public void emptyActionShouldReportNoCustomOnError() {
-        CallbackCompletableObserver o = new CallbackCompletableObserver(Functions.EMPTY_ACTION);
+        CallbackCompletableObserver o = new CallbackCompletableObserver(Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
 
         assertFalse(o.hasCustomOnError());
     }


### PR DESCRIPTION
…ambdaObserver, ConsumerSingleObserver and so on

Background:
`CallbackCompletableObserver.hasCustomOnError` has a different implementation than other `LambdaConsumerIntrospection` implementations. This causes `hasCustomOnError` to return true even if one passes `Functions.ON_ERROR_MISSING` to `Completable.subscribe(onComplete, onError)`. In contrast, if one passes `Functions.ON_ERROR_MISSING` to `Single.subscribe(onComplete, onError)`, the ConsumerSingleObserver returns false from `hasCustomOnError`, and the case is the same with `Single` for `Observable`, `Maybe` and `Flowable`. This makes `Completable` a bit unnecessarily special.

Changes made:
Use the same strategy from other observable classes.

Might be breaking:
This change is making ABI changes on `CallbackCompletableObserver`.  I am not sure if we need to maintain ABI stability even for classes in internal package. If it is needed, I am happy to add one more commit to keep`CallbackCompletableObserver`'s ABI stable.