### PR TITLE
3.x: Add module-info.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,12 +49,36 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+    modularity.inferModulePath.set(true)
 }
 
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-parameters"
+}
+
+Provider<SourceSet> java11 = sourceSets.register("java11") {
+    it.java {
+        srcDir("src/main/java11")
+    }
+}
+
+tasks.withType(JavaCompile).named("compileJava11Java") { compileTask ->
+    compileTask.javaCompiler = javaToolchains.compilerFor {
+        // We use a LTS version of Java for building
+        // but use target 9 for maximum compatibility
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+    compileTask.options.release.set(9)
+}
+
+configurations {
+    "java11Implementation" {
+        extendsFrom(api)
+        extendsFrom(implementation)
+    }
 }
 
 apply from: file("gradle/javadoc_cleanup.gradle")
@@ -86,6 +110,12 @@ animalsniffer {
 }
 
 jar {
+    from(java11.map { it.output }) {
+        into("META-INF/versions/9")
+        include("module-info.class")
+    }
+    // Cover for bnd still not supporting MR Jars: https://github.com/bndtools/bnd/issues/2227
+    bnd('-fixupmessages': '^Classes found in the wrong directory: \\\\{META-INF/versions/9/module-info\\\\.class=module-info}$')
     bnd(
             "Bundle-Name": "rxjava",
             "Bundle-Vendor": "RxJava Contributors",
@@ -95,7 +125,8 @@ jar {
             "Eclipse-ExtensibleAPI": "true",
             "Automatic-Module-Name": "io.reactivex.rxjava3",
             "Export-Package": "!io.reactivex.rxjava3.internal.*, io.reactivex.rxjava3.*",
-            "Bundle-SymbolicName": "io.reactivex.rxjava3.rxjava"
+            "Bundle-SymbolicName": "io.reactivex.rxjava3.rxjava",
+            "Multi-Release": "true"
     )
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,9 @@ checkstyle {
             "checkstyle.suppressions.file": project.file("config/checkstyle/suppressions.xml"),
             "checkstyle.header.file"      : project.file("config/license/HEADER_JAVA")
     ]
+    // Don't enable on the java11 source set as checkstyle hiccups on those sources and they're
+    // just a module-info and bogus files anyway
+    sourceSets = [project.sourceSets.main, project.sourceSets.test, project.sourceSets.jmh]
 }
 
 if (project.hasProperty("releaseMode")) {

--- a/src/main/java11/io/reactivex/rxjava3/annotations/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/annotations/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.annotations;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/core/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/core/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.core;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/disposables/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/disposables/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.disposables;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/exceptions/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/exceptions/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.exceptions;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/flowables/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/flowables/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.flowables;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/functions/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/functions/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.functions;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/observables/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/observables/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.observables;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/observers/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/observers/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.observers;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/parallel/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/parallel/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.parallel;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/plugins/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/plugins/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.plugins;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/processors/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/processors/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.processors;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/schedulers/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/schedulers/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.schedulers;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/subjects/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/subjects/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.subjects;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/io/reactivex/rxjava3/subscribers/Bogus.java
+++ b/src/main/java11/io/reactivex/rxjava3/subscribers/Bogus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package io.reactivex.rxjava3.subscribers;
+
+/** Stub file to make javac happy about the module referencing this package. */
+public class Bogus {
+
+}

--- a/src/main/java11/module-info.java
+++ b/src/main/java11/module-info.java
@@ -28,5 +28,5 @@ module io.reactivex.rxjava3 {
   exports io.reactivex.rxjava3.subjects;
   exports io.reactivex.rxjava3.subscribers;
 
-  requires org.reactivestreams;
+  requires transitive org.reactivestreams;
 }

--- a/src/main/java11/module-info.java
+++ b/src/main/java11/module-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+@SuppressWarnings("JavaModuleNaming")
+module io.reactivex.rxjava3 {
+  exports io.reactivex.rxjava3.annotations;
+  exports io.reactivex.rxjava3.core;
+  exports io.reactivex.rxjava3.disposables;
+  exports io.reactivex.rxjava3.exceptions;
+  exports io.reactivex.rxjava3.functions;
+  exports io.reactivex.rxjava3.observables;
+  exports io.reactivex.rxjava3.observers;
+  exports io.reactivex.rxjava3.parallel;
+  exports io.reactivex.rxjava3.plugins;
+  exports io.reactivex.rxjava3.processors;
+  exports io.reactivex.rxjava3.schedulers;
+  exports io.reactivex.rxjava3.subjects;
+  exports io.reactivex.rxjava3.subscribers;
+
+  requires org.reactivestreams;
+}

--- a/src/main/java11/module-info.java
+++ b/src/main/java11/module-info.java
@@ -17,6 +17,7 @@ module io.reactivex.rxjava3 {
   exports io.reactivex.rxjava3.core;
   exports io.reactivex.rxjava3.disposables;
   exports io.reactivex.rxjava3.exceptions;
+  exports io.reactivex.rxjava3.flowables;
   exports io.reactivex.rxjava3.functions;
   exports io.reactivex.rxjava3.observables;
   exports io.reactivex.rxjava3.observers;


### PR DESCRIPTION
This uses basic Gradle APIs to configure an MR-Jar with a `module-info.java` file. Resolves #7240, continuation from #7241 but without the need for an extra plugin and works around the `bnd` issue (they lack support for this and seeing as the issue is 4 years old it's not clear that they ever will).

This uses Gradle toolchains for simpler control over compilations, allowing us to target Java 8 for the `main` java sources and use Java 11 (but targeting java 9) for the `module-info.java` file, then adding the compiled `module-info.class` to the final jar under the appropriate `META-INF/versions/9` path.