### PR TITLE
Update assert messages format to be compliant with JUnitTestRunner and GradleTestRunner

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -351,11 +351,11 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     public final U assertValue(T value) {
         int s = values.size();
         if (s != 1) {
-            throw fail("expected: " + valueAndClass(value) + " but was: " + values);
+            throw fail("\nexpected: " + valueAndClass(value) + "\ngot: " + values);
         }
         T v = values.get(0);
         if (!ObjectHelper.equals(value, v)) {
-            throw fail("expected: " + valueAndClass(value) + " but was: " + valueAndClass(v));
+            throw fail("\nexpected: " + valueAndClass(value) + "\ngot: " + valueAndClass(v));
         }
         return (U)this;
     }
@@ -450,7 +450,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
         T v = values.get(index);
         if (!ObjectHelper.equals(value, v)) {
-            throw fail("expected: " + valueAndClass(value) + " but was: " + valueAndClass(v));
+            throw fail("\nexpected: " + valueAndClass(value) + "\ngot: " + valueAndClass(v));
         }
         return (U)this;
     }
@@ -512,7 +512,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     public final U assertValueCount(int count) {
         int s = values.size();
         if (s != count) {
-            throw fail("Value counts differ; expected: " + count + " but was: " + s);
+            throw fail("Value counts differ;\nexpected: " + count + "\ngot: " + s);
         }
         return (U)this;
     }
@@ -535,14 +535,14 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     public final U assertValues(T... values) {
         int s = this.values.size();
         if (s != values.length) {
-            throw fail("Value count differs; expected: " + values.length + " " + Arrays.toString(values)
-            + " but was: " + s + " " + this.values);
+            throw fail("Value count differs;\nexpected: " + values.length + " " + Arrays.toString(values)
+            + "\ngot: " + s + " " + this.values);
         }
         for (int i = 0; i < s; i++) {
             T v = this.values.get(i);
             T u = values[i];
             if (!ObjectHelper.equals(u, v)) {
-                throw fail("Values at position " + i + " differ; expected: " + valueAndClass(u) + " but was: " + valueAndClass(v));
+                throw fail("Values at position " + i + " differ;\nexpected: " + valueAndClass(u) + "\ngot: " + valueAndClass(v));
             }
         }
         return (U)this;
@@ -627,7 +627,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
             T v = actualIterator.next();
 
             if (!ObjectHelper.equals(u, v)) {
-                throw fail("Values at position " + i + " differ; expected: " + valueAndClass(u) + " but was: " + valueAndClass(v));
+                throw fail("Values at position " + i + " differ;\nexpected: " + valueAndClass(u) + "\ngot: " + valueAndClass(v));
             }
             i++;
         }
@@ -737,7 +737,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
             Throwable e = errors.get(0);
             String errorMessage = e.getMessage();
             if (!ObjectHelper.equals(message, errorMessage)) {
-                throw fail("Error message differs; exptected: " + message + " but was: " + errorMessage);
+                throw fail("Error message differs;\nexpected: " + message + "\ngot: " + errorMessage);
             }
         } else {
             throw fail("Multiple errors");

--- a/src/main/java/io/reactivex/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/observers/TestObserver.java
@@ -298,8 +298,8 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
         int m = establishedFusionMode;
         if (m != mode) {
             if (qd != null) {
-                throw new AssertionError("Fusion mode different. Expected: " + fusionModeToString(mode)
-                + ", actual: " + fusionModeToString(m));
+                throw new AssertionError("Fusion mode different.\nexpected: " + fusionModeToString(mode)
+                + "\n got: " + fusionModeToString(m));
             } else {
                 throw fail("Upstream is not fuseable");
             }

--- a/src/main/java/io/reactivex/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/subscribers/TestSubscriber.java
@@ -349,8 +349,8 @@ implements FlowableSubscriber<T>, Subscription, Disposable {
         int m = establishedFusionMode;
         if (m != mode) {
             if (qs != null) {
-                throw new AssertionError("Fusion mode different. Expected: " + fusionModeToString(mode)
-                + ", actual: " + fusionModeToString(m));
+                throw new AssertionError("Fusion mode different.\nexpected: " + fusionModeToString(mode)
+                + "\ngot: " + fusionModeToString(m));
             } else {
                 throw fail("Upstream is not fuseable");
             }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1407,7 +1407,7 @@ public class TestObserverTest {
         Observable.just("a", "b", "c").subscribe(to);
 
         thrown.expect(AssertionError.class);
-        thrown.expectMessage("expected: b (class: String) but was: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)");
+        thrown.expectMessage("\nexpected: b (class: String)\ngot: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)");
         to.assertValueAt(2, "b");
     }
 


### PR DESCRIPTION
Currently assert messages match this regex `expected: (.*)\s*but was: (.*)` which is compliant with the `JUnitTestRunner` but not with the `GradleTestRunner`. (which is now default runner on Android Studio)

I propose to change regex to `\nexpected: (.*)\n\s*got: (.*)`.
This way IDEA will be able to enable diff feature no matter which runner you use.

[JUnitTestRunner available regexes](https://github.com/JetBrains/intellij-community/blob/99614a63425774df58eea3ac92e2b20af1633663/plugins/junit_rt/src/com/intellij/junit4/ExpectedPatterns.java#L27)
[GradleTestRunner available regexes](https://github.com/JetBrains/intellij-community/blob/213.3714/plugins/gradle/java/src/execution/GradleRunnerUtil.java#99)