### PR TITLE
Fix a possible issue introduced with #7799

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/queue/MpscLinkedQueue.java
@@ -92,7 +92,7 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
             final T nextValue = nextNode.getAndNullValue();
             spConsumerNode(nextNode);
             // unlink previous consumer to help gc
-            currConsumerNode.soNext(null);
+            currConsumerNode.soNext(currConsumerNode);
             return nextValue;
         }
         else if (currConsumerNode != lvProducerNode()) {
@@ -104,7 +104,7 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
             final T nextValue = nextNode.getAndNullValue();
             spConsumerNode(nextNode);
             // unlink previous consumer to help gc
-            currConsumerNode.soNext(null);
+            currConsumerNode.soNext(currConsumerNode);
             return nextValue;
         }
         return null;


### PR DESCRIPTION
In JCTools, the current node's next is set to itself as null could mean trouble.

https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/BaseLinkedQueue.java#L232

Related #7790