### PR TITLE
Make inner class static for CompletableOnErrorComplete

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorComplete.java
@@ -35,7 +35,7 @@ public final class CompletableOnErrorComplete extends Completable {
         source.subscribe(new OnError(observer));
     }
 
-    final class OnError implements CompletableObserver {
+    static final class OnError implements CompletableObserver {
 
         private final CompletableObserver downstream;
 


### PR DESCRIPTION
Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

After taking a heap dump for a Rx chain that was completed, we saw evidence of inner class showing up on the heap dump analysis. It apears that CompletableOnErrorComplete#onError is leaking the predicate

For instance

class Foo {

fun test(): Completable {
Completable.fromCallable {
println("hello world")
}.onErrorComplete { --> leaks after chain completion
true
}

}

}

Verified with kotlin bytecode dump and heap analysis

  - [x] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
