### PR TITLE
Javadoc: Overveable.takeWhile vs. takeUntil: the condition is inverted

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava3/core/Observable.java
@@ -14147,7 +14147,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.p.v3.png" alt="">
      * <p>
      * The difference between this operator and {@link #takeWhile(Predicate)} is that here, the condition is
-     * evaluated <em>after</em> the item is emitted.
+     * evaluated <em>after</em> the item is emitted. (Also, the condition is inverted.)
      *
      * <dl>
      *  <dt><b>Scheduler:</b></dt>


### PR DESCRIPTION
The current description of the difference between takeWhile and takeUntil just points to the evaluation time (before or after the element is emitted), but the (IMHO) more important fact is that the predicate is inverted between both: `takeWhile` emits just elements where the predicate is true, `takeUntil` just elements where the predicate is false (and the first true one).