### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -11,13 +11,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 8.0.192, 8 ]
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '8'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -11,16 +11,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java-version: [ 8.0.192, 8 ]
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: ${{ matrix.java-version }}
+        java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -13,16 +13,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java-version: [ 11.0.3, 11 ]
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: ${{ matrix.java-version }}
+        java-version: '11'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -13,13 +13,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 11.0.3, 11 ]
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '11'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -11,13 +11,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 8.0.192, 8 ]
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '8'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -11,16 +11,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java-version: [ 8.0.192, 8 ]
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: ${{ matrix.java-version }}
+        java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -14,15 +14,18 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 8 ]
     env:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '8'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -14,18 +14,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java-version: [ 8 ]
     env:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: ${{ matrix.java-version }}
+        java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -11,17 +11,20 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 8 ]
     if: github.repository == 'ReactiveX/RxJava'
     env:
       # ------------------------------------------------------------------------------ 
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '8'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -11,20 +11,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java-version: [ 8 ]
     if: github.repository == 'ReactiveX/RxJava'
     env:
       # ------------------------------------------------------------------------------ 
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@v2.3.5
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: ${{ matrix.java-version }}
+        java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6
       with:


### PR DESCRIPTION
Signed-off-by: Carl Dea <carldea@gmail.com>

### Using the latest LTS and fixed (major) versions of the OpenJDK.

The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). This request is to switch the distribution from `adopt` to Azul `zulu`. When using Zulu you get all the latest updated (TCK Tested & security patches) builds for all versions of OpenJDK (even archived fixed versions and early access releases).

In the workflow (GH Action) I added a fixed (major) release version such as `JDK 11.0.3`. This is often a good practice whenever a build triggers to help determine if the latest (`JDK 11`) had failed and why. Usually you're trying to figure out what happened whether it is from the **latest build** vs something in **your code** that caused (or introduced) the issue. 

**For example**, when building with `JDK 11.0.3` (fixed version) the build/tests passes (Green) and JDK 11 fails (Red) will mean that the latest `JDK 11` was the cause and not your code. Some _customers/vendors_ typically have `JDK 11.0.3` and aren't ready to move to the latest.

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to **Sept. 2021** and many of the non-LTS (long term support) releases (ie: 18-ea). This is often the case when/if you are planning to try out newer features in the Java language.
The following are benefits:

- Ensure backwards compatibility on fixed (major) releases of OpenJDK
- TCK tested builds of the OpenJDK
- Get the latest of LTS and non-LTS versions, means security updates.
- Experimentation with newer language features.

### Updating 5 Github Actions (workflow files) 

- Changed the distribution to use Zulu
- Added a matrix (array) of JDK versions to provide better coverage
The following is an excerpt of the changes in the workflow `gradle_jdk11.yml`
```yaml
   strategy:
      matrix:
        java-version: [ 11.0.3, 11 ]
        
... later in steps:

   - name: Set up JDK ${{ matrix.java-version }}
      uses: actions/setup-java@v2
      with:
        java-version: ${{ matrix.java-version }}
        distribution: 'zulu'        
        
```

I assume you only want one deployment (binary and Javadoc) so, in the files `gradle_release.yml` and `gradle_snapshot.yml` I just kept the existing JDK 8 (latest) version. These files I still added a matrix of one OpenJDK version just in case in the future you'll want to build on JDK 11 or 17+ (next LTS release). 

Thank you, 
:-)

Carl

