### PR TITLE
Fix of small Javadoc mistake

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -1709,7 +1709,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * Example:
      * <pre><code>
-     * Observable.&lt;Event&gt;create(emitter -&gt; {
+     * Observable&lt;Event&gt;.create(emitter -&gt; {
      *     Callback listener = new Callback() {
      *         &#64;Override
      *         public void onEvent(Event e) {


### PR DESCRIPTION
Fixed a wrong placed dot in the Javadoc of the create method in the Observable class.