### PR TITLE
3.x: Add missing exports packages, fix param overrides

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,6 @@ if (releaseTag != null && !releaseTag.isEmpty()) {
     logger.lifecycle("Releasing with version: " + project.version)
 }
 
-group = "io.reactivex.rxjava3"
-version = project.properties["VERSION_NAME"]
-description = "RxJava: Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM."
-
 repositories {
     mavenCentral()
 }
@@ -57,7 +53,6 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
-ext.javaCompatibility = JavaVersion.VERSION_1_8
 
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-parameters"

--- a/src/main/module/module-info.java
+++ b/src/main/module/module-info.java
@@ -16,9 +16,11 @@ module io.reactivex.rxjava3 {
     exports io.reactivex.rxjava3.core;
     exports io.reactivex.rxjava3.disposables;
     exports io.reactivex.rxjava3.exceptions;
+    exports io.reactivex.rxjava3.flowables;
     exports io.reactivex.rxjava3.functions;
     exports io.reactivex.rxjava3.observables;
     exports io.reactivex.rxjava3.observers;
+    exports io.reactivex.rxjava3.operators;
     exports io.reactivex.rxjava3.parallel;
     exports io.reactivex.rxjava3.plugins;
     exports io.reactivex.rxjava3.processors;
@@ -26,5 +28,5 @@ module io.reactivex.rxjava3 {
     exports io.reactivex.rxjava3.subjects;
     exports io.reactivex.rxjava3.subscribers;
 
-    requires org.reactivestreams;
+    requires transitive org.reactivestreams;
 }


### PR DESCRIPTION
- Add missing exported packages `flowables` and `operators`
- Remove assigning to `group`, `version` and `description` as it breaks the naming of the generated jar file and manifest
- I think the dependency on `org.reactivestreams` should be transitive as users of RxJava have to interact with RS types too.
- Removed `ext.javaCompatibility` because looks like it always forced it to Java 8 despite the -PjavaCompatibility provided in the GHA