### PR TITLE
3.x: Fix delay-cancellation race producing random subsequent emissions

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableDelay.java
@@ -111,7 +111,9 @@ public final class FlowableDelay<T> extends AbstractFlowableWithUpstream<T, T> {
 
             @Override
             public void run() {
-                downstream.onNext(t);
+                if (!w.isDisposed()) {
+                    downstream.onNext(t);
+                }
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDelay.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableDelay.java
@@ -111,7 +111,9 @@ public final class ObservableDelay<T> extends AbstractObservableWithUpstream<T, 
 
             @Override
             public void run() {
-                downstream.onNext(t);
+                if (!w.isDisposed()) {
+                    downstream.onNext(t);
+                }
             }
         }
 


### PR DESCRIPTION
When a sequence using `delay` is cancelled asynchronously, there is a race between cancelling each individual `Future` inside the executor and them running, causing skips in the `onNext` emissions.

For example, let's say there are 3 futures waiting to be executed. The Future-1 triggers the cancellation asynchronously and emits `1`. This asynchronous routine will start cancelling Future-2 and Future-3 one by one. Concurrently, the executor will look at Future-2, see it cancelled and moves onto Future-3, which is still executable as the asynchronous routine hasn't gotten to cancel Future-3. Now Future-3 runs and emits `3`. This will appear to produce a sequence of `[1, 3]` where `2` is missing.

The fix is to hard-check for a disposed worker and prevent the `onNext` emissions in the operator.

Resolves #7851