### PR TITLE
3.x: Fix ReplaySubject termination-subscription race emitting wrongly

### DIFF
--- a/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava3/subjects/ReplaySubject.java
@@ -652,8 +652,6 @@ public final class ReplaySubject<T> extends Subject<T> {
 
         final List<Object> buffer;
 
-        volatile boolean done;
-
         volatile int size;
 
         UnboundedReplayBuffer(int capacityHint) {
@@ -671,7 +669,6 @@ public final class ReplaySubject<T> extends Subject<T> {
             buffer.add(notificationLite);
             trimHead();
             size++;
-            done = true;
         }
 
         @Override
@@ -772,20 +769,17 @@ public final class ReplaySubject<T> extends Subject<T> {
 
                     Object o = b.get(index);
 
-                    if (done) {
-                        if (index + 1 == s) {
-                            s = size;
-                            if (index + 1 == s) {
-                                if (NotificationLite.isComplete(o)) {
-                                    a.onComplete();
-                                } else {
-                                    a.onError(NotificationLite.getError(o));
-                                }
-                                rs.index = null;
-                                rs.cancelled = true;
-                                return;
-                            }
-                        }
+                    if (NotificationLite.isComplete(o)) {
+                        a.onComplete();
+                        rs.index = null;
+                        rs.cancelled = true;
+                        return;
+                    } else
+                    if (NotificationLite.isError(o)) {
+                        a.onError(NotificationLite.getError(o));
+                        rs.index = null;
+                        rs.cancelled = true;
+                        return;
                     }
 
                     a.onNext((T)o);
@@ -856,8 +850,6 @@ public final class ReplaySubject<T> extends Subject<T> {
 
         Node<Object> tail;
 
-        volatile boolean done;
-
         SizeBoundReplayBuffer(int maxSize) {
             this.maxSize = maxSize;
             Node<Object> h = new Node<>(null);
@@ -895,7 +887,6 @@ public final class ReplaySubject<T> extends Subject<T> {
             t.lazySet(n); // releases both the tail and size
 
             trimHead();
-            done = true;
         }
 
         /**
@@ -1000,18 +991,17 @@ public final class ReplaySubject<T> extends Subject<T> {
 
                     Object o = n.value;
 
-                    if (done) {
-                        if (n.get() == null) {
-
-                            if (NotificationLite.isComplete(o)) {
-                                a.onComplete();
-                            } else {
-                                a.onError(NotificationLite.getError(o));
-                            }
-                            rs.index = null;
-                            rs.cancelled = true;
-                            return;
-                        }
+                    if (NotificationLite.isComplete(o)) {
+                        a.onComplete();
+                        rs.index = null;
+                        rs.cancelled = true;
+                        return;
+                    } else
+                    if (NotificationLite.isError(o)) {
+                        a.onError(NotificationLite.getError(o));
+                        rs.index = null;
+                        rs.cancelled = true;
+                        return;
                     }
 
                     a.onNext((T)o);
@@ -1068,8 +1058,6 @@ public final class ReplaySubject<T> extends Subject<T> {
         volatile TimedNode<Object> head;
 
         TimedNode<Object> tail;
-
-        volatile boolean done;
 
         SizeAndTimeBoundReplayBuffer(int maxSize, long maxAge, TimeUnit unit, Scheduler scheduler) {
             this.maxSize = maxSize;
@@ -1163,8 +1151,6 @@ public final class ReplaySubject<T> extends Subject<T> {
             size++;
             t.lazySet(n); // releases both the tail and size
             trimFinal();
-
-            done = true;
         }
 
         /**
@@ -1290,18 +1276,17 @@ public final class ReplaySubject<T> extends Subject<T> {
 
                     Object o = n.value;
 
-                    if (done) {
-                        if (n.get() == null) {
-
-                            if (NotificationLite.isComplete(o)) {
-                                a.onComplete();
-                            } else {
-                                a.onError(NotificationLite.getError(o));
-                            }
-                            rs.index = null;
-                            rs.cancelled = true;
-                            return;
-                        }
+                    if (NotificationLite.isComplete(o)) {
+                        a.onComplete();
+                        rs.index = null;
+                        rs.cancelled = true;
+                        return;
+                    } else
+                    if (NotificationLite.isError(o)) {
+                        a.onError(NotificationLite.getError(o));
+                        rs.index = null;
+                        rs.cancelled = true;
+                        return;
                     }
 
                     a.onNext((T)o);

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableAmbTest.java
@@ -402,7 +402,8 @@ public class FlowableAmbTest extends RxJavaTest {
 
     @Test
     public void manySources() {
-        Flowable<?>[] a = new Flowable[32];
+        @SuppressWarnings("unchecked")
+        Flowable<Object>[] a = new Flowable[32];
         Arrays.fill(a, Flowable.never());
         a[31] = Flowable.just(1);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableAmbTest.java
@@ -235,7 +235,8 @@ public class ObservableAmbTest extends RxJavaTest {
 
     @Test
     public void manySources() {
-        Observable<?>[] a = new Observable[32];
+        @SuppressWarnings("unchecked")
+        Observable<Object>[] a = new Observable[32];
         Arrays.fill(a, Observable.never());
         a[31] = Observable.just(1);
 

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/single/SingleAmbTest.java
@@ -249,7 +249,8 @@ public class SingleAmbTest extends RxJavaTest {
 
     @Test
     public void manySources() {
-        Single<?>[] sources = new Single[32];
+        @SuppressWarnings("unchecked")
+        Single<Object>[] sources = new Single[32];
         Arrays.fill(sources, Single.never());
         sources[31] = Single.just(31);
 

--- a/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava3/processors/ReplayProcessorTest.java
@@ -1832,4 +1832,69 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         rp.test().assertValuesOnly(4, 5);
     }
-}
+
+    @Test
+    public void terminationSubscriptionRaceUnbounded() throws Throwable {
+        for (int i = 1; i <= 10000; i++) {
+            ReplayProcessor<String> source = ReplayProcessor.create();
+            PublishProcessor<String> sink = PublishProcessor.create();
+            TestSubscriber<String> subscriber = sink.test();
+            Schedulers.computation().scheduleDirect(() -> {
+                // issue signals to the source in adherence to the reactive streams specification
+                source.onSubscribe(new BooleanSubscription());
+                source.onNext("hello");
+                source.onNext("world");
+                source.onComplete();
+            });
+            Schedulers.computation().scheduleDirect(() -> {
+                // connect the source to the sink in parallel with the signals issued to the source
+                // note the cast() operator, which is here to detect non-String escapees
+                source.cast(String.class).subscribe(sink);
+            });
+            subscriber.await().assertValues("hello", "world").assertComplete();
+        }
+    }
+
+    @Test
+    public void terminationSubscriptionRaceSizeBound() throws Throwable {
+        for (int i = 1; i <= 10000; i++) {
+            ReplayProcessor<String> source = ReplayProcessor.createWithSize(20);
+            PublishProcessor<String> sink = PublishProcessor.create();
+            TestSubscriber<String> subscriber = sink.test();
+            Schedulers.computation().scheduleDirect(() -> {
+                // issue signals to the source in adherence to the reactive streams specification
+                source.onSubscribe(new BooleanSubscription());
+                source.onNext("hello");
+                source.onNext("world");
+                source.onComplete();
+            });
+            Schedulers.computation().scheduleDirect(() -> {
+                // connect the source to the sink in parallel with the signals issued to the source
+                // note the cast() operator, which is here to detect non-String escapees
+                source.cast(String.class).subscribe(sink);
+            });
+            subscriber.await().assertValues("hello", "world").assertComplete();
+        }
+    }
+
+    @Test
+    public void terminationSubscriptionRaceTimeBound() throws Throwable {
+        for (int i = 1; i <= 10000; i++) {
+            ReplayProcessor<String> source = ReplayProcessor.createWithTime(20, TimeUnit.MINUTES, Schedulers.computation());
+            PublishProcessor<String> sink = PublishProcessor.create();
+            TestSubscriber<String> subscriber = sink.test();
+            Schedulers.computation().scheduleDirect(() -> {
+                // issue signals to the source in adherence to the reactive streams specification
+                source.onSubscribe(new BooleanSubscription());
+                source.onNext("hello");
+                source.onNext("world");
+                source.onComplete();
+            });
+            Schedulers.computation().scheduleDirect(() -> {
+                // connect the source to the sink in parallel with the signals issued to the source
+                // note the cast() operator, which is here to detect non-String escapees
+                source.cast(String.class).subscribe(sink);
+            });
+            subscriber.await().assertValues("hello", "world").assertComplete();
+        }
+    }}


### PR DESCRIPTION
When the subject's termination was racing with an incoming observer, there was a window when the buffer contained the terminal `NotificationLite` object but `done` was still false, causing the leak of said `NotificationLite` object as an `onNext` signal. `ReplayProcessor` is not affected.

The fix is to simply check if the next buffered item is a terminal signal and act accordingly. There is no need for a `done` indicator.

The bug affects the unbounded, size- and time-bounded variants as well. The mistake was introduced almost 10 years ago in the very early days.

Tests were added to verify the correct behavior for `ReplaySubject` and `ReplayProcessor`.

:information_source: There were small updates to 3 `Amb` operator tests because the new Eclipse 2025.06 was showing compiler error due to type-inference issues on them. Javac never complained so this could be one of those Eclipse weirdnesses that creep up sometimes. Now Eclipse is happy.

Resolves #7878 