### PR TITLE
3.x: Fix javadoc wording of {Publish|Behavior}Processor::offer()

### DIFF
--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -11,6 +11,16 @@ task javadocCleanup(dependsOn: "javadoc") doLast {
 
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/subjects/ReplaySubject.html'))
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/processors/ReplayProcessor.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/subjects/PublishSubject.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/processors/PublishProcessor.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/subjects/AsyncSubject.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/processors/AsyncProcessor.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/subjects/BehaviorSubject.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/processors/BehaviorProcessor.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/processors/MulticastProcessor.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/subjects/UnicastSubject.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/processors/UnicastProcessor.html'))
+
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/plugins/RxJavaPlugins.html'))
 
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/parallel/ParallelFlowable.html'))

--- a/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
@@ -306,17 +306,14 @@ public final class BehaviorProcessor<@NonNull T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Tries to emit the item to all currently subscribed Subscribers if all of them
-     * has requested some value, returns false otherwise.
+     * Tries to emit the item to all currently subscribed {@link Subscriber}s if all of them
+     * has requested some value, returns {@code false} otherwise.
      * <p>
-     * This method should be called in a sequential manner just like the onXXX methods
-     * of the PublishProcessor.
-     * <p>
-     * Calling with a null value will terminate the PublishProcessor and a NullPointerException
-     * is signaled to the Subscribers.
+     * This method should be called in a sequential manner just like the {@code onXXX} methods
+     * of this {@code BehaviorProcessor}.
      * <p>History: 2.0.8 - experimental
-     * @param t the item to emit, not null
-     * @return true if the item was emitted to all Subscribers
+     * @param t the item to emit, not {@code null}
+     * @return {@code true} if the item was emitted to all {@code Subscriber}s
      * @throws NullPointerException if {@code t} is {@code null}
      * @since 2.2
      */

--- a/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
@@ -271,17 +271,14 @@ public final class PublishProcessor<@NonNull T> extends FlowableProcessor<T> {
     }
 
     /**
-     * Tries to emit the item to all currently subscribed Subscribers if all of them
-     * has requested some value, returns false otherwise.
+     * Tries to emit the item to all currently subscribed {@link Subscriber}s if all of them
+     * has requested some value, returns {@code false} otherwise.
      * <p>
-     * This method should be called in a sequential manner just like the onXXX methods
-     * of the PublishProcessor.
-     * <p>
-     * Calling with a null value will terminate the PublishProcessor and a NullPointerException
-     * is signaled to the Subscribers.
+     * This method should be called in a sequential manner just like the {@code onXXX} methods
+     * of this {@code PublishProcessor}.
      * <p>History: 2.0.8 - experimental
-     * @param t the item to emit, not null
-     * @return true if the item was emitted to all Subscribers
+     * @param t the item to emit, not {@code null}
+     * @return {@code true} if the item was emitted to all {@code Subscriber}s
      * @throws NullPointerException if {@code t} is {@code null}
      * @since 2.2
      */


### PR DESCRIPTION
The Javadoc of `BehaviorProcessor::offer` still mentioned `PublishProcessor`. Also calling with null would throw an NPE and no longer error the subscribers.