### PR TITLE
Convert CompletableOnErrorComplete$onError inner class to static 

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorComplete.java
@@ -35,7 +35,7 @@ public final class CompletableOnErrorComplete extends Completable {
         source.subscribe(new OnError(observer));
     }
 
-    final class OnError implements CompletableObserver {
+    static final class OnError implements CompletableObserver {
 
         private final CompletableObserver downstream;
         private final Predicate<? super Throwable> predicate;

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorComplete.java
@@ -38,9 +38,12 @@ public final class CompletableOnErrorComplete extends Completable {
     final class OnError implements CompletableObserver {
 
         private final CompletableObserver downstream;
+        private final Predicate<? super Throwable> predicate;
 
-        OnError(CompletableObserver observer) {
+        OnError(CompletableObserver observer,
+                Predicate<? super Throwable> predicate) {
             this.downstream = observer;
+            this.predicate = predicate;
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/completable/CompletableOnErrorComplete.java
@@ -32,7 +32,7 @@ public final class CompletableOnErrorComplete extends Completable {
     @Override
     protected void subscribeActual(final CompletableObserver observer) {
 
-        source.subscribe(new OnError(observer));
+        source.subscribe(new OnError(observer, predicate));
     }
 
     static final class OnError implements CompletableObserver {


### PR DESCRIPTION
Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

The OnError class not being static ends up holding a reference to predicate which will avoid it from being garbage collected.
Make OnError static and pass predicate to avoid leaking the predicate

See discussion in PR: https://github.com/ReactiveX/RxJava/pull/7574



  - [x] Please give a description about what and why you are contributing, even if it's trivial.

  - [x] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
