### PR TITLE
Update BlockingFlowableIterable.onNext() to set error before cancel

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/BlockingFlowableIterable.java
@@ -138,9 +138,12 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
         @Override
         public void onNext(T t) {
             if (!queue.offer(t)) {
+                // Error must be set first before calling cancel to avoid race
+                // with hasNext(), which checks for cancel first before checking
+                // for error.
+                error = new QueueOverflowException();
                 SubscriptionHelper.cancel(this);
-
-                onError(new QueueOverflowException());
+                onComplete();
             } else {
                 signalConsumer();
             }


### PR DESCRIPTION
To avoid race with hasNext(), which checks for cancel first before checking for error. For example, in the following case, hasNext() may return false to the caller, making the caller assume the iterable finished successfully.
1. onNext() called cancel
2. hasNext() found the iterable is cancelled
3. hasNext() found that error is null thus returned false to the caller, without throwing the error
4. onNext() set error

It's a bit hard to test this race condition in unit tests. Existing tests can make sure no regression is introduced.