### PR TITLE
3.x: Upgrade to Gradle 8.14, toolchains, Central release

### DIFF
--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: 'zulu'
-        java-version: '8'
+        java-version: '11'
     - name: Cache Gradle packages
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -38,5 +38,5 @@ jobs:
       run: ./gradlew -PjavaCompatibility=9 jar
     - name: Build RxJava
       run: ./gradlew build --stacktrace
-    - name: Generate Javadoc
-      run: ./gradlew javadoc --stacktrace
+#    - name: Generate Javadoc
+#      run: ./gradlew javadoc --stacktrace

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  BUILD_WITH_11: true
+
 jobs:
   build:
 

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: 'zulu'
-        java-version: '8'
+        java-version: '11'
     - name: Cache Gradle packages
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -23,11 +23,11 @@ jobs:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: 'zulu'
-        java-version: '8'
+        java-version: '11'
     - name: Cache Gradle packages
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
@@ -54,7 +54,7 @@ jobs:
         ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
         ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
     - name: Publish release
-      run: ./gradlew -PreleaseMode=full closeAndReleaseRepository --no-daemon --no-parallel --stacktrace
+      run: ./gradlew -PreleaseMode=full publishAndReleaseToMavenCentral --no-configuration-cache --no-daemon --no-parallel --stacktrace
       env:
         # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
         # ------------------------------------------------------------------------------ 

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -22,11 +22,11 @@ jobs:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: 'zulu'
-        java-version: '8'
+        java-version: '11'
     - name: Cache Gradle packages
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
@@ -40,7 +40,7 @@ jobs:
     - name: Build RxJava
       run: ./gradlew build --stacktrace --no-daemon
     - name: Upload Snapshot
-      run: ./gradlew -PreleaseMode=branch publish --no-daemon --no-parallel --stacktrace
+      run: ./gradlew -PreleaseMode=branch publishAllPublicationsToMavenCentralRepository --no-daemon --no-parallel --stacktrace
       env:
         # Define secrets at https://github.com/ReactiveX/RxJava/settings/secrets/actions
         # ------------------------------------------------------------------------------ 

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ plugins {
     id("me.champeau.gradle.jmh") version "0.5.3"
     id("com.github.hierynomus.license") version "0.16.1"
     id("biz.aQute.bnd.builder") version "6.4.0"
-    id("com.vanniktech.maven.publish") version "0.19.0"
-    id("org.beryx.jar") version "1.2.0"
+    id("com.vanniktech.maven.publish") version "0.32.0"
+    id("org.beryx.jar") version "2.0.0"
 }
 
 ext {
@@ -54,6 +54,18 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+def buildWith11 = System.getenv("BUILD_WITH_11")
+java {
+    toolchain {
+        vendor = JvmVendorSpec.ADOPTIUM
+        if ("true".equals(buildWith11)) {
+            languageVersion = JavaLanguageVersion.of(11)
+        } else {
+            languageVersion = JavaLanguageVersion.of(8)
+        }
+    }
+}
+
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-parameters"
 }
@@ -86,12 +98,18 @@ animalsniffer {
     annotation = "io.reactivex.rxjava3.internal.util.SuppressAnimalSniffer"
 }
 
+moduleConfig {
+    moduleInfoPath = 'src/main/module/module-info.java'
+    multiReleaseVersion = 9
+}
+
 jar {
     from('.') {
         include 'LICENSE'
         include 'COPYRIGHT'
         into('META-INF/')
     }
+    exclude("module-info.class")
 
     // Cover for bnd still not supporting MR Jars: https://github.com/bndtools/bnd/issues/2227
     bnd('-fixupmessages': '^Classes found in the wrong directory: \\\\{META-INF/versions/9/module-info\\\\.class=module-info}$')
@@ -106,8 +124,6 @@ jar {
             "Bundle-SymbolicName": "io.reactivex.rxjava3.rxjava",
             "Multi-Release": "true"
     )
-
-    moduleInfoPath = 'src/main/module/module-info.java'
 }
 
 license {
@@ -166,8 +182,9 @@ jacocoTestReport {
     dependsOn testNG
 
     reports {
-        xml.enabled = true
-        html.enabled = true
+            xml.required.set(true)
+	    csv.required.set(false)
+            html.required.set(true)
     }
 }
 
@@ -184,26 +201,6 @@ checkstyle {
 if (project.hasProperty("releaseMode")) {
     logger.lifecycle("ReleaseMode: {}", project.releaseMode)
 
-  /*
-  if ("branch" == project.releaseMode) {
-
-    if (version.endsWith("-SNAPSHOT")) {
-      publishing {
-        repositories {
-          maven {
-             url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-          }
-        }
-      }
-
-      mavenPublish {
-        nexus {
-          stagingProfile = "io.reactivex"
-        }
-      }
-    }
-  }
-  */
 
   if ("full" == project.releaseMode) {
     signing {
@@ -211,12 +208,5 @@ if (project.hasProperty("releaseMode")) {
          useInMemoryPgpKeys(project.getProperty("SIGNING_PRIVATE_KEY"), project.getProperty("SIGNING_PASSWORD"))
       }
     }
-    /*
-    mavenPublish {
-      nexus {
-        stagingProfile = "io.reactivex"
-      }
-    }
-    */
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,7 @@ checkstyle {
             "checkstyle.suppressions.file": project.file("config/checkstyle/suppressions.xml"),
             "checkstyle.header.file"      : project.file("config/license/HEADER_JAVA")
     ]
+    checkstyleMain.exclude '**/module-info.java'
 }
 
 if (project.hasProperty("releaseMode")) {

--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,6 @@ dependencies {
     testImplementation "com.google.guava:guava:$guavaVersion"
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 def buildWith11 = System.getenv("BUILD_WITH_11")
 java {
     toolchain {
@@ -64,6 +59,8 @@ java {
             languageVersion = JavaLanguageVersion.of(8)
         }
     }
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,5 @@ POM_DEVELOPER_ID=akarnokd
 POM_DEVELOPER_NAME=David Karnok
 POM_DEVELOPER_URL=https://github.com/akarnokd/
 POM_DEVELOPER_EMAIL=akarnokd@gmail.com
+
+SONATYPE_HOST=CENTRAL_PORTAL

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade to Gradle 8.14 so the Maven Publish plugin that supports the new Sonatype Central plugin depository can work.

Might take several tries and "googling the error message".