### PR TITLE
Remove @NonNull annotations for functions with void return type

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -5520,7 +5520,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @see #blockingForEach(Consumer, int)
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
     public final void blockingForEach(@NonNull Consumer<? super T> onNext) {
         blockingForEach(onNext, bufferSize());
     }
@@ -5560,7 +5559,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @see #subscribe(Consumer)
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
     public final void blockingForEach(@NonNull Consumer<? super T> onNext, int capacityHint) {
         Objects.requireNonNull(onNext, "onNext is null");
         Iterator<T> it = blockingIterable(capacityHint).iterator();
@@ -12036,7 +12034,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @throws NullPointerException if {@code observer} is {@code null}
      */
     @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
     public final void safeSubscribe(@NonNull Observer<? super T> observer) {
         Objects.requireNonNull(observer, "observer is null");
         if (observer instanceof SafeObserver) {


### PR DESCRIPTION
Minor code readability improvement, which does not make you wonder on @NonNull void type.
