### PR TITLE
3.x: Add step to JDK 11 build to verify generated module-info

### DIFF
--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -28,6 +28,8 @@ jobs:
         restore-keys: ${{ runner.os }}-gradle-1-
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+    - name: Verify generated module-info
+      run: ./gradlew -PjavaCompatibility=9 jar
     - name: Build RxJava
       run: ./gradlew build --stacktrace
     - name: Generate Javadoc


### PR DESCRIPTION
When building the module-info via the beryx plugin on Java 8, there is no verification for the contents possible. Therefore, the [plugin documentation](https://github.com/beryx/badass-jar-plugin#usage) suggest building with a newer JDK and specifying a 9+ target.

Related #7241