### PR TITLE
Fix assert message format

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava3/observers/BaseTestConsumer.java
@@ -359,7 +359,8 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
 
         T v = values.get(index);
         if (!Objects.equals(value, v)) {
-            throw fail("Values at position " + index + " differ;\nexpected: " + valueAndClass(value) + "\ngot: " + valueAndClass(v));
+            throw fail("\nexpected: " + valueAndClass(value) + "\ngot: " + valueAndClass(v)
+                    + "; Value at position " + index + " differ");
         }
         return (U)this;
     }
@@ -425,7 +426,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     public final U assertValueCount(int count) {
         int s = values.size();
         if (s != count) {
-            throw fail("Value counts differ;\nexpected: " + count + "\ngot: " + s);
+            throw fail("\nexpected: " + count + "\ngot: " + s + "; Value counts differ");
         }
         return (U)this;
     }
@@ -450,14 +451,15 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     public final U assertValues(@NonNull T... values) {
         int s = this.values.size();
         if (s != values.length) {
-            throw fail("Value count differs;\nexpected: " + values.length + " " + Arrays.toString(values)
-            + "\ngot: " + s + " " + this.values);
+            throw fail("\nexpected: " + values.length + " " + Arrays.toString(values)
+                    + "\ngot: " + s + " " + this.values + "; Value count differs");
         }
         for (int i = 0; i < s; i++) {
             T v = this.values.get(i);
             T u = values[i];
             if (!Objects.equals(u, v)) {
-                throw fail("Values at position " + i + " differ;\nexpected: " + valueAndClass(u) + "\ngot: " + valueAndClass(v));
+                throw fail("\nexpected: " + valueAndClass(u) + "\ngot: " + valueAndClass(v)
+                        + "; Value at position " + i + " differ");
             }
         }
         return (U)this;
@@ -504,7 +506,8 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
             T v = actualIterator.next();
 
             if (!Objects.equals(u, v)) {
-                throw fail("Values at position " + i + " differ;\nexpected: " + valueAndClass(u) + "\ngot: " + valueAndClass(v));
+                throw fail("\nexpected: " + valueAndClass(u) + "\ngot: " + valueAndClass(v)
+                + "; Value at position " + i + " differ");
             }
             i++;
         }

--- a/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
@@ -999,7 +999,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        assertThrowsWithMessage("Values at position 2 differ;\nexpected: b (class: String)\ngot: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("\nexpected: b (class: String)\ngot: c (class: String); Value at position 2 differ (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);

--- a/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/observers/TestObserverTest.java
@@ -44,6 +44,12 @@ public class TestObserverTest extends RxJavaTest {
         assertEquals(message, assertThrows(clazz, run).getMessage());
     }
 
+    static void assertThrowsWithMessageMatchRegex(String regex, Class<? extends Throwable> clazz, ThrowingRunnable run) {
+        assertTrue(assertThrows(clazz, run).getMessage().matches(regex));
+    }
+
+    private static final String ASSERT_MESSAGE_REGEX  = "\nexpected: (.*)\n\\s*got: (.*)";
+
     @Test
     public void assertTestObserver() {
         Flowable<Integer> oi = Flowable.fromIterable(Arrays.asList(1, 2));
@@ -1005,6 +1011,105 @@ public class TestObserverTest extends RxJavaTest {
             Observable.just("a", "b", "c").subscribe(to);
 
             to.assertValueAt(2, "b");
+        });
+    }
+
+    @Test
+    public void assertValueAtIndexThrowsMessageMatchRegex() {
+        assertThrowsWithMessageMatchRegex(ASSERT_MESSAGE_REGEX, AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValueAt(2, "b");
+        });
+    }
+
+    @Test
+    public void assertValuesCountNoMatch() {
+        assertThrowsWithMessage("\nexpected: 2 [a, b]\ngot: 3 [a, b, c]; Value count differs (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValues("a", "b");
+        });
+    }
+
+    @Test
+    public void assertValuesCountThrowsMessageMatchRegex() {
+        assertThrowsWithMessageMatchRegex(ASSERT_MESSAGE_REGEX, AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValues("a", "b");
+        });
+    }
+
+    @Test
+    public void assertValuesNoMatch() {
+        assertThrowsWithMessage("\nexpected: d (class: String)\ngot: c (class: String); Value at position 2 differ (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValues("a", "b", "d");
+        });
+    }
+
+    @Test
+    public void assertValuesThrowsMessageMatchRegex() {
+        assertThrowsWithMessageMatchRegex(ASSERT_MESSAGE_REGEX, AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValues("a", "b", "d");
+        });
+    }
+
+    @Test
+    public void assertValueCountNoMatch() {
+        assertThrowsWithMessage("\nexpected: 2\ngot: 3; Value counts differ (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValueCount(2);
+        });
+    }
+
+    @Test
+    public void assertValueCountThrowsMessageMatchRegex() {
+        assertThrowsWithMessageMatchRegex(ASSERT_MESSAGE_REGEX, AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValueCount(2);
+        });
+    }
+
+    @Test
+    public void assertValueSequenceNoMatch() {
+        assertThrowsWithMessage("\nexpected: d (class: String)\ngot: c (class: String); Value at position 2 differ (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValueSequence(Arrays.asList("a", "b", "d"));
+        });
+    }
+
+    @Test
+    public void assertValueSequenceThrowsMessageMatchRegex() {
+        assertThrowsWithMessageMatchRegex(ASSERT_MESSAGE_REGEX, AssertionError.class, () -> {
+            TestObserver<String> to = new TestObserver<>();
+
+            Observable.just("a", "b", "c").subscribe(to);
+
+            to.assertValueSequence(Arrays.asList("a", "b", "d"));
         });
     }
 

--- a/src/test/java/io/reactivex/rxjava3/testsupport/BaseTestConsumerEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/BaseTestConsumerEx.java
@@ -160,7 +160,8 @@ extends BaseTestConsumer<T, U> {
             Throwable e = errors.get(0);
             String errorMessage = e.getMessage();
             if (!Objects.equals(message, errorMessage)) {
-                throw fail("Error message differs;\nexpected: " + message + "\ngot: " + errorMessage);
+                throw fail("\nexpected: " + message + "\ngot: " + errorMessage
+                + "; Error message differs");
             }
         } else {
             throw fail("Multiple errors");

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestObserverEx.java
@@ -254,8 +254,8 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
         int m = establishedFusionMode;
         if (m != mode) {
             if (qd != null) {
-                throw new AssertionError("Fusion mode different.\nexpected: " + fusionModeToString(mode)
-                + "\ngot: " + fusionModeToString(m));
+                throw new AssertionError("\nexpected: " + fusionModeToString(mode)
+                + "\ngot: " + fusionModeToString(m) + "; Fusion mode different");
             } else {
                 throw fail("Upstream is not fuseable");
             }

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberEx.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestSubscriberEx.java
@@ -317,8 +317,8 @@ implements FlowableSubscriber<T>, Subscription {
         int m = establishedFusionMode;
         if (m != mode) {
             if (qs != null) {
-                throw new AssertionError("Fusion mode different. Expected: " + fusionModeToString(mode)
-                + ", actual: " + fusionModeToString(m));
+                throw new AssertionError("\nexpected: " + fusionModeToString(mode)
+                + "\ngot: " + fusionModeToString(m) + "; Fusion mode different");
             } else {
                 throw fail("Upstream is not fuseable");
             }


### PR DESCRIPTION
This PR is related to a previous one I opened: #7345

I've made a mistake when I tested regex because `\nexpected: (.*)\n\s*got: (.*)` does not allow prefixes.
I changed assert messages to use suffixes instead of prefixes.

Sorry about that !