### PR TITLE
3.x: Remove redundant interface declarations

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferExactBoundary.java
@@ -45,7 +45,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     }
 
     static final class BufferExactBoundarySubscriber<T, U extends Collection<? super T>, B>
-    extends QueueDrainSubscriber<T, U, U> implements FlowableSubscriber<T>, Subscription, Disposable {
+    extends QueueDrainSubscriber<T, U, U> implements Subscription, Disposable {
 
         final Supplier<U> bufferSupplier;
         final Publisher<B> boundary;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
@@ -244,8 +244,7 @@ final Scheduler scheduler;
         }
     }
 
-    static final class ObserveOnSubscriber<T> extends BaseObserveOnSubscriber<T>
-    implements FlowableSubscriber<T> {
+    static final class ObserveOnSubscriber<T> extends BaseObserveOnSubscriber<T> {
 
         private static final long serialVersionUID = -4547113800637756442L;
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableToList.java
@@ -46,7 +46,7 @@ public final class FlowableToList<T, U extends Collection<? super T>> extends Ab
 
     static final class ToListSubscriber<T, U extends Collection<? super T>>
     extends DeferredScalarSubscription<U>
-    implements FlowableSubscriber<T>, Subscription {
+    implements FlowableSubscriber<T> {
 
         private static final long serialVersionUID = -8134157938864266736L;
         Subscription upstream;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferExactBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferExactBoundary.java
@@ -43,7 +43,7 @@ extends AbstractObservableWithUpstream<T, U> {
     }
 
     static final class BufferExactBoundaryObserver<T, U extends Collection<? super T>, B>
-    extends QueueDrainObserver<T, U, U> implements Observer<T>, Disposable {
+    extends QueueDrainObserver<T, U, U> implements Disposable {
 
         final Supplier<U> bufferSupplier;
         final ObservableSource<B> boundary;

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/NewThreadWorker.java
@@ -26,7 +26,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
  * worker but doesn't perform task-tracking operations.
  *
  */
-public class NewThreadWorker extends Scheduler.Worker implements Disposable {
+public class NewThreadWorker extends Scheduler.Worker {
     private final ScheduledExecutorService executor;
 
     volatile boolean disposed;

--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/TrampolineScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/TrampolineScheduler.java
@@ -62,7 +62,7 @@ public final class TrampolineScheduler extends Scheduler {
         return EmptyDisposable.INSTANCE;
     }
 
-    static final class TrampolineWorker extends Scheduler.Worker implements Disposable {
+    static final class TrampolineWorker extends Scheduler.Worker {
         final PriorityBlockingQueue<TimedRunnable> queue = new PriorityBlockingQueue<>();
 
         private final AtomicInteger wip = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -560,6 +560,7 @@ public class ParamValidationCheckerTest {
         for (Class<?> interfaces : AllFunctionals.class.getInterfaces()) {
             defaultValues.put(interfaces, af);
         }
+        defaultValues.put(Subscriber.class, af);
         defaultValues.put(TimeUnit.class, TimeUnit.SECONDS);
         defaultValues.put(Scheduler.class, Schedulers.single());
         defaultValues.put(BackpressureStrategy.class, BackpressureStrategy.MISSING);

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -926,7 +926,7 @@ public class ParamValidationCheckerTest {
     Function3, Function4, Function5, Function6, Function7, Function8, Function9,
     FlowableOnSubscribe, ObservableOnSubscribe, SingleOnSubscribe, MaybeOnSubscribe, CompletableOnSubscribe,
     FlowableTransformer, ObservableTransformer, SingleTransformer, MaybeTransformer, CompletableTransformer,
-    Subscriber, FlowableSubscriber, Observer, SingleObserver, MaybeObserver, CompletableObserver,
+    FlowableSubscriber, Observer, SingleObserver, MaybeObserver, CompletableObserver,
     FlowableOperator, ObservableOperator, SingleOperator, MaybeOperator, CompletableOperator,
     Comparator, ParallelTransformer
     {


### PR DESCRIPTION
Trying out the GitPod integration. Got these warnings about redundant interface declarations in internal components.