### PR TITLE
3.x: Add onDropped callback to throttleLatest operator

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -14362,7 +14362,55 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     public final Observable<T> throttleLatest(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean emitLast) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableThrottleLatest<>(this, timeout, unit, scheduler, emitLast));
+        return RxJavaPlugins.onAssembly(new ObservableThrottleLatest<>(this, timeout, unit, scheduler, emitLast, null));
+    }
+
+    /**
+     * Throttles items from the current {@code Observable} by first emitting the next
+     * item from upstream, then periodically emitting the latest item (if any) when
+     * the specified timeout elapses between them, invoking the consumer for any dropped item.
+     * <p>
+     * <img width="640" height="326" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/throttleLatest.se.png" alt="">
+     * <p>
+     * If no items were emitted from the upstream during this timeout phase, the next
+     * upstream item is emitted immediately and the timeout window starts from then.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@link Scheduler} this operator will use.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>
+     *  If the upstream signals an {@code onError} or {@code onDropped} callback crashes,
+     *  the error is delivered immediately to the downstream. If both happen, a {@link CompositeException}
+     *  is created, containing both the upstream and the callback error.
+     *  If the {@code onDropped} callback crashes when the sequence gets disposed, the exception is forwarded
+     *  to the global error handler via {@link RxJavaPlugins#onError(Throwable)}.
+     *  </dd>
+     * </dl>
+     * @param timeout the time to wait after an item emission towards the downstream
+     *                before trying to emit the latest item from upstream again
+     * @param unit    the time unit
+     * @param scheduler the {@code Scheduler} where the timed wait and latest item
+     *                  emission will be performed
+     * @param emitLast If {@code true}, the very last item from the upstream will be emitted
+     *                 immediately when the upstream completes, regardless if there is
+     *                 a timeout window active or not. If {@code false}, the very last
+     *                 upstream item is ignored and the flow terminates.
+     * @param onDropped called when an item is replaced by a newer item that doesn't get delivered
+     *                 to the downstream, including the very last item if {@code emitLast} is {@code false}
+     *                 and the current undelivered item when the sequence gets disposed.
+     * @return the new {@code Observable} instance
+     * @throws NullPointerException if {@code unit}, {@code scheduler} or {@code onDropped} is {@code null}
+     * @since 3.1.6 - Experimental
+     */
+    @CheckReturnValue
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    @NonNull
+    @Experimental
+    public final Observable<T> throttleLatest(long timeout, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean emitLast, @NonNull Consumer<? super T> onDropped) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
+        Objects.requireNonNull(onDropped, "onDropped is null");
+        return RxJavaPlugins.onAssembly(new ObservableThrottleLatest<>(this, timeout, unit, scheduler, emitLast, onDropped));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleLatest.java
@@ -19,9 +19,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
-import io.reactivex.rxjava3.exceptions.CompositeException;
-import io.reactivex.rxjava3.exceptions.Exceptions;
-import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.BackpressureHelper;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleLatest.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleLatest.java
@@ -14,15 +14,11 @@
 package io.reactivex.rxjava3.internal.operators.observable;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.*;
 
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.core.Observer;
-import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.CompositeException;
-import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -13,28 +13,21 @@
 
 package io.reactivex.rxjava3.internal.operators.flowable;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 
-import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.core.RxJavaTest;
-import io.reactivex.rxjava3.exceptions.CompositeException;
-import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
-import io.reactivex.rxjava3.exceptions.TestException;
-import io.reactivex.rxjava3.functions.Action;
-import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.subscriptions.EmptySubscription;
 import io.reactivex.rxjava3.processors.PublishProcessor;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
-import io.reactivex.rxjava3.testsupport.TestHelper;
-import io.reactivex.rxjava3.testsupport.TestSubscriberEx;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class FlowableThrottleLatestTest extends RxJavaTest {
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -13,19 +13,26 @@
 
 package io.reactivex.rxjava3.internal.operators.observable;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.RxJavaTest;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.CompositeException;
 import io.reactivex.rxjava3.exceptions.TestException;
-import io.reactivex.rxjava3.functions.*;
+import io.reactivex.rxjava3.functions.Action;
+import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.reactivex.rxjava3.subjects.PublishSubject;
 import io.reactivex.rxjava3.testsupport.TestHelper;
+import io.reactivex.rxjava3.testsupport.TestObserverEx;
 
 public class ObservableThrottleLatestTest extends RxJavaTest {
 
@@ -220,5 +227,425 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
         sch.advanceTimeBy(1, TimeUnit.SECONDS);
 
         to.assertResult(1, 2);
+    }
+
+    /** Emit 1, 2, 3, then advance time by a second; 1 and 3 should end up in downstream, 2 should be dropped. */
+    @Test
+    public void onDroppedBasicNoEmitLast() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        TestObserver<Object> drops = new TestObserver<>();
+        drops.onSubscribe(Disposable.empty());
+
+        TestObserver<Integer> to = ps.throttleLatest(1, TimeUnit.SECONDS, sch, false, drops::onNext)
+        .test();
+
+        to.assertEmpty();
+        drops.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        ps.onNext(3);
+
+        to.assertValuesOnly(1);
+        drops.assertValuesOnly(2);
+
+        sch.advanceTimeBy(1, TimeUnit.SECONDS);
+
+        to.assertValuesOnly(1, 3);
+        drops.assertValuesOnly(2);
+
+        ps.onComplete();
+
+        to.assertResult(1, 3);
+
+        drops.assertValuesOnly(2);
+    }
+
+    /** Emit 1, 2, 3; 1 should end up in downstream, 2, 3 should be dropped. */
+    @Test
+    public void onDroppedBasicNoEmitLastDropLast() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        TestObserver<Object> drops = new TestObserver<>();
+        drops.onSubscribe(Disposable.empty());
+
+        TestObserver<Integer> to = ps.throttleLatest(1, TimeUnit.SECONDS, sch, false, drops::onNext)
+        .test();
+
+        to.assertEmpty();
+        drops.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        ps.onNext(3);
+
+        to.assertValuesOnly(1);
+        drops.assertValuesOnly(2);
+
+        ps.onComplete();
+
+        to.assertResult(1);
+
+        drops.assertValuesOnly(2, 3);
+    }
+
+    /** Emit 1, 2, 3; 1 and 3 should end up in downstream, 2 should be dropped. */
+    @Test
+    public void onDroppedBasicEmitLast() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        TestObserver<Object> drops = new TestObserver<>();
+        drops.onSubscribe(Disposable.empty());
+
+        TestObserver<Integer> to = ps.throttleLatest(1, TimeUnit.SECONDS, sch, true, drops::onNext)
+        .test();
+
+        to.assertEmpty();
+        drops.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        ps.onNext(3);
+
+        to.assertValuesOnly(1);
+        drops.assertValuesOnly(2);
+
+        ps.onComplete();
+
+        to.assertResult(1, 3);
+
+        drops.assertValuesOnly(2);
+    }
+
+    /** Emit 1, 2, 3; 3 should trigger an error to the downstream because 2 is dropped and the callback crashes. */
+    @Test
+    public void onDroppedBasicNoEmitLastFirstDropCrash() throws Throwable {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        Action whenDisposed = mock(Action.class);
+
+        TestObserver<Integer> to = ps
+        .doOnDispose(whenDisposed)
+        .throttleLatest(1, TimeUnit.SECONDS, sch, false, d -> {
+            if (d == 2) {
+                throw new TestException("forced");
+            }
+        })
+        .test();
+
+        to.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(3);
+
+        to.assertFailure(TestException.class, 1);
+
+        verify(whenDisposed).run();
+    }
+
+    /**
+     * Emit 1, 2, Error; the error should trigger the drop callback and crash it too,
+     * downstream gets 1, composite(source, drop-crash).
+     */
+    @Test
+    public void onDroppedBasicNoEmitLastOnErrorDropCrash() throws Throwable {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        Action whenDisposed = mock(Action.class);
+
+        TestObserverEx<Integer> to = ps
+        .doOnDispose(whenDisposed)
+        .throttleLatest(1, TimeUnit.SECONDS, sch, false, d -> { throw new TestException("forced " + d); })
+        .subscribeWith(new TestObserverEx<>());
+
+        to.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+
+        ps.onError(new TestException("source"));
+
+        to.assertFailure(CompositeException.class, 1);
+
+        TestHelper.assertCompositeExceptions(to, TestException.class, "source", TestException.class, "forced 2");
+
+        verify(whenDisposed, never()).run();
+    }
+
+    /**
+     * Emit 1, 2, 3; 3 should trigger a drop-crash for 2, which then would trigger the error path and drop-crash for 3,
+     * the last item not delivered, downstream gets 1, composite(drop-crash 2, drop-crash 3).
+     */
+    @Test
+    public void onDroppedBasicEmitLastOnErrorDropCrash() throws Throwable {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        Action whenDisposed = mock(Action.class);
+
+        TestObserverEx<Integer> to = ps
+        .doOnDispose(whenDisposed)
+        .throttleLatest(1, TimeUnit.SECONDS, sch, true, d -> { throw new TestException("forced " + d); })
+        .subscribeWith(new TestObserverEx<>());
+
+        to.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(3);
+
+        to.assertFailure(CompositeException.class, 1);
+
+        TestHelper.assertCompositeExceptions(to, TestException.class, "forced 2", TestException.class, "forced 3");
+
+        verify(whenDisposed).run();
+    }
+
+    /** Emit 1, complete; Downstream gets 1, complete, no drops. */
+    @Test
+    public void onDroppedBasicNoEmitLastNoLastToDrop() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        TestObserver<Object> drops = new TestObserver<>();
+        drops.onSubscribe(Disposable.empty());
+
+        TestObserver<Integer> to = ps.throttleLatest(1, TimeUnit.SECONDS, sch, false, drops::onNext)
+        .test();
+
+        to.assertEmpty();
+        drops.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        ps.onComplete();
+
+        to.assertResult(1);
+        drops.assertEmpty();
+    }
+
+    /** Emit 1, error; Downstream gets 1, error, no drops. */
+    @Test
+    public void onDroppedErrorNoEmitLastNoLastToDrop() {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        TestObserver<Object> drops = new TestObserver<>();
+        drops.onSubscribe(Disposable.empty());
+
+        TestObserver<Integer> to = ps.throttleLatest(1, TimeUnit.SECONDS, sch, false, drops::onNext)
+        .test();
+
+        to.assertEmpty();
+        drops.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        ps.onError(new TestException());
+
+        to.assertFailure(TestException.class, 1);
+        drops.assertEmpty();
+    }
+
+    /**
+     * Emit 1, 2, complete; complete should crash drop, downstream gets 1, drop-crash 2.
+     */
+    @Test
+    public void onDroppedHasLastNoEmitLastDropCrash() throws Throwable {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        Action whenDisposed = mock(Action.class);
+
+        TestObserverEx<Integer> to = ps
+        .doOnDispose(whenDisposed)
+        .throttleLatest(1, TimeUnit.SECONDS, sch, false, d -> { throw new TestException("forced " + d); })
+        .subscribeWith(new TestObserverEx<>());
+
+        to.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+
+        ps.onComplete();
+
+        to.assertFailureAndMessage(TestException.class, "forced 2", 1);
+
+        verify(whenDisposed, never()).run();
+    }
+
+    /**
+     * Emit 1, 2 then dispose the sequence; downstream gets 1, drop should get for 2.
+     */
+    @Test
+    public void onDroppedDisposeDrops() throws Throwable {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        Action whenDisposed = mock(Action.class);
+
+        TestObserver<Object> drops = new TestObserver<>();
+        drops.onSubscribe(Disposable.empty());
+
+        TestObserverEx<Integer> to = ps
+        .doOnDispose(whenDisposed)
+        .throttleLatest(1, TimeUnit.SECONDS, sch, false, drops::onNext)
+        .subscribeWith(new TestObserverEx<>());
+
+        to.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+
+        ps.onNext(2);
+
+        to.assertValuesOnly(1);
+
+        to.dispose();
+
+        to.assertValuesOnly(1);
+        drops.assertValuesOnly(2);
+
+        verify(whenDisposed).run();
+    }
+
+    /**
+     * Emit 1 then dispose the sequence; downstream gets 1, drop should not get called.
+     */
+    @Test
+    public void onDroppedDisposeNoDrops() throws Throwable {
+        PublishSubject<Integer> ps = PublishSubject.create();
+
+        TestScheduler sch = new TestScheduler();
+
+        Action whenDisposed = mock(Action.class);
+
+        TestObserver<Object> drops = new TestObserver<>();
+        drops.onSubscribe(Disposable.empty());
+
+        TestObserverEx<Integer> to = ps
+        .doOnDispose(whenDisposed)
+        .throttleLatest(1, TimeUnit.SECONDS, sch, false, drops::onNext)
+        .subscribeWith(new TestObserverEx<>());
+
+        to.assertEmpty();
+
+        ps.onNext(1);
+
+        to.assertValuesOnly(1);
+
+        to.dispose();
+
+        to.assertValuesOnly(1);
+        drops.assertEmpty();
+
+        verify(whenDisposed).run();
+    }
+
+    /**
+     * Emit 1, 2 then dispose the sequence; downstream gets 1, global error handler should get drop-crash 2.
+     */
+    @Test
+    public void onDroppedDisposeCrashesDrop() throws Throwable {
+        TestHelper.withErrorTracking(errors -> {
+            PublishSubject<Integer> ps = PublishSubject.create();
+
+            TestScheduler sch = new TestScheduler();
+
+            Action whenDisposed = mock(Action.class);
+
+            TestObserverEx<Integer> to = ps
+            .doOnDispose(whenDisposed)
+            .throttleLatest(1, TimeUnit.SECONDS, sch, false, d -> { throw new TestException("forced " + d); })
+            .subscribeWith(new TestObserverEx<>());
+
+            to.assertEmpty();
+
+            ps.onNext(1);
+
+            to.assertValuesOnly(1);
+
+            ps.onNext(2);
+
+            to.assertValuesOnly(1);
+
+            to.dispose();
+
+            to.assertValuesOnly(1);
+
+            verify(whenDisposed).run();
+
+            TestHelper.assertUndeliverable(errors, 0, TestException.class, "forced 2");
+        });
     }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -13,26 +13,20 @@
 
 package io.reactivex.rxjava3.internal.operators.observable;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.core.RxJavaTest;
+import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.exceptions.CompositeException;
-import io.reactivex.rxjava3.exceptions.TestException;
-import io.reactivex.rxjava3.functions.Action;
-import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.exceptions.*;
+import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.reactivex.rxjava3.subjects.PublishSubject;
-import io.reactivex.rxjava3.testsupport.TestHelper;
-import io.reactivex.rxjava3.testsupport.TestObserverEx;
+import io.reactivex.rxjava3.testsupport.*;
 
 public class ObservableThrottleLatestTest extends RxJavaTest {
 

--- a/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava3/testsupport/TestHelper.java
@@ -2440,23 +2440,16 @@ public enum TestHelper {
      * Check if the TestSubscriber has a CompositeException with the specified class
      * of Throwables in the given order.
      * @param ts the TestSubscriber instance
-     * @param classes the array of subsequent Class and String instances representing the
+     * @param classesAndMessages the array of subsequent Class and String instances representing the
      * expected Throwable class and the expected error message
      */
-    @SuppressWarnings("unchecked")
-    public static void assertCompositeExceptions(TestSubscriberEx<?> ts, Object... classes) {
+    public static void assertCompositeExceptions(TestSubscriberEx<?> ts, Object... classesAndMessages) {
         ts
         .assertSubscribed()
         .assertError(CompositeException.class)
         .assertNotComplete();
 
-        List<Throwable> list = compositeList(ts.errors().get(0));
-
-        assertEquals(classes.length, list.size());
-
-        for (int i = 0; i < classes.length; i += 2) {
-            assertError(list, i, (Class<Throwable>)classes[i], (String)classes[i + 1]);
-        }
+        assertCompositeExceptionListOf(ts.errors().get(0), classesAndMessages);
     }
 
     /**
@@ -2485,22 +2478,26 @@ public enum TestHelper {
      * Check if the TestSubscriber has a CompositeException with the specified class
      * of Throwables in the given order.
      * @param to the TestSubscriber instance
-     * @param classes the array of subsequent Class and String instances representing the
+     * @param classesAndMessages the array of subsequent Class and String instances representing the
      * expected Throwable class and the expected error message
      */
-    @SuppressWarnings("unchecked")
-    public static void assertCompositeExceptions(TestObserverEx<?> to, Object... classes) {
+    public static void assertCompositeExceptions(TestObserverEx<?> to, Object... classesAndMessages) {
         to
         .assertSubscribed()
         .assertError(CompositeException.class)
         .assertNotComplete();
 
-        List<Throwable> list = compositeList(to.errors().get(0));
+        assertCompositeExceptionListOf(to.errors().get(0), classesAndMessages);
+    }
 
-        assertEquals(classes.length, list.size());
+    @SuppressWarnings("unchecked")
+    static void assertCompositeExceptionListOf(Throwable ex, Object... classesAndMessages) {
+        List<Throwable> list = compositeList(ex);
 
-        for (int i = 0; i < classes.length; i += 2) {
-            assertError(list, i, (Class<Throwable>)classes[i], (String)classes[i + 1]);
+        assertEquals(classesAndMessages.length, 2 * list.size());
+
+        for (int i = 0; i < list.size(); i++) {
+            assertError(list, i, (Class<Throwable>)classesAndMessages[2 * i], (String)classesAndMessages[2 * i + 1]);
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/validators/ParamValidationCheckerTest.java
@@ -230,6 +230,7 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Boolean.TYPE));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Consumer.class));
 
         // negative buffer time is considered as zero buffer time
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "window", Long.TYPE, TimeUnit.class));
@@ -474,6 +475,7 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Boolean.TYPE));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "throttleLatest", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Consumer.class));
 
         // negative buffer time is considered as zero buffer time
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "window", Long.TYPE, TimeUnit.class));


### PR DESCRIPTION
This PR adds an overload to the `throttleLatest` operator which takes an `onDropped` consumer. 

This consumer is called when the latest known item is replaced by a newer item, or the sequence gets terminated with a latest known item. It should allow some per-item cleanup to happen.

If the `onDropped` crashes, the exception is either delivered to the downstream (if the sequence is still live at that point) or to the global error handler (sequence is stopped).

*(Also fixed a bug in one of the test helpers regarding asserting composite exception members.)*