### PR TITLE
Eclipse 2025-09 type inference bug workaround

### DIFF
--- a/src/jmh/java/io/reactivex/rxjava3/core/BinaryFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/core/BinaryFlatMapPerf.java
@@ -139,9 +139,9 @@ public class BinaryFlatMapPerf {
             }
         });
 
-        singleFlatMapHideObservable = Single.just(1).flatMapObservable(new Function<Integer, Observable<? extends Integer>>() {
+        singleFlatMapHideObservable = Single.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return arrayObservableHide;
             }
         });
@@ -153,16 +153,16 @@ public class BinaryFlatMapPerf {
             }
         });
 
-        maybeFlatMapObservable = Maybe.just(1).flatMapObservable(new Function<Integer, Observable<? extends Integer>>() {
+        maybeFlatMapObservable = Maybe.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return arrayObservable;
             }
         });
 
-        maybeFlatMapHideObservable = Maybe.just(1).flatMapObservable(new Function<Integer, Observable<? extends Integer>>() {
+        maybeFlatMapHideObservable = Maybe.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return arrayObservableHide;
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableConcatMapMaybePerf.java
@@ -60,9 +60,9 @@ public class FlowableConcatMapMaybePerf {
             }
         });
 
-        flowableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+        flowableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v) {
+            public Maybe<Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapMaybeEmptyPerf.java
@@ -60,9 +60,9 @@ public class FlowableFlatMapMaybeEmptyPerf {
             }
         });
 
-        flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+        flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v) {
+            public Maybe<Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapMaybePerf.java
@@ -60,9 +60,9 @@ public class FlowableFlatMapMaybePerf {
             }
         });
 
-        flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+        flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v) {
+            public Maybe<Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableFlatMapSinglePerf.java
@@ -60,9 +60,9 @@ public class FlowableFlatMapSinglePerf {
             }
         });
 
-        flowableDedicated = source.flatMapSingle(new Function<Integer, Single<? extends Integer>>() {
+        flowableDedicated = source.flatMapSingle(new Function<Integer, Single<Integer>>() {
             @Override
-            public Single<? extends Integer> apply(Integer v) {
+            public Single<Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapMaybeEmptyPerf.java
@@ -60,9 +60,9 @@ public class FlowableSwitchMapMaybeEmptyPerf {
             }
         });
 
-        flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+        flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v) {
+            public Maybe<Integer> apply(Integer v) {
                 return Maybe.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapMaybePerf.java
@@ -60,9 +60,9 @@ public class FlowableSwitchMapMaybePerf {
             }
         });
 
-        flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
+        flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
             @Override
-            public Maybe<? extends Integer> apply(Integer v) {
+            public Maybe<Integer> apply(Integer v) {
                 return Maybe.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/FlowableSwitchMapSinglePerf.java
@@ -60,9 +60,9 @@ public class FlowableSwitchMapSinglePerf {
             }
         });
 
-        flowableDedicated = source.switchMapSingle(new Function<Integer, Single<? extends Integer>>() {
+        flowableDedicated = source.switchMapSingle(new Function<Integer, Single<Integer>>() {
             @Override
-            public Single<? extends Integer> apply(Integer v) {
+            public Single<Integer> apply(Integer v) {
                 return Single.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapCompletablePerf.java
@@ -45,9 +45,9 @@ public class ObservableConcatMapCompletablePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.concatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapMaybeEmptyPerf.java
@@ -45,9 +45,9 @@ public class ObservableConcatMapMaybeEmptyPerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.concatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapMaybePerf.java
@@ -45,9 +45,9 @@ public class ObservableConcatMapMaybePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.concatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableConcatMapSinglePerf.java
@@ -52,9 +52,9 @@ public class ObservableConcatMapSinglePerf {
             }
         });
 
-        observableConvert = source.concatMap(new Function<Integer, Observable<? extends Integer>>() {
+        observableConvert = source.concatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Single.just(v).toObservable();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapCompletablePerf.java
@@ -45,9 +45,9 @@ public class ObservableFlatMapCompletablePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapMaybeEmptyPerf.java
@@ -45,9 +45,9 @@ public class ObservableFlatMapMaybeEmptyPerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapMaybePerf.java
@@ -45,9 +45,9 @@ public class ObservableFlatMapMaybePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableFlatMapSinglePerf.java
@@ -45,9 +45,9 @@ public class ObservableFlatMapSinglePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.flatMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.flatMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapCompletablePerf.java
@@ -45,9 +45,9 @@ public class ObservableSwitchMapCompletablePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.switchMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapMaybeEmptyPerf.java
@@ -45,9 +45,9 @@ public class ObservableSwitchMapMaybeEmptyPerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.switchMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.empty();
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapMaybePerf.java
@@ -45,9 +45,9 @@ public class ObservableSwitchMapMaybePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.switchMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });

--- a/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava3/xmapz/ObservableSwitchMapSinglePerf.java
@@ -45,9 +45,9 @@ public class ObservableSwitchMapSinglePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.switchMap(new Function<Integer, Observable<? extends Integer>>() {
+        observablePlain = source.switchMap(new Function<Integer, Observable<Integer>>() {
             @Override
-            public Observable<? extends Integer> apply(Integer v) {
+            public Observable<Integer> apply(Integer v) {
                 return Observable.just(v);
             }
         });

--- a/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCache.java
+++ b/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableCache.java
@@ -112,6 +112,9 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
 
     static final class Multicaster<T> extends AtomicReference<CacheDisposable<T>[]> implements Observer<T> {
 
+        /** */
+        private static final long serialVersionUID = 8514643269016498691L;
+
         /**
          * The number of items per cached nodes.
          */

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/flowable/FlowableZipTest.java
@@ -1870,7 +1870,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void firstErrorPreventsSecondSubscription() {
         final AtomicInteger counter = new AtomicInteger();
 
-        List<Flowable<?>> flowableList = new ArrayList<>();
+        List<Flowable<Object>> flowableList = new ArrayList<>();
         flowableList.add(Flowable.create(new FlowableOnSubscribe<Object>() {
             @Override
             public void subscribe(FlowableEmitter<Object> e)

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableBufferTest.java
@@ -1301,9 +1301,9 @@ public class ObservableBufferTest extends RxJavaTest {
                             }
                         })
                 .buffer(Observable.interval(0, 100, TimeUnit.MILLISECONDS),
-                        new Function<Long, Observable<?>>() {
+                        new Function<Long, Observable<Long>>() {
                             @Override
-                            public Observable<?> apply(Long a) {
+                            public Observable<Long> apply(Long a) {
                                 return Observable.just(a).delay(200, TimeUnit.MILLISECONDS);
                             }
                         })

--- a/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava3/internal/operators/observable/ObservableZipTest.java
@@ -1403,7 +1403,7 @@ public class ObservableZipTest extends RxJavaTest {
     public void firstErrorPreventsSecondSubscription() {
         final AtomicInteger counter = new AtomicInteger();
 
-        List<Observable<?>> observableList = new ArrayList<>();
+        List<Observable<Object>> observableList = new ArrayList<>();
         observableList.add(Observable.create(new ObservableOnSubscribe<Object>() {
             @Override
             public void subscribe(ObservableEmitter<Object> e)


### PR DESCRIPTION
It's silly. The first wildcard use breaks other wildcard uses. Fixing the first occurrence by removing the wildcard often lets the other wildcard uses compile.

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4332 
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4402
