### PR TITLE
Declare `<? super @Nullable Foo>` instead of `<@Nullable ? super Foo>`.

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Completable.java
@@ -1868,7 +1868,7 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Completable doOnEvent(@NonNull Consumer<@Nullable ? super Throwable> onEvent) {
+    public final Completable doOnEvent(@NonNull Consumer<? super @Nullable Throwable> onEvent) {
         Objects.requireNonNull(onEvent, "onEvent is null");
         return RxJavaPlugins.onAssembly(new CompletableDoOnEvent(this, onEvent));
     }

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -3714,7 +3714,7 @@ public abstract class Maybe<T> implements MaybeSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final Maybe<T> doOnEvent(@NonNull BiConsumer<@Nullable ? super T, @Nullable ? super Throwable> onEvent) {
+    public final Maybe<T> doOnEvent(@NonNull BiConsumer<? super @Nullable T, ? super @Nullable Throwable> onEvent) {
         Objects.requireNonNull(onEvent, "onEvent is null");
         return RxJavaPlugins.onAssembly(new MaybeDoOnEvent<>(this, onEvent));
     }

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -3288,7 +3288,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Single<T> doOnEvent(@NonNull BiConsumer<@Nullable ? super T, @Nullable ? super Throwable> onEvent) {
+    public final Single<T> doOnEvent(@NonNull BiConsumer<? super @Nullable T, ? super @Nullable Throwable> onEvent) {
         Objects.requireNonNull(onEvent, "onEvent is null");
         return RxJavaPlugins.onAssembly(new SingleDoOnEvent<>(this, onEvent));
     }
@@ -4735,7 +4735,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final Disposable subscribe(@NonNull BiConsumer<@Nullable ? super T, @Nullable ? super Throwable> onCallback) {
+    public final Disposable subscribe(@NonNull BiConsumer<? super @Nullable T, ? super @Nullable Throwable> onCallback) {
         Objects.requireNonNull(onCallback, "onCallback is null");
 
         BiConsumerSingleObserver<T> observer = new BiConsumerSingleObserver<>(onCallback);


### PR DESCRIPTION
The latter results in runtime errors when using `-Xnullability-annotations=@io.reactivex.rxjava3.annotations:strict`: Kotlin interprets `? super Foo` to force the callback parameters to be non-nullable types, apparently effectively ignoring the `@Nullable` part?

Even if this is technically a Kotlin bug (and I don't know if it is), I recommend `<? super @Nullable Foo>`: That is the syntax that is preferred [by the Checker Framework](https://checkerframework.org/manual/#annotations-on-wildcards) and by [JSpecify](https://jspecify.dev/).

(In fact, I'd likewise recommend changing `class Foo<@NonNull T>` to `class Foo<T extends @NonNull Object>`. In that case, Kotlin handles both versions fine. But the latter version is better for Checker Framework and JSpecify. I've experimented with a version of that, and I'd be happy to send it as a pull request if you'd like to go that direction.)