### PR TITLE
3.x: Standardize MissingBackpressureException message, introduce QueueOverflowException

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/exceptions/MissingBackpressureException.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/MissingBackpressureException.java
@@ -21,6 +21,25 @@ public final class MissingBackpressureException extends RuntimeException {
     private static final long serialVersionUID = 8517344746016032542L;
 
     /**
+     * The default error message.
+     * <p>
+     * This can happen if the downstream doesn't call {@link org.reactivestreams.Subscription#request(long)}
+     * in time or at all.
+     * @since 3.1.6
+     */
+    public static final String DEFAULT_MESSAGE = "Could not emit value due to lack of requests";
+
+    /**
+     * The message for queue overflows.
+     * <p>
+     * This can happen if the upstream disregards backpressure completely or calls
+     * {@link org.reactivestreams.Subscriber#onNext(Object)} concurrently from multiple threads
+     * without synchronization. Rarely, it is an indication of bugs inside RxJava
+     * @since 3.1.6
+     */
+    public static final String QUEUE_OVERFLOW_MESSAGE = "Queue overflow due to illegal concurrent onNext calls or a bug in RxJava";
+
+    /**
      * Constructs a MissingBackpressureException without message or cause.
      */
     public MissingBackpressureException() {
@@ -35,4 +54,23 @@ public final class MissingBackpressureException extends RuntimeException {
         super(message);
     }
 
+    /**
+     * Constructs a new {@code MissingBackpressureException} with the
+     * default message {@value #DEFAULT_MESSAGE}.
+     * @return the new {@code MissingBackpressureException} instance.
+     * @since 3.1.6
+     */
+    public static MissingBackpressureException createDefault() {
+        return new MissingBackpressureException(DEFAULT_MESSAGE);
+    }
+
+    /**
+     * Constructs a new {@code MissingBackpressureException} with the
+     * default message {@value #QUEUE_OVERFLOW_MESSAGE}.
+     * @return the new {@code MissingBackpressureException} instance.
+     * @since 3.1.6
+     */
+    public static MissingBackpressureException createQueueOverflow() {
+        return new MissingBackpressureException(QUEUE_OVERFLOW_MESSAGE);
+    }
 }

--- a/src/main/java/io/reactivex/rxjava3/exceptions/MissingBackpressureException.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/MissingBackpressureException.java
@@ -30,16 +30,6 @@ public final class MissingBackpressureException extends RuntimeException {
     public static final String DEFAULT_MESSAGE = "Could not emit value due to lack of requests";
 
     /**
-     * The message for queue overflows.
-     * <p>
-     * This can happen if the upstream disregards backpressure completely or calls
-     * {@link org.reactivestreams.Subscriber#onNext(Object)} concurrently from multiple threads
-     * without synchronization. Rarely, it is an indication of bugs inside RxJava
-     * @since 3.1.6
-     */
-    public static final String QUEUE_OVERFLOW_MESSAGE = "Queue overflow due to illegal concurrent onNext calls or a bug in RxJava";
-
-    /**
      * Constructs a MissingBackpressureException without message or cause.
      */
     public MissingBackpressureException() {
@@ -62,15 +52,5 @@ public final class MissingBackpressureException extends RuntimeException {
      */
     public static MissingBackpressureException createDefault() {
         return new MissingBackpressureException(DEFAULT_MESSAGE);
-    }
-
-    /**
-     * Constructs a new {@code MissingBackpressureException} with the
-     * default message {@value #QUEUE_OVERFLOW_MESSAGE}.
-     * @return the new {@code MissingBackpressureException} instance.
-     * @since 3.1.6
-     */
-    public static MissingBackpressureException createQueueOverflow() {
-        return new MissingBackpressureException(QUEUE_OVERFLOW_MESSAGE);
     }
 }

--- a/src/main/java/io/reactivex/rxjava3/exceptions/QueueOverflowException.java
+++ b/src/main/java/io/reactivex/rxjava3/exceptions/QueueOverflowException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.exceptions;
+
+/**
+ * Indicates an overflow happened because the upstream disregarded backpressure completely or
+ * {@link org.reactivestreams.Subscriber#onNext(Object)} was called concurrently from multiple threads
+ * without synchronization. Rarely, it is an indication of bugs inside an operator.
+ * @since 3.1.6
+ */
+public final class QueueOverflowException extends RuntimeException {
+
+    private static final long serialVersionUID = 8517344746016032542L;
+
+    /**
+     * The message for queue overflows.
+     * <p>
+     * This can happen if the upstream disregards backpressure completely or calls
+     * {@link org.reactivestreams.Subscriber#onNext(Object)} concurrently from multiple threads
+     * without synchronization. Rarely, it is an indication of bugs inside an operator.
+     */
+    private static final String DEFAULT_MESSAGE = "Queue overflow due to illegal concurrent onNext calls or a bug in an operator";
+
+    /**
+     * Constructs a QueueOverflowException with the default message.
+     */
+    public QueueOverflowException() {
+        this(DEFAULT_MESSAGE);
+    }
+
+    /**
+     * Constructs a QueueOverflowException with the given message but no cause.
+     * @param message the error message
+     */
+    public QueueOverflowException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStream.java
@@ -174,7 +174,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
             if (sourceMode != QueueFuseable.ASYNC) {
                 if (!queue.offer(t)) {
                     upstream.cancel();
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStream.java
@@ -174,7 +174,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
             if (sourceMode != QueueFuseable.ASYNC) {
                 if (!queue.offer(t)) {
                     upstream.cancel();
-                    onError(new MissingBackpressureException("Queue full?!"));
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcat.java
@@ -120,7 +120,7 @@ public final class CompletableConcat extends Completable {
         public void onNext(CompletableSource t) {
             if (sourceFused == QueueSubscription.NONE) {
                 if (!queue.offer(t)) {
-                    onError(MissingBackpressureException.createDefault());
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcat.java
@@ -120,7 +120,7 @@ public final class CompletableConcat extends Completable {
         public void onNext(CompletableSource t) {
             if (sourceFused == QueueSubscription.NONE) {
                 if (!queue.offer(t)) {
-                    onError(new MissingBackpressureException());
+                    onError(MissingBackpressureException.createDefault());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcat.java
@@ -120,7 +120,7 @@ public final class CompletableConcat extends Completable {
         public void onNext(CompletableSource t) {
             if (sourceFused == QueueSubscription.NONE) {
                 if (!queue.offer(t)) {
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
@@ -140,7 +140,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
             if (!queue.offer(t)) {
                 SubscriptionHelper.cancel(this);
 
-                onError(new MissingBackpressureException("Queue full?!"));
+                onError(MissingBackpressureException.createQueueOverflow());
             } else {
                 signalConsumer();
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
@@ -140,7 +140,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
             if (!queue.offer(t)) {
                 SubscriptionHelper.cancel(this);
 
-                onError(MissingBackpressureException.createQueueOverflow());
+                onError(new QueueOverflowException());
             } else {
                 signalConsumer();
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMap.java
@@ -152,7 +152,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
             if (sourceMode != QueueSubscription.ASYNC) {
                 if (!queue.offer(t)) {
                     upstream.cancel();
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMap.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
-import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.subscriptions.*;
 import io.reactivex.rxjava3.internal.util.*;
@@ -152,7 +152,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
             if (sourceMode != QueueSubscription.ASYNC) {
                 if (!queue.offer(t)) {
                     upstream.cancel();
-                    onError(new IllegalStateException("Queue full?!"));
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapEager.java
@@ -200,7 +200,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
                 drain();
             } else {
                 inner.cancel();
-                innerError(inner, new MissingBackpressureException());
+                innerError(inner, MissingBackpressureException.createDefault());
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
@@ -151,7 +151,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
             if (sourceMode != QueueSubscription.ASYNC) {
                 if (!queue.offer(t)) {
                     upstream.cancel();
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapScheduler.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
-import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.operators.flowable.FlowableConcatMap.*;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
@@ -151,7 +151,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
             if (sourceMode != QueueSubscription.ASYNC) {
                 if (!queue.offer(t)) {
                     upstream.cancel();
-                    onError(new IllegalStateException("Queue full?!"));
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableCreate.java
@@ -442,7 +442,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         @Override
         void onOverflow() {
-            onError(new MissingBackpressureException("create: could not emit value due to lack of requests"));
+            onError(new MissingBackpressureException("create: " + MissingBackpressureException.DEFAULT_MESSAGE));
         }
 
     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounce.java
@@ -148,7 +148,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
                     BackpressureHelper.produced(this, 1);
                 } else {
                     cancel();
-                    downstream.onError(new MissingBackpressureException("Could not deliver value due to lack of requests"));
+                    downstream.onError(MissingBackpressureException.createDefault());
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDebounceTimed.java
@@ -159,7 +159,7 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
                     emitter.dispose();
                 } else {
                     cancel();
-                    downstream.onError(new MissingBackpressureException("Could not deliver value due to lack of requests"));
+                    downstream.onError(MissingBackpressureException.createDefault());
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMap.java
@@ -243,7 +243,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                         q = getMainQueue();
                     }
                     if (!q.offer(value)) {
-                        onError(new MissingBackpressureException("Scalar queue full?!"));
+                        onError(MissingBackpressureException.createQueueOverflow());
                     }
                 }
                 if (decrementAndGet() == 0) {
@@ -252,7 +252,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
             } else {
                 SimpleQueue<U> q = getMainQueue();
                 if (!q.offer(value)) {
-                    onError(new MissingBackpressureException("Scalar queue full?!"));
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
                 if (getAndIncrement() != 0) {
@@ -278,7 +278,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                         inner.queue = q;
                     }
                     if (!q.offer(value)) {
-                        onError(new MissingBackpressureException("Inner queue full?!"));
+                        onError(MissingBackpressureException.createQueueOverflow());
                     }
                 }
                 if (decrementAndGet() == 0) {
@@ -291,7 +291,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                     inner.queue = q;
                 }
                 if (!q.offer(value)) {
-                    onError(new MissingBackpressureException("Inner queue full?!"));
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
                 if (getAndIncrement() != 0) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMap.java
@@ -243,7 +243,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                         q = getMainQueue();
                     }
                     if (!q.offer(value)) {
-                        onError(MissingBackpressureException.createQueueOverflow());
+                        onError(new QueueOverflowException());
                     }
                 }
                 if (decrementAndGet() == 0) {
@@ -252,7 +252,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
             } else {
                 SimpleQueue<U> q = getMainQueue();
                 if (!q.offer(value)) {
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
                 if (getAndIncrement() != 0) {
@@ -278,7 +278,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                         inner.queue = q;
                     }
                     if (!q.offer(value)) {
-                        onError(MissingBackpressureException.createQueueOverflow());
+                        onError(new QueueOverflowException());
                     }
                 }
                 if (decrementAndGet() == 0) {
@@ -291,7 +291,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
                     inner.queue = q;
                 }
                 if (!q.offer(value)) {
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
                 if (getAndIncrement() != 0) {

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterable.java
@@ -180,7 +180,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
                 return;
             }
             if (fusionMode == NONE && !queue.offer(t)) {
-                onError(MissingBackpressureException.createQueueOverflow());
+                onError(new QueueOverflowException());
                 return;
             }
             drain();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterable.java
@@ -180,7 +180,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
                 return;
             }
             if (fusionMode == NONE && !queue.offer(t)) {
-                onError(new MissingBackpressureException("Queue is full?!"));
+                onError(MissingBackpressureException.createQueueOverflow());
                 return;
             }
             drain();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupBy.java
@@ -168,7 +168,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                     if (emittedGroups != get()) {
                         downstream.onNext(group);
                     } else {
-                        MissingBackpressureException mbe = new MissingBackpressureException(groupHangWarning(emittedGroups));
+                        MissingBackpressureException mbe = groupHangWarning(emittedGroups);
                         mbe.initCause(ex);
                         onError(mbe);
                         return;
@@ -194,13 +194,13 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                     }
                 } else {
                     upstream.cancel();
-                    onError(new MissingBackpressureException(groupHangWarning(emittedGroups)));
+                    onError(groupHangWarning(emittedGroups));
                 }
             }
         }
 
-        static String groupHangWarning(long n) {
-            return "Unable to emit a new group (#" + n + ") due to lack of requests. Please make sure the downstream can always accept a new group as well as each group is consumed in order for the whole operator to be able to proceed.";
+        static MissingBackpressureException groupHangWarning(long n) {
+            return new MissingBackpressureException("Unable to emit a new group (#" + n + ") due to lack of requests. Please make sure the downstream can always accept a new group as well as each group is consumed in order for the whole operator to be able to proceed.");
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableGroupJoin.java
@@ -276,7 +276,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
                             a.onNext(w);
                             BackpressureHelper.produced(requested, 1);
                         } else {
-                            fail(new MissingBackpressureException("Could not emit value due to lack of requests"), a, q);
+                            fail(MissingBackpressureException.createDefault(), a, q);
                             return;
                         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableInterval.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableInterval.java
@@ -93,7 +93,7 @@ public final class FlowableInterval extends Flowable<Long> {
                     downstream.onNext(count++);
                     BackpressureHelper.produced(this, 1);
                 } else {
-                    downstream.onError(new MissingBackpressureException("Can't deliver value " + count + " due to lack of requests"));
+                    downstream.onError(new MissingBackpressureException("Could not emit value " + count + " due to lack of requests"));
                     DisposableHelper.dispose(resource);
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIntervalRange.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableIntervalRange.java
@@ -114,7 +114,7 @@ public final class FlowableIntervalRange extends Flowable<Long> {
                         decrementAndGet();
                     }
                 } else {
-                    downstream.onError(new MissingBackpressureException("Can't deliver value " + count + " due to lack of requests"));
+                    downstream.onError(new MissingBackpressureException("Could not emit value " + count + " due to lack of requests"));
                     DisposableHelper.dispose(resource);
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableJoin.java
@@ -260,7 +260,7 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
 
                                 e++;
                             } else {
-                                ExceptionHelper.addThrowable(error, new MissingBackpressureException("Could not emit value due to lack of requests"));
+                                ExceptionHelper.addThrowable(error, MissingBackpressureException.createDefault());
                                 q.clear();
                                 cancelAll();
                                 errorAll(a);
@@ -321,7 +321,7 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
 
                                 e++;
                             } else {
-                                ExceptionHelper.addThrowable(error, new MissingBackpressureException("Could not emit value due to lack of requests"));
+                                ExceptionHelper.addThrowable(error, MissingBackpressureException.createDefault());
                                 q.clear();
                                 cancelAll();
                                 errorAll(a);

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
@@ -113,7 +113,7 @@ final Scheduler scheduler;
             if (!queue.offer(t)) {
                 upstream.cancel();
 
-                error = new MissingBackpressureException("Queue is full?!");
+                error = MissingBackpressureException.createQueueOverflow();
                 done = true;
             }
             trySchedule();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOn.java
@@ -113,7 +113,7 @@ final Scheduler scheduler;
             if (!queue.offer(t)) {
                 upstream.cancel();
 
-                error = MissingBackpressureException.createQueueOverflow();
+                error = new QueueOverflowException();
                 done = true;
             }
             trySchedule();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
@@ -140,7 +140,7 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
                 }
             } else if (callError) {
                 upstream.cancel();
-                onError(new MissingBackpressureException());
+                onError(MissingBackpressureException.createDefault());
             } else {
                 drain();
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureError.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableOnBackpressureError.java
@@ -66,7 +66,7 @@ public final class FlowableOnBackpressureError<T> extends AbstractFlowableWithUp
                 BackpressureHelper.produced(this, 1);
             } else {
                 upstream.cancel();
-                onError(new MissingBackpressureException("could not emit value due to lack of requests"));
+                onError(MissingBackpressureException.createDefault());
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublish.java
@@ -226,7 +226,7 @@ implements HasUpstreamPublisher<T> {
         public void onNext(T t) {
             // we expect upstream to honor backpressure requests
             if (sourceMode == QueueSubscription.NONE && !queue.offer(t)) {
-                onError(MissingBackpressureException.createQueueOverflow());
+                onError(new QueueOverflowException());
                 return;
             }
             // since many things can happen concurrently, we have a common dispatch

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublish.java
@@ -226,7 +226,7 @@ implements HasUpstreamPublisher<T> {
         public void onNext(T t) {
             // we expect upstream to honor backpressure requests
             if (sourceMode == QueueSubscription.NONE && !queue.offer(t)) {
-                onError(new MissingBackpressureException("Prefetch queue is full?!"));
+                onError(MissingBackpressureException.createQueueOverflow());
                 return;
             }
             // since many things can happen concurrently, we have a common dispatch

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishMulticast.java
@@ -212,7 +212,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             }
             if (sourceMode == QueueSubscription.NONE && !queue.offer(t)) {
                 upstream.get().cancel();
-                onError(new MissingBackpressureException());
+                onError(MissingBackpressureException.createDefault());
                 return;
             }
             drain();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSamplePublisher.java
@@ -129,7 +129,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
                     BackpressureHelper.produced(requested, 1);
                 } else {
                     cancel();
-                    downstream.onError(new MissingBackpressureException("Couldn't emit value due to lack of requests!"));
+                    downstream.onError(MissingBackpressureException.createDefault());
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSampleTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSampleTimed.java
@@ -125,7 +125,7 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
                     BackpressureHelper.produced(requested, 1);
                 } else {
                     cancel();
-                    downstream.onError(new MissingBackpressureException("Couldn't emit value due to lack of requests!"));
+                    downstream.onError(MissingBackpressureException.createDefault());
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqual.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSequenceEqual.java
@@ -300,7 +300,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
         public void onNext(T t) {
             if (sourceMode == QueueSubscription.NONE) {
                 if (!queue.offer(t)) {
-                    onError(new MissingBackpressureException());
+                    onError(MissingBackpressureException.createDefault());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
@@ -381,7 +381,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
             SwitchMapSubscriber<T, R> p = parent;
             if (index == p.unique) {
                 if (fusionMode == QueueSubscription.NONE && !queue.offer(t)) {
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
                 p.drain();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchMap.java
@@ -381,7 +381,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
             SwitchMapSubscriber<T, R> p = parent;
             if (index == p.unique) {
                 if (fusionMode == QueueSubscription.NONE && !queue.offer(t)) {
-                    onError(new MissingBackpressureException("Queue full?!"));
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
                 p.drain();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -96,7 +96,7 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
                 } else {
                     done = true;
                     cancel();
-                    downstream.onError(new MissingBackpressureException("Could not deliver value due to lack of requests"));
+                    downstream.onError(MissingBackpressureException.createDefault());
                     return;
                 }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimer.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableTimer.java
@@ -78,7 +78,7 @@ public final class FlowableTimer extends Flowable<Long> {
                     downstream.onComplete();
                 } else {
                     lazySet(EmptyDisposable.INSTANCE);
-                    downstream.onError(new MissingBackpressureException("Can't deliver value due to lack of requests"));
+                    downstream.onError(MissingBackpressureException.createDefault());
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundary.java
@@ -248,7 +248,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
                         } else {
                             SubscriptionHelper.cancel(upstream);
                             boundarySubscriber.dispose();
-                            errors.tryAddThrowableOrReport(new MissingBackpressureException("Could not deliver a window due to lack of requests"));
+                            errors.tryAddThrowableOrReport(MissingBackpressureException.createDefault());
                             done = true;
                         }
                     }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -272,7 +272,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                                     upstream.cancel();
                                     startSubscriber.cancel();
                                     resources.dispose();
-                                    error.tryAddThrowableOrReport(new MissingBackpressureException(FlowableWindowTimed.missingBackpressureMessage(emitted)));
+                                    error.tryAddThrowableOrReport(FlowableWindowTimed.missingBackpressureMessage(emitted));
                                     upstreamDone = true;
                                 }
                             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableWindowTimed.java
@@ -213,7 +213,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     upstream.request(Long.MAX_VALUE);
                 } else {
                     upstream.cancel();
-                    downstream.onError(new MissingBackpressureException(missingBackpressureMessage(emitted)));
+                    downstream.onError(missingBackpressureMessage(emitted));
 
                     cleanupResources();
                     upstreamCancelled = true;
@@ -282,7 +282,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                     cleanupResources();
                                     upstreamCancelled = true;
 
-                                    downstream.onError(new MissingBackpressureException(missingBackpressureMessage(emitted)));
+                                    downstream.onError(missingBackpressureMessage(emitted));
                                 } else {
                                     emitted++;
 
@@ -386,7 +386,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     upstream.request(Long.MAX_VALUE);
                 } else {
                     upstream.cancel();
-                    downstream.onError(new MissingBackpressureException(missingBackpressureMessage(emitted)));
+                    downstream.onError(missingBackpressureMessage(emitted));
 
                     cleanupResources();
                     upstreamCancelled = true;
@@ -499,7 +499,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     cleanupResources();
                     upstreamCancelled = true;
 
-                    downstream.onError(new MissingBackpressureException(missingBackpressureMessage(emitted)));
+                    downstream.onError(missingBackpressureMessage(emitted));
                 } else {
                     this.emitted = ++emitted;
 
@@ -584,7 +584,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                     upstream.request(Long.MAX_VALUE);
                 } else {
                     upstream.cancel();
-                    downstream.onError(new MissingBackpressureException(missingBackpressureMessage(emitted)));
+                    downstream.onError(missingBackpressureMessage(emitted));
 
                     cleanupResources();
                     upstreamCancelled = true;
@@ -654,7 +654,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                                     }
                                 } else {
                                     upstream.cancel();
-                                    Throwable ex = new MissingBackpressureException(missingBackpressureMessage(emitted));
+                                    Throwable ex = missingBackpressureMessage(emitted);
                                     for (UnicastProcessor<T> window : windows) {
                                         window.onError(ex);
                                     }
@@ -717,8 +717,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
         }
     }
 
-    static String missingBackpressureMessage(long index) {
-        return "Unable to emit the next window (#" + index + ") due to lack of requests. Please make sure the downstream is ready to consume windows.";
+    static MissingBackpressureException missingBackpressureMessage(long index) {
+        return new MissingBackpressureException("Unable to emit the next window (#" + index + ") due to lack of requests. Please make sure the downstream is ready to consume windows.");
     }
 
 }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ConcatMapXMainSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ConcatMapXMainSubscriber.java
@@ -99,7 +99,7 @@ implements FlowableSubscriber<T> {
         if (t != null) {
             if (!queue.offer(t)) {
                 upstream.cancel();
-                onError(new MissingBackpressureException("queue full?!"));
+                onError(MissingBackpressureException.createQueueOverflow());
                 return;
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ConcatMapXMainSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/mixed/ConcatMapXMainSubscriber.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.rxjava3.core.FlowableSubscriber;
-import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.operators.QueueFuseable;
@@ -99,7 +99,7 @@ implements FlowableSubscriber<T> {
         if (t != null) {
             if (!queue.offer(t)) {
                 upstream.cancel();
-                onError(MissingBackpressureException.createQueueOverflow());
+                onError(new QueueOverflowException());
                 return;
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFromPublisher.java
@@ -204,7 +204,7 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
             if (sourceMode == QueueSubscription.NONE) {
                 if (!queue.offer(t)) {
                     upstream.cancel();
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelFromPublisher.java
@@ -204,7 +204,7 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
             if (sourceMode == QueueSubscription.NONE) {
                 if (!queue.offer(t)) {
                     upstream.cancel();
-                    onError(new MissingBackpressureException("Queue is full?"));
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelJoin.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.*;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
-import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.*;
 import io.reactivex.rxjava3.operators.SimplePlainQueue;
@@ -153,7 +153,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     if (!q.offer(value)) {
                         cancelAll();
-                        Throwable mbe = MissingBackpressureException.createQueueOverflow();
+                        Throwable mbe = new QueueOverflowException();
                         if (errors.compareAndSet(null, mbe)) {
                             downstream.onError(mbe);
                         } else {
@@ -170,7 +170,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                 if (!q.offer(value)) {
                     cancelAll();
-                    onError(MissingBackpressureException.createQueueOverflow());
+                    onError(new QueueOverflowException());
                     return;
                 }
 
@@ -333,7 +333,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     if (!q.offer(value)) {
                         inner.cancel();
-                        errors.tryAddThrowableOrReport(MissingBackpressureException.createQueueOverflow());
+                        errors.tryAddThrowableOrReport(new QueueOverflowException());
                         done.decrementAndGet();
                         drainLoop();
                         return;
@@ -347,7 +347,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                 if (!q.offer(value)) {
                     inner.cancel();
-                    errors.tryAddThrowableOrReport(MissingBackpressureException.createQueueOverflow());
+                    errors.tryAddThrowableOrReport(new QueueOverflowException());
                     done.decrementAndGet();
                 }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelJoin.java
@@ -153,7 +153,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     if (!q.offer(value)) {
                         cancelAll();
-                        Throwable mbe = new MissingBackpressureException("Queue full?!");
+                        Throwable mbe = MissingBackpressureException.createQueueOverflow();
                         if (errors.compareAndSet(null, mbe)) {
                             downstream.onError(mbe);
                         } else {
@@ -170,7 +170,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                 if (!q.offer(value)) {
                     cancelAll();
-                    onError(new MissingBackpressureException("Queue full?!"));
+                    onError(MissingBackpressureException.createQueueOverflow());
                     return;
                 }
 
@@ -333,7 +333,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     if (!q.offer(value)) {
                         inner.cancel();
-                        errors.tryAddThrowableOrReport(new MissingBackpressureException("Queue full?!"));
+                        errors.tryAddThrowableOrReport(MissingBackpressureException.createQueueOverflow());
                         done.decrementAndGet();
                         drainLoop();
                         return;
@@ -347,7 +347,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                 if (!q.offer(value)) {
                     inner.cancel();
-                    errors.tryAddThrowableOrReport(new MissingBackpressureException("Queue full?!"));
+                    errors.tryAddThrowableOrReport(MissingBackpressureException.createQueueOverflow());
                     done.decrementAndGet();
                 }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelRunOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelRunOn.java
@@ -19,7 +19,7 @@ import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
-import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.exceptions.*;
 import io.reactivex.rxjava3.internal.schedulers.SchedulerMultiWorkerSupport;
 import io.reactivex.rxjava3.internal.schedulers.SchedulerMultiWorkerSupport.WorkerCallback;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
@@ -148,7 +148,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
             }
             if (!queue.offer(t)) {
                 upstream.cancel();
-                onError(MissingBackpressureException.createQueueOverflow());
+                onError(new QueueOverflowException());
                 return;
             }
             schedule();

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelRunOn.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/parallel/ParallelRunOn.java
@@ -148,7 +148,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
             }
             if (!queue.offer(t)) {
                 upstream.cancel();
-                onError(new MissingBackpressureException("Queue is full?!"));
+                onError(MissingBackpressureException.createQueueOverflow());
                 return;
             }
             schedule();

--- a/src/main/java/io/reactivex/rxjava3/internal/subscribers/QueueDrainSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/subscribers/QueueDrainSubscriber.java
@@ -84,7 +84,7 @@ public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriber
                 }
             } else {
                 dispose.dispose();
-                s.onError(new MissingBackpressureException("Could not emit buffer due to lack of requests"));
+                s.onError(MissingBackpressureException.createDefault());
                 return;
             }
         } else {
@@ -118,7 +118,7 @@ public abstract class QueueDrainSubscriber<T, U, V> extends QueueDrainSubscriber
             } else {
                 cancelled = true;
                 dispose.dispose();
-                s.onError(new MissingBackpressureException("Could not emit buffer due to lack of requests"));
+                s.onError(MissingBackpressureException.createDefault());
                 return;
             }
         } else {

--- a/src/main/java/io/reactivex/rxjava3/internal/util/QueueDrainHelper.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/util/QueueDrainHelper.java
@@ -78,7 +78,7 @@ public final class QueueDrainHelper {
                     if (dispose != null) {
                         dispose.dispose();
                     }
-                    a.onError(new MissingBackpressureException("Could not emit value due to lack of requests."));
+                    a.onError(MissingBackpressureException.createDefault());
                     return;
                 }
             }

--- a/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java
@@ -402,8 +402,11 @@ public final class RxJavaPlugins {
             return true;
         }
         // the sender didn't honor the request amount
-        // it's either due to an operator bug or concurrent onNext
         if (error instanceof MissingBackpressureException) {
+            return true;
+        }
+        // it's either due to an operator bug or concurrent onNext
+        if (error instanceof QueueOverflowException) {
             return true;
         }
         // general protocol violations

--- a/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/BehaviorProcessor.java
@@ -590,7 +590,7 @@ public final class BehaviorProcessor<@NonNull T> extends FlowableProcessor<T> {
                 return false;
             }
             cancel();
-            downstream.onError(new MissingBackpressureException("Could not deliver value due to lack of requests"));
+            downstream.onError(MissingBackpressureException.createDefault());
             return true;
         }
 

--- a/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/MulticastProcessor.java
@@ -295,7 +295,7 @@ public final class MulticastProcessor<@NonNull T> extends FlowableProcessor<T> {
             ExceptionHelper.nullCheck(t, "onNext called with a null value.");
             if (!queue.offer(t)) {
                 SubscriptionHelper.cancel(upstream);
-                onError(new MissingBackpressureException());
+                onError(MissingBackpressureException.createDefault());
                 return;
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava3/processors/PublishProcessor.java
@@ -362,7 +362,7 @@ public final class PublishProcessor<@NonNull T> extends FlowableProcessor<T> {
                 BackpressureHelper.producedCancel(this, 1);
             } else {
                 cancel();
-                downstream.onError(new MissingBackpressureException("Could not emit value due to lack of requests"));
+                downstream.onError(MissingBackpressureException.createDefault());
             }
         }
 

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableBackpressureTests.java
@@ -24,7 +24,7 @@ import org.junit.rules.TestName;
 import org.reactivestreams.*;
 
 import io.reactivex.rxjava3.core.*;
-import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.exceptions.QueueOverflowException;
 import io.reactivex.rxjava3.functions.*;
 import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava3.internal.util.BackpressureHelper;
@@ -475,7 +475,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         int vc = ts.values().size();
         assertTrue("10 < " + vc, vc <= 10);
 
-        ts.assertError(MissingBackpressureException.class);
+        ts.assertError(QueueOverflowException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/jdk8/FlowableFlatMapStreamTest.java
@@ -274,7 +274,7 @@ public class FlowableFlatMapStreamTest extends RxJavaTest {
             }
             .flatMapStream(v -> Stream.of(1, 2), 1)
             .test(0)
-            .assertFailure(MissingBackpressureException.class);
+            .assertFailure(QueueOverflowException.class);
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         });

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcatTest.java
@@ -52,7 +52,7 @@ public class CompletableConcatTest extends RxJavaTest {
                 }), 1
             )
             .test()
-            .assertFailure(MissingBackpressureException.class);
+            .assertFailure(QueueOverflowException.class);
 
             TestHelper.assertError(errors, 0, MissingBackpressureException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/completable/CompletableConcatTest.java
@@ -54,7 +54,7 @@ public class CompletableConcatTest extends RxJavaTest {
             .test()
             .assertFailure(QueueOverflowException.class);
 
-            TestHelper.assertError(errors, 0, MissingBackpressureException.class);
+            TestHelper.assertError(errors, 0, QueueOverflowException.class);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableToIteratorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableToIteratorTest.java
@@ -152,7 +152,7 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
         it.next();
     }
 
-    @Test(expected = MissingBackpressureException.class)
+    @Test(expected = QueueOverflowException.class)
     public void overflowQueue() {
         Iterator<Integer> it = new Flowable<Integer>() {
             @Override

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -624,7 +624,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         }
         .concatMap(Functions.justFunction(Flowable.just(2)), 8, ImmediateThinScheduler.INSTANCE)
         .test(0L)
-        .assertFailure(IllegalStateException.class);
+        .assertFailure(MissingBackpressureException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -624,7 +624,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         }
         .concatMap(Functions.justFunction(Flowable.just(2)), 8, ImmediateThinScheduler.INSTANCE)
         .test(0L)
-        .assertFailure(MissingBackpressureException.class);
+        .assertFailure(QueueOverflowException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
@@ -1291,7 +1291,7 @@ public class FlowableConcatTest {
         }
         .concatMap(Functions.justFunction(Flowable.just(2)), 8)
         .test(0L)
-        .assertFailure(MissingBackpressureException.class);
+        .assertFailure(QueueOverflowException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableConcatTest.java
@@ -1291,7 +1291,7 @@ public class FlowableConcatTest {
         }
         .concatMap(Functions.justFunction(Flowable.just(2)), 8)
         .test(0L)
-        .assertFailure(IllegalStateException.class);
+        .assertFailure(MissingBackpressureException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlatMapTest.java
@@ -1391,7 +1391,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         }
         .flatMap(v -> Flowable.just(v), 1)
         .test(0L)
-        .assertFailure(MissingBackpressureException.class);
+        .assertFailure(QueueOverflowException.class);
     }
 
     @Test
@@ -1413,7 +1413,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
             }
         })
         .test()
-        .assertFailure(MissingBackpressureException.class, 1);
+        .assertFailure(QueueOverflowException.class, 1);
     }
 
     @Test
@@ -1430,7 +1430,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
             }
         }, false, 1, 1)
         .test(0L)
-        .assertFailure(MissingBackpressureException.class);
+        .assertFailure(QueueOverflowException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -814,7 +814,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         }
         .flatMapIterable(Functions.justFunction(Arrays.asList(1)), 1)
         .test(0L)
-        .assertFailure(MissingBackpressureException.class);
+        .assertFailure(QueueOverflowException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableFromSourceTest.java
@@ -137,7 +137,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotComplete();
 
-        Assert.assertEquals("create: could not emit value due to lack of requests", ts.errors().get(0).getMessage());
+        Assert.assertEquals("create: " + MissingBackpressureException.DEFAULT_MESSAGE, ts.errors().get(0).getMessage());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableObserveOnTest.java
@@ -579,13 +579,13 @@ public class FlowableObserveOnTest extends RxJavaTest {
         assertEquals(1, errors.size());
         System.out.println("Errors: " + errors);
         Throwable t = errors.get(0);
-        if (t instanceof MissingBackpressureException) {
+        if (t instanceof QueueOverflowException) {
             // success, we expect this
         } else {
-            if (t.getCause() instanceof MissingBackpressureException) {
+            if (t.getCause() instanceof QueueOverflowException) {
                 // this is also okay
             } else {
-                fail("Expecting MissingBackpressureException");
+                fail("Expecting QueueOverflowException");
             }
         }
     }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -189,7 +189,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotComplete();
 
-        Assert.assertEquals("Could not emit value due to lack of requests",
+        Assert.assertEquals(MissingBackpressureException.DEFAULT_MESSAGE,
                 ts.errors().get(0).getMessage());
         Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
@@ -212,7 +212,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotComplete();
 
-        Assert.assertEquals("Could not emit value due to lack of requests", ts.errors().get(0).getMessage());
+        Assert.assertEquals(MissingBackpressureException.DEFAULT_MESSAGE, ts.errors().get(0).getMessage());
         Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowablePublishTest.java
@@ -905,9 +905,9 @@ public class FlowablePublishTest extends RxJavaTest {
             .test(0L)
             // 3.x emits errors last, even the full queue errors
             .requestMore(10)
-            .assertFailure(MissingBackpressureException.class, 0, 1, 2, 3, 4, 5, 6, 7);
+            .assertFailure(QueueOverflowException.class, 0, 1, 2, 3, 4, 5, 6, 7);
 
-            TestHelper.assertError(errors, 0, MissingBackpressureException.class);
+            TestHelper.assertError(errors, 0, QueueOverflowException.class);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1596,7 +1596,7 @@ public class FlowablePublishTest extends RxJavaTest {
         .refCount()
         .test(0)
         .requestMore(1)
-        .assertFailure(MissingBackpressureException.class, 1);
+        .assertFailure(QueueOverflowException.class, 1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchTest.java
@@ -1076,7 +1076,7 @@ public class FlowableSwitchTest extends RxJavaTest {
             }
         }), 8)
         .test(1L)
-        .assertFailure(MissingBackpressureException.class, 0);
+        .assertFailure(QueueOverflowException.class, 0);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapCompletableTest.java
@@ -285,7 +285,7 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
                     Functions.justFunction(Completable.never()), 1
             )
             .test()
-            .assertFailure(MissingBackpressureException.class);
+            .assertFailure(QueueOverflowException.class);
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -249,7 +249,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
                     Functions.justFunction(Maybe.never()), 1
             )
             .test()
-            .assertFailure(MissingBackpressureException.class);
+            .assertFailure(QueueOverflowException.class);
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -167,7 +167,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
                     Functions.justFunction(Single.never()), 1
             )
             .test()
-            .assertFailure(MissingBackpressureException.class);
+            .assertFailure(QueueOverflowException.class);
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelFromPublisherTest.java
@@ -50,7 +50,7 @@ public class ParallelFromPublisherTest extends RxJavaTest {
         .parallel(1, 1)
         .sequential(1)
         .test(0)
-        .assertFailure(MissingBackpressureException.class);
+        .assertFailure(QueueOverflowException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelJoinTest.java
@@ -48,7 +48,7 @@ public class ParallelJoinTest extends RxJavaTest {
         }
         .sequential(1)
         .test(0)
-        .assertFailure(MissingBackpressureException.class);
+        .assertFailure(QueueOverflowException.class);
     }
 
     @Test
@@ -81,7 +81,7 @@ public class ParallelJoinTest extends RxJavaTest {
         .sequential(1)
         .subscribe(ts);
 
-        ts.assertFailure(MissingBackpressureException.class, 1);
+        ts.assertFailure(QueueOverflowException.class, 1);
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ParallelJoinTest extends RxJavaTest {
         .sequentialDelayError(1)
         .test(0)
         .requestMore(1)
-        .assertFailure(MissingBackpressureException.class, 1);
+        .assertFailure(QueueOverflowException.class, 1);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
         ts.request(1);
 
-        ts.assertFailure(MissingBackpressureException.class, 1, 2);
+        ts.assertFailure(QueueOverflowException.class, 1, 2);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava3/parallel/ParallelRunOnTest.java
+++ b/src/test/java/io/reactivex/rxjava3/parallel/ParallelRunOnTest.java
@@ -98,7 +98,7 @@ public class ParallelRunOnTest extends RxJavaTest {
         .runOn(ImmediateThinScheduler.INSTANCE, 1)
         .sequential(1)
         .test(0)
-        .assertFailure(MissingBackpressureException.class);
+        .assertFailure(QueueOverflowException.class);
     }
 
     @Test


### PR DESCRIPTION
Extend `MissingBackpressureException` with a standard message string and a static methods to create the exception with the standard message. This will make sure every case reports the same consistent message.

In addition, the queue overflows now have a separate exception class `QueueOverflowException`. This exception should not happen during normal operations and is mainly there to detect misuse or bugs in operators. Consequencly, even though many places used to signal `MissingBackpressureException` for such queue overflows, there was no reason to check for this specific exception class outside developing RxJava itself.

ThrottleLatest needs to be updated after #7457