### PR TITLE
Fix cancellation order in ThrottleFirst

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id("me.champeau.gradle.jmh") version "0.5.3"
     id("com.github.hierynomus.license") version "0.16.1"
     id("biz.aQute.bnd.builder") version "6.3.1"
-    id("com.vanniktech.maven.publish") version "0.20.0"
+    id("com.vanniktech.maven.publish") version "0.19.0"
     id("org.beryx.jar") version "1.2.0"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id("me.champeau.gradle.jmh") version "0.5.3"
     id("com.github.hierynomus.license") version "0.16.1"
     id("biz.aQute.bnd.builder") version "6.3.1"
-    id("com.vanniktech.maven.publish") version "0.19.0"
+    id("com.vanniktech.maven.publish") version "0.20.0"
     id("org.beryx.jar") version "1.2.0"
 }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -105,9 +105,10 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
                     downstream.onNext(t);
                     BackpressureHelper.produced(this, 1);
                 } else {
+                    upstream.cancel();
                     done = true;
-                    cancel();
                     downstream.onError(MissingBackpressureException.createDefault());
+                    worker.dispose();
                     return;
                 }
 
@@ -122,10 +123,10 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
                     onDropped.accept(t);
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-                    downstream.onError(ex);
-                    worker.dispose();
                     upstream.cancel();
                     done = true;
+                    downstream.onError(ex);
+                    worker.dispose();
                 }
             }
         }

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableThrottleFirstTimed.java
@@ -32,7 +32,7 @@ public final class ObservableThrottleFirstTimed<T> extends AbstractObservableWit
 
     public ObservableThrottleFirstTimed(
             ObservableSource<T> source,
-            long timeout, 
+            long timeout,
             TimeUnit unit,
             Scheduler scheduler,
             Consumer<? super T> onDropped) {
@@ -102,9 +102,9 @@ public final class ObservableThrottleFirstTimed<T> extends AbstractObservableWit
                     onDropped.accept(t);
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
+                    upstream.dispose();
                     downstream.onError(ex);
                     worker.dispose();
-                    upstream.dispose();
                 }
             }
         }


### PR DESCRIPTION
Dispose the upstream first, then dispose the worker after.