### PR TITLE
add copyright and license to jar

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,13 @@
+Copyright (c) 2016-present, RxJava Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,11 @@ animalsniffer {
 }
 
 jar {
+    from('.') {
+        include 'LICENSE'
+        include 'COPYRIGHT'
+    }
+
     // Cover for bnd still not supporting MR Jars: https://github.com/bndtools/bnd/issues/2227
     bnd('-fixupmessages': '^Classes found in the wrong directory: \\\\{META-INF/versions/9/module-info\\\\.class=module-info}$')
     bnd(

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ jar {
     from('.') {
         include 'LICENSE'
         include 'COPYRIGHT'
+        into('META-INF/')
     }
 
     // Cover for bnd still not supporting MR Jars: https://github.com/bndtools/bnd/issues/2227


### PR DESCRIPTION
### Add copyright and license information to Jar.

For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the copyright and licence information from our dependencies. This scanner can extract all informaton from the Jar file. Therefore it would be great to have the copyright and license information included in the jar File as COPYRIGHT and LICENSE files. 