### PR TITLE
ScheduledRunnable to honor interrupt settings from Schedulers.from usage

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/schedulers/ExecutorScheduler.java
@@ -204,7 +204,7 @@ public final class ExecutorScheduler extends Scheduler {
 
             final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
 
-            ScheduledRunnable sr = new ScheduledRunnable(new SequentialDispose(mar, decoratedRun), tasks);
+            ScheduledRunnable sr = new ScheduledRunnable(new SequentialDispose(mar, decoratedRun), tasks, interruptibleWorker);
             tasks.add(sr);
 
             if (executor instanceof ScheduledExecutorService) {


### PR DESCRIPTION
When using `Schedulers.from` and running a delayed task via `schedule(Runnable, long, TimeUnit)`, the `ExecutorScheduler` uses the standard `ScheduledRunnable` infrastructure for the initial delay.

When the task is disposed during this initial delay, the cancellation always triggers with an interrupted on inside `ScheduledRunnable` as it is not aware the `Schedulers.from` may run in no-interrupt mode. 

When the dispose happens after the delay, during the actual task's runtime, the no-interrupt mode is honored as expected (as `ScheduledRunnable` is no longer involved).

This PR adds an `interruptOnCancel` flag to `ScheduledRunnable`, an overloaded constructor to minimize the change impact and several tests that check for the aforementioned situations.

Resolves #7744 