### PR TITLE
3.x: Add missing `@NonNull` annotation to `Maybe` type argument

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -110,7 +110,7 @@ import io.reactivex.rxjava3.schedulers.*;
  * @since 2.0
  * @see io.reactivex.rxjava3.observers.DisposableMaybeObserver
  */
-public abstract class Maybe<T> implements MaybeSource<T> {
+public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
 
     /**
      * Runs multiple {@link MaybeSource}s provided by an {@link Iterable} sequence and


### PR DESCRIPTION
This PR adds a missing `@NonNull` annotation to the `Maybe` type argument.

Resolves #7435 