### PR TITLE
3.x: Fix Single.timeout race condition

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleTimeout.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/single/SingleTimeout.java
@@ -113,11 +113,7 @@ public final class SingleTimeout<T> extends Single<T> {
 
         @Override
         public void run() {
-            Disposable d = get();
-            if (d != DisposableHelper.DISPOSED && compareAndSet(d, DisposableHelper.DISPOSED)) {
-                if (d != null) {
-                    d.dispose();
-                }
+            if (DisposableHelper.dispose(this)) {
                 SingleSource<? extends T> other = this.other;
                 if (other == null) {
                     downstream.onError(new TimeoutException(timeoutMessage(timeout, unit)));

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleTimeoutTest.java
@@ -28,7 +28,7 @@ import io.reactivex.rxjava3.exceptions.TestException;
 import io.reactivex.rxjava3.functions.Action;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
-import io.reactivex.rxjava3.schedulers.TestScheduler;
+import io.reactivex.rxjava3.schedulers.*;
 import io.reactivex.rxjava3.subjects.*;
 import io.reactivex.rxjava3.testsupport.TestHelper;
 
@@ -254,5 +254,25 @@ public class SingleTimeoutTest extends RxJavaTest {
         .assertResult(1);
 
         assertTrue(d.isDisposed());
+    }
+
+    @Test
+    public void timeoutWithZero() throws InterruptedException {
+        int n = 10_000;
+        Scheduler sch = Schedulers.single();
+        for (int i = 0; i < n; i++) {
+            final int y = i;
+            final CountDownLatch latch = new CountDownLatch(1);
+            Disposable d = Single.never()
+                    .timeout(0, TimeUnit.NANOSECONDS, sch)
+                    .subscribe(v -> {}, e -> {
+                        //System.out.println("timeout " + y);
+                        latch.countDown();
+                    });
+            if (!latch.await(2, TimeUnit.SECONDS)) {
+                System.out.println(d + " " + sch);
+                throw new IllegalStateException("Timeout did not work at y = " + y);
+            }
+        }
     }
 }


### PR DESCRIPTION
The PR fixes a race condition in `Single.timeout` where when the time was really small, the timeout logic in `run` would race with the `onSubscribe` logic and not handle the the timeout case.

The race happened between `Disposable d = get()` and the later `compareAndSet(d, DisposableHelper.DISPOSED)`. When the `get` executes, it sees `null`. Then comes `onSubscribe` and atomically sets some `Disposable` in `this`. Now `compareAndSet` fails because the `null -> Disposed` transition can't be made.

The fix is to use `DisposableHelper.dispose` which returns true iff the current thread managed to transition from a non-disposed state into a disposed state.

Fixes #7514