### PR TITLE
3.x: Apply the Javadoc format cleanup to Disposable.html

### DIFF
--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -24,6 +24,8 @@ task javadocCleanup(dependsOn: "javadoc") doLast {
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/plugins/RxJavaPlugins.html'))
 
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/parallel/ParallelFlowable.html'))
+
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/disposables/Disposable.html'))
 }
 
 def fixJavadocFile(file) {


### PR DESCRIPTION
Add Disposable.html to the javadoc_cleanup.gradle program to fix unnecessary newlines and duplicate annotations in the docs.