### PR TITLE
Add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -10,10 +10,15 @@ on:
     tags:
       - 'v3.*.*'   
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -6,12 +6,17 @@ name: Snapshot
 on:
   push:
     branches: [ '3.x' ]
+    
+permissions:
+  contents: read
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
     if: github.repository == 'ReactiveX/RxJava'
+    permissions:
+      contents: write
     env:
       # ------------------------------------------------------------------------------ 
       CI_BUILD_NUMBER: ${{ github.run_number }}


### PR DESCRIPTION
Closes #7540 

### Changes

Set top level as contents: read and job level permission as contents: write to the following workflows

- gradle_release.yml
- gradle_snapshot.yml

Let me know if anything fail and I'll try to guess which permission may still be missing, but looking at the script that had failed, it seems it was only the contents: write indeed.
