### PR TITLE
Prevent NPE when catching exception from LambdaObservable#onNext (#7720)

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/observers/LambdaObserver.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/observers/LambdaObserver.java
@@ -63,7 +63,10 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable>
                 onNext.accept(t);
             } catch (Throwable e) {
                 Exceptions.throwIfFatal(e);
-                get().dispose();
+                Disposable d = get();
+                if (d != null) {
+                    d.dispose();
+                }
                 onError(e);
             }
         }

--- a/src/test/java/io/reactivex/rxjava3/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/observers/LambdaObserverTest.java
@@ -408,4 +408,34 @@ public class LambdaObserverTest extends RxJavaTest {
             RxJavaPlugins.reset();
         }
     }
+
+    @Test
+    public void onErrorComingFromOnNextShouldBeObservableErrorHandler() {
+        List<Throwable> errors = TestHelper.trackPluginErrors();
+        try {
+            final List<Throwable> observerErrors = Collections.synchronizedList(new ArrayList<>());
+
+            LambdaObserver<Integer> o = new LambdaObserver<>(new Consumer<Integer>() {
+                @Override
+                public void accept(Integer v) {
+                    throw new TestException();
+                }
+            },
+                    new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable t) {
+                            observerErrors.add(t);
+                        }
+                    },
+                    Functions.EMPTY_ACTION,
+                    Functions.<Disposable>emptyConsumer());
+
+            o.onNext(1);
+
+            TestHelper.assertError(observerErrors, 0, TestException.class);
+            assertTrue(errors.isEmpty());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
 }


### PR DESCRIPTION
Closes (#7720)

I added a check to prevent NullPointerException when handling exception caught when trying to execute the code from the subscriber and trying to push to the Observer error handler
