### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,9 @@
 name: "Validate Gradle Wrapper"
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"

--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches-ignore: [ '3.x' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ 3.x ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ 3.x ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - 'v3.*.*'   
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [ '3.x' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
