### PR TITLE
3.x: Fix thread-safety issue reported by infer

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferBoundary.java
@@ -82,7 +82,7 @@ extends AbstractFlowableWithUpstream<T, U> {
 
         Map<Long, C> buffers;
 
-        long emitted;
+        AtomicLong emitted = new AtomicLong();
 
         BufferBoundarySubscriber(Subscriber<? super C> actual,
                 Publisher<? extends Open> bufferOpen,
@@ -245,7 +245,7 @@ extends AbstractFlowableWithUpstream<T, U> {
             }
 
             int missed = 1;
-            long e = emitted;
+            long e = emitted.get();
             Subscriber<? super C> a = downstream;
             SpscLinkedArrayQueue<C> q = queue;
 
@@ -299,7 +299,7 @@ extends AbstractFlowableWithUpstream<T, U> {
                     }
                 }
 
-                emitted = e;
+                emitted.set(e);
                 missed = addAndGet(-missed);
                 if (missed == 0) {
                     break;


### PR DESCRIPTION
 * Fix BufferBoundarySubscriber.emmited

   The issue was discovered during code static analysis with [infer](https://github.com/facebook/infer).  
Full issue text:  
```
src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableBufferBoundary.java:138: warning: Thread Safety Violation
 Unprotected write. Non-private method `FlowableBufferBoundary$BufferBoundarySubscriber.onError(...)` indirectly writes to field `this.emitted` outside of synchronization.
Reporting because this access may occur on a background thread.  
 136.                   }
 137.                   done = true;
 138. >                 drain();
 139.               }
 140.           }
```

   I think it's not a false positive and suggest to make `BufferBoundarySubscriber.emmited` field `AtomicLong`.  This change solves issue and shouldn't create new problems per my understanding.


