### PR TITLE
Remove `@NonNull` annotation from `Collector` container type parameter.

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -20394,7 +20394,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R, @NonNull A> Single<R> collect(@NonNull Collector<? super T, A, R> collector) {
+    public final <@NonNull R, @Nullable A> Single<R> collect(@NonNull Collector<? super T, A, R> collector) {
         Objects.requireNonNull(collector, "collector is null");
         return RxJavaPlugins.onAssembly(new FlowableCollectWithCollectorSingle<>(this, collector));
     }


### PR DESCRIPTION
`collect` delegates to `FlowableCollectWithCollectorSingle`, which
is not annotated to require a non-nullable type for its corresponding
type parameter and whose implementation works fine with a null
container.

This PR lets Kotlin code pass a `Collector<T, A, R>`, where `A` is
declared as `<A: Any?>`.
