### PR TITLE
3.x: Try using https to access the reactive streams javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ javadoc {
 
     options.links(
             "https://docs.oracle.com/javase/8/docs/api/",
-            "http://www.reactive-streams.org/reactive-streams-${reactiveStreamsVersion}-javadoc/"
+            "https://www.reactive-streams.org/reactive-streams-${reactiveStreamsVersion}-javadoc/"
     )
 
     finalizedBy javadocCleanup

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ javadoc {
 
     options.links(
             "https://docs.oracle.com/javase/8/docs/api/",
-            "https://www.reactive-streams.org/reactive-streams-${reactiveStreamsVersion}-javadoc/"
+            "https://reactivex.io/RxJava/org.reactivestreams.javadoc/${reactiveStreamsVersion}/"
     )
 
     finalizedBy javadocCleanup


### PR DESCRIPTION
You know, instead of just disabling all javadoc external links.