### PR TITLE
Fix MpscLinkedQueue GC issues

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
@@ -91,6 +91,8 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
             // we have to null out the value because we are going to hang on to the node
             final T nextValue = nextNode.getAndNullValue();
             spConsumerNode(nextNode);
+            // unlink previous consumer to help gc
+            currConsumerNode.soNext(null);
             return nextValue;
         }
         else if (currConsumerNode != lvProducerNode()) {
@@ -101,6 +103,8 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
             // we have to null out the value because we are going to hang on to the node
             final T nextValue = nextNode.getAndNullValue();
             spConsumerNode(nextNode);
+            // unlink previous consumer to help gc
+            currConsumerNode.soNext(null);
             return nextValue;
         }
         return null;

--- a/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
@@ -87,23 +87,19 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
     public T poll() {
         LinkedQueueNode<T> currConsumerNode = lpConsumerNode(); // don't load twice, it's alright
         LinkedQueueNode<T> nextNode = currConsumerNode.lvNext();
-        if (nextNode != null) {
-            // we have to null out the value because we are going to hang on to the node
-            final T nextValue = nextNode.getAndNullValue();
-            spConsumerNode(nextNode);
-            return nextValue;
+        final T nextValue;
+        if (nextNode == null && currConsumerNode == lvProducerNode()) {
+            return null;
         }
-        else if (currConsumerNode != lvProducerNode()) {
+        if (nextNode == null) {
             // spin, we are no longer wait free
             while ((nextNode = currConsumerNode.lvNext()) == null) { } // NOPMD
             // got the next node...
-
-            // we have to null out the value because we are going to hang on to the node
-            final T nextValue = nextNode.getAndNullValue();
-            spConsumerNode(nextNode);
-            return nextValue;
         }
-        return null;
+        // we have to null out the value because we are going to hang on to the node
+        nextValue = nextNode.getAndNullValue();
+        spConsumerNode(nextNode);
+        return nextValue;
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
@@ -87,19 +87,23 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
     public T poll() {
         LinkedQueueNode<T> currConsumerNode = lpConsumerNode(); // don't load twice, it's alright
         LinkedQueueNode<T> nextNode = currConsumerNode.lvNext();
-        final T nextValue;
-        if (nextNode == null && currConsumerNode == lvProducerNode()) {
-            return null;
+        if (nextNode != null) {
+            // we have to null out the value because we are going to hang on to the node
+            final T nextValue = nextNode.getAndNullValue();
+            spConsumerNode(nextNode);
+            return nextValue;
         }
-        if (nextNode == null) {
+        else if (currConsumerNode != lvProducerNode()) {
             // spin, we are no longer wait free
             while ((nextNode = currConsumerNode.lvNext()) == null) { } // NOPMD
             // got the next node...
+
+            // we have to null out the value because we are going to hang on to the node
+            final T nextValue = nextNode.getAndNullValue();
+            spConsumerNode(nextNode);
+            return nextValue;
         }
-        // we have to null out the value because we are going to hang on to the node
-        nextValue = nextNode.getAndNullValue();
-        spConsumerNode(nextNode);
-        return nextValue;
+        return null;
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
@@ -99,8 +99,6 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
         // we have to null out the value because we are going to hang on to the node
         nextValue = nextNode.getAndNullValue();
         spConsumerNode(nextNode);
-        // unlink previous consumer to help gc
-        currConsumerNode.soNext(null);
         return nextValue;
     }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
@@ -99,6 +99,8 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
         // we have to null out the value because we are going to hang on to the node
         nextValue = nextNode.getAndNullValue();
         spConsumerNode(nextNode);
+        // unlink previous consumer to help gc
+        currConsumerNode.soNext(null);
         return nextValue;
     }
 


### PR DESCRIPTION
Similar to https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/          MpscLinkedQueue.java#L120, null out the next pointer in the discarded consumer node when polling from the queue. If not, we leave behind a (potentially long) chain of connected garbage nodes. If we're unlucky (for example one of the early nodes is promoted to old generation, triggering nepotism), this can cause GC issues as now we have a long linked list which must be marked by young collections.

I noticed this in one of my applications, a heap dump showed an unreachable list of a few hundred thousand nodes all with null values.

~~Note: There are two commits here. One refactors poll() to (IMO) simplify the different cases, and the second actually fixes the GC issue. If preferred I can just fix the GC issue without the refactoring.~~

Reproducer:

```
import io.reactivex.rxjava3.internal.queue.MpscLinkedQueue;

public class MpscLinkedQueueGC {
    public static void main(String[] args) {
        MpscLinkedQueue<Integer> queue = new MpscLinkedQueue<>();
        for (int i = 0; i < 10; i++) System.gc(); // tenure consumer node
        while (true) {
            queue.offer(123);
            queue.poll();
        }
    }
}
```

```
Before fix:
$ java -Xlog:gc -Xmx1G -cp build/classes/java/main MpscLinkedQueueGC.java
...
[1.261s] GC(20) Pause Young (Normal) (G1 Preventive Collection) 115M->115M(204M) 209.335ms
[1.385s] GC(23) Pause Young (Normal) (G1 Evacuation Pause) 148M->149M(204M) 31.491ms
[1.417s] GC(24) Pause Young (Normal) (G1 Evacuation Pause) 157M->158M(204M) 19.333ms
[1.453s] GC(25) Pause Young (Normal) (G1 Evacuation Pause) 166M->167M(599M) 22.678ms
[1.966s] GC(26) Pause Young (Normal) (G1 Evacuation Pause) 249M->249M(497M) 305.238ms
...

After fix:
$ java -Xlog:gc -Xmx1G -cp build/classes/java/main MpscLinkedQueueGC.java
...
[1.169s] GC(14) Pause Young (Normal) (G1 Evacuation Pause) 304M->2M(506M) 0.755ms
[1.558s] GC(15) Pause Young (Normal) (G1 Evacuation Pause) 304M->2M(506M) 0.689ms
[1.948s] GC(16) Pause Young (Normal) (G1 Evacuation Pause) 304M->2M(506M) 0.800ms
[2.337s] GC(17) Pause Young (Normal) (G1 Evacuation Pause) 304M->2M(506M) 0.714ms
...
```