### PR TITLE
4.x: Improve Javadocs + limit line length + cleanup indentation + check

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -5,18 +5,11 @@
     This configuration file was written by the eclipse-cs plugin configuration editor
 -->
 <!--
-    Checkstyle-Configuration: rxjava
+    Checkstyle-Configuration: local
     Description: none
 -->
 <module name="Checker">
   <property name="severity" value="warning"/>
-  <module name="SuppressionFilter">
-    <property name="file" value="${config_loc}/suppressions.xml"/>
-    <property name="optional" value="false"/>
-  </module>
-  <module name="BeforeExecutionExclusionFileFilter">
-    <property name="fileNamePattern" value="module\-info\.java$"/>
-  </module>
   <module name="TreeWalker">
     <module name="MissingJavadocMethod"/>
     <module name="JavadocMethod"/>
@@ -25,9 +18,38 @@
       <property name="format" value="^(?!\s+\* $).*?\s+$"/>
       <property name="message" value="Line has trailing spaces."/>
     </module>
+    <module name="RegexpSinglelineJava">
+      <property name="severity" value="warning"/>
+      <property name="format" value="^\*|^ {2,4}\*|^ {6,8}\*|^ {10,12}\*|\t"/>
+      <property name="message" value="Javadoc Indentation must be 1, 5, 9, 13, etc spaces"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="severity" value="warning"/>
+      <property name="format" value="^ {1,3}//|^ {5,7}//|^ {9,11}//|^ {13,15}//|\t"/>
+      <property name="message" value="// comments must be prefixed by 4, 8, 12, etc spaces"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="severity" value="warning"/>
+      <property name="format" value="^ {1,3}/\*|^ {5,7}/\*|^ {9,11}/\*|^ {13,15}/\*|\t"/>
+      <property name="message" value="/* comments must be prefixed by 4, 8, 12, etc spaces"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="severity" value="warning"/>
+      <property name="format" value="^(?!\s*\*)(( {1,3}\S)|( {5,7}\S)|( {9,11}\S)|( {13,15}\S))|\t"/>
+      <property name="message" value="Indentation must be a multiple of exactly 4 spaces (no tabs allowed)"/>
+    </module>
+  </module>
+  <module name="SuppressionFilter">
+    <property name="file" value="${config_loc}/suppressions.xml"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
   </module>
   <module name="Header">
     <property name="fileExtensions" value="java"/>
     <property name="headerFile" value="${config_loc}/../license/HEADER_JAVA"/>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="175"/>
   </module>
 </module>

--- a/src/jmh/java/io/reactivex/rxjava4/core/MemoryPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/MemoryPerf.java
@@ -234,21 +234,28 @@ public final class MemoryPerf {
         checkMemory(new Callable<Object>() {
             @Override
             public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10).subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
+                return io.reactivex.rxjava4.core.Observable.range(1, 10)
+                        .subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
+                        .subscribeWith(new MyRx2Observer());
             }
         }, "range+subscribeOn+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
             public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10).observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
+                return io.reactivex.rxjava4.core.Observable.range(1, 10)
+                        .observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
+                        .subscribeWith(new MyRx2Observer());
             }
         }, "range+observeOn+consumer", "Rx2Observable");
 
         checkMemory(new Callable<Object>() {
             @Override
             public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10).subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation()).observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Observer());
+                return io.reactivex.rxjava4.core.Observable.range(1, 10)
+                        .subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
+                        .observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
+                        .subscribeWith(new MyRx2Observer());
             }
         }, "range+subscribeOn+observeOn+consumer", "Rx2Observable");
 
@@ -424,21 +431,28 @@ public final class MemoryPerf {
         checkMemory(new Callable<Object>() {
             @Override
             public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10).subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
+                return io.reactivex.rxjava4.core.Flowable.range(1, 10)
+                        .subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
+                        .subscribeWith(new MyRx2Subscriber());
             }
         }, "range+subscribeOn+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
             public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10).observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
+                return io.reactivex.rxjava4.core.Flowable.range(1, 10)
+                        .observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
+                        .subscribeWith(new MyRx2Subscriber());
             }
         }, "range+observeOn+consumer", "Rx2Flowable");
 
         checkMemory(new Callable<Object>() {
             @Override
             public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10).subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation()).observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation()).subscribeWith(new MyRx2Subscriber());
+                return io.reactivex.rxjava4.core.Flowable.range(1, 10)
+                        .subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
+                        .observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
+                        .subscribeWith(new MyRx2Subscriber());
             }
         }, "range+subscribeOn+observeOn+consumer", "Rx2Flowable");
 

--- a/src/main/java/io/reactivex/rxjava4/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Completable.java
@@ -2855,7 +2855,9 @@ public abstract class Completable implements CompletableSource {
 
             observer = RxJavaPlugins.onSubscribe(this, observer);
 
-            Objects.requireNonNull(observer, "The RxJavaPlugins.onSubscribe hook returned a null CompletableObserver. Please check the handler provided to RxJavaPlugins.setOnCompletableSubscribe for invalid null returns. Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
+            Objects.requireNonNull(observer, "The RxJavaPlugins.onSubscribe hook returned a null CompletableObserver. "
+                    + "Please check the handler provided to RxJavaPlugins.setOnCompletableSubscribe for invalid null returns. "
+                    + "Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
 
             subscribeActual(observer);
         } catch (NullPointerException ex) { // NOPMD

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -300,7 +300,8 @@ FlowableDocBasic<T>
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @NonNull
-    public static <@NonNull T, @NonNull R> Flowable<R> combineLatestArray(@NonNull Publisher<? extends T>[] sources, @NonNull Function<? super Object[], ? extends R> combiner) {
+    public static <@NonNull T, @NonNull R> Flowable<R> combineLatestArray(@NonNull Publisher<? extends T>[] sources,
+            @NonNull Function<? super Object[], ? extends R> combiner) {
         return combineLatestArray(sources, combiner, bufferSize());
     }
 
@@ -348,7 +349,8 @@ FlowableDocBasic<T>
     @CheckReturnValue
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
-    public static <@NonNull T, @NonNull R> Flowable<R> combineLatestArray(@NonNull Publisher<? extends T>[] sources, @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
+    public static <@NonNull T, @NonNull R> Flowable<R> combineLatestArray(@NonNull Publisher<? extends T>[] sources,
+            @NonNull Function<? super Object[], ? extends R> combiner, int bufferSize) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return empty();
@@ -1161,7 +1163,9 @@ FlowableDocBasic<T>
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return combineLatestArray(new Publisher[] { source1, source2, source3, source4, source5, source6, source7, source8, source9 }, Functions.toFunction(combiner), bufferSize());
+        return combineLatestArray(new Publisher[] { source1, source2, source3,
+                source4, source5, source6,
+                source7, source8, source9 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -2791,7 +2795,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T, @NonNull S> Flowable<T> generate(@NonNull Supplier<S> initialState, @NonNull BiFunction<S, @NonNull Emitter<T>, S> generator, @NonNull Consumer<? super S> disposeState) {
+    public static <@NonNull T, @NonNull S> Flowable<T> generate(@NonNull Supplier<S> initialState,
+            @NonNull BiFunction<S, @NonNull Emitter<T>, S> generator, @NonNull Consumer<? super S> disposeState) {
         Objects.requireNonNull(initialState, "initialState is null");
         Objects.requireNonNull(generator, "generator is null");
         Objects.requireNonNull(disposeState, "disposeState is null");
@@ -4310,7 +4315,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends T> source1, @NonNull Publisher<? extends T> source2, @NonNull Publisher<? extends T> source3) {
+    public static <@NonNull T> Flowable<T> mergeDelayError(@NonNull Publisher<? extends T> source1,
+            @NonNull Publisher<? extends T> source2, @NonNull Publisher<? extends T> source3) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -5015,7 +5021,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T, @NonNull R> Flowable<R> zip(@NonNull Iterable<@NonNull ? extends Publisher<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
+    public static <@NonNull T, @NonNull R> Flowable<R> zip(@NonNull Iterable<@NonNull ? extends Publisher<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new FlowableZip<>(null, sources, zipper, bufferSize(), false));
@@ -7747,7 +7754,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <@NonNull R> Flowable<R> concatMap(@NonNull Function<? super T, @NonNull ? extends Publisher<? extends R>> mapper, int prefetch, @NonNull Scheduler scheduler) {
+    public final <@NonNull R> Flowable<R> concatMap(@NonNull Function<? super T, @NonNull ? extends Publisher<? extends R>> mapper,
+            int prefetch, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -8639,7 +8647,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <@NonNull R> Flowable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int prefetch) {
+    public final <@NonNull R> Flowable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper,
+            boolean tillTheEnd, int prefetch) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
         return RxJavaPlugins.onAssembly(new FlowableConcatMapSingle<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, prefetch));
@@ -11075,7 +11084,7 @@ FlowableDocBasic<T>
      * Note that the {@code GroupedFlowable}s should be subscribed to as soon as possible, otherwise,
      * the unconsumed groups may starve other groups due to the internal backpressure
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
-     * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
+     * {@link #flatMap(Function, FlatMapConfig)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
@@ -11133,7 +11142,7 @@ FlowableDocBasic<T>
      * Note that the {@code GroupedFlowable}s should be subscribed to as soon as possible, otherwise,
      * the unconsumed groups may starve other groups due to the internal backpressure
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
-     * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
+     * {@link #flatMap(Function, FlatMapConfig)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
@@ -11192,7 +11201,7 @@ FlowableDocBasic<T>
      * Note that the {@code GroupedFlowable}s should be subscribed to as soon as possible, otherwise,
      * the unconsumed groups may starve other groups due to the internal backpressure
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
-     * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
+     * {@link #flatMap(Function, FlatMapConfig)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
@@ -11256,7 +11265,7 @@ FlowableDocBasic<T>
      * Note that the {@code GroupedFlowable}s should be subscribed to as soon as possible, otherwise,
      * the unconsumed groups may starve other groups due to the internal backpressure
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
-     * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
+     * {@link #flatMap(Function, FlatMapConfig)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
@@ -11321,7 +11330,7 @@ FlowableDocBasic<T>
      * Note that the {@code GroupedFlowable}s should be subscribed to as soon as possible, otherwise,
      * the unconsumed groups may starve other groups due to the internal backpressure
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
-     * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
+     * {@link #flatMap(Function, FlatMapConfig)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
@@ -11394,7 +11403,9 @@ FlowableDocBasic<T>
      *
      * <p>The map created by an {@code evictingMapFactory} must be thread-safe.
      *
-     * <p>An example of an {@code evictingMapFactory} using <a href="https://google.github.io/guava/releases/24.0-jre/api/docs/com/google/common/cache/CacheBuilder.html">CacheBuilder</a> from the Guava library is below:
+     * <p>An example of an {@code evictingMapFactory} using
+     * <a href="https://google.github.io/guava/releases/24.0-jre/api/docs/com/google/common/cache/CacheBuilder.html">CacheBuilder</a>
+     * from the Guava library is below:
      *
      * <pre><code>
      * Function&lt;Consumer&lt;Object&gt;, Map&lt;Integer, Object&gt;&gt; evictingMapFactory =
@@ -11434,7 +11445,7 @@ FlowableDocBasic<T>
      * Note that the {@code GroupedFlowable}s should be subscribed to as soon as possible, otherwise,
      * the unconsumed groups may starve other groups due to the internal backpressure
      * coordination of the {@code groupBy} operator. Such hangs can be usually avoided by using
-     * {@link #flatMap(Function, int)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
+     * {@link #flatMap(Function, FlatMapConfig)} or {@link #concatMapEager(Function, int, int)} and overriding the default maximum concurrency
      * value to be greater or equal to the expected number of groups, possibly using
      * {@link Integer#MAX_VALUE} if the number of expected groups is unknown.
      * <p>
@@ -12605,7 +12616,8 @@ FlowableDocBasic<T>
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @Experimental
-    public final Flowable<T> onBackpressureBuffer(long capacity, @Nullable Action onOverflow, @NonNull BackpressureOverflowStrategy overflowStrategy, @NonNull Consumer<? super T> onDropped) {
+    public final Flowable<T> onBackpressureBuffer(long capacity, @Nullable Action onOverflow,
+            @NonNull BackpressureOverflowStrategy overflowStrategy, @NonNull Consumer<? super T> onDropped) {
         Objects.requireNonNull(overflowStrategy, "overflowStrategy is null");
         Objects.requireNonNull(onDropped, "onDropped is null");
         ObjectHelper.verifyPositive(capacity, "capacity");
@@ -12738,7 +12750,7 @@ FlowableDocBasic<T>
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     @Experimental
-     public final Flowable<T> onBackpressureLatest(@NonNull Consumer<? super T> onDropped) {
+    public final Flowable<T> onBackpressureLatest(@NonNull Consumer<? super T> onDropped) {
         Objects.requireNonNull(onDropped, "onDropped is null");
         return RxJavaPlugins.onAssembly(new FlowableOnBackpressureLatest<>(this, onDropped));
     }
@@ -13769,7 +13781,8 @@ FlowableDocBasic<T>
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
-    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit) {
+    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector,
+            int bufferSize, long time, @NonNull TimeUnit unit) {
         return replay(selector, bufferSize, time, unit, Schedulers.computation());
     }
 
@@ -13815,7 +13828,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector,
+            int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -13868,7 +13882,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
+    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector,
+            int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
@@ -13948,7 +13963,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector,
+            long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -13992,7 +14008,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.CUSTOM)
-    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
+    public final <@NonNull R> Flowable<R> replay(@NonNull Function<? super Flowable<T>, @NonNull ? extends Publisher<R>> selector,
+            long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -15993,7 +16010,9 @@ FlowableDocBasic<T>
         try {
             Subscriber<? super T> flowableSubscriber = RxJavaPlugins.onSubscribe(this, subscriber);
 
-            Objects.requireNonNull(flowableSubscriber, "The RxJavaPlugins.onSubscribe hook returned a null FlowableSubscriber. Please check the handler provided to RxJavaPlugins.setOnFlowableSubscribe for invalid null returns. Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
+            Objects.requireNonNull(flowableSubscriber, "The RxJavaPlugins.onSubscribe hook returned a null FlowableSubscriber. "
+                    + "Please check the handler provided to RxJavaPlugins.setOnFlowableSubscribe for invalid null returns. "
+                    + "Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
 
             subscribeActual(flowableSubscriber);
         } catch (NullPointerException e) { // NOPMD
@@ -17848,7 +17867,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <@NonNull V> Flowable<T> timeout(@NonNull Function<? super T, @NonNull ? extends Publisher<V>> itemTimeoutIndicator, @NonNull Publisher<? extends T> fallback) {
+    public final <@NonNull V> Flowable<T> timeout(@NonNull Function<? super T, @NonNull ? extends Publisher<V>> itemTimeoutIndicator,
+            @NonNull Publisher<? extends T> fallback) {
         Objects.requireNonNull(fallback, "fallback is null");
         return timeout0(null, itemTimeoutIndicator, fallback);
     }
@@ -18405,7 +18425,8 @@ FlowableDocBasic<T>
     @NonNull
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final <@NonNull K, @NonNull V> Single<Map<K, V>> toMap(@NonNull Function<? super T, ? extends K> keySelector, @NonNull Function<? super T, ? extends V> valueSelector) {
+    public final <@NonNull K, @NonNull V> Single<Map<K, V>> toMap(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMapSupplier.asSupplier(), Functions.toMapKeyValueSelector(keySelector, valueSelector));
@@ -18518,7 +18539,8 @@ FlowableDocBasic<T>
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull K, @NonNull V> Single<Map<K, Collection<V>>> toMultimap(@NonNull Function<? super T, ? extends K> keySelector, @NonNull Function<? super T, ? extends V> valueSelector) {
+    public final <@NonNull K, @NonNull V> Single<Map<K, Collection<V>>> toMultimap(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull Function<? super T, ? extends V> valueSelector) {
         Supplier<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<V>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
@@ -20732,7 +20754,7 @@ FlowableDocBasic<T>
      * @throws NullPointerException if {@code mapper} is {@code null}
      * @throws IllegalArgumentException if {@code prefetch} is non-positive
      * @since 3.0.0
-     * @see #flatMap(Function, int)
+     * @see #flatMap(Function, FlatMapConfig)
      * @see #flatMapIterable(Function, int)
      * @see #concatMapStream(Function, int)
      */

--- a/src/main/java/io/reactivex/rxjava4/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Maybe.java
@@ -285,7 +285,8 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> concat(
-            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2, @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4) {
+            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
+            @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1513,7 +1514,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> merge(
             @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return mergeArray(source1, source2);
@@ -1565,7 +1566,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     public static <@NonNull T> Flowable<T> merge(
             @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
             @NonNull MaybeSource<? extends T> source3
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1620,7 +1621,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     public static <@NonNull T> Flowable<T> merge(
             @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
             @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2320,7 +2321,8 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T, @NonNull R> Maybe<R> zip(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
+    public static <@NonNull T, @NonNull R> Maybe<R> zip(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new MaybeZipIterable<>(sources, zipper));
@@ -5371,7 +5373,9 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
 
         observer = RxJavaPlugins.onSubscribe(this, observer);
 
-        Objects.requireNonNull(observer, "The RxJavaPlugins.onSubscribe hook returned a null MaybeObserver. Please check the handler provided to RxJavaPlugins.setOnMaybeSubscribe for invalid null returns. Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
+        Objects.requireNonNull(observer, "The RxJavaPlugins.onSubscribe hook returned a null MaybeObserver. "
+                + "Please check the handler provided to RxJavaPlugins.setOnMaybeSubscribe for invalid null returns. "
+                + "Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
 
         try {
             subscribeActual(observer);

--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -774,7 +774,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return combineLatestArray(new ObservableSource[] { source1, source2, source3, source4, source5, source6, source7, source8 }, Functions.toFunction(combiner), bufferSize());
+        return combineLatestArray(new ObservableSource[] { source1, source2, source3,
+                source4, source5, source6, source7, source8 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -832,7 +833,10 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T1, @NonNull T2, @NonNull T3, @NonNull T4, @NonNull T5, @NonNull T6, @NonNull T7, @NonNull T8, @NonNull T9, @NonNull R> Observable<R> combineLatest(
+    public static <@NonNull T1, @NonNull T2, @NonNull T3,
+    @NonNull T4, @NonNull T5, @NonNull T6,
+    @NonNull T7, @NonNull T8, @NonNull T9,
+    @NonNull R> Observable<R> combineLatest(
             @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
             @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
             @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
@@ -849,7 +853,10 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return combineLatestArray(new ObservableSource[] { source1, source2, source3, source4, source5, source6, source7, source8, source9 }, Functions.toFunction(combiner), bufferSize());
+        return combineLatestArray(new ObservableSource[] {
+                source1, source2, source3,
+                source4, source5, source6,
+                source7, source8, source9 }, Functions.toFunction(combiner), bufferSize());
     }
 
     /**
@@ -1643,7 +1650,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T> Observable<T> concatEagerDelayError(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
+    public static <@NonNull T> Observable<T> concatEagerDelayError(
+            @NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
         return fromIterable(sources).concatMapEagerDelayError((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
@@ -1700,7 +1708,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T> Observable<T> concatEagerDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
+    public static <@NonNull T> Observable<T> concatEagerDelayError(
+            @NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
         return wrap(sources).concatMapEagerDelayError((Function)Functions.identity(), true, maxConcurrency, bufferSize);
     }
 
@@ -2861,7 +2870,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7) {
+    public static <@NonNull T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3,
+            @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2909,7 +2919,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8) {
+    public static <@NonNull T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3,
+            @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -2960,7 +2971,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8, @NonNull T item9) {
+    public static <@NonNull T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3,
+            @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8, @NonNull T item9) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -3015,7 +3027,9 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3, @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8, @NonNull T item9, @NonNull T item10) {
+    public static <@NonNull T> Observable<T> just(@NonNull T item1, @NonNull T item2, @NonNull T item3,
+            @NonNull T item4, @NonNull T item5, @NonNull T item6, @NonNull T item7, @NonNull T item8,
+            @NonNull T item9, @NonNull T item10) {
         Objects.requireNonNull(item1, "item1 is null");
         Objects.requireNonNull(item2, "item2 is null");
         Objects.requireNonNull(item3, "item3 is null");
@@ -3422,7 +3436,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(ObservableSource, ObservableSource, ObservableSource, ObservableSource)} to merge sources and terminate only when all source {@code ObservableSource}s
+     *  Use {@link #mergeDelayError(ObservableSource, ObservableSource, ObservableSource, ObservableSource)} to merge sources
+     *  and terminate only when all source {@code ObservableSource}s
      *  have completed or failed with an error.
      *  </dd>
      * </dl>
@@ -4489,7 +4504,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T, @NonNull R> Observable<R> zip(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, @NonNull Function<? super Object[], ? extends R> zipper) {
+    public static <@NonNull T, @NonNull R> Observable<R> zip(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources,
+            @NonNull Function<? super Object[], ? extends R> zipper) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
         return RxJavaPlugins.onAssembly(new ObservableZip<>(null, sources, zipper, bufferSize(), false));
@@ -6183,7 +6199,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final <@NonNull U extends Collection<? super T>> Observable<U> buffer(long timespan, long timeskip, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, @NonNull Supplier<U> bufferSupplier) {
+    public final <@NonNull U extends Collection<? super T>> Observable<U> buffer(long timespan, long timeskip,
+            @NonNull TimeUnit unit, @NonNull Scheduler scheduler, @NonNull Supplier<U> bufferSupplier) {
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
@@ -6543,7 +6560,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull B, @NonNull U extends Collection<? super T>> Observable<U> buffer(@NonNull ObservableSource<B> boundaryIndicator, @NonNull Supplier<U> bufferSupplier) {
+    public final <@NonNull B, @NonNull U extends Collection<? super T>> Observable<U> buffer(
+            @NonNull ObservableSource<B> boundaryIndicator, @NonNull Supplier<U> bufferSupplier) {
         Objects.requireNonNull(boundaryIndicator, "boundaryIndicator is null");
         Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return RxJavaPlugins.onAssembly(new ObservableBufferExactBoundary<>(this, boundaryIndicator, bufferSupplier));
@@ -6897,7 +6915,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final <@NonNull R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize, @NonNull Scheduler scheduler) {
+    public final <@NonNull R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+            int bufferSize, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -7479,7 +7498,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int bufferSize) {
+    public final <@NonNull R> Observable<R> concatMapMaybeDelayError(
+            @NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, bufferSize));
@@ -7640,7 +7660,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int bufferSize) {
+    public final <@NonNull R> Observable<R> concatMapSingleDelayError(
+            @NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int bufferSize) {
         Objects.requireNonNull(mapper, "mapper is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, bufferSize));
@@ -8668,7 +8689,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    private Observable<T> doOnEach(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError, @NonNull Action onComplete, @NonNull Action onAfterTerminate) {
+    private Observable<T> doOnEach(@NonNull Consumer<? super T> onNext, @NonNull Consumer<? super Throwable> onError,
+            @NonNull Action onComplete, @NonNull Action onAfterTerminate) {
         Objects.requireNonNull(onNext, "onNext is null");
         Objects.requireNonNull(onError, "onError is null");
         Objects.requireNonNull(onComplete, "onComplete is null");
@@ -11344,7 +11366,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
-    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit) {
+    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector,
+            int bufferSize, long time, @NonNull TimeUnit unit) {
         return replay(selector, bufferSize, time, unit, Schedulers.computation());
     }
 
@@ -11386,7 +11409,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector,
+            int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(unit, "unit is null");
@@ -11434,7 +11458,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
+    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector,
+            int bufferSize, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(unit, "unit is null");
@@ -11504,7 +11529,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
+    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector,
+            long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -11543,7 +11569,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector, long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
+    public final <@NonNull R> Observable<R> replay(@NonNull Function<? super Observable<T>, ? extends ObservableSource<R>> selector,
+            long time, @NonNull TimeUnit unit, @NonNull Scheduler scheduler, boolean eagerTruncate) {
         Objects.requireNonNull(selector, "selector is null");
         Objects.requireNonNull(unit, "unit is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
@@ -13258,7 +13285,9 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         try {
             observer = RxJavaPlugins.onSubscribe(this, observer);
 
-            Objects.requireNonNull(observer, "The RxJavaPlugins.onSubscribe hook returned a null Observer. Please change the handler provided to RxJavaPlugins.setOnObservableSubscribe for invalid null returns. Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
+            Objects.requireNonNull(observer, "The RxJavaPlugins.onSubscribe hook returned a null Observer. "
+                    + "Please change the handler provided to RxJavaPlugins.setOnObservableSubscribe for invalid null returns. "
+                    + "Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
 
             subscribeActual(observer);
         } catch (NullPointerException e) { // NOPMD
@@ -15439,7 +15468,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull K, @NonNull V> Single<@NonNull Map<K, Collection<V>>> toMultimap(@NonNull Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
+    public final <@NonNull K, @NonNull V> Single<@NonNull Map<K, Collection<V>>> toMultimap(
+            @NonNull Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
         Supplier<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<V>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);
@@ -16399,7 +16429,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull U, @NonNull R> Observable<R> withLatestFrom(@NonNull ObservableSource<? extends U> other, @NonNull BiFunction<? super T, ? super U, ? extends R> combiner) {
+    public final <@NonNull U, @NonNull R> Observable<R> withLatestFrom(@NonNull ObservableSource<? extends U> other,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner) {
         Objects.requireNonNull(other, "other is null");
         Objects.requireNonNull(combiner, "combiner is null");
 

--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -833,10 +833,8 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T1, @NonNull T2, @NonNull T3,
-    @NonNull T4, @NonNull T5, @NonNull T6,
-    @NonNull T7, @NonNull T8, @NonNull T9,
-    @NonNull R> Observable<R> combineLatest(
+    public static <@NonNull T1, @NonNull T2, @NonNull T3, @NonNull T4, @NonNull T5, @NonNull T6, @NonNull T7, @NonNull T8, @NonNull T9, @NonNull R> Observable<R>
+    combineLatest(
             @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
             @NonNull ObservableSource<? extends T3> source3, @NonNull ObservableSource<? extends T4> source4,
             @NonNull ObservableSource<? extends T5> source5, @NonNull ObservableSource<? extends T6> source6,
@@ -15469,7 +15467,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull K, @NonNull V> Single<@NonNull Map<K, Collection<V>>> toMultimap(
-            @NonNull Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
+            @NonNull Function<? super T, ? extends K> keySelector, @NonNull Function<? super T, ? extends V> valueSelector) {
         Supplier<Map<K, Collection<V>>> mapSupplier = HashMapSupplier.asSupplier();
         Function<K, List<V>> collectionFactory = ArrayListSupplier.asFunction();
         return toMultimap(keySelector, valueSelector, mapSupplier, collectionFactory);

--- a/src/main/java/io/reactivex/rxjava4/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Scheduler.java
@@ -44,7 +44,8 @@ import io.reactivex.rxjava4.schedulers.SchedulerRunnableIntrospection;
  * In addition, outstanding or running tasks can be cancelled together via
  * {@link Worker#dispose()} without affecting any other {@code Worker} instances of the same {@code Scheduler}.
  * <p>
- * Implementations of the {@link #scheduleDirect} and {@link Worker#schedule} methods are encouraged to call the {@link io.reactivex.rxjava4.plugins.RxJavaPlugins#onSchedule(Runnable)}
+ * Implementations of the {@link #scheduleDirect} and {@link Worker#schedule} methods are encouraged to call the
+ * {@link io.reactivex.rxjava4.plugins.RxJavaPlugins#onSchedule(Runnable)}
  * method to allow a scheduler hook to manipulate (wrap or replace) the original {@code Runnable} task before it is submitted to the
  * underlying task-execution scheme.
  * <p>

--- a/src/main/java/io/reactivex/rxjava4/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Single.java
@@ -302,7 +302,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> concat(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return Flowable.fromArray(source1, source2).concatMapSingleDelayError(Functions.identity(), false);
@@ -337,7 +337,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     public static <@NonNull T> Flowable<T> concat(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
             @NonNull SingleSource<? extends T> source3
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -375,7 +375,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     public static <@NonNull T> Flowable<T> concat(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
             @NonNull SingleSource<? extends T> source3, @NonNull SingleSource<? extends T> source4
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1397,7 +1397,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> merge(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return Flowable.fromArray(source1, source2).flatMapSingle(Functions.identity(), false, Integer.MAX_VALUE);
@@ -1449,7 +1449,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     public static <@NonNull T> Flowable<T> merge(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
             @NonNull SingleSource<? extends T> source3
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1504,7 +1504,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     public static <@NonNull T> Flowable<T> merge(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
             @NonNull SingleSource<? extends T> source3, @NonNull SingleSource<? extends T> source4
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1674,7 +1674,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public static <@NonNull T> Flowable<T> mergeDelayError(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         return Flowable.fromArray(source1, source2).flatMapSingle(Functions.identity(), true, Integer.MAX_VALUE);
@@ -1715,7 +1715,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     public static <@NonNull T> Flowable<T> mergeDelayError(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
             @NonNull SingleSource<? extends T> source3
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -1759,7 +1759,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     public static <@NonNull T> Flowable<T> mergeDelayError(
             @NonNull SingleSource<? extends T> source1, @NonNull SingleSource<? extends T> source2,
             @NonNull SingleSource<? extends T> source3, @NonNull SingleSource<? extends T> source4
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2125,7 +2125,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     public static <@NonNull T1, @NonNull T2, @NonNull R> Single<R> zip(
             @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
             @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(zipper, "zipper is null");
@@ -2166,7 +2166,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
             @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
             @NonNull SingleSource<? extends T3> source3,
             @NonNull Function3<? super T1, ? super T2, ? super T3, ? extends R> zipper
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2211,7 +2211,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
             @NonNull SingleSource<? extends T1> source1, @NonNull SingleSource<? extends T2> source2,
             @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
             @NonNull Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> zipper
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2262,7 +2262,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
             @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
             @NonNull SingleSource<? extends T5> source5,
             @NonNull Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> zipper
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2317,7 +2317,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
             @NonNull SingleSource<? extends T3> source3, @NonNull SingleSource<? extends T4> source4,
             @NonNull SingleSource<? extends T5> source5, @NonNull SingleSource<? extends T6> source6,
             @NonNull Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> zipper
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2377,7 +2377,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
             @NonNull SingleSource<? extends T5> source5, @NonNull SingleSource<? extends T6> source6,
             @NonNull SingleSource<? extends T7> source7,
             @NonNull Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> zipper
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2441,7 +2441,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
             @NonNull SingleSource<? extends T5> source5, @NonNull SingleSource<? extends T6> source6,
             @NonNull SingleSource<? extends T7> source7, @NonNull SingleSource<? extends T8> source8,
             @NonNull Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> zipper
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -2511,7 +2511,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
             @NonNull SingleSource<? extends T7> source7, @NonNull SingleSource<? extends T8> source8,
             @NonNull SingleSource<? extends T9> source9,
             @NonNull Function9<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? extends R> zipper
-     ) {
+    ) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
@@ -4849,7 +4849,9 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
 
         observer = RxJavaPlugins.onSubscribe(this, observer);
 
-        Objects.requireNonNull(observer, "The RxJavaPlugins.onSubscribe hook returned a null SingleObserver. Please check the handler provided to RxJavaPlugins.setOnSingleSubscribe for invalid null returns. Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
+        Objects.requireNonNull(observer, "The RxJavaPlugins.onSubscribe hook returned a null SingleObserver. "
+                + "Please check the handler provided to RxJavaPlugins.setOnSingleSubscribe for invalid null returns. "
+                + "Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins");
 
         try {
             subscribeActual(observer);

--- a/src/main/java/io/reactivex/rxjava4/core/VirtualGenerator.java
+++ b/src/main/java/io/reactivex/rxjava4/core/VirtualGenerator.java
@@ -15,7 +15,7 @@ package io.reactivex.rxjava4.core;
 
 /**
  * Interface to implement to produce elements when asked by
- * {@link Flowable#virtaulCreate(VirtualGenerator, java.util.concurrent.ExecutorService)}.
+ * {@link Flowable#virtualCreate(VirtualGenerator, java.util.concurrent.ExecutorService)}.
  * <p>
  * To signal {@code onComplete}, return normally from {@link #generate(VirtualEmitter)}.
  * To signal {@code onError}, throw any exception from {@link #generate(VirtualEmitter)}.

--- a/src/main/java/io/reactivex/rxjava4/core/config/FlatMapConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/FlatMapConfig.java
@@ -20,6 +20,9 @@ import io.reactivex.rxjava4.internal.functions.ObjectHelper;
  * Generic configuration block with option to delay errors, change prefetch
  * amounts and buffer sizes.
  * TODO once value classes are available, make this a record class.
+ * @param delayErrors should the error be delayed?
+ * @param maxConcurrency the maximum number of concurrent flows?
+ * @param bufferSize what would be the buffer size?
  * @since 4.0.0
  */
 public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferSize) {
@@ -51,7 +54,7 @@ public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferS
 
     /**
      * Optionally delays errors and sets the buffer size too.
-     * @param delayError should the errors be delayed?
+     * @param delayErrors should the errors be delayed?
      * @param maxConcurrency the maximum number of concurrent flows
      */
     public FlatMapConfig(boolean delayErrors, int maxConcurrency) {
@@ -63,8 +66,8 @@ public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferS
     /**
      * Fully customize the configuration.
      * @param delayErrors should the errors be delayed
+     * @param maxConcurrency the maximum number of concurrent flows?
      * @param bufferSize what would be the buffer size
-     * @param prefetch what would be the prefetch amount
      */
     public FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferSize) {
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");

--- a/src/main/java/io/reactivex/rxjava4/core/config/GenericConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/GenericConfig.java
@@ -20,9 +20,12 @@ import io.reactivex.rxjava4.internal.functions.ObjectHelper;
  * Generic configuration block with option to delay errors, change prefetch
  * amounts and buffer sizes.
  * TODO once value classes are available, make this a record class.
+ * @param delayErrors should the error be delayed?
+ * @param bufferSize what would be the buffer size?
+ * @param prefetch how many upstream items to request upfront, then 75% of it later?
  * @since 4.0.0
  */
-public record GenericConfig(boolean delayError, int bufferSize, int prefetch) {
+public record GenericConfig(boolean delayErrors, int bufferSize, int prefetch) {
 
     /**
      * Default config: no error delay, {@link Flowable#bufferSize()} sizes.
@@ -58,14 +61,14 @@ public record GenericConfig(boolean delayError, int bufferSize, int prefetch) {
 
     /**
      * Fully customize the configuration.
-     * @param delayError should the errors be delayed
+     * @param delayErrors should the errors be delayed
      * @param bufferSize what would be the buffer size
      * @param prefetch what would be the prefetch amount
      */
-    public GenericConfig(boolean delayError, int bufferSize, int prefetch) {
+    public GenericConfig(boolean delayErrors, int bufferSize, int prefetch) {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        this.delayError = delayError;
+        this.delayErrors = delayErrors;
         this.bufferSize = bufferSize;
         this.prefetch = prefetch;
     }

--- a/src/main/java/io/reactivex/rxjava4/core/docs/FlowableDocBasic.java
+++ b/src/main/java/io/reactivex/rxjava4/core/docs/FlowableDocBasic.java
@@ -41,7 +41,7 @@ public sealed interface FlowableDocBasic<T> permits Flowable {
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/map.html">ReactiveX operators documentation: Map</a>
-     * @see #mapOptional(Function)
+     * @see Flowable#mapOptional(Function)
      */
     @CheckReturnValue
     @NonNull

--- a/src/main/java/io/reactivex/rxjava4/core/package-info.java
+++ b/src/main/java/io/reactivex/rxjava4/core/package-info.java
@@ -46,7 +46,8 @@
  * {@link io.reactivex.rxjava4.core.Flowable}, {@link io.reactivex.rxjava4.core.Observable}, {@link io.reactivex.rxjava4.core.Single},
  * {@link io.reactivex.rxjava4.core.Maybe} or {@link io.reactivex.rxjava4.core.Completable} class which then allow
  * consumers to subscribe to them and receive events.</p>
- * <p>Usage examples can be found on the {@link io.reactivex.rxjava4.core.Flowable}/{@link io.reactivex.rxjava4.core.Observable} and {@link java.util.concurrent.Flow.Subscriber} classes.</p>
+ * <p>Usage examples can be found on the {@link io.reactivex.rxjava4.core.Flowable}/{@link io.reactivex.rxjava4.core.Observable}
+ * and {@link java.util.concurrent.Flow.Subscriber} classes.</p>
  */
 package io.reactivex.rxjava4.core;
 

--- a/src/main/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedException.java
@@ -48,6 +48,7 @@ public final class OnErrorNotImplementedException extends RuntimeException {
      *          the {@code Throwable} to signal; if null, a NullPointerException is constructed
      */
     public OnErrorNotImplementedException(@NonNull Throwable e) {
-        this("The exception was not handled due to missing onError handler in the subscribe() method call. Further reading: https://github.com/ReactiveX/RxJava/wiki/Error-Handling | " + e, e);
+        this("The exception was not handled due to missing onError handler in the subscribe() method call. "
+                + "Further reading: https://github.com/ReactiveX/RxJava/wiki/Error-Handling | " + e, e);
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/exceptions/UndeliverableException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/UndeliverableException.java
@@ -28,6 +28,8 @@ public final class UndeliverableException extends IllegalStateException {
      * @param cause the cause, not null
      */
     public UndeliverableException(Throwable cause) {
-        super("The exception could not be delivered to the consumer because it has already canceled/disposed the flow or the exception has nowhere to go to begin with. Further reading: https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling | " + cause, cause);
+        super("The exception could not be delivered to the consumer because it has already canceled/disposed the flow "
+                + "or the exception has nowhere to go to begin with. "
+                + "Further reading: https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling | " + cause, cause);
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/functions/Functions.java
@@ -453,7 +453,8 @@ public final class Functions {
         }
     }
 
-    public static <T, K, V> BiConsumer<Map<K, V>, T> toMapKeyValueSelector(final Function<? super T, ? extends K> keySelector, final Function<? super T, ? extends V> valueSelector) {
+    public static <T, K, V> BiConsumer<Map<K, V>, T> toMapKeyValueSelector(final Function<? super T, ? extends K> keySelector,
+            final Function<? super T, ? extends V> valueSelector) {
         return new ToMapKeyValueSelector<>(valueSelector, keySelector);
     }
 

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/DeferredScalarDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/DeferredScalarDisposable.java
@@ -90,7 +90,7 @@ public class DeferredScalarDisposable<T> extends BasicIntQueueDisposable<T> {
      * Complete the target with an error signal.
      * @param t the Throwable to signal, not null (not verified)
      */
-     public final void error(Throwable t) {
+    public final void error(Throwable t) {
         int state = get();
         if ((state & (FUSED_READY | FUSED_CONSUMED | TERMINATED | DISPOSED)) != 0) {
             RxJavaPlugins.onError(t);
@@ -100,9 +100,9 @@ public class DeferredScalarDisposable<T> extends BasicIntQueueDisposable<T> {
         downstream.onError(t);
     }
 
-     /**
-      * Complete the target without any value.
-      */
+    /**
+     * Complete the target without any value.
+     */
     public final void complete() {
         int state = get();
         if ((state & (FUSED_READY | FUSED_CONSUMED | TERMINATED | DISPOSED)) != 0) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBuffer.java
@@ -51,7 +51,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
     }
 
     static final class PublisherBufferExactSubscriber<T, C extends Collection<? super T>>
-      implements FlowableSubscriber<T>, Subscription {
+    implements FlowableSubscriber<T>, Subscription {
 
         final Subscriber<? super C> downstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreate.java
@@ -13,9 +13,8 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.*;
-
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
@@ -24,8 +23,7 @@ import io.reactivex.rxjava4.functions.Cancellable;
 import io.reactivex.rxjava4.internal.disposables.*;
 import io.reactivex.rxjava4.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava4.internal.util.*;
-import io.reactivex.rxjava4.operators.SimplePlainQueue;
-import io.reactivex.rxjava4.operators.SpscLinkedArrayQueue;
+import io.reactivex.rxjava4.operators.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
 public final class FlowableCreate<T> extends Flowable<T> {
@@ -135,18 +133,18 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
         @Override
         public boolean tryOnError(Throwable t) {
-           if (emitter.isCancelled() || done) {
-               return false;
-           }
-           if (t == null) {
-               t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
-           }
-           if (errors.tryAddThrowable(t)) {
-               done = true;
-               drain();
-               return true;
-           }
-           return false;
+            if (emitter.isCancelled() || done) {
+                return false;
+            }
+            if (t == null) {
+                t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
+            }
+            if (errors.tryAddThrowable(t)) {
+                done = true;
+                drain();
+                return true;
+            }
+            return false;
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -94,8 +94,8 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
                     last = key;
                 }
             } catch (Throwable ex) {
-               fail(ex);
-               return true;
+                fail(ex);
+                return true;
             }
 
             downstream.onNext(t);
@@ -184,8 +184,8 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
                     last = key;
                 }
             } catch (Throwable ex) {
-               fail(ex);
-               return true;
+                fail(ex);
+                return true;
             }
 
             downstream.onNext(t);

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupBy.java
@@ -200,7 +200,9 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         }
 
         static MissingBackpressureException groupHangWarning(long n) {
-            return new MissingBackpressureException("Unable to emit a new group (#" + n + ") due to lack of requests. Please make sure the downstream can always accept a new group as well as each group is consumed in order for the whole operator to be able to proceed.");
+            return new MissingBackpressureException("Unable to emit a new group (#" + n + ") due to lack of requests. "
+                    + "Please make sure the downstream can always accept a new group as well as each group is consumed "
+                    + "in order for the whole operator to be able to proceed.");
         }
 
         @Override
@@ -658,7 +660,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
                 outputFused = true;
                 return ASYNC;
             }
-            */
+             */
             return NONE;
         }
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableInternalHelper.java
@@ -202,11 +202,13 @@ public final class FlowableInternalHelper {
         return new BufferedReplaySupplier<>(parent, bufferSize, eagerTruncate);
     }
 
-    public static <T> Supplier<ConnectableFlowable<T>> replaySupplier(final Flowable<T> parent, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    public static <T> Supplier<ConnectableFlowable<T>> replaySupplier(final Flowable<T> parent,
+            final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
         return new BufferedTimedReplay<>(parent, bufferSize, time, unit, scheduler, eagerTruncate);
     }
 
-    public static <T> Supplier<ConnectableFlowable<T>> replaySupplier(final Flowable<T> parent, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    public static <T> Supplier<ConnectableFlowable<T>> replaySupplier(final Flowable<T> parent,
+            final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
         return new TimedReplay<>(parent, time, unit, scheduler, eagerTruncate);
     }
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
@@ -116,7 +116,7 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
             Deque<T> dq = deque;
             T toDrop = null;
             synchronized (dq) {
-               if (dq.size() == bufferSize) {
+                if (dq.size() == bufferSize) {
                    switch (strategy) {
                    case DROP_LATEST:
                        toDrop = dq.pollLast();
@@ -134,10 +134,10 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
                        callError = true;
                        break;
                    }
-               } else {
+                } else {
                    dq.offer(t);
                    callDrain = true;
-               }
+                }
             }
 
             if (callOnOverflow && onOverflow != null) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceMaybe.java
@@ -123,7 +123,7 @@ implements HasUpstreamPublisher<T>, FuseToFlowable<T> {
             }
             done = true;
             downstream.onError(t);
-         }
+        }
 
         @Override
         public void onComplete() {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSampleTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSampleTimed.java
@@ -91,14 +91,14 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
         public void onNext(T t) {
             T oldValue = getAndSet(t);
             if (oldValue != null && onDropped != null) {
-              try {
-                  onDropped.accept(oldValue);
-              } catch (Throwable throwable) {
-                  Exceptions.throwIfFatal(throwable);
-                  cancelTimer();
-                  upstream.cancel();
-                  downstream.onError(throwable);
-              }
+                try {
+                    onDropped.accept(oldValue);
+                } catch (Throwable throwable) {
+                    Exceptions.throwIfFatal(throwable);
+                    cancelTimer();
+                    upstream.cancel();
+                    downstream.onError(throwable);
+                }
             }
         }
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowTimed.java
@@ -718,7 +718,8 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
     }
 
     static MissingBackpressureException missingBackpressureMessage(long index) {
-        return new MissingBackpressureException("Unable to emit the next window (#" + index + ") due to lack of requests. Please make sure the downstream is ready to consume windows.");
+        return new MissingBackpressureException("Unable to emit the next window (#" + index
+                + ") due to lack of requests. Please make sure the downstream is ready to consume windows.");
     }
 
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoAfterSuccess.java
@@ -70,7 +70,7 @@ public final class MaybeDoAfterSuccess<T> extends AbstractMaybeWithUpstream<T, T
                 onAfterSuccess.accept(t);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-             // remember, onSuccess is a terminal event and we can't call onError
+                // remember, onSuccess is a terminal event and we can't call onError
                 RxJavaPlugins.onError(ex);
             }
         }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctUntilChanged.java
@@ -78,8 +78,8 @@ public final class ObservableDistinctUntilChanged<T, K> extends AbstractObservab
                     last = key;
                 }
             } catch (Throwable ex) {
-               fail(ex);
-               return;
+                fail(ex);
+                return;
             }
 
             downstream.onNext(t);

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupBy.java
@@ -64,7 +64,8 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
 
         final AtomicBoolean cancelled = new AtomicBoolean();
 
-        public GroupByObserver(Observer<? super GroupedObservable<K, V>> actual, Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError) {
+        public GroupByObserver(Observer<? super GroupedObservable<K, V>> actual, Function<? super T, ? extends K> keySelector,
+                Function<? super T, ? extends V> valueSelector, int bufferSize, boolean delayError) {
             this.downstream = actual;
             this.keySelector = keySelector;
             this.valueSelector = valueSelector;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableInternalHelper.java
@@ -207,11 +207,13 @@ public final class ObservableInternalHelper {
         return new BufferedReplaySupplier<>(parent, bufferSize, eagerTruncate);
     }
 
-    public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent, final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent, final int bufferSize,
+            final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
         return new BufferedTimedReplaySupplier<>(parent, bufferSize, time, unit, scheduler, eagerTruncate);
     }
 
-    public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent, final long time, final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
+    public static <T> Supplier<ConnectableObservable<T>> replaySupplier(final Observable<T> parent, final long time,
+            final TimeUnit unit, final Scheduler scheduler, boolean eagerTruncate) {
         return new TimedReplayCallable<>(parent, time, unit, scheduler, eagerTruncate);
     }
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -51,7 +51,8 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
         this.combiner = combiner;
     }
 
-    public ObservableWithLatestFromMany(@NonNull ObservableSource<T> source, @NonNull Iterable<? extends ObservableSource<?>> otherIterable, @NonNull Function<? super Object[], R> combiner) {
+    public ObservableWithLatestFromMany(@NonNull ObservableSource<T> source, @NonNull Iterable<? extends ObservableSource<?>> otherIterable,
+            @NonNull Function<? super Object[], R> combiner) {
         super(source);
         this.otherArray = null;
         this.otherIterable = otherIterable;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelFilterTry.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelFilterTry.java
@@ -109,7 +109,8 @@ public final class ParallelFilterTry<T> extends ParallelFlowable<T> {
 
         final Subscriber<? super T> downstream;
 
-        ParallelFilterSubscriber(Subscriber<? super T> actual, Predicate<? super T> predicate, BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+        ParallelFilterSubscriber(Subscriber<? super T> actual, Predicate<? super T> predicate,
+                BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
             super(predicate, errorHandler);
             this.downstream = actual;
         }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterSuccess.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterSuccess.java
@@ -72,7 +72,7 @@ public final class SingleDoAfterSuccess<T> extends Single<T> {
                 onAfterSuccess.accept(t);
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-             // remember, onSuccess is a terminal event and we can't call onError
+                // remember, onSuccess is a terminal event and we can't call onError
                 RxJavaPlugins.onError(ex);
             }
         }

--- a/src/main/java/io/reactivex/rxjava4/internal/util/BlockingHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/BlockingHelper.java
@@ -57,7 +57,8 @@ public final class BlockingHelper {
         if (RxJavaPlugins.isFailOnNonBlockingScheduler()
                 && (Thread.currentThread() instanceof NonBlockingThread
                         || RxJavaPlugins.onBeforeBlocking())) {
-            throw new IllegalStateException("Attempt to block on a Scheduler " + Thread.currentThread().getName() + " that doesn't support blocking operators as they may lead to deadlock");
+            throw new IllegalStateException("Attempt to block on a Scheduler " + Thread.currentThread().getName()
+                    + " that doesn't support blocking operators as they may lead to deadlock");
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/observers/DefaultObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/DefaultObserver.java
@@ -21,19 +21,19 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
 
 /**
  * Abstract base implementation of an {@link io.reactivex.rxjava4.core.Observer Observer} with support for cancelling a
- * subscription via {@link #cancel()} (synchronously) and calls {@link #onStart()}
+ * subscription via {@code #cancel()} (synchronously) and calls {@code #onStart()}
  * when the subscription happens.
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
- * <p>Use the protected {@link #cancel()} to dispose the sequence from within an
+ * <p>Use the protected {@code #cancel()} to dispose the sequence from within an
  * {@code onNext} implementation.
  *
  * <p>Like all other consumers, {@code DefaultObserver} can be subscribed only once.
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  * If for some reason this can't be avoided, use {@link io.reactivex.rxjava4.core.Observable#safeSubscribe(io.reactivex.rxjava4.core.Observer)}
  * instead of the standard {@code subscribe()} method.

--- a/src/main/java/io/reactivex/rxjava4/observers/DisposableCompletableObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/DisposableCompletableObserver.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onError(Throwable)} and
+ * <p>Implementation of {@code #onStart()}, {@link #onError(Throwable)} and
  * {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  *
  * <p>Example<pre><code>

--- a/src/main/java/io/reactivex/rxjava4/observers/DisposableMaybeObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/DisposableMaybeObserver.java
@@ -34,7 +34,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)}, {@link #onError(Throwable)} and
+ * <p>Implementation of {@code #onStart()}, {@link #onSuccess(Object)}, {@link #onError(Throwable)} and
  * {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  *
  * <p>Example<pre><code>

--- a/src/main/java/io/reactivex/rxjava4/observers/DisposableObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/DisposableObserver.java
@@ -33,7 +33,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  * If for some reason this can't be avoided, use {@link io.reactivex.rxjava4.core.Observable#safeSubscribe(io.reactivex.rxjava4.core.Observer)}
  * instead of the standard {@code subscribe()} method.

--- a/src/main/java/io/reactivex/rxjava4/observers/DisposableSingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/DisposableSingleObserver.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)} and {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onSuccess(Object)} and {@link #onError(Throwable)}
  * are not allowed to throw any unchecked exceptions.
  *
  * <p>Example<pre><code>

--- a/src/main/java/io/reactivex/rxjava4/observers/ResourceCompletableObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/ResourceCompletableObserver.java
@@ -27,7 +27,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
- * <p>Override the protected {@link #onStart()} to perform initialization when this
+ * <p>Override the protected {@code #onStart()} to perform initialization when this
  * {@code ResourceCompletableObserver} is subscribed to a source.
  *
  * <p>Use the public {@link #dispose()} method to dispose the sequence externally and release
@@ -47,7 +47,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  *
  * <p>Example<pre><code>

--- a/src/main/java/io/reactivex/rxjava4/observers/ResourceMaybeObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/ResourceMaybeObserver.java
@@ -31,7 +31,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * exclusive to each other, unlike a regular {@link io.reactivex.rxjava4.core.Observer Observer}, and
  * {@code onComplete()} is never called after an {@code onSuccess()}.
  *
- * <p>Override the protected {@link #onStart()} to perform initialization when this
+ * <p>Override the protected {@code #onStart()} to perform initialization when this
  * {@code ResourceMaybeObserver} is subscribed to a source.
  *
  * <p>Use the public {@link #dispose()} method to dispose the sequence externally and release
@@ -51,7 +51,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)}, {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onSuccess(Object)}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  *
  * <p>Example<pre><code>

--- a/src/main/java/io/reactivex/rxjava4/observers/ResourceObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/ResourceObserver.java
@@ -44,7 +44,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  * If for some reason this can't be avoided, use {@link io.reactivex.rxjava4.core.Observable#safeSubscribe(io.reactivex.rxjava4.core.Observer)}
  * instead of the standard {@code subscribe()} method.

--- a/src/main/java/io/reactivex/rxjava4/observers/ResourceSingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/ResourceSingleObserver.java
@@ -28,7 +28,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
- * <p>Override the protected {@link #onStart()} to perform initialization when this
+ * <p>Override the protected {@code #onStart()} to perform initialization when this
  * {@code ResourceSingleObserver} is subscribed to a source.
  *
  * <p>Use the public {@link #dispose()} method to dispose the sequence externally and release
@@ -48,7 +48,7 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onSuccess(Object)} and {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onSuccess(Object)} and {@link #onError(Throwable)}
  * are not allowed to throw any unchecked exceptions.
  *
  * <p>Example<pre><code>

--- a/src/main/java/io/reactivex/rxjava4/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/rxjava4/parallel/ParallelFlowable.java
@@ -255,7 +255,8 @@ public abstract class ParallelFlowable<@NonNull T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final <@NonNull R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+    public final <@NonNull R> ParallelFlowable<R> map(@NonNull Function<? super T, ? extends R> mapper,
+            @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(errorHandler, "errorHandler is null");
         return RxJavaPlugins.onAssembly(new ParallelMapTry<>(this, mapper, errorHandler));
@@ -340,7 +341,8 @@ public abstract class ParallelFlowable<@NonNull T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final ParallelFlowable<T> filter(@NonNull Predicate<? super T> predicate, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+    public final ParallelFlowable<T> filter(@NonNull Predicate<? super T> predicate,
+            @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         Objects.requireNonNull(predicate, "predicate is null");
         Objects.requireNonNull(errorHandler, "errorHandler is null");
         return RxJavaPlugins.onAssembly(new ParallelFilterTry<>(this, predicate, errorHandler));
@@ -792,7 +794,8 @@ public abstract class ParallelFlowable<@NonNull T> {
     @NonNull
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerSupport.NONE)
-    public final ParallelFlowable<T> doOnNext(@NonNull Consumer<? super T> onNext, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+    public final ParallelFlowable<T> doOnNext(@NonNull Consumer<? super T> onNext,
+            @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         Objects.requireNonNull(onNext, "onNext is null");
         Objects.requireNonNull(errorHandler, "errorHandler is null");
         return RxJavaPlugins.onAssembly(new ParallelDoOnNextTry<>(this, onNext, errorHandler));
@@ -1516,7 +1519,8 @@ public abstract class ParallelFlowable<@NonNull T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final <@NonNull R> ParallelFlowable<R> mapOptional(@NonNull Function<? super T, @NonNull Optional<? extends R>> mapper, @NonNull ParallelFailureHandling errorHandler) {
+    public final <@NonNull R> ParallelFlowable<R> mapOptional(@NonNull Function<? super T, @NonNull Optional<? extends R>> mapper,
+            @NonNull ParallelFailureHandling errorHandler) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(errorHandler, "errorHandler is null");
         return RxJavaPlugins.onAssembly(new ParallelMapTryOptional<>(this, mapper, errorHandler));
@@ -1548,7 +1552,8 @@ public abstract class ParallelFlowable<@NonNull T> {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
-    public final <@NonNull R> ParallelFlowable<R> mapOptional(@NonNull Function<? super T, @NonNull Optional<? extends R>> mapper, @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
+    public final <@NonNull R> ParallelFlowable<R> mapOptional(@NonNull Function<? super T, @NonNull Optional<? extends R>> mapper,
+            @NonNull BiFunction<? super Long, ? super Throwable, ParallelFailureHandling> errorHandler) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(errorHandler, "errorHandler is null");
         return RxJavaPlugins.onAssembly(new ParallelMapTryOptional<>(this, mapper, errorHandler));

--- a/src/main/java/io/reactivex/rxjava4/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava4/plugins/RxJavaPlugins.java
@@ -1160,7 +1160,8 @@ public final class RxJavaPlugins {
      * @since 3.1.0
      */
     @SuppressWarnings("rawtypes")
-    public static void setOnParallelSubscribe(@Nullable BiFunction<? super ParallelFlowable, @NonNull ? super Subscriber<@NonNull ?>[], @NonNull ? extends Subscriber<@NonNull ?>[]> handler) {
+    public static void setOnParallelSubscribe(@Nullable BiFunction<? super ParallelFlowable, @NonNull ? super Subscriber<@NonNull ?>[],
+            @NonNull ? extends Subscriber<@NonNull ?>[]> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }

--- a/src/main/java/io/reactivex/rxjava4/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/BehaviorProcessor.java
@@ -127,35 +127,35 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * Example usage:
  * <pre> {@code
 
-  // subscriber will receive all events.
-  BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
-  processor.subscribe(subscriber);
-  processor.onNext("one");
-  processor.onNext("two");
-  processor.onNext("three");
+    // subscriber will receive all events.
+    BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
+    processor.subscribe(subscriber);
+    processor.onNext("one");
+    processor.onNext("two");
+    processor.onNext("three");
 
-  // subscriber will receive the "one", "two" and "three" events, but not "zero"
-  BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
-  processor.onNext("zero");
-  processor.onNext("one");
-  processor.subscribe(subscriber);
-  processor.onNext("two");
-  processor.onNext("three");
+    // subscriber will receive the "one", "two" and "three" events, but not "zero"
+    BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
+    processor.onNext("zero");
+    processor.onNext("one");
+    processor.subscribe(subscriber);
+    processor.onNext("two");
+    processor.onNext("three");
 
-  // subscriber will receive only onComplete
-  BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
-  processor.onNext("zero");
-  processor.onNext("one");
-  processor.onComplete();
-  processor.subscribe(subscriber);
+    // subscriber will receive only onComplete
+    BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
+    processor.onNext("zero");
+    processor.onNext("one");
+    processor.onComplete();
+    processor.subscribe(subscriber);
 
-  // subscriber will receive only onError
-  BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
-  processor.onNext("zero");
-  processor.onNext("one");
-  processor.onError(new RuntimeException("error"));
-  processor.subscribe(subscriber);
-  } </pre>
+    // subscriber will receive only onError
+    BehaviorProcessor<Object> processor = BehaviorProcessor.create("default");
+    processor.onNext("zero");
+    processor.onNext("one");
+    processor.onError(new RuntimeException("error"));
+    processor.subscribe(subscriber);
+    } </pre>
  *
  * @param <T>
  *          the type of item expected to be observed and emitted by the Processor

--- a/src/main/java/io/reactivex/rxjava4/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/PublishProcessor.java
@@ -93,17 +93,17 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * Example usage:
  * <pre> {@code
 
-  PublishProcessor<Object> processor = PublishProcessor.create();
-  // subscriber1 will receive all onNext and onComplete events
-  processor.subscribe(subscriber1);
-  processor.onNext("one");
-  processor.onNext("two");
-  // subscriber2 will only receive "three" and onComplete
-  processor.subscribe(subscriber2);
-  processor.onNext("three");
-  processor.onComplete();
+    PublishProcessor<Object> processor = PublishProcessor.create();
+    // subscriber1 will receive all onNext and onComplete events
+    processor.subscribe(subscriber1);
+    processor.onNext("one");
+    processor.onNext("two");
+    // subscriber2 will only receive "three" and onComplete
+    processor.subscribe(subscriber2);
+    processor.onNext("three");
+    processor.onComplete();
 
-  } </pre>
+    } </pre>
  * @param <T> the value type multicasted to Subscribers.
  * @see MulticastProcessor
  */

--- a/src/main/java/io/reactivex/rxjava4/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/ReplayProcessor.java
@@ -127,17 +127,17 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * Example usage:
  * <pre> {@code
 
-  ReplayProcessor<Object> processor = new ReplayProcessor<T>();
-  processor.onNext("one");
-  processor.onNext("two");
-  processor.onNext("three");
-  processor.onComplete();
+    ReplayProcessor<Object> processor = new ReplayProcessor<T>();
+    processor.onNext("one");
+    processor.onNext("two");
+    processor.onNext("three");
+    processor.onComplete();
 
-  // both of the following will get the onNext/onComplete calls from above
-  processor.subscribe(subscriber1);
-  processor.subscribe(subscriber2);
+    // both of the following will get the onNext/onComplete calls from above
+    processor.subscribe(subscriber1);
+    processor.subscribe(subscriber2);
 
-  } </pre>
+    } </pre>
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/rxjava4/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/Schedulers.java
@@ -32,7 +32,8 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * <p>
  * <strong>Supported system properties ({@code System.getProperty()}):</strong>
  * <ul>
- * <li>{@code rx3.io-keep-alive-time} (long): sets the keep-alive time of the {@link #io()} {@code Scheduler} workers, default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
+ * <li>{@code rx3.io-keep-alive-time} (long): sets the keep-alive time of the {@link #io()} {@code Scheduler} workers,
+ * default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
  * <li>{@code rx3.io-priority} (int): sets the thread priority of the {@link #io()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
  * <li>{@code rx3.io-scheduled-release} (boolean): {@code true} sets the worker release mode of the
  * {@link #io()} {@code Scheduler} to <em>scheduled</em>, default is {@code false} for <em>eager</em> mode.</li>
@@ -162,7 +163,8 @@ public final class Schedulers {
      * before the {@code Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.io-keep-alive-time} (long): sets the keep-alive time of the {@code io()} {@code Scheduler} workers, default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
+     * <li>{@code rx3.io-keep-alive-time} (long): sets the keep-alive time of the {@code io()} {@code Scheduler} workers,
+     * default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
      * <li>{@code rx3.io-priority} (int): sets the thread priority of the {@code io()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
      * <li>{@code rx3.io-scheduled-release} (boolean): {@code true} sets the worker release mode of the
      * {@code #io()} {@code Scheduler} to <em>scheduled</em>, default is {@code false} for <em>eager</em> mode.</li>

--- a/src/main/java/io/reactivex/rxjava4/schedulers/Timed.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/Timed.java
@@ -89,10 +89,10 @@ public final class Timed<T> {
 
     @Override
     public int hashCode() {
-         int h = value.hashCode();
-         h = h * 31 + (int)((time >>> 31) ^ time);
-         h = h * 31 + unit.hashCode();
-         return h;
+        int h = value.hashCode();
+        h = h * 31 + (int)((time >>> 31) ^ time);
+        h = h * 31 + unit.hashCode();
+        return h;
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/BehaviorSubject.java
@@ -114,35 +114,35 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * Example usage:
  * <pre> {@code
 
-  // observer will receive all 4 events (including "default").
-  BehaviorSubject<Object> subject = BehaviorSubject.createDefault("default");
-  subject.subscribe(observer);
-  subject.onNext("one");
-  subject.onNext("two");
-  subject.onNext("three");
+    // observer will receive all 4 events (including "default").
+    BehaviorSubject<Object> subject = BehaviorSubject.createDefault("default");
+    subject.subscribe(observer);
+    subject.onNext("one");
+    subject.onNext("two");
+    subject.onNext("three");
 
-  // observer will receive the "one", "two" and "three" events, but not "zero"
-  BehaviorSubject<Object> subject = BehaviorSubject.create();
-  subject.onNext("zero");
-  subject.onNext("one");
-  subject.subscribe(observer);
-  subject.onNext("two");
-  subject.onNext("three");
+    // observer will receive the "one", "two" and "three" events, but not "zero"
+    BehaviorSubject<Object> subject = BehaviorSubject.create();
+    subject.onNext("zero");
+    subject.onNext("one");
+    subject.subscribe(observer);
+    subject.onNext("two");
+    subject.onNext("three");
 
-  // observer will receive only onComplete
-  BehaviorSubject<Object> subject = BehaviorSubject.create();
-  subject.onNext("zero");
-  subject.onNext("one");
-  subject.onComplete();
-  subject.subscribe(observer);
+    // observer will receive only onComplete
+    BehaviorSubject<Object> subject = BehaviorSubject.create();
+    subject.onNext("zero");
+    subject.onNext("one");
+    subject.onComplete();
+    subject.subscribe(observer);
 
-  // observer will receive only onError
-  BehaviorSubject<Object> subject = BehaviorSubject.create();
-  subject.onNext("zero");
-  subject.onNext("one");
-  subject.onError(new RuntimeException("error"));
-  subject.subscribe(observer);
-  } </pre>
+    // observer will receive only onError
+    BehaviorSubject<Object> subject = BehaviorSubject.create();
+    subject.onNext("zero");
+    subject.onNext("one");
+    subject.onError(new RuntimeException("error"));
+    subject.subscribe(observer);
+    } </pre>
  *
  * @param <T>
  *          the type of item expected to be observed by the Subject

--- a/src/main/java/io/reactivex/rxjava4/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/PublishSubject.java
@@ -76,19 +76,19 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * Example usage:
  * <pre> {@code
 
-  PublishSubject<Object> subject = PublishSubject.create();
-  // observer1 will receive all onNext and onComplete events
-  subject.subscribe(observer1);
-  subject.onNext("one");
-  subject.onNext("two");
-  // observer2 will only receive "three" and onComplete
-  subject.subscribe(observer2);
-  subject.onNext("three");
-  subject.onComplete();
+    PublishSubject<Object> subject = PublishSubject.create();
+    // observer1 will receive all onNext and onComplete events
+    subject.subscribe(observer1);
+    subject.onNext("one");
+    subject.onNext("two");
+    // observer2 will only receive "three" and onComplete
+    subject.subscribe(observer2);
+    subject.onNext("three");
+    subject.onComplete();
 
-  // late Observers only receive the terminal event
-  subject.test().assertEmpty();
-  } </pre>
+    // late Observers only receive the terminal event
+    subject.test().assertEmpty();
+    } </pre>
  *
  * @param <T>
  *          the type of items observed and emitted by the Subject

--- a/src/main/java/io/reactivex/rxjava4/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/ReplaySubject.java
@@ -117,17 +117,17 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * Example usage:
  * <pre> {@code
 
-  ReplaySubject<Object> subject = ReplaySubject.create();
-  subject.onNext("one");
-  subject.onNext("two");
-  subject.onNext("three");
-  subject.onComplete();
+    ReplaySubject<Object> subject = ReplaySubject.create();
+    subject.onNext("one");
+    subject.onNext("two");
+    subject.onNext("three");
+    subject.onComplete();
 
-  // both of the following will get the onNext/onComplete calls from above
-  subject.subscribe(observer1);
-  subject.subscribe(observer2);
+    // both of the following will get the onNext/onComplete calls from above
+    subject.subscribe(observer1);
+    subject.subscribe(observer2);
 
-  } </pre>
+    } </pre>
  *
  * @param <T> the value type
  */

--- a/src/main/java/io/reactivex/rxjava4/subscribers/DefaultSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/subscribers/DefaultSubscriber.java
@@ -21,29 +21,29 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
 
 /**
  * Abstract base implementation of a {@link java.util.concurrent.Flow.Subscriber Subscriber} with
- * support for requesting via {@link #request(long)}, cancelling via
- * via {@link #cancel()} (both synchronously) and calls {@link #onStart()}
+ * support for requesting via {@code #request(long)}, cancelling via
+ * via {@code #cancel()} (both synchronously) and calls {@code #onStart()}
  * when the subscription happens.
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
- * <p>The default {@link #onStart()} requests {@link Long#MAX_VALUE} by default. Override
+ * <p>The default {@code #onStart()} requests {@link Long#MAX_VALUE} by default. Override
  * the method to request a custom <em>positive</em> amount.
  *
- * <p>Note that calling {@link #request(long)} from {@link #onStart()} may trigger
+ * <p>Note that calling {@code #request(long)} from {@code #onStart()} may trigger
  * an immediate, asynchronous emission of data to {@link #onNext(Object)}. Make sure
  * all initialization happens before the call to {@code request()} in {@code onStart()}.
- * Calling {@link #request(long)} inside {@link #onNext(Object)} can happen at any time
+ * Calling {@code #request(long)} inside {@link #onNext(Object)} can happen at any time
  * because by design, {@code onNext} calls from upstream are non-reentrant and non-overlapping.
  *
- * <p>Use the protected {@link #cancel()} to cancel the sequence from within an
+ * <p>Use the protected {@code #cancel()} to cancel the sequence from within an
  * {@code onNext} implementation.
  *
  * <p>Like all other consumers, {@code DefaultSubscriber} can be subscribed only once.
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  * If for some reason this can't be avoided, use {@link io.reactivex.rxjava4.core.Flowable#safeSubscribe(java.util.concurrent.Flow.Subscriber)}
  * instead of the standard {@code subscribe()} method.

--- a/src/main/java/io/reactivex/rxjava4/subscribers/DisposableSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/subscribers/DisposableSubscriber.java
@@ -27,22 +27,22 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  *
  * <p>All pre-implemented final methods are thread-safe.
  *
- * <p>The default {@link #onStart()} requests {@link Long#MAX_VALUE} by default. Override
- * the method to request a custom <em>positive</em> amount. Use the protected {@link #request(long)}
- * to request more items and {@link #cancel()} to cancel the sequence from within an
+ * <p>The default {@code #onStart()} requests {@link Long#MAX_VALUE} by default. Override
+ * the method to request a custom <em>positive</em> amount. Use the protected {@code #request(long)}
+ * to request more items and {@code #cancel()} to cancel the sequence from within an
  * {@code onNext} implementation.
  *
- * <p>Note that calling {@link #request(long)} from {@link #onStart()} may trigger
+ * <p>Note that calling {@code #request(long)} from {@code #onStart()} may trigger
  * an immediate, asynchronous emission of data to {@link #onNext(Object)}. Make sure
  * all initialization happens before the call to {@code request()} in {@code onStart()}.
- * Calling {@link #request(long)} inside {@link #onNext(Object)} can happen at any time
+ * Calling {@code #request(long)} inside {@link #onNext(Object)} can happen at any time
  * because by design, {@code onNext} calls from upstream are non-reentrant and non-overlapping.
  *
  * <p>Like all other consumers, {@code DisposableSubscriber} can be subscribed only once.
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  * If for some reason this can't be avoided, use {@link io.reactivex.rxjava4.core.Flowable#safeSubscribe(java.util.concurrent.Flow.Subscriber)}
  * instead of the standard {@code subscribe()} method.

--- a/src/main/java/io/reactivex/rxjava4/subscribers/ResourceSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/subscribers/ResourceSubscriber.java
@@ -40,22 +40,22 @@ import io.reactivex.rxjava4.internal.util.EndConsumerHelper;
  * {@code ResourceSubscriber} and then add/remove resources to/from the {@code CompositeDisposable}
  * freely.
  *
- * <p>The default {@link #onStart()} requests {@link Long#MAX_VALUE} by default. Override
- * the method to request a custom <em>positive</em> amount. Use the protected {@link #request(long)}
+ * <p>The default {@code #onStart()} requests {@link Long#MAX_VALUE} by default. Override
+ * the method to request a custom <em>positive</em> amount. Use the protected {@code #request(long)}
  * to request more items and {@link #dispose()} to cancel the sequence from within an
  * {@code onNext} implementation.
  *
- * <p>Note that calling {@link #request(long)} from {@link #onStart()} may trigger
+ * <p>Note that calling {@code #request(long)} from {@code #onStart()} may trigger
  * an immediate, asynchronous emission of data to {@link #onNext(Object)}. Make sure
  * all initialization happens before the call to {@code request()} in {@code onStart()}.
- * Calling {@link #request(long)} inside {@link #onNext(Object)} can happen at any time
+ * Calling {@code #request(long)} inside {@link #onNext(Object)} can happen at any time
  * because by design, {@code onNext} calls from upstream are non-reentrant and non-overlapping.
  *
  * <p>Like all other consumers, {@code ResourceSubscriber} can be subscribed only once.
  * Any subsequent attempt to subscribe it to a new source will yield an
  * {@link IllegalStateException} with message {@code "It is not allowed to subscribe with a(n) <class name> multiple times."}.
  *
- * <p>Implementation of {@link #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
+ * <p>Implementation of {@code #onStart()}, {@link #onNext(Object)}, {@link #onError(Throwable)}
  * and {@link #onComplete()} are not allowed to throw any unchecked exceptions.
  * If for some reason this can't be avoided, use {@link io.reactivex.rxjava4.core.Flowable#safeSubscribe(java.util.concurrent.Flow.Subscriber)}
  * instead of the standard {@code subscribe()} method.

--- a/src/test/java/io/reactivex/rxjava4/core/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/SchedulerTest.java
@@ -27,34 +27,34 @@ public class SchedulerTest {
 
     @After
     public void cleanup() {
-      // reset value to default in order to not influence other tests
-      Scheduler.IS_DRIFT_USE_NANOTIME = false;
+        // reset value to default in order to not influence other tests
+        Scheduler.IS_DRIFT_USE_NANOTIME = false;
     }
 
     @Test
     public void driftUseNanoTimeNotSetByDefault() {
-      assertFalse(Scheduler.IS_DRIFT_USE_NANOTIME);
-      assertFalse(Boolean.getBoolean(DRIFT_USE_NANOTIME));
+        assertFalse(Scheduler.IS_DRIFT_USE_NANOTIME);
+        assertFalse(Boolean.getBoolean(DRIFT_USE_NANOTIME));
     }
 
     @Test
     public void computeNow_currentTimeMillis() {
-      TimeUnit unit = TimeUnit.MILLISECONDS;
-      assertTrue(isInRange(System.currentTimeMillis(), Scheduler.computeNow(unit), unit, 250, TimeUnit.MILLISECONDS));
+        TimeUnit unit = TimeUnit.MILLISECONDS;
+        assertTrue(isInRange(System.currentTimeMillis(), Scheduler.computeNow(unit), unit, 250, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void computeNow_nanoTime() {
-      TimeUnit unit = TimeUnit.NANOSECONDS;
-      Scheduler.IS_DRIFT_USE_NANOTIME = true;
+        TimeUnit unit = TimeUnit.NANOSECONDS;
+        Scheduler.IS_DRIFT_USE_NANOTIME = true;
 
-      assertFalse(isInRange(System.currentTimeMillis(), Scheduler.computeNow(unit), unit, 250, TimeUnit.MILLISECONDS));
-      assertTrue(isInRange(System.nanoTime(), Scheduler.computeNow(unit), TimeUnit.NANOSECONDS, 250, TimeUnit.MILLISECONDS));
+        assertFalse(isInRange(System.currentTimeMillis(), Scheduler.computeNow(unit), unit, 250, TimeUnit.MILLISECONDS));
+        assertTrue(isInRange(System.nanoTime(), Scheduler.computeNow(unit), TimeUnit.NANOSECONDS, 250, TimeUnit.MILLISECONDS));
     }
 
     private boolean isInRange(long start, long stop, TimeUnit source, long maxDiff, TimeUnit diffUnit) {
-      long diff = Math.abs(stop - start);
-      return diffUnit.convert(diff, source) <= maxDiff;
+        long diff = Math.abs(stop - start);
+        return diffUnit.convert(diff, source) <= maxDiff;
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedExceptionTest.java
@@ -30,7 +30,7 @@ public class OnErrorNotImplementedExceptionTest extends RxJavaTest {
 
     @Before
     public void before() {
-       errors = TestHelper.trackPluginErrors();
+        errors = TestHelper.trackPluginErrors();
     }
 
     @After

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
@@ -207,7 +207,8 @@ public class FlowableBackpressureTests extends RxJavaTest {
         // either one can starve the other, but neither should be capable of doing more than 5 batches (taking 4.1)
         // TODO is it possible to make this deterministic rather than one possibly starving the other?
         // benjchristensen => In general I'd say it's not worth trying to make it so, as "fair" algorithms generally take a performance hit
-        // akarnokd => run this in a loop over 10k times and never saw values get as high as 7*SIZE, but since observeOn delays the unsubscription non-deterministically, the test will remain unreliable
+        // akarnokd => run this in a loop over 10k times and never saw values get as high as 7*SIZE, but since observeOn
+        // delays the unsubscription non-deterministically, the test will remain unreliable
         assertTrue(c1.get() < Flowable.bufferSize() * 7);
         assertTrue(c2.get() < Flowable.bufferSize() * 7);
     }
@@ -545,7 +546,8 @@ public class FlowableBackpressureTests extends RxJavaTest {
 
             List<Integer> onNextEvents = ts.values();
             Integer lastEvent = onNextEvents.get(num - 1);
-            System.out.println(testName.getMethodName() + " => Received: " + onNextEvents.size() + " Passed: " + passCount.get() + " Dropped: " + dropCount.get() + "  Emitted: " + emitCount.get() + " Last value: " + lastEvent);
+            System.out.println(testName.getMethodName() + " => Received: " + onNextEvents.size() + " Passed: "
+            + passCount.get() + " Dropped: " + dropCount.get() + "  Emitted: " + emitCount.get() + " Last value: " + lastEvent);
             assertEquals(num, onNextEvents.size());
             // in reality, num < passCount
             assertTrue(num <= passCount.get());
@@ -600,7 +602,8 @@ public class FlowableBackpressureTests extends RxJavaTest {
 
             Integer lastEvent = onNextEvents.get(num - 1);
 
-            System.out.println("testOnBackpressureDrop => Received: " + onNextEvents.size() + " Dropped: " + dropCount.get() + "  Emitted: " + c.get() + " Last value: " + lastEvent);
+            System.out.println("testOnBackpressureDrop => Received: " + onNextEvents.size() + " Dropped: " + dropCount.get()
+                + "  Emitted: " + c.get() + " Last value: " + lastEvent);
             // it drop, so we should get some number far higher than what would have sequentially incremented
             assertTrue(num - 1 <= lastEvent.intValue());
             // no drop in synchronous mode

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
@@ -168,7 +168,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromFutureTimedReturnsNull() {
-      FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
+        FutureTask<Object> f = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
         f.run();
         Flowable.fromFuture(f, 1, TimeUnit.SECONDS).blockingLast();
     }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
@@ -786,7 +786,9 @@ public class FlowableSubscriberTest {
                 Flowable.just(1).test();
                 fail("Should have thrown");
             } catch (NullPointerException ex) {
-                assertEquals("The RxJavaPlugins.onSubscribe hook returned a null FlowableSubscriber. Please check the handler provided to RxJavaPlugins.setOnFlowableSubscribe for invalid null returns. Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins", ex.getMessage());
+                assertEquals("The RxJavaPlugins.onSubscribe hook returned a null FlowableSubscriber. "
+                        + "Please check the handler provided to RxJavaPlugins.setOnFlowableSubscribe for invalid null returns. "
+                        + "Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins", ex.getMessage());
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableThrottleLastTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableThrottleLastTests.java
@@ -40,12 +40,12 @@ public class FlowableThrottleLastTests extends RxJavaTest {
         TestScheduler s = new TestScheduler();
         PublishProcessor<Integer> o = PublishProcessor.create();
         o.doOnCancel(whenDisposed)
-         .throttleLast(500, TimeUnit.MILLISECONDS, s, e-> {
-                    if (e == 1) {
-                        throw new TestException("forced");
-                    }
-                })
-               .subscribe(subscriber);
+        .throttleLast(500, TimeUnit.MILLISECONDS, s, e-> {
+            if (e == 1) {
+                throw new TestException("forced");
+            }
+        })
+        .subscribe(subscriber);
 
         // send events with simulated time increments
         s.advanceTimeTo(0, TimeUnit.MILLISECONDS);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
@@ -73,12 +73,12 @@ public class FlowableAmbTest extends RxJavaTest {
                 long delay = interval;
                 for (final String value : values) {
                     parentSubscription.add(innerScheduler.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            subscriber.onNext(value);
+                            @Override
+                            public void run() {
+                                subscriber.onNext(value);
+                            }
                         }
-                    }
-                    , delay, TimeUnit.MILLISECONDS));
+                        , delay, TimeUnit.MILLISECONDS));
                     delay += interval;
                 }
                 parentSubscription.add(innerScheduler.schedule(new Runnable() {
@@ -98,11 +98,11 @@ public class FlowableAmbTest extends RxJavaTest {
     @Test
     public void amb() {
         Flowable<String> flowable1 = createFlowable(new String[] {
-                "1", "11", "111", "1111" }, 2000, null);
+            "1", "11", "111", "1111" }, 2000, null);
         Flowable<String> flowable2 = createFlowable(new String[] {
-                "2", "22", "222", "2222" }, 1000, null);
+            "2", "22", "222", "2222" }, 1000, null);
         Flowable<String> flowable3 = createFlowable(new String[] {
-                "3", "33", "333", "3333" }, 3000, null);
+            "3", "33", "333", "3333" }, 3000, null);
 
         Flowable<String> f = Flowable.ambArray(flowable1,
                 flowable2, flowable3);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -808,7 +808,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> f = Flowable.combineLatest(sources, new Function<Object[], Integer>() {
             @Override
             public Integer apply(Object[] args) {
-               return (Integer) args[0];
+                return (Integer) args[0];
             }});
         //should get at least 4
         final CountDownLatch latch = new CountDownLatch(4);
@@ -850,17 +850,17 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         final AtomicBoolean errorOccurred = new AtomicBoolean(false);
         TestSubscriber<Integer> ts = TestSubscriber.create(1);
         Flowable<Integer> source = Flowable.just(1)
-          // if haven't caught exception in combineLatest operator then would incorrectly
-          // be picked up by this call to doOnError
-          .doOnError(new Consumer<Throwable>() {
+            // if haven't caught exception in combineLatest operator then would incorrectly
+            // be picked up by this call to doOnError
+            .doOnError(new Consumer<Throwable>() {
                 @Override
                 public void accept(Throwable t) {
                     errorOccurred.set(true);
                 }
             });
         Flowable
-          .combineLatest(Collections.singletonList(source), THROW_NON_FATAL)
-          .subscribe(ts);
+            .combineLatest(Collections.singletonList(source), THROW_NON_FATAL)
+            .subscribe(ts);
         assertFalse(errorOccurred.get());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -212,16 +212,16 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void delayErrorCallableTillTheEnd() {
         Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
         .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-          @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
-            return Flowable.fromCallable(new Callable<Integer>() {
-              @Override public Integer call() throws Exception {
-                if (integer >= 100) {
-                  throw new NullPointerException("test null exp");
-                }
-                return integer;
-              }
-            });
-          }
+            @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
+                return Flowable.fromCallable(new Callable<Integer>() {
+                    @Override public Integer call() throws Exception {
+                        if (integer >= 100) {
+                            throw new NullPointerException("test null exp");
+                        }
+                        return integer;
+                    }
+                });
+            }
         }, true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
@@ -231,16 +231,16 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void delayErrorCallableEager() {
         Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
         .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-          @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
-            return Flowable.fromCallable(new Callable<Integer>() {
-              @Override public Integer call() throws Exception {
-                if (integer >= 100) {
-                  throw new NullPointerException("test null exp");
-                }
-                return integer;
-              }
-            });
-          }
+            @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
+                return Flowable.fromCallable(new Callable<Integer>() {
+                    @Override public Integer call() throws Exception {
+                        if (integer >= 100) {
+                            throw new NullPointerException("test null exp");
+                        }
+                        return integer;
+                    }
+                });
+            }
         }, false, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapTest.java
@@ -225,16 +225,16 @@ public class FlowableConcatMapTest extends RxJavaTest {
     public void delayErrorCallableTillTheEnd() {
         Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
         .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-          @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
-            return Flowable.fromCallable(new Callable<Integer>() {
-              @Override public Integer call() throws Exception {
-                if (integer >= 100) {
-                  throw new NullPointerException("test null exp");
-                }
-                return integer;
-              }
-            });
-          }
+            @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
+                return Flowable.fromCallable(new Callable<Integer>() {
+                    @Override public Integer call() throws Exception {
+                        if (integer >= 100) {
+                            throw new NullPointerException("test null exp");
+                        }
+                        return integer;
+                    }
+                });
+            }
         })
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
@@ -244,16 +244,16 @@ public class FlowableConcatMapTest extends RxJavaTest {
     public void delayErrorCallableEager() {
         Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
         .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-          @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
-            return Flowable.fromCallable(new Callable<Integer>() {
-              @Override public Integer call() throws Exception {
-                if (integer >= 100) {
-                  throw new NullPointerException("test null exp");
-                }
-                return integer;
-              }
-            });
-          }
+            @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
+                return Flowable.fromCallable(new Callable<Integer>() {
+                    @Override public Integer call() throws Exception {
+                        if (integer >= 100) {
+                            throw new NullPointerException("test null exp");
+                        }
+                        return integer;
+                    }
+                });
+            }
         }, false, 2)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -191,14 +191,14 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
         Flowable<String> src = Flowable.just("a", "b", "null", "c");
         final AtomicBoolean errorOccurred = new AtomicBoolean(false);
         src
-          .doOnError(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) {
-                    errorOccurred.set(true);
-                }
-            })
-          .distinctUntilChanged(THROWS_NON_FATAL)
-          .subscribe(w);
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable t) {
+                errorOccurred.set(true);
+            }
+        })
+        .distinctUntilChanged(THROWS_NON_FATAL)
+        .subscribe(w);
         Assert.assertFalse(errorOccurred.get());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -111,7 +111,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         .assertComplete();
 
         TestHelper.assertValueSet(ts, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-     }
+    }
 
     @Test
     public void normalAsyncMaxConcurrency1() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -97,7 +97,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         .assertComplete();
 
         TestHelper.assertValueSet(ts, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-     }
+    }
 
     @Test
     public void normalAsyncMaxConcurrency1() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -1899,10 +1899,10 @@ public class FlowableGroupByTest extends RxJavaTest {
                     }
                 };
         Flowable.just(1)
-          .groupBy(Functions.<Integer>identity(), Functions.identity(), true, 16, evictingMapFactory)
-          .test()
-          .assertNoValues()
-          .assertError(ex);
+        .groupBy(Functions.<Integer>identity(), Functions.identity(), true, 16, evictingMapFactory)
+        .test()
+        .assertNoValues()
+        .assertError(ex);
     }
     // -----------------------------------------------------------------------------------------------------------------------
 
@@ -1951,7 +1951,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         subject.onNext(2);
         subject.onNext(3);
         ts.assertValues(1, 2, 3)
-          .assertNotTerminated();
+        .assertNotTerminated();
         assertEquals(Arrays.asList(1, 2), completed);
         //ensure coverage of the code that clears the evicted queue
         subject.onComplete();
@@ -1977,7 +1977,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         //ensure coverage of the code that clears the evicted queue
         subject.onError(ex);
         ts.assertNoValues()
-          .assertError(ex);
+        .assertError(ex);
     }
 
     @Test
@@ -2164,9 +2164,9 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         @Override
         public void putAll(Map<? extends K, ? extends V> m) {
-           for (Entry<? extends K, ? extends V> entry: m.entrySet()) {
-               put(entry.getKey(), entry.getValue());
-           }
+            for (Entry<? extends K, ? extends V> entry: m.entrySet()) {
+                put(entry.getKey(), entry.getValue());
+            }
         }
 
         @Override
@@ -2664,7 +2664,7 @@ public class FlowableGroupByTest extends RxJavaTest {
             issue6974Part2Case2();
         }
     }
-    */
+     */
 
     static void issue6974RunPart2NoEvict(int groupByBufferSize, int flatMapMaxConcurrency, int groups,
             boolean notifyOnExplicitEviction) {
@@ -2700,7 +2700,7 @@ public class FlowableGroupByTest extends RxJavaTest {
             issue6974Part2Case1NoEvict();
         }
     }
-    */
+     */
 
     @Test
     public void issue6974Part2Case1ObserveOn() {
@@ -2814,7 +2814,7 @@ public class FlowableGroupByTest extends RxJavaTest {
             issue6974Part2Case1ObserveOnNoCapHide();
         }
     }
-    */
+     */
 
     @Test
     public void issue6974Part2Case1ObserveOnConditional() {
@@ -2877,7 +2877,7 @@ public class FlowableGroupByTest extends RxJavaTest {
             issue6974Part2Case1ObserveOnHide();
         }
     }
-    */
+     */
 
     static <T> Function<Consumer<Object>, ConcurrentMap<T, Object>> ttlCapGuava(Duration ttl) {
         return itemEvictConsumer ->

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapTest.java
@@ -478,7 +478,7 @@ public class FlowableMapTest extends RxJavaTest {
                     return true;
                 }
             })
-           .test()
+            .test()
             .assertFailure(TestException.class);
 
             TestHelper.assertUndeliverable(errors, 0, IOException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -42,7 +42,8 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void errorDelayed1() {
-        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six"));
         final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
 
         Flowable<String> m = Flowable.mergeDelayError(f1, f2);
@@ -64,7 +65,8 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
     @Test
     public void errorDelayed2() {
         final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", "three"));
-        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six"));
         final Flowable<String> f3 = Flowable.unsafeCreate(new TestErrorFlowable("seven", "eight", null));
         final Flowable<String> f4 = Flowable.unsafeCreate(new TestErrorFlowable("nine"));
 
@@ -167,7 +169,8 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void compositeErrorDelayed1() {
-        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six"));
         final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
 
         Flowable<String> m = Flowable.mergeDelayError(f1, f2);
@@ -187,7 +190,8 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void compositeErrorDelayed2() {
-        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Flowable<String> f1 = Flowable.unsafeCreate(new TestErrorFlowable("four", null, "six"));
         final Flowable<String> f2 = Flowable.unsafeCreate(new TestErrorFlowable("one", "two", null));
 
         Flowable<String> m = Flowable.mergeDelayError(f1, f2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
@@ -931,14 +931,14 @@ public class FlowableObserveOnTest extends RxJavaTest {
                 requests.add(r);
             }
         })
-       .rebatchRequests(20)
-       .subscribe(ts);
+        .rebatchRequests(20)
+        .subscribe(ts);
 
-       ts.assertValueCount(50);
-       ts.assertNoErrors();
-       ts.assertComplete();
+        ts.assertValueCount(50);
+        ts.assertNoErrors();
+        ts.assertComplete();
 
-       assertEquals(Arrays.asList(20L, 15L, 15L, 15L), requests);
+        assertEquals(Arrays.asList(20L, 15L, 15L, 15L), requests);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -135,14 +135,14 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
 
         ts.request(100);
         infinite.subscribeOn(Schedulers.computation())
-             .onBackpressureBuffer(500, new Action() {
-                 @Override
-                 public void run() {
-                     backpressureCallback.countDown();
-                 }
-             })
-             /*.take(1000)*/
-             .subscribe(ts);
+        .onBackpressureBuffer(500, new Action() {
+            @Override
+            public void run() {
+                backpressureCallback.countDown();
+            }
+        })
+        /*.take(1000)*/
+        .subscribe(ts);
         l1.await();
 
         ts.request(50);
@@ -180,20 +180,20 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
 
     @Test
     public void nonFatalExceptionThrownByOnOverflowIsNotReportedByUpstream() {
-         final AtomicBoolean errorOccurred = new AtomicBoolean(false);
-         TestSubscriber<Long> ts = TestSubscriber.create(0);
-         infinite
-           .subscribeOn(Schedulers.computation())
-           .doOnError(new Consumer<Throwable>() {
-                 @Override
-                 public void accept(Throwable t) {
-                     errorOccurred.set(true);
-                 }
-             })
-           .onBackpressureBuffer(1, THROWS_NON_FATAL)
-           .subscribe(ts);
-         ts.awaitDone(5, TimeUnit.SECONDS);
-         assertFalse(errorOccurred.get());
+        final AtomicBoolean errorOccurred = new AtomicBoolean(false);
+        TestSubscriber<Long> ts = TestSubscriber.create(0);
+        infinite
+        .subscribeOn(Schedulers.computation())
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable t) {
+                errorOccurred.set(true);
+            }
+        })
+        .onBackpressureBuffer(1, THROWS_NON_FATAL)
+        .subscribe(ts);
+        ts.awaitDone(5, TimeUnit.SECONDS);
+        assertFalse(errorOccurred.get());
     }
 
     @Test
@@ -256,8 +256,8 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
         Flowable.range(1, 10).onBackpressureBuffer().subscribe(ts);
 
         ts.assertFuseable()
-          .assertFusionMode(QueueFuseable.ASYNC)
-          .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 
     @Test
@@ -267,8 +267,8 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
         Flowable.<Integer>error(new TestException()).onBackpressureBuffer().subscribe(ts);
 
         ts.assertFuseable()
-          .assertFusionMode(QueueFuseable.ASYNC)
-          .assertFailure(TestException.class);
+        .assertFusionMode(QueueFuseable.ASYNC)
+        .assertFailure(TestException.class);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -167,16 +167,16 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
         TestSubscriber<Long> ts = TestSubscriber.create(0);
         //range method emits regardless of requests so should trigger onBackpressureDrop action
         range(2)
-          // if haven't caught exception in onBackpressureDrop operator then would incorrectly
-          // be picked up by this call to doOnError
-          .doOnError(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) {
-                    errorOccurred.set(true);
-                }
-            })
-          .onBackpressureDrop(THROW_NON_FATAL)
-          .subscribe(ts);
+        // if haven't caught exception in onBackpressureDrop operator then would incorrectly
+        // be picked up by this call to doOnError
+        .doOnError(new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable t) {
+                errorOccurred.set(true);
+            }
+        })
+        .onBackpressureDrop(THROW_NON_FATAL)
+        .subscribe(ts);
 
         assertFalse(errorOccurred.get());
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeatTest.java
@@ -325,24 +325,24 @@ public class FlowableRepeatTest {
 
     @Test
     public void shouldDisposeInnerObservable() {
-      final PublishProcessor<Object> processor = PublishProcessor.create();
-      final Disposable disposable = Flowable.just("Leak")
-          .repeatWhen(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> completions) throws Exception {
-                return completions.switchMap(new Function<Object, Flowable<Object>>() {
+        final PublishProcessor<Object> processor = PublishProcessor.create();
+        final Disposable disposable = Flowable.just("Leak")
+                .repeatWhen(new Function<Flowable<Object>, Flowable<Object>>() {
                     @Override
-                    public Flowable<Object> apply(Object ignore) throws Exception {
-                        return processor;
+                    public Flowable<Object> apply(Flowable<Object> completions) throws Exception {
+                        return completions.switchMap(new Function<Object, Flowable<Object>>() {
+                            @Override
+                            public Flowable<Object> apply(Object ignore) throws Exception {
+                                return processor;
+                            }
+                        });
                     }
-                });
-            }
-        })
-          .subscribe();
+                })
+                .subscribe();
 
-      assertTrue(processor.hasSubscribers());
-      disposable.dispose();
-      assertFalse(processor.hasSubscribers());
+        assertTrue(processor.hasSubscribers());
+        disposable.dispose();
+        assertFalse(processor.hasSubscribers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
@@ -1010,24 +1010,24 @@ public class FlowableRetryTest extends RxJavaTest {
 
     @Test
     public void shouldDisposeInnerFlowable() {
-      final PublishProcessor<Object> processor = PublishProcessor.create();
-      final Disposable disposable = Flowable.error(new RuntimeException("Leak"))
-          .retryWhen(new Function<Flowable<Throwable>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Throwable> errors) throws Exception {
-                return errors.switchMap(new Function<Throwable, Flowable<Object>>() {
+        final PublishProcessor<Object> processor = PublishProcessor.create();
+        final Disposable disposable = Flowable.error(new RuntimeException("Leak"))
+                .retryWhen(new Function<Flowable<Throwable>, Flowable<Object>>() {
                     @Override
-                    public Flowable<Object> apply(Throwable ignore) throws Exception {
-                        return processor;
+                    public Flowable<Object> apply(Flowable<Throwable> errors) throws Exception {
+                        return errors.switchMap(new Function<Throwable, Flowable<Object>>() {
+                            @Override
+                            public Flowable<Object> apply(Throwable ignore) throws Exception {
+                                return processor;
+                            }
+                        });
                     }
-                });
-            }
-        })
-          .subscribe();
+                })
+                .subscribe();
 
-      assertTrue(processor.hasSubscribers());
-      disposable.dispose();
-      assertFalse(processor.hasSubscribers());
+        assertTrue(processor.hasSubscribers());
+        disposable.dispose();
+        assertFalse(processor.hasSubscribers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
@@ -474,10 +474,10 @@ public class FlowableScanTest extends RxJavaTest {
             final RuntimeException e = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
             Burst.items(1).error(e2)
-              .scan(0, throwingBiFunction(e))
-              .test()
-              .assertValues(0)
-              .assertError(e);
+            .scan(0, throwingBiFunction(e))
+            .test()
+            .assertValues(0)
+            .assertError(e);
 
             assertEquals("" + list, 1, list.size());
             assertTrue("" + list, list.get(0) instanceof UndeliverableException);
@@ -491,10 +491,10 @@ public class FlowableScanTest extends RxJavaTest {
     public void scanWithSeedDoesNotEmitTerminalEventTwiceIfScanFunctionThrows() {
         final RuntimeException e = new RuntimeException();
         Burst.item(1).create()
-          .scan(0, throwingBiFunction(e))
-          .test()
-          .assertValue(0)
-          .assertError(e);
+        .scan(0, throwingBiFunction(e))
+        .test()
+        .assertValue(0)
+        .assertError(e);
     }
 
     @Test
@@ -508,18 +508,18 @@ public class FlowableScanTest extends RxJavaTest {
                 count.incrementAndGet();
                 throw e;
             }})
-          .test()
-          .assertValues(0)
-          .assertError(e);
+        .test()
+        .assertValues(0)
+        .assertError(e);
         assertEquals(1, count.get());
     }
 
     @Test
     public void scanWithSeedCompletesNormally() {
         Flowable.just(1, 2, 3).scan(0, SUM)
-          .test()
-          .assertValues(0, 1, 3, 6)
-          .assertComplete();
+        .test()
+        .assertValues(0, 1, 3, 6)
+        .assertComplete();
     }
 
     @Test
@@ -527,18 +527,18 @@ public class FlowableScanTest extends RxJavaTest {
         final RuntimeException e = new RuntimeException();
         Flowable.just(1, 2, 3).scanWith(throwingSupplier(e),
             SUM)
-          .test()
-          .assertError(e)
-          .assertNoValues();
+        .test()
+        .assertError(e)
+        .assertNoValues();
     }
 
     @Test
     public void scanNoSeed() {
         Flowable.just(1, 2, 3)
-           .scan(SUM)
-           .test()
-           .assertValues(1, 3, 6)
-           .assertComplete();
+        .scan(SUM)
+        .test()
+        .assertValues(1, 3, 6)
+        .assertComplete();
     }
 
     @Test
@@ -554,10 +554,10 @@ public class FlowableScanTest extends RxJavaTest {
             final RuntimeException e = new RuntimeException();
             final RuntimeException e2 = new RuntimeException();
             Burst.items(1, 2).error(e2)
-              .scan(throwingBiFunction(e))
-              .test()
-              .assertValue(1)
-              .assertError(e);
+            .scan(throwingBiFunction(e))
+            .test()
+            .assertValue(1)
+            .assertError(e);
 
             assertEquals("" + list, 1, list.size());
             assertTrue("" + list, list.get(0) instanceof UndeliverableException);
@@ -571,10 +571,10 @@ public class FlowableScanTest extends RxJavaTest {
     public void scanNoSeedDoesNotEmitTerminalEventTwiceIfScanFunctionThrows() {
         final RuntimeException e = new RuntimeException();
         Burst.items(1, 2).create()
-          .scan(throwingBiFunction(e))
-          .test()
-          .assertValue(1)
-          .assertError(e);
+        .scan(throwingBiFunction(e))
+        .test()
+        .assertValue(1)
+        .assertError(e);
     }
 
     @Test
@@ -588,9 +588,9 @@ public class FlowableScanTest extends RxJavaTest {
                 count.incrementAndGet();
                 throw e;
             }})
-          .test()
-          .assertValue(1)
-          .assertError(e);
+        .test()
+        .assertValue(1)
+        .assertError(e);
         assertEquals(1, count.get());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -197,9 +197,9 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
                     }
                 });
             }})
-          .switchIfEmpty(Flowable.fromIterable(Arrays.asList(1L, 2L, 3L)))
-          .subscribeOn(Schedulers.computation())
-          .subscribe(ts);
+        .switchIfEmpty(Flowable.fromIterable(Arrays.asList(1L, 2L, 3L)))
+        .subscribeOn(Schedulers.computation())
+        .subscribe(ts);
 
         Thread.sleep(50);
         //request while first observable is still finishing (as empty)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
@@ -158,10 +158,10 @@ public class FlowableTakeTest extends RxJavaTest {
             .take(3)
             .test(0);
         ts.requestMore(1)
-          .assertValues(1)
-          .assertNotComplete()
-          .requestMore(Long.MAX_VALUE)
-          .assertValues(1, 2, 3);
+        .assertValues(1)
+        .assertNotComplete()
+        .requestMore(Long.MAX_VALUE)
+        .assertValues(1, 2, 3);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -399,7 +399,10 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
         drops.assertValuesOnly(2);
     }
 
-    /** Emit 1, 2, 3; 3 should trigger an error to the downstream because 2 is dropped and the callback crashes. */
+    /**
+     * Emit 1, 2, 3; 3 should trigger an error to the downstream because 2 is dropped and the callback crashes.
+     * @throws Throwable in case of any error
+     */
     @Test
     public void onDroppedBasicNoEmitLastFirstDropCrash() throws Throwable {
         PublishProcessor<Integer> pp =PublishProcessor.create();
@@ -437,6 +440,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
     /**
      * Emit 1, 2, Error; the error should trigger the drop callback and crash it too,
      * downstream gets 1, composite(source, drop-crash).
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedBasicNoEmitLastOnErrorDropCrash() throws Throwable {
@@ -473,6 +477,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
     /**
      * Emit 1, 2, 3; 3 should trigger a drop-crash for 2, which then would trigger the error path and drop-crash for 3,
      * the last item not delivered, downstream gets 1, composite(drop-crash 2, drop-crash 3).
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedBasicEmitLastOnErrorDropCrash() throws Throwable {
@@ -562,6 +567,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
 
     /**
      * Emit 1, 2, complete; complete should crash drop, downstream gets 1, drop-crash 2.
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedHasLastNoEmitLastDropCrash() throws Throwable {
@@ -595,6 +601,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
 
     /**
      * Emit 1, 2 then dispose the sequence; downstream gets 1, drop should get for 2.
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedDisposeDrops() throws Throwable {
@@ -632,6 +639,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
 
     /**
      * Emit 1 then dispose the sequence; downstream gets 1, drop should not get called.
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedDisposeNoDrops() throws Throwable {
@@ -665,6 +673,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
 
     /**
      * Emit 1, 2 then dispose the sequence; downstream gets 1, global error handler should get drop-crash 2.
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedDisposeCrashesDrop() throws Throwable {
@@ -700,7 +709,10 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
         });
     }
 
-    /** Emit 1 but downstream is backpressured; downstream gets MBE, drops gets 1. */
+    /**
+     * Emit 1 but downstream is backpressured; downstream gets MBE, drops gets 1.
+     * @throws Throwable in case of any error
+     */
     @Test
     public void onDroppedBackpressured() throws Throwable {
         PublishProcessor<Integer> pp =PublishProcessor.create();
@@ -729,7 +741,10 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
         verify(whenDisposed).run();
     }
 
-    /** Emit 1 but downstream is backpressured; drop crashes, downstream gets composite(MBE, drop-crash 1). */
+    /**
+     * Emit 1 but downstream is backpressured; drop crashes, downstream gets composite(MBE, drop-crash 1).
+     * @throws Throwable in case of any error
+     */
     @Test
     public void onDroppedBackpressuredDropCrash() throws Throwable {
         PublishProcessor<Integer> pp =PublishProcessor.create();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -575,51 +575,51 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
             final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
-                 @Override
-                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
-                     subscriber.onSubscribe(new BooleanSubscription());
-                     refMain.set(subscriber);
-                 }
-             }
-             .window(new Flowable<Object>() {
-                 @Override
-                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
-                     final AtomicInteger counter = new AtomicInteger();
-                     subscriber.onSubscribe(new Subscription() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    refMain.set(subscriber);
+                }
+            }
+            .window(new Flowable<Object>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    final AtomicInteger counter = new AtomicInteger();
+                    subscriber.onSubscribe(new Subscription() {
 
-                         @Override
-                         public void cancel() {
-                             // about a microsecond
-                             for (int i = 0; i < 100; i++) {
-                                 counter.incrementAndGet();
-                             }
-                         }
+                        @Override
+                        public void cancel() {
+                            // about a microsecond
+                            for (int i = 0; i < 100; i++) {
+                                counter.incrementAndGet();
+                            }
+                        }
 
-                         @Override
+                        @Override
                         public void request(long n) {
                         }
-                     });
-                     ref.set(subscriber);
-                 }
-             })
-             .test();
+                    });
+                    ref.set(subscriber);
+                }
+            })
+            .test();
 
-             Runnable r1 = new Runnable() {
-                 @Override
-                 public void run() {
-                     ts.cancel();
-                 }
-             };
-             Runnable r2 = new Runnable() {
-                 @Override
-                 public void run() {
-                     Subscriber<Object> subscriber = ref.get();
-                     subscriber.onNext(1);
-                     subscriber.onComplete();
-                 }
-             };
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    ts.cancel();
+                }
+            };
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    Subscriber<Object> subscriber = ref.get();
+                    subscriber.onNext(1);
+                    subscriber.onComplete();
+                }
+            };
 
-             TestHelper.race(r1, r2);
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -629,38 +629,38 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         final TestException ex = new TestException();
 
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-           final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
-           final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
+            final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
+            final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-           final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
-               @Override
-               protected void subscribeActual(Subscriber<? super Object> subscriber) {
-                   subscriber.onSubscribe(new BooleanSubscription());
-                   refMain.set(subscriber);
-               }
-           }
-           .window(new Flowable<Object>() {
-               @Override
-               protected void subscribeActual(Subscriber<? super Object> subscriber) {
-                   final AtomicInteger counter = new AtomicInteger();
-                   subscriber.onSubscribe(new Subscription() {
+            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    refMain.set(subscriber);
+                }
+            }
+            .window(new Flowable<Object>() {
+                @Override
+                protected void subscribeActual(Subscriber<? super Object> subscriber) {
+                    final AtomicInteger counter = new AtomicInteger();
+                    subscriber.onSubscribe(new Subscription() {
 
-                       @Override
-                       public void cancel() {
-                           // about a microsecond
-                           for (int i = 0; i < 100; i++) {
-                               counter.incrementAndGet();
-                           }
-                       }
+                        @Override
+                        public void cancel() {
+                            // about a microsecond
+                            for (int i = 0; i < 100; i++) {
+                                counter.incrementAndGet();
+                            }
+                        }
 
-                       @Override
-                      public void request(long n) {
-                      }
-                   });
-                   ref.set(subscriber);
-               }
-           })
-           .test();
+                        @Override
+                        public void request(long n) {
+                        }
+                    });
+                    ref.set(subscriber);
+                }
+            })
+            .test();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
@@ -172,7 +172,8 @@ public class FlowableZipTest extends RxJavaTest {
     };
 
     /**
-     * Testing internal private logic due to the complexity so I want to use TDD to test as a I build it rather than relying purely on the overall functionality expected by the public methods.
+     * Testing internal private logic due to the complexity so I want to use TDD to test as a I build it rather than
+     * relying purely on the overall functionality expected by the public methods.
      */
     @Test
     public void aggregatorSimple() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
@@ -68,16 +68,15 @@ public final class ObservableCollectTest extends RxJavaTest {
             public StringBuilder get() {
                 return new StringBuilder();
             }
-        },
-            new BiConsumer<StringBuilder, Integer>() {
-                @Override
-                public void accept(StringBuilder sb, Integer v) {
+        }, new BiConsumer<StringBuilder, Integer>() {
+            @Override
+            public void accept(StringBuilder sb, Integer v) {
                 if (sb.length() > 0) {
                     sb.append("-");
                 }
                 sb.append(v);
-      }
-            }).toObservable().blockingLast().toString();
+            }
+        }).toObservable().blockingLast().toString();
 
         assertEquals("1-2-3", value);
     }
@@ -193,16 +192,15 @@ public final class ObservableCollectTest extends RxJavaTest {
             public StringBuilder get() {
                 return new StringBuilder();
             }
-        },
-            new BiConsumer<StringBuilder, Integer>() {
-                @Override
-                public void accept(StringBuilder sb, Integer v) {
+        }, new BiConsumer<StringBuilder, Integer>() {
+            @Override
+            public void accept(StringBuilder sb, Integer v) {
                 if (sb.length() > 0) {
                     sb.append("-");
                 }
                 sb.append(v);
-      }
-            }).blockingGet().toString();
+            }
+        }).blockingGet().toString();
 
         assertEquals("1-2-3", value);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -212,7 +212,8 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         /* define an Observer to receive aggregated events */
         Observer<String> observer = TestHelper.mockObserver();
 
-        Observable<String> w = Observable.combineLatest(Observable.just("one"), Observable.just(2), Observable.just(new int[] { 4, 5, 6 }, new int[] { 7, 8 }), combineLatestFunction);
+        Observable<String> w = Observable.combineLatest(Observable.just("one"), Observable.just(2),
+                Observable.just(new int[] { 4, 5, 6 }, new int[] { 7, 8 }), combineLatestFunction);
         w.subscribe(observer);
 
         verify(observer, never()).onError(any(Throwable.class));

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -164,16 +164,16 @@ public class ObservableConcatMapSchedulerTest {
     public void delayErrorCallableTillTheEnd() {
         Observable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
         .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-          @Override public Observable<Integer> apply(final Integer integer) throws Exception {
-            return Observable.fromCallable(new Callable<Integer>() {
-              @Override public Integer call() throws Exception {
-                if (integer >= 100) {
-                  throw new NullPointerException("test null exp");
-                }
-                return integer;
-              }
-            });
-          }
+            @Override public Observable<Integer> apply(final Integer integer) throws Exception {
+                return Observable.fromCallable(new Callable<Integer>() {
+                    @Override public Integer call() throws Exception {
+                        if (integer >= 100) {
+                            throw new NullPointerException("test null exp");
+                        }
+                        return integer;
+                    }
+                });
+            }
         }, true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
@@ -183,16 +183,16 @@ public class ObservableConcatMapSchedulerTest {
     public void delayErrorCallableEager() {
         Observable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
         .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-          @Override public Observable<Integer> apply(final Integer integer) throws Exception {
-            return Observable.fromCallable(new Callable<Integer>() {
-              @Override public Integer call() throws Exception {
-                if (integer >= 100) {
-                  throw new NullPointerException("test null exp");
-                }
-                return integer;
-              }
-            });
-          }
+            @Override public Observable<Integer> apply(final Integer integer) throws Exception {
+                return Observable.fromCallable(new Callable<Integer>() {
+                    @Override public Integer call() throws Exception {
+                        if (integer >= 100) {
+                            throw new NullPointerException("test null exp");
+                        }
+                        return integer;
+                    }
+                });
+            }
         }, false, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -217,7 +217,7 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
         } finally {
             RxJavaPlugins.reset();
         }
-   }
+    }
 
     class Mutable {
         int value;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -41,7 +41,8 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void errorDelayed1() {
-        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
         final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
@@ -63,7 +64,8 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
     @Test
     public void errorDelayed2() {
         final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
         final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));
         final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
@@ -166,7 +168,8 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void compositeErrorDelayed1() {
-        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
         final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", null));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);
@@ -186,7 +189,8 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void compositeErrorDelayed2() {
-        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        // we expect to lose "six" from the source (and it should never be sent by the source since onError was called
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
         final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", null));
 
         Observable<String> m = Observable.mergeDelayError(o1, o2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
@@ -295,8 +295,10 @@ public class ObservableMergeTest extends RxJavaTest {
     @Test
     public void error1() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
-        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
-        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three")); // we expect to lose all of these since o1 is done first and fails
+        // we expect to lose "six"
+        final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
+        // we expect to lose all of these since o1 is done first and fails
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
 
         Observable<String> m = Observable.merge(o1, o2);
         m.subscribe(stringObserver);
@@ -318,9 +320,12 @@ public class ObservableMergeTest extends RxJavaTest {
     public void error2() {
         // we are using synchronous execution to test this exactly rather than non-deterministic concurrent behavior
         final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
-        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six")); // we expect to lose "six"
-        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null)); // we expect to lose all of these since o2 is done first and fails
-        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine")); // we expect to lose all of these since o2 is done first and fails
+        // we expect to lose "six"
+        final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
+        // we expect to lose all of these since o2 is done first and fails
+        final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));
+        // we expect to lose all of these since o2 is done first and fails
+        final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
         Observable<String> m = Observable.merge(o1, o2, o3, o4);
         m.subscribe(stringObserver);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRepeatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRepeatTest.java
@@ -263,24 +263,24 @@ public class ObservableRepeatTest extends RxJavaTest {
 
     @Test
     public void shouldDisposeInnerObservable() {
-      final PublishSubject<Object> subject = PublishSubject.create();
-      final Disposable disposable = Observable.just("Leak")
-          .repeatWhen(new Function<Observable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Object> completions) throws Exception {
-                return completions.switchMap(new Function<Object, ObservableSource<Object>>() {
+        final PublishSubject<Object> subject = PublishSubject.create();
+        final Disposable disposable = Observable.just("Leak")
+                .repeatWhen(new Function<Observable<Object>, ObservableSource<Object>>() {
                     @Override
-                    public ObservableSource<Object> apply(Object ignore) throws Exception {
-                        return subject;
+                    public ObservableSource<Object> apply(Observable<Object> completions) throws Exception {
+                        return completions.switchMap(new Function<Object, ObservableSource<Object>>() {
+                            @Override
+                            public ObservableSource<Object> apply(Object ignore) throws Exception {
+                                return subject;
+                            }
+                        });
                     }
-                });
-            }
-        })
-          .subscribe();
+                })
+                .subscribe();
 
-      assertTrue(subject.hasObservers());
-      disposable.dispose();
-      assertFalse(subject.hasObservers());
+        assertTrue(subject.hasObservers());
+        disposable.dispose();
+        assertFalse(subject.hasObservers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
@@ -920,24 +920,24 @@ public class ObservableRetryTest extends RxJavaTest {
 
     @Test
     public void shouldDisposeInnerObservable() {
-      final PublishSubject<Object> subject = PublishSubject.create();
-      final Disposable disposable = Observable.error(new RuntimeException("Leak"))
-          .retryWhen(new Function<Observable<Throwable>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Throwable> errors) throws Exception {
-                return errors.switchMap(new Function<Throwable, ObservableSource<Object>>() {
+        final PublishSubject<Object> subject = PublishSubject.create();
+        final Disposable disposable = Observable.error(new RuntimeException("Leak"))
+                .retryWhen(new Function<Observable<Throwable>, ObservableSource<Object>>() {
                     @Override
-                    public ObservableSource<Object> apply(Throwable ignore) throws Exception {
-                        return subject;
+                    public ObservableSource<Object> apply(Observable<Throwable> errors) throws Exception {
+                        return errors.switchMap(new Function<Throwable, ObservableSource<Object>>() {
+                            @Override
+                            public ObservableSource<Object> apply(Throwable ignore) throws Exception {
+                                return subject;
+                            }
+                        });
                     }
-                });
-            }
-        })
-          .subscribe();
+                })
+                .subscribe();
 
-      assertTrue(subject.hasObservers());
-      disposable.dispose();
-      assertFalse(subject.hasObservers());
+        assertTrue(subject.hasObservers());
+        disposable.dispose();
+        assertFalse(subject.hasObservers());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -345,7 +345,10 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
         drops.assertValuesOnly(2);
     }
 
-    /** Emit 1, 2, 3; 3 should trigger an error to the downstream because 2 is dropped and the callback crashes. */
+    /**
+     * Emit 1, 2, 3; 3 should trigger an error to the downstream because 2 is dropped and the callback crashes.
+     * @throws Throwable in case of any error
+     */
     @Test
     public void onDroppedBasicNoEmitLastFirstDropCrash() throws Throwable {
         PublishSubject<Integer> ps = PublishSubject.create();
@@ -383,6 +386,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
     /**
      * Emit 1, 2, Error; the error should trigger the drop callback and crash it too,
      * downstream gets 1, composite(source, drop-crash).
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedBasicNoEmitLastOnErrorDropCrash() throws Throwable {
@@ -419,6 +423,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
     /**
      * Emit 1, 2, 3; 3 should trigger a drop-crash for 2, which then would trigger the error path and drop-crash for 3,
      * the last item not delivered, downstream gets 1, composite(drop-crash 2, drop-crash 3).
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedBasicEmitLastOnErrorDropCrash() throws Throwable {
@@ -510,6 +515,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
     /**
      * Emit 1, 2, complete; complete should crash drop, downstream gets 1, drop-crash 2.
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedHasLastNoEmitLastDropCrash() throws Throwable {
@@ -543,6 +549,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
     /**
      * Emit 1, 2 then dispose the sequence; downstream gets 1, drop should get for 2.
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedDisposeDrops() throws Throwable {
@@ -581,6 +588,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
     /**
      * Emit 1 then dispose the sequence; downstream gets 1, drop should not get called.
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedDisposeNoDrops() throws Throwable {
@@ -615,6 +623,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
     /**
      * Emit 1, 2 then dispose the sequence; downstream gets 1, global error handler should get drop-crash 2.
+     * @throws Throwable in case of any error
      */
     @Test
     public void onDroppedDisposeCrashesDrop() throws Throwable {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -536,52 +536,52 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
             final TestObserver<Observable<Object>> to = new Observable<Object>() {
-                 @Override
-                 protected void subscribeActual(Observer<? super Object> observer) {
-                     observer.onSubscribe(Disposable.empty());
-                     refMain.set(observer);
-                 }
-             }
-             .window(new Observable<Object>() {
-                 @Override
-                 protected void subscribeActual(Observer<? super Object> observer) {
-                     final AtomicInteger counter = new AtomicInteger();
-                     observer.onSubscribe(new Disposable() {
+                @Override
+                protected void subscribeActual(Observer<? super Object> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    refMain.set(observer);
+                }
+            }
+            .window(new Observable<Object>() {
+                @Override
+                protected void subscribeActual(Observer<? super Object> observer) {
+                    final AtomicInteger counter = new AtomicInteger();
+                    observer.onSubscribe(new Disposable() {
 
-                         @Override
-                         public void dispose() {
-                             // about a microsecond
-                             for (int i = 0; i < 100; i++) {
-                                 counter.incrementAndGet();
-                             }
-                         }
+                        @Override
+                        public void dispose() {
+                            // about a microsecond
+                            for (int i = 0; i < 100; i++) {
+                                counter.incrementAndGet();
+                            }
+                        }
 
-                         @Override
-                         public boolean isDisposed() {
-                             return false;
-                         }
-                      });
-                     ref.set(observer);
-                 }
-             })
-             .test();
+                        @Override
+                        public boolean isDisposed() {
+                            return false;
+                        }
+                    });
+                    ref.set(observer);
+                }
+            })
+            .test();
 
-             Runnable r1 = new Runnable() {
-                 @Override
-                 public void run() {
-                     to.dispose();
-                 }
-             };
-             Runnable r2 = new Runnable() {
-                 @Override
-                 public void run() {
-                     Observer<Object> o = ref.get();
-                     o.onNext(1);
-                     o.onComplete();
-                 }
-             };
+            Runnable r1 = new Runnable() {
+                @Override
+                public void run() {
+                    to.dispose();
+                }
+            };
+            Runnable r2 = new Runnable() {
+                @Override
+                public void run() {
+                    Observer<Object> o = ref.get();
+                    o.onNext(1);
+                    o.onComplete();
+                }
+            };
 
-             TestHelper.race(r1, r2);
+            TestHelper.race(r1, r2);
         }
     }
 
@@ -591,39 +591,39 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
         final TestException ex = new TestException();
 
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-           final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
-           final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
+            final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
+            final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-           final TestObserver<Observable<Object>> to = new Observable<Object>() {
-               @Override
-               protected void subscribeActual(Observer<? super Object> observer) {
-                   observer.onSubscribe(Disposable.empty());
-                   refMain.set(observer);
-               }
-           }
-           .window(new Observable<Object>() {
-               @Override
-               protected void subscribeActual(Observer<? super Object> observer) {
-                   final AtomicInteger counter = new AtomicInteger();
-                   observer.onSubscribe(new Disposable() {
+            final TestObserver<Observable<Object>> to = new Observable<Object>() {
+                @Override
+                protected void subscribeActual(Observer<? super Object> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    refMain.set(observer);
+                }
+            }
+            .window(new Observable<Object>() {
+                @Override
+                protected void subscribeActual(Observer<? super Object> observer) {
+                    final AtomicInteger counter = new AtomicInteger();
+                    observer.onSubscribe(new Disposable() {
 
-                       @Override
-                       public void dispose() {
-                           // about a microsecond
-                           for (int i = 0; i < 100; i++) {
-                               counter.incrementAndGet();
-                           }
-                       }
+                        @Override
+                        public void dispose() {
+                            // about a microsecond
+                            for (int i = 0; i < 100; i++) {
+                                counter.incrementAndGet();
+                            }
+                        }
 
-                       @Override
-                       public boolean isDisposed() {
-                           return false;
-                       }
+                        @Override
+                        public boolean isDisposed() {
+                            return false;
+                        }
                     });
-                   ref.set(observer);
-               }
-           })
-           .test();
+                    ref.set(observer);
+                }
+            })
+            .test();
 
             Runnable r1 = new Runnable() {
                 @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
@@ -170,7 +170,8 @@ public class ObservableZipTest extends RxJavaTest {
     };
 
     /**
-     * Testing internal private logic due to the complexity so I want to use TDD to test as a I build it rather than relying purely on the overall functionality expected by the public methods.
+     * Testing internal private logic due to the complexity so I want to use TDD to test as a I build it
+     * rather than relying purely on the overall functionality expected by the public methods.
      */
     @Test
     public void aggregatorSimple() {

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerWhenTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerWhenTest.java
@@ -263,31 +263,31 @@ public class SchedulerWhenTest extends RxJavaTest {
     @Test
     public void scheduledActiondisposedSetRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            @SuppressWarnings("resource")
-            final ScheduledAction sa = new ScheduledAction() {
+            try (final var sa = new ScheduledAction() {
 
-                private static final long serialVersionUID = -672980251643733156L;
+                    private static final long serialVersionUID = -672980251643733156L;
 
-                @Override
-                protected Disposable callActual(Worker actualWorker,
-                        CompletableObserver actionCompletable) {
-                    return Disposable.empty();
-                }
+                    @Override
+                    protected Disposable callActual(Worker actualWorker,
+                            CompletableObserver actionCompletable) {
+                        return Disposable.empty();
+                    }
 
-            };
+                }) {
 
-            assertFalse(sa.isDisposed());
+                assertFalse(sa.isDisposed());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    sa.dispose();
-                }
-            };
+                Runnable r1 = new Runnable() {
+                    @Override
+                    public void run() {
+                        sa.dispose();
+                    }
+                };
 
-            TestHelper.race(r1, r1);
+                TestHelper.race(r1, r1);
 
-            assertTrue(sa.isDisposed());
+                assertTrue(sa.isDisposed());
+            }
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/util/OperatorMatrixGenerator.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/OperatorMatrixGenerator.java
@@ -66,7 +66,8 @@ public final class OperatorMatrixGenerator {
         List<String> sortedOperators = new ArrayList<>(operatorSet);
         sortedOperators.sort(Comparator.naturalOrder());
 
-        try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get("docs", "Operator-Matrix.md"), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))) {
+        try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get("docs", "Operator-Matrix.md"),
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))) {
             out.print("Operator |");
             for (Class<?> clazz : CLASSES) {
                 out.print(" ");
@@ -219,10 +220,12 @@ public final class OperatorMatrixGenerator {
             "    C buffer                               Always empty. Use [`andThen()`](#andThen) to bring in a list/collection.",
             "  MSC cacheWithInitialCapacity             At most one element to store. Use [`cache()`](#cache).",
             "    C cast                                 Always empty.",
-            "  M   collect                              At most one element to collect. Use [`map()`](#map) and [`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
+            "  M   collect                              At most one element to collect. Use [`map()`](#map) and "
+                    + "[`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
             "   S  collect                              One element to collect. Use [`map()`](#map) to transform into a list/collection.",
             "    C collect                              Always empty. Use [`andThen()`](#andThen) to bring in a collection.",
-            "  M   collectInto                          At most one element to collect. Use [`map()`](#map) and [`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
+            "  M   collectInto                          At most one element to collect. Use [`map()`](#map) and "
+                    + "[`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
             "   S  collectInto                          One element to collect. Use [`map()`](#map) to transform into a list/collection.",
             "    C collectInto                          Always empty. Use [`andThen()`](#andThen) to bring in a collection.",
             "  MS  combineLatest                        At most one element per source. Use [`zip()`](#zip).",
@@ -241,7 +244,8 @@ public final class OperatorMatrixGenerator {
             "    C concatEagerDelayError                No items to keep ordered. Use [`mergeDelayError()`](#mergeDelayError).",
             "    C concatMap                            Always empty thus no items to map.",
             "    C concatMapCompletable                 Always empty thus no items to map.",
-            "  MS  concatMapCompletableDelayError       Either the upstream fails (thus no inner) or the mapped-in source, but never both. Use [`concatMapCompletable`](#concatMapCompletable).",
+            "  MS  concatMapCompletableDelayError       Either the upstream fails (thus no inner) or the mapped-in source, "
+                    + "but never both. Use [`concatMapCompletable`](#concatMapCompletable).",
             "    C concatMapCompletableDelayError       Always empty thus no items to map.",
             "  MS  concatMapDelayError                  Either the upstream fails (thus no inner) or the mapped-in source, but never both.  Use [`concatMap`](#concatMap).",
             "    C concatMapDelayError                  Always empty thus no items to map.",
@@ -252,15 +256,18 @@ public final class OperatorMatrixGenerator {
             "    C concatMapIterable                    Always empty thus no items to map.",
             "  M   concatMapMaybe                       Use [`concatMap`](#concatMap).",
             "    C concatMapMaybe                       Always empty thus no items to map.",
-            "  MS  concatMapMaybeDelayError             Either the upstream fails (thus no inner) or the mapped-in source, but never both.  Use [`concatMapMaybe`](#concatMapMaybe).",
+            "  MS  concatMapMaybeDelayError             Either the upstream fails (thus no inner) or the mapped-in source, "
+                    + "but never both.  Use [`concatMapMaybe`](#concatMapMaybe).",
             "    C concatMapMaybeDelayError             Always empty thus no items to map.",
             "   S  concatMapSingle                      Use [`concatMap()`](#concatMap).",
             "    C concatMapSingle                      Always empty thus no items to map.",
-            "  MS  concatMapSingleDelayError            Either the upstream fails (thus no inner) or the mapped-in source, but never both.  Use [`concatMapSingle`](#concatMapSingle).",
+            "  MS  concatMapSingleDelayError            Either the upstream fails (thus no inner) or the mapped-in source, "
+                    + "but never both.  Use [`concatMapSingle`](#concatMapSingle).",
             "    C concatMapSingleDelayError            Always empty thus no items to map.",
             "    C concatMapStream                      Always empty thus no items to map.",
             "  MS  concatMapIterable                    At most one item. Use [`flattenAsFlowable`](#flattenAsFlowable) or [`flattenAsObservable`](#flattenAsObservable).",
-            "  MS  concatMapStream                      At most one item. Use [`flattenStreamAsFlowable`](#flattenStreamAsFlowable) or [`flattenStreamAsObservable`](#flattenStreamAsObservable).",
+            "  MS  concatMapStream                      At most one item. Use [`flattenStreamAsFlowable`](#flattenStreamAsFlowable) "
+                    + "or [`flattenStreamAsObservable`](#flattenStreamAsObservable).",
             "    C contains                             Always empty.",
             "   S  count                                Never empty thus always 1.",
             "    C count                                Always empty thus always 0.",
@@ -320,7 +327,8 @@ public final class OperatorMatrixGenerator {
             "    C flatMapSingle                        Always empty thus no items to map.",
             "    C flatMapStream                        Always empty thus no items to map.",
             "  MS  flatMapIterable                      At most one item. Use [`flattenAsFlowable`](#flattenAsFlowable) or [`flattenAsObservable`](#flattenAsObservable).",
-            "  MS  flatMapStream                        At most one item. Use [`flattenStreamAsFlowable`](#flattenStreamAsFlowable) or [`flattenStreamAsObservable`](#flattenStreamAsObservable).",
+            "  MS  flatMapStream                        At most one item. Use [`flattenStreamAsFlowable`](#flattenStreamAsFlowable) "
+                    + "or [`flattenStreamAsObservable`](#flattenStreamAsObservable).",
             "F     flatMapObservable                    Not supported. Use [`flatMap`](#flatMap) and [`toFlowable()`](#toFlowable).",
             " O    flatMapObservable                    Use [`flatMap`](#flatMap).",
             "    C flatMapObservable                    Always empty thus no items to map.",
@@ -473,13 +481,16 @@ public final class OperatorMatrixGenerator {
             "    C timestamp                            Always empty thus no items to work with.",
             "FO    toCompletionStage                    Use [`firstStage`](#firstStage), [`lastStage`](#lastStage) or [`singleStage`](#singleStage).",
             "F     toFlowable                           Would be no-op.",
-            "  M   toList                               At most one element to collect. Use [`map()`](#map) and [`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
+            "  M   toList                               At most one element to collect. Use [`map()`](#map) and "
+                    + "[`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
             "   S  toList                               One element to collect. Use [`map()`](#map) to transform into a list/collection.",
             "    C toList                               Always empty. Use [`andThen()`](#andThen) to bring in a collection.",
-            "  M   toMap                                At most one element to collect. Use [`map()`](#map) and [`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
+            "  M   toMap                                At most one element to collect. Use [`map()`](#map) and "
+                    + "[`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
             "   S  toMap                                One element to collect. Use [`map()`](#map) to transform into a list/collection.",
             "    C toMap                                Always empty. Use [`andThen()`](#andThen) to bring in a collection.",
-            "  M   toMultimap                           At most one element to collect. Use [`map()`](#map) and [`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
+            "  M   toMultimap                           At most one element to collect. Use [`map()`](#map) and "
+                    + "[`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
             "   S  toMultimap                           One element to collect. Use [`map()`](#map) to transform into a list/collection.",
             "    C toMultimap                           Always empty. Use [`andThen()`](#andThen) to bring in a collection.",
             "FO    toMaybe                              Use [`firstElement`](#firstElement), [`lastElement`](#lastElement) or [`singleElement`](#singleElement).",
@@ -490,7 +501,8 @@ public final class OperatorMatrixGenerator {
             "FO    toSingleDefault                      Use [`first`](#first), [`last`](#last) or [`single`](#single).",
             "  M   toSingleDefault                      Use [`defaultIfEmpty()`](#defaultIfEmpty).",
             "   S  toSingleDefault                      Would be no-op.",
-            "  M   toSortedList                         At most one element to collect. Use [`map()`](#map) and [`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
+            "  M   toSortedList                         At most one element to collect. Use [`map()`](#map) and "
+                    + "[`switchIfEmpty()`](#switchIfEmpty) to transform into a list/collection.",
             "   S  toSortedList                         One element to collect. Use [`map()`](#map) to transform into a list/collection.",
             "    C toSortedList                         Always empty. Use [`andThen()`](#andThen) to bring in a collection.",
             "  M   window                               Use [`map()`](#map) and [`switchIfEmpty()`](#switchIfEmpty) to transform into a nested source.",

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableSubscriberTest.java
@@ -206,7 +206,9 @@ public class ObservableSubscriberTest extends RxJavaTest {
                 Observable.just(1).test();
                 fail("Should have thrown");
             } catch (NullPointerException ex) {
-                assertEquals("The RxJavaPlugins.onSubscribe hook returned a null Observer. Please change the handler provided to RxJavaPlugins.setOnObservableSubscribe for invalid null returns. Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins", ex.getMessage());
+                assertEquals("The RxJavaPlugins.onSubscribe hook returned a null Observer. "
+                        + "Please change the handler provided to RxJavaPlugins.setOnObservableSubscribe for invalid null returns. "
+                        + "Further reading: https://github.com/ReactiveX/RxJava/wiki/Plugins", ex.getMessage());
             }
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
@@ -100,7 +100,8 @@ public class SerializedObserverTest extends RxJavaTest {
         onSubscribe.waitToFinish();
         busySubscriber.terminalEvent.await();
 
-        System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get() + "  Observer maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
+        System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get()
+        + "  Observer maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
 
         // we can't know how many onNext calls will occur since they each run on a separate thread
         // that depends on thread scheduling so 0, 1, 2 and 3 are all valid options
@@ -133,7 +134,8 @@ public class SerializedObserverTest extends RxJavaTest {
             w.subscribe(aw);
             onSubscribe.waitToFinish();
 
-            System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get() + "  Observer maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
+            System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get()
+            + "  Observer maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
 
             // we can have concurrency ...
             assertTrue(onSubscribe.maxConcurrentThreads.get() > 1);

--- a/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
@@ -890,7 +890,8 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        assertThrowsWithMessage("Value 1 (class: Integer) at position 0 did not pass the predicate (latch = 0, values = 1, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Value 1 (class: Integer) at position 0 did not pass the predicate "
+                + "(latch = 0, values = 1, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Integer> to = new TestObserver<>();
 
             Observable.just(1).subscribe(to);
@@ -905,7 +906,8 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        assertThrowsWithMessage("The first value passed the predicate but this consumer received more than one value (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("The first value passed the predicate but this consumer received more than one value "
+                + "(latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Integer> to = new TestObserver<>();
 
             Observable.just(1, 2).subscribe(to);
@@ -948,7 +950,8 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        assertThrowsWithMessage("Value 3 (class: Integer) at position 2 did not pass the predicate (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Value 3 (class: Integer) at position 2 did not pass the predicate "
+                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<Integer> to = new TestObserver<>();
 
             Observable.just(1, 2, 3).subscribe(to);
@@ -1013,7 +1016,8 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        assertThrowsWithMessage("\nexpected: b (class: String)\ngot: c (class: String); Value at position 2 differ (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("\nexpected: b (class: String)\ngot: c (class: String); Value at position 2 differ "
+                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);
@@ -1035,7 +1039,8 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuesCountNoMatch() {
-        assertThrowsWithMessage("\nexpected: 2 [a, b]\ngot: 3 [a, b, c]; Value count differs (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("\nexpected: 2 [a, b]\ngot: 3 [a, b, c]; "
+                + "Value count differs (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);
@@ -1057,7 +1062,8 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuesNoMatch() {
-        assertThrowsWithMessage("\nexpected: d (class: String)\ngot: c (class: String); Value at position 2 differ (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("\nexpected: d (class: String)\ngot: c (class: String); Value at position 2 differ "
+                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);
@@ -1101,7 +1107,8 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueSequenceNoMatch() {
-        assertThrowsWithMessage("\nexpected: d (class: String)\ngot: c (class: String); Value at position 2 differ (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("\nexpected: d (class: String)\ngot: c (class: String); Value at position 2 differ "
+                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);

--- a/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
@@ -1012,13 +1012,15 @@ public class RxJavaPluginsTest extends RxJavaTest {
                     return schedulerSupplier.get();
                 }
             };
-            Function<? super ConnectableFlowable, ? extends ConnectableFlowable> connectableFlowable2ConnectableFlowable = new Function<ConnectableFlowable, ConnectableFlowable>() {
+            Function<? super ConnectableFlowable, ? extends ConnectableFlowable> connectableFlowable2ConnectableFlowable
+                = new Function<ConnectableFlowable, ConnectableFlowable>() {
                 @Override
                 public ConnectableFlowable apply(ConnectableFlowable connectableFlowable) throws Exception {
                     return connectableFlowable;
                 }
             };
-            Function<? super ConnectableObservable, ? extends ConnectableObservable> connectableObservable2ConnectableObservable = new Function<ConnectableObservable, ConnectableObservable>() {
+            Function<? super ConnectableObservable, ? extends ConnectableObservable> connectableObservable2ConnectableObservable
+                = new Function<ConnectableObservable, ConnectableObservable>() {
                 @Override
                 public ConnectableObservable apply(ConnectableObservable connectableObservable) throws Exception {
                     return connectableObservable;
@@ -1084,7 +1086,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
                     return runnable;
                 }
             };
-            BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> completableObserver2completableObserver = new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
+            BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> completableObserver2completableObserver
+                = new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
                 @Override
                 public CompletableObserver apply(Completable completable, CompletableObserver completableObserver) throws Exception {
                     return completableObserver;

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SafeSubscriberTest.java
@@ -831,7 +831,7 @@ public class SafeSubscriberTest extends RxJavaTest {
 
             TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> ce = TestHelper.compositeList(list.get(0));
-           TestHelper.assertError(ce, 0, TestException.class, "request()");
+            TestHelper.assertError(ce, 0, TestException.class, "request()");
             TestHelper.assertError(ce, 1, TestException.class, "cancel()");
         } finally {
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
@@ -101,7 +101,8 @@ public class SerializedSubscriberTest extends RxJavaTest {
         onSubscribe.waitToFinish();
         busySubscriber.terminalEvent.await();
 
-        System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get() + "  Subscriber maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
+        System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get()
+        + "  Subscriber maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
 
         // we can't know how many onNext calls will occur since they each run on a separate thread
         // that depends on thread scheduling so 0, 1, 2 and 3 are all valid options
@@ -134,7 +135,8 @@ public class SerializedSubscriberTest extends RxJavaTest {
             w.subscribe(aw);
             onSubscribe.waitToFinish();
 
-            System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get() + "  Subscriber maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
+            System.out.println("OnSubscribe maxConcurrentThreads: " + onSubscribe.maxConcurrentThreads.get()
+            + "  Subscriber maxConcurrentThreads: " + busySubscriber.maxConcurrentThreads.get());
 
             // we can have concurrency ...
             assertTrue(onSubscribe.maxConcurrentThreads.get() > 1);

--- a/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
@@ -1398,7 +1398,8 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateNoMatch() {
-        assertThrowsWithMessage("Value 1 (class: Integer) at position 0 did not pass the predicate (latch = 0, values = 1, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Value 1 (class: Integer) at position 0 did not pass the predicate "
+                + "(latch = 0, values = 1, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1).subscribe(ts);
@@ -1413,7 +1414,8 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValuePredicateMatchButMore() {
-        assertThrowsWithMessage("The first value passed the predicate but this consumer received more than one value (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("The first value passed the predicate but this consumer received more than one value "
+                + "(latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).subscribe(ts);
@@ -1456,7 +1458,8 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateNoMatch() {
-        assertThrowsWithMessage("Value 3 (class: Integer) at position 2 did not pass the predicate (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Value 3 (class: Integer) at position 2 did not pass the predicate "
+                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2, 3).subscribe(ts);

--- a/src/test/java/io/reactivex/rxjava4/validators/JavadocForAnnotations.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/JavadocForAnnotations.java
@@ -163,7 +163,8 @@ public class JavadocForAnnotations {
 
                                         if (p < 0 || p > o) {
                                             // when printed on the console, IDEs will create a clickable link to help navigate to the offending point
-                                            e.append("java.lang.RuntimeException: wrong method name in description of ").append(inDoc).append(" '").append(mname).append("'\r\n")
+                                            e.append("java.lang.RuntimeException: wrong method name in description of ")
+                                            .append(inDoc).append(" '").append(mname).append("'\r\n")
                                             ;
                                             int lc = lineNumber(sourceCode, idx);
 

--- a/src/test/java/io/reactivex/rxjava4/validators/JavadocWording.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/JavadocWording.java
@@ -208,7 +208,8 @@ public class JavadocWording {
                     }
                 }
 
-                checkAtReturnAndSignatureMatch("Maybe", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
+                checkAtReturnAndSignatureMatch("Maybe", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable",
+                        "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
 
                 aOrAn(e, m, "Maybe");
                 missingClosingDD(e, m, "Maybe", "io.reactivex.rxjava4.core");
@@ -351,7 +352,8 @@ public class JavadocWording {
                     }
                 }
 
-                checkAtReturnAndSignatureMatch("Flowable", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable", "ConnectableFlowable", "ParallelFlowable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
+                checkAtReturnAndSignatureMatch("Flowable", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable",
+                        "ConnectableFlowable", "ParallelFlowable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
 
                 aOrAn(e, m, "Flowable");
                 missingClosingDD(e, m, "Flowable", "io.reactivex.rxjava4.core");
@@ -493,7 +495,8 @@ public class JavadocWording {
                     }
                 }
 
-                checkAtReturnAndSignatureMatch("ParallelFlowable", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable", "ConnectableFlowable", "ParallelFlowable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
+                checkAtReturnAndSignatureMatch("ParallelFlowable", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable",
+                        "ConnectableFlowable", "ParallelFlowable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
 
                 aOrAn(e, m, "ParallelFlowable");
                 missingClosingDD(e, m, "ParallelFlowable", "io.reactivex.rxjava4.parallel");
@@ -596,7 +599,8 @@ public class JavadocWording {
                         break;
                     }
                 }
-                checkAtReturnAndSignatureMatch("Observable", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable", "ConnectableObservable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
+                checkAtReturnAndSignatureMatch("Observable", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable",
+                        "ConnectableObservable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
 
                 aOrAn(e, m, "Observable");
                 missingClosingDD(e, m, "Observable", "io.reactivex.rxjava4.core");
@@ -772,7 +776,8 @@ public class JavadocWording {
                     }
                 }
 
-                checkAtReturnAndSignatureMatch("Single", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
+                checkAtReturnAndSignatureMatch("Single", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable",
+                        "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
 
                 aOrAn(e, m, "Single");
                 missingClosingDD(e, m, "Single", "io.reactivex.rxjava4.core");
@@ -963,7 +968,8 @@ public class JavadocWording {
                     }
                 }
 
-                checkAtReturnAndSignatureMatch("Completable", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable", "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
+                checkAtReturnAndSignatureMatch("Completable", m, e, "Flowable", "Observable", "Maybe", "Single", "Completable",
+                        "Disposable", "Iterable", "Stream", "Future", "CompletionStage");
 
                 aOrAn(e, m, "Completable");
                 missingClosingDD(e, m, "Completable", "io.reactivex.rxjava4.core");

--- a/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
@@ -204,7 +204,8 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.ANY, "takeLast", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Integer.TYPE));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.NON_NEGATIVE, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Flowable.class, 0, ParamMode.NON_NEGATIVE, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class));
-        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.NON_NEGATIVE, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Integer.TYPE));
+        addOverride(new ParamOverride(Flowable.class, 0, ParamMode.NON_NEGATIVE, "takeLast",
+                Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Integer.TYPE));
         addOverride(new ParamOverride(Flowable.class, 1, ParamMode.ANY, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Flowable.class, 1, ParamMode.ANY, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Flowable.class, 1, ParamMode.ANY, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Integer.TYPE));
@@ -454,7 +455,8 @@ public class ParamValidationCheckerTest {
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.ANY, "takeLast", Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Integer.TYPE));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.NON_NEGATIVE, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Observable.class, 0, ParamMode.NON_NEGATIVE, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class));
-        addOverride(new ParamOverride(Observable.class, 0, ParamMode.NON_NEGATIVE, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Integer.TYPE));
+        addOverride(new ParamOverride(Observable.class, 0, ParamMode.NON_NEGATIVE, "takeLast",
+                Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Integer.TYPE));
         addOverride(new ParamOverride(Observable.class, 1, ParamMode.ANY, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class));
         addOverride(new ParamOverride(Observable.class, 1, ParamMode.ANY, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Observable.class, 1, ParamMode.ANY, "takeLast", Long.TYPE, Long.TYPE, TimeUnit.class, Scheduler.class, Boolean.TYPE, Integer.TYPE));
@@ -905,19 +907,22 @@ public class ParamValidationCheckerTest {
                             if (!success && error.getCause() instanceof NullPointerException) {
                                 if (!error.getCause().toString().contains("is null")) {
                                     fail++;
-                                    b.append("\r\nNPEs should indicate which argument failed: " + m + " # " + i + " = " + p + ", tag = " + tag + ", params = " + Arrays.toString(callParams2));
+                                    b.append("\r\nNPEs should indicate which argument failed: "
+                                    + m + " # " + i + " = " + p + ", tag = " + tag + ", params = " + Arrays.toString(callParams2));
                                 }
                             }
                             if (success != shouldSucceed) {
                                 fail++;
                                 if (shouldSucceed) {
-                                    b.append("\r\nFailed (should have succeeded): " + m + " # " + i + " = " + p + ", tag = " + tag + ", params = " + Arrays.toString(callParams2));
+                                    b.append("\r\nFailed (should have succeeded): "
+                                    + m + " # " + i + " = " + p + ", tag = " + tag + ", params = " + Arrays.toString(callParams2));
                                     b.append("\r\n    ").append(error);
                                     if (error.getCause() != null) {
                                         b.append("\r\n    ").append(error.getCause());
                                     }
                                 } else {
-                                    b.append("\r\nNo failure (should have failed): " + m + " # " + i + " = " + p + ", tag = " + tag + ", params = " + Arrays.toString(callParams2));
+                                    b.append("\r\nNo failure (should have failed): "
+                                    + m + " # " + i + " = " + p + ", tag = " + tag + ", params = " + Arrays.toString(callParams2));
                                 }
                                 continue outer;
                             }


### PR DESCRIPTION
- Fix javadocs warnings
- Limit line length to 175 characters to avoid supply-chain-attacks with horizontal out-of-view code tricks
- Force multiple of four spaces before code and comments

I know its a lot, but all this was accumulated over a decade.