### PR TITLE
Update assert messages format to be compliant with JUnitTestRunner and GradleTestRunner

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
@@ -307,11 +307,11 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     public final U assertValue(@NonNull T value) {
         int s = values.size();
         if (s != 1) {
-            throw fail("expected: " + valueAndClass(value) + " but was: " + values);
+            throw fail("\nexpected: " + valueAndClass(value) + "\ngot: " + values);
         }
         T v = values.get(0);
         if (!Objects.equals(value, v)) {
-            throw fail("expected: " + valueAndClass(value) + " but was: " + valueAndClass(v));
+            throw fail("\nexpected: " + valueAndClass(value) + "\ngot: " + valueAndClass(v));
         }
         return (U)this;
     }
@@ -359,7 +359,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
 
         T v = values.get(index);
         if (!Objects.equals(value, v)) {
-            throw fail("expected: " + valueAndClass(value) + " but was: " + valueAndClass(v) + " at position " + index);
+            throw fail("Values at position " + index + " differ;\nexpected: " + valueAndClass(value) + "\ngot: " + valueAndClass(v));
         }
         return (U)this;
     }
@@ -425,7 +425,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     public final U assertValueCount(int count) {
         int s = values.size();
         if (s != count) {
-            throw fail("Value counts differ; expected: " + count + " but was: " + s);
+            throw fail("Value counts differ;\nexpected: " + count + "\ngot: " + s);
         }
         return (U)this;
     }
@@ -450,14 +450,14 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     public final U assertValues(@NonNull T... values) {
         int s = this.values.size();
         if (s != values.length) {
-            throw fail("Value count differs; expected: " + values.length + " " + Arrays.toString(values)
-            + " but was: " + s + " " + this.values);
+            throw fail("Value count differs;\nexpected: " + values.length + " " + Arrays.toString(values)
+            + "\ngot: " + s + " " + this.values);
         }
         for (int i = 0; i < s; i++) {
             T v = this.values.get(i);
             T u = values[i];
             if (!Objects.equals(u, v)) {
-                throw fail("Values at position " + i + " differ; expected: " + valueAndClass(u) + " but was: " + valueAndClass(v));
+                throw fail("Values at position " + i + " differ;\nexpected: " + valueAndClass(u) + "\ngot: " + valueAndClass(v));
             }
         }
         return (U)this;
@@ -504,7 +504,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
             T v = actualIterator.next();
 
             if (!Objects.equals(u, v)) {
-                throw fail("Values at position " + i + " differ; expected: " + valueAndClass(u) + " but was: " + valueAndClass(v));
+                throw fail("Values at position " + i + " differ;\nexpected: " + valueAndClass(u) + "\ngot: " + valueAndClass(v));
             }
             i++;
         }

--- a/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
@@ -999,7 +999,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        assertThrowsWithMessage("expected: b (class: String) but was: c (class: String) at position 2 (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Values at position 2 differ;\nexpected: b (class: String)\ngot: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/testsupport/BaseTestConsumerEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/BaseTestConsumerEx.java
@@ -160,7 +160,7 @@ extends BaseTestConsumer<T, U> {
             Throwable e = errors.get(0);
             String errorMessage = e.getMessage();
             if (!Objects.equals(message, errorMessage)) {
-                throw fail("Error message differs; exptected: " + message + " but was: " + errorMessage);
+                throw fail("Error message differs;\nexpected: " + message + "\ngot: " + errorMessage);
             }
         } else {
             throw fail("Multiple errors");

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverEx.java
@@ -254,8 +254,8 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
         int m = establishedFusionMode;
         if (m != mode) {
             if (qd != null) {
-                throw new AssertionError("Fusion mode different. Expected: " + fusionModeToString(mode)
-                + ", actual: " + fusionModeToString(m));
+                throw new AssertionError("Fusion mode different.\nexpected: " + fusionModeToString(mode)
+                + "\ngot: " + fusionModeToString(m));
             } else {
                 throw fail("Upstream is not fuseable");
             }

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverExTest.java
@@ -1274,7 +1274,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        assertThrows("expected: b (class: String) but was: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrows("\nexpected: b (class: String)\ngot: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserverEx<String> to = new TestObserverEx<>();
 
             Observable.just("a", "b", "c").subscribe(to);


### PR DESCRIPTION
Currently assert messages match this regex `expected: (.*)\s*but was: (.*)` which is compliant with the `JUnitTestRunner` but not with the `GradleTestRunner`.

I propose to change regex to `\nexpected: (.*)\n\s*got: (.*)`.
This way IDEA will be able to enable diff feature no matter which runner you use.

[JUnitTestRunner available regexes](https://github.com/JetBrains/intellij-community/blob/99614a63425774df58eea3ac92e2b20af1633663/plugins/junit_rt/src/com/intellij/junit4/ExpectedPatterns.java#L27)
[GradleTestRunner available regexes](https://github.com/JetBrains/intellij-community/blob/213.3714/plugins/gradle/java/src/execution/GradleRunnerUtil.java#99)