### PR TITLE
3.x: Fix formatting in TestObserver/Consumer/Subscriber javadoc html

### DIFF
--- a/gradle/javadoc_cleanup.gradle
+++ b/gradle/javadoc_cleanup.gradle
@@ -26,6 +26,10 @@ task javadocCleanup(dependsOn: "javadoc") doLast {
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/parallel/ParallelFlowable.html'))
 
     fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/disposables/Disposable.html'))
+    
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/observers/TestObserver.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/observers/BaseTestConsumer.html'))
+    fixJavadocFile(rootProject.file('build/docs/javadoc/io/reactivex/rxjava3/subscribers/TestSubscriber.html'))
 }
 
 def fixJavadocFile(file) {


### PR DESCRIPTION
The Javadoc htmls of `TestObserver`, `TestSubscriber` and `BaseTestConsumer` have those unnecessary duplications and newlines:

![image](https://user-images.githubusercontent.com/1269832/173231149-13f8adef-4fb1-4080-82f6-791b9c61c640.png)

Adding them to the cleanup routine.