### PR TITLE
3.x: Fix ObservableSwitchMap NPE due to onSubscribe-cancel race

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchMap.java
@@ -349,9 +349,10 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
 
         @Override
         public void onNext(R t) {
-            if (index == parent.unique) {
+            SimpleQueue<R> q = queue;
+            if (index == parent.unique && q != null) {
                 if (t != null) {
-                    queue.offer(t);
+                    q.offer(t);
                 }
                 parent.drain();
             }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableSwitchTest.java
@@ -1377,4 +1377,19 @@ public class FlowableSwitchTest extends RxJavaTest {
             inner.incrementAndGet();
         });
     }
+
+    @Test
+    public void innerOnSubscribeOuterCancelRace() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+
+        Flowable.just(1)
+        .hide()
+        .switchMap(v -> Flowable.just(1)
+                .doOnSubscribe(d -> ts.cancel())
+                .scan(1, (a, b) -> a)
+        )
+        .subscribe(ts);
+
+        ts.assertEmpty();
+    }
 }

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchTest.java
@@ -1438,4 +1438,19 @@ public class ObservableSwitchTest extends RxJavaTest {
             inner.incrementAndGet();
         });
     }
+
+    @Test
+    public void innerOnSubscribeOuterCancelRace() {
+        TestObserver<Integer> to = new TestObserver<Integer>();
+
+        Observable.just(1)
+        .hide()
+        .switchMap(v -> Observable.just(1)
+                .doOnSubscribe(d -> to.dispose())
+                .scan(1, (a, b) -> a)
+        )
+        .subscribe(to);
+
+        to.assertEmpty();
+    }
 }


### PR DESCRIPTION
If the dispose of the outer `switchMap` happens just before the inner `onSubscribe` is invoked, the `queue` is not set. Subsequently, if an operator signals `onNext` right after (such as `scan`), it will result in a `NullPointerException`.

The fix is to do a null check on the `queue` before offering.

Fixes #7596