### PR TITLE
chore: fix some typos in comments

### DIFF
--- a/docs/Phantom-Operators.md
+++ b/docs/Phantom-Operators.md
@@ -127,7 +127,7 @@ streamOfItems.flatMap(item -> {
    itemToObservable(item).subscribeOn(Schedulers.io());
 });
 ```
-Kick off your work for each item inside [`flatMap`](Transforming-Observables#flatmap-concatmap-and-flatmapiterable) using [`subscribeOn`](Observable-Utility-Operators#subscribeon) to make it asynchronous, or by using a function that already makes asychronous calls.
+Kick off your work for each item inside [`flatMap`](Transforming-Observables#flatmap-concatmap-and-flatmapiterable) using [`subscribeOn`](Observable-Utility-Operators#subscribeon) to make it asynchronous, or by using a function that already makes asynchronous calls.
 
 #### see also:
 * <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a> by Graham Lea

--- a/src/test/java/io/reactivex/rxjava3/disposables/CompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava3/disposables/CompositeDisposableTest.java
@@ -290,7 +290,7 @@ public class CompositeDisposableTest extends RxJavaTest {
         cd.remove(cd1);
         cd.add(cd2);
 
-        cd.remove(cd1); // try removing agian
+        cd.remove(cd1); // try removing again
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/rxjava3/exceptions/TestException.java
+++ b/src/test/java/io/reactivex/rxjava3/exceptions/TestException.java
@@ -14,7 +14,7 @@
 package io.reactivex.rxjava3.exceptions;
 
 /**
- * Exception for testing if unchecked expections propagate as-is without confusing with
+ * Exception for testing if unchecked exceptions propagate as-is without confusing with
  * other type of common exceptions.
  */
 public final class TestException extends RuntimeException {

--- a/src/test/java/io/reactivex/rxjava3/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava3/flowable/FlowableBackpressureTests.java
@@ -132,7 +132,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         assertEquals(num, ts.values().size());
         // either one can starve the other, but neither should be capable of doing more than 5 batches (taking 4.1)
         // TODO is it possible to make this deterministic rather than one possibly starving the other?
-        // benjchristensen => In general I'd say it's not worth trying to make it so, as "fair" algoritms generally take a performance hit
+        // benjchristensen => In general I'd say it's not worth trying to make it so, as "fair" algorithms generally take a performance hit
         assertTrue(c1.get() < Flowable.bufferSize() * 5);
         assertTrue(c2.get() < Flowable.bufferSize() * 5);
     }
@@ -154,7 +154,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         assertEquals(num, ts.values().size());
         // either one can starve the other, but neither should be capable of doing more than 5 batches (taking 4.1)
         // TODO is it possible to make this deterministic rather than one possibly starving the other?
-        // benjchristensen => In general I'd say it's not worth trying to make it so, as "fair" algoritms generally take a performance hit
+        // benjchristensen => In general I'd say it's not worth trying to make it so, as "fair" algorithms generally take a performance hit
         int max = Flowable.bufferSize() * 7;
         assertTrue("" + c1.get() + " >= " + max, c1.get() < max);
         assertTrue("" + c2.get() + " >= " + max, c2.get() < max);
@@ -206,7 +206,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         assertEquals(num, ts.values().size());
         // either one can starve the other, but neither should be capable of doing more than 5 batches (taking 4.1)
         // TODO is it possible to make this deterministic rather than one possibly starving the other?
-        // benjchristensen => In general I'd say it's not worth trying to make it so, as "fair" algoritms generally take a performance hit
+        // benjchristensen => In general I'd say it's not worth trying to make it so, as "fair" algorithms generally take a performance hit
         // akarnokd => run this in a loop over 10k times and never saw values get as high as 7*SIZE, but since observeOn delays the unsubscription non-deterministically, the test will remain unreliable
         assertTrue(c1.get() < Flowable.bufferSize() * 7);
         assertTrue(c2.get() < Flowable.bufferSize() * 7);


### PR DESCRIPTION
fix some typos in comments