### PR TITLE
3.x: Move nullness annotation to use sites of Supplier

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -479,7 +479,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable defer(@NonNull Supplier<? extends CompletableSource> supplier) {
+    public static Completable defer(@NonNull Supplier<? extends @NonNull CompletableSource> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new CompletableDefer(supplier));
     }
@@ -503,7 +503,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable error(@NonNull Supplier<? extends Throwable> supplier) {
+    public static Completable error(@NonNull Supplier<? extends @NonNull Throwable> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new CompletableErrorSupplier(supplier));
     }

--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -2040,7 +2040,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> defer(@NonNull Supplier<? extends Publisher<? extends T>> supplier) {
+    public static <@NonNull T> Flowable<T> defer(@NonNull Supplier<? extends @NonNull Publisher<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new FlowableDefer<>(supplier));
     }
@@ -2095,7 +2095,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> error(@NonNull Supplier<? extends Throwable> supplier) {
+    public static <@NonNull T> Flowable<T> error(@NonNull Supplier<? extends @NonNull Throwable> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new FlowableError<>(supplier));
     }

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -889,7 +889,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Maybe<T> defer(@NonNull Supplier<? extends MaybeSource<? extends T>> supplier) {
+    public static <@NonNull T> Maybe<T> defer(@NonNull Supplier<? extends @NonNull MaybeSource<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new MaybeDefer<>(supplier));
     }
@@ -961,7 +961,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Maybe<T> error(@NonNull Supplier<? extends Throwable> supplier) {
+    public static <@NonNull T> Maybe<T> error(@NonNull Supplier<? extends @NonNull Throwable> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new MaybeErrorCallable<>(supplier));
     }
@@ -1079,7 +1079,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Maybe<T> fromCallable(@NonNull Callable<? extends T> callable) {
+    public static <T> Maybe<@NonNull T> fromCallable(@NonNull Callable<? extends @Nullable T> callable) {
         Objects.requireNonNull(callable, "callable is null");
         return RxJavaPlugins.onAssembly(new MaybeFromCallable<>(callable));
     }
@@ -1285,7 +1285,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Maybe<T> fromSupplier(@NonNull Supplier<? extends T> supplier) {
+    public static <T> Maybe<@NonNull T> fromSupplier(@NonNull Supplier<? extends @Nullable T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new MaybeFromSupplier<>(supplier));
     }

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -1790,7 +1790,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Observable<T> defer(@NonNull Supplier<? extends ObservableSource<? extends T>> supplier) {
+    public static <@NonNull T> Observable<T> defer(@NonNull Supplier<? extends @NonNull ObservableSource<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new ObservableDefer<>(supplier));
     }
@@ -1839,7 +1839,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Observable<T> error(@NonNull Supplier<? extends Throwable> supplier) {
+    public static <@NonNull T> Observable<T> error(@NonNull Supplier<? extends @NonNull Throwable> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new ObservableError<>(supplier));
     }

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -895,7 +895,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Single<T> defer(@NonNull Supplier<? extends SingleSource<? extends T>> supplier) {
+    public static <@NonNull T> Single<T> defer(@NonNull Supplier<? extends @NonNull SingleSource<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new SingleDefer<>(supplier));
     }
@@ -917,7 +917,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Single<T> error(@NonNull Supplier<? extends Throwable> supplier) {
+    public static <@NonNull T> Single<T> error(@NonNull Supplier<? extends @NonNull Throwable> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new SingleError<>(supplier));
     }

--- a/src/main/java/io/reactivex/rxjava3/functions/Supplier.java
+++ b/src/main/java/io/reactivex/rxjava3/functions/Supplier.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.rxjava3.functions;
 
-import io.reactivex.rxjava3.annotations.NonNull;
-
 /**
  * A functional interface (callback) that provides a single value or
  * throws an exception.
@@ -25,7 +23,7 @@ import io.reactivex.rxjava3.annotations.NonNull;
  * @since 3.0.0
  */
 @FunctionalInterface
-public interface Supplier<@NonNull T> {
+public interface Supplier<T> {
 
     /**
      * Produces a value or throws an exception.

--- a/src/test/java/io/reactivex/rxjava3/validators/NonNullMethodTypeArgumentCheck.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/NonNullMethodTypeArgumentCheck.java
@@ -57,10 +57,12 @@ public class NonNullMethodTypeArgumentCheck {
 
                             for (String ta : parseTypeArguments(line)) {
                                 if (!ta.startsWith("@NonNull") && !ta.startsWith("@Nullable")) {
-                                    result.append("Missing annotation on argument ").append(ta).append("\r\nat ")
-                                    .append(parentPackage).append(".").append(className).append(".method(")
-                                    .append(className).append(".java:").append(lineCount).append(")\r\n");
-                                    count++;
+                                    if (!("Maybe".equals(clazz.getSimpleName()) && (line.contains("fromCallable(") || line.contains("fromSupplier(")))) {
+                                        result.append("Missing annotation on argument ").append(ta).append("\r\nat ")
+                                        .append(parentPackage).append(".").append(className).append(".method(")
+                                        .append(className).append(".java:").append(lineCount).append(")\r\n");
+                                        count++;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Adds a nullability to `Maybe.fromSupplier` and `Maybe.fromCallable` to avoid warnings in Kotlin when returning nulls from the callbacks.

The previous attempt at fixing it in #7384 turned out to be not correct. Based on the responses in the Kotlin Issue report, the lack of warning was the bug and the approach was incorrect from the typesystem perspective. 

Therefore, the workaround is to drop the non-null constraint from the `Supplier` declaration and have them at relevant use sites. (https://youtrack.jetbrains.com/issue/KT-50734#focus=Comments-27-5706908.0-0)

There was no need to add `@NonNull` everywhere where `Supplier` is used because such sites were already constrained by `@NonNull` in the type variable declaration.

Resolves #7376 