### PR TITLE
3.x: Maybe.fromSupplier & fromCallable Nullable annotation fix

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -1079,7 +1079,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Maybe<T> fromCallable(@NonNull Callable<? extends T> callable) {
+    public static <@NonNull T> Maybe<T> fromCallable(@NonNull Callable<? extends @Nullable T> callable) {
         Objects.requireNonNull(callable, "callable is null");
         return RxJavaPlugins.onAssembly(new MaybeFromCallable<>(callable));
     }
@@ -1285,7 +1285,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Maybe<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
+    public static <@NonNull T> Maybe<T> fromSupplier(@NonNull Supplier<? extends @Nullable T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new MaybeFromSupplier<>(supplier));
     }


### PR DESCRIPTION
Adds a nullability override to `Maybe.fromSupplier` and `Maybe.fromCallable` to avoid warnings in Kotlin when returning nulls from the callbacks.

While coming up with the fix, it appears the Kotlin compiler misinterprets the `@NonNull` on the `supplier` parameter itself and still gives the warning. In my understanding, this might be a bug with the compiler. Reported https://youtrack.jetbrains.com/issue/KT-50734 .

Resolves #7376