### PR TITLE
3.x: Update the javadoc description of cast()

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Flowable.java
@@ -7475,8 +7475,10 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     }
 
     /**
-     * Returns a {@code Flowable} that emits the items emitted by the current {@code Flowable}, converted to the specified
-     * type.
+     * Returns a {@code Flowable} that emits the upstream items while
+     * they can be cast via {@link Class#cast(Object)} until the upstream terminates,
+     * or until the upstream signals an item which can't be cast,
+     * resulting in a {@link ClassCastException} to be signaled to the downstream.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/cast.v3.png" alt="">
      * <dl>
@@ -7489,8 +7491,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
      *
      * @param <U> the output value type cast to
      * @param clazz
-     *            the target class type that {@code cast} will cast the items emitted by the current {@code Flowable}
-     *            into before emitting them from the resulting {@code Flowable}
+     *            the target class to use to try and cast the upstream items into
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code clazz} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>

--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -6668,8 +6668,10 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     }
 
     /**
-     * Returns an {@code Observable} that emits the items emitted by the current {@code Observable}, converted to the specified
-     * type.
+     * Returns an {@code Observable} that emits the upstream items while
+     * they can be cast via {@link Class#cast(Object)} until the upstream terminates,
+     * or until the upstream signals an item which can't be cast,
+     * resulting in a {@link ClassCastException} to be signaled to the downstream.
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/cast.v3.png" alt="">
      * <dl>
@@ -6679,8 +6681,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *
      * @param <U> the output value type cast to
      * @param clazz
-     *            the target class type that {@code cast} will cast the items emitted by the current {@code Observable}
-     *            into before emitting them from the resulting {@code Observable}
+     *            the target class to use to try and cast the upstream items into
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code clazz} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>


### PR DESCRIPTION
Reword the operator description to avoid some confusion how `cast()` works.

Resolves #7605

The related images had mistakes too and have been updated in the wiki section separately:

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/cast.v3.png)]

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.cast.png)

![image](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.cast.png)