### PR TITLE
3.x: Javadocs: indicate takeUntil stops on completion of other

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -16972,9 +16972,9 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
 
     /**
      * Returns a {@code Flowable} that emits the items emitted by the current {@code Flowable} until a second {@link Publisher}
-     * emits an item.
+     * emits an item or completes.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.v3.png" alt="">
+     * <img width="640" height="188" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.takeUntil.p.png" alt="">
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator doesn't interfere with backpressure which is determined by the current {@code Flowable}'s backpressure
@@ -16984,7 +16984,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      * </dl>
      *
      * @param other
-     *            the {@code Publisher} whose first emitted item will cause {@code takeUntil} to stop emitting items
+     *            the {@code Publisher} whose first emitted item or completion will cause {@code takeUntil} to stop emitting items
      *            from the current {@code Flowable}
      * @param <U>
      *            the type of items emitted by {@code other}

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -14028,16 +14028,16 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
 
     /**
      * Returns an {@code Observable} that emits the items emitted by the current {@code Observable} until a second {@link ObservableSource}
-     * emits an item.
+     * emits an item or completes.
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.v3.png" alt="">
+     * <img width="640" height="213" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Observable.takeUntil.o.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code takeUntil} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param other
-     *            the {@code ObservableSource} whose first emitted item will cause {@code takeUntil} to stop emitting items
+     *            the {@code ObservableSource} whose first emitted item or completion will cause {@code takeUntil} to stop emitting items
      *            from the current {@code Observable}
      * @param <U>
      *            the type of items emitted by {@code other}

--- a/src/main/java/io/reactivex/rxjava3/operators/QueueDisposable.java
+++ b/src/main/java/io/reactivex/rxjava3/operators/QueueDisposable.java
@@ -18,7 +18,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 
 /**
  * An interface extending {@link SimpleQueue} and {@link Disposable} and allows negotiating
- * the fusion mode between subsequent operators of the {@link Observable} base reactive type.
+ * the fusion mode between subsequent operators of the {@link io.reactivex.rxjava3.core.Observable Observable} base reactive type.
  * <p>
  * The negotiation happens in subscription time when the upstream
  * calls the {@code onSubscribe} with an instance of this interface. The

--- a/src/main/java/io/reactivex/rxjava3/operators/QueueSubscription.java
+++ b/src/main/java/io/reactivex/rxjava3/operators/QueueSubscription.java
@@ -19,7 +19,7 @@ import io.reactivex.rxjava3.annotations.NonNull;
 
 /**
  * An interface extending {@link SimpleQueue} and {@link Subscription} and allows negotiating
- * the fusion mode between subsequent operators of the {@link Flowable} base reactive type.
+ * the fusion mode between subsequent operators of the {@link io.reactivex.rxjava3.core.Flowable Flowable} base reactive type.
  * <p>
  * The negotiation happens in subscription time when the upstream
  * calls the {@code onSubscribe} with an instance of this interface. The


### PR DESCRIPTION
Update the Javadocs of the `takeUntil()` operator to explicitly mention it stops if the other source just completes without an item.

Images: https://github.com/ReactiveX/RxJava/issues/7339#issuecomment-925770441

Resolves #7339