### PR TITLE
In ofType methods, cast outer Rx construct directly instead of casting each element

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -12388,7 +12388,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <@NonNull U> Flowable<U> ofType(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
-        return filter(Functions.isInstanceOf(clazz)).cast(clazz);
+        return (Flowable<U>) filter(Functions.isInstanceOf(clazz));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Maybe.java
@@ -4455,7 +4455,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <@NonNull U> Maybe<U> ofType(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
-        return filter(Functions.isInstanceOf(clazz)).cast(clazz);
+        return (Maybe<U>) filter(Functions.isInstanceOf(clazz));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -10686,7 +10686,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @NonNull
     public final <@NonNull U> Observable<U> ofType(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
-        return filter(Functions.isInstanceOf(clazz)).cast(clazz);
+        return (Observable<U>) filter(Functions.isInstanceOf(clazz));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava3/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Single.java
@@ -4041,7 +4041,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final <@NonNull U> Maybe<U> ofType(@NonNull Class<U> clazz) {
         Objects.requireNonNull(clazz, "clazz is null");
-        return filter(Functions.isInstanceOf(clazz)).cast(clazz);
+        return (Maybe<U>) filter(Functions.isInstanceOf(clazz));
     }
 
     /**


### PR DESCRIPTION
  - [X] Please give a description about what and why you are contributing, even if it's trivial.

Currently, `ofType` works by combining a `filter` and a `cast`. After the `filter` is done, we already know that the resulting Rx construct only emits elements of the desired type. We can cast the resulting construct to indicate this known type, instead of performing a cast on the element itself, which is an unnecessary ceremony that creates an additional segment of the Rx chain and all of the overhead that entails.

  - [X] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

None, a direct proposal as a PR.

  - [X] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.

Does not add any new behavior, existing unit tests suffice.