### PR TITLE
Try fixing Jacoco - codecov errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id("java-library")
     id("checkstyle")
     id("eclipse")
-    id("jacoco")
+    id("jacoco") version "0.8.8"
     id("maven-publish")
     id("ru.vyarus.animalsniffer") version "1.7.1"
     id("me.champeau.gradle.jmh") version "0.5.3"


### PR DESCRIPTION
Looking at similar issues, 0.8.9+ changed something that breaks codecov. Others have success downgrading to 0.8.8