### PR TITLE
4.x: Intro Schedulers.virtual(), deprecate Schedulers.io(), fix tests

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/annotations/SchedulerSupport.java
+++ b/src/main/java/io/reactivex/rxjava4/annotations/SchedulerSupport.java
@@ -46,10 +46,24 @@ public @interface SchedulerSupport {
      */
     String COMPUTATION = "io.reactivex:computation";
     /**
-     * The operator/class runs on RxJava's {@linkplain Schedulers#io() I/O scheduler} or takes
+     * The operator/class runs on RxJava's {@linkplain Schedulers#cached() I/O scheduler} or takes
      * timing information from it.
+     * @deprecated since 4.0.0, use the more specific {@link #CACHED} or {@link #VIRTUAL} constants
      */
+    @Deprecated(since = "4.0.0")
     String IO = "io.reactivex:io";
+    /**
+     * The operator/class runs on RxJava's {@linkplain Schedulers#cached() I/O scheduler} or takes
+     * timing information from it.
+     * @since 4.0.0
+     */
+    String CACHED = "io.reactivex:cached";
+    /**
+     * The operator/class runs on RxJava's {@linkplain Schedulers#virtual() Virtual scheduler} or takes
+     * timing information from it.
+     * @since 4.0.0
+     */
+    String VIRTUAL = "io.reactivex:virtual";
     /**
      * The operator/class runs on RxJava's {@linkplain Schedulers#newThread() new thread scheduler}
      * or takes timing information from it.

--- a/src/main/java/io/reactivex/rxjava4/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Completable.java
@@ -69,7 +69,7 @@ import io.reactivex.rxjava4.schedulers.Schedulers;
  * Example:
  * <pre><code>
  * Disposable d = Completable.complete()
- *    .delay(10, TimeUnit.SECONDS, Schedulers.io())
+ *    .delay(10, TimeUnit.SECONDS, Schedulers.cached())
  *    .subscribeWith(new DisposableCompletableObserver() {
  *        &#64;Override
  *        public void onStart() {

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -51,7 +51,7 @@ import io.reactivex.rxjava4.subscribers.*;
  * <em>Reactive Streams</em> implementations.
  * <p>
  * The {@code Flowable} hosts the default buffer size of 128 elements for operators, accessible via {@link #bufferSize()},
- * that can be overridden globally via the system parameter {@code rx3.buffer-size}. Most operators, however, have
+ * that can be overridden globally via the system parameter {@code rx4.buffer-size}. Most operators, however, have
  * overloads that allow setting their internal buffer size explicitly.
  * <p>
  * The documentation for this class makes use of marble diagrams. The following legend explains these diagrams:
@@ -161,7 +161,7 @@ FlowableDocBasic<T>
     /** The default buffer size. */
     static final int BUFFER_SIZE;
     static {
-        BUFFER_SIZE = Math.max(1, Integer.getInteger("rx3.buffer-size", 128));
+        BUFFER_SIZE = Math.max(1, Integer.getInteger("rx4.buffer-size", 128));
     }
 
     /**
@@ -250,7 +250,7 @@ FlowableDocBasic<T>
 
     /**
      * Returns the default internal buffer size used by most async operators.
-     * <p>The value can be overridden via system parameter {@code rx3.buffer-size}
+     * <p>The value can be overridden via system parameter {@code rx4.buffer-size}
      * <em>before</em> the {@code Flowable} class is loaded.
      * @return the default internal buffer size.
      */
@@ -20815,7 +20815,100 @@ FlowableDocBasic<T>
     public static <@NonNull T> Flowable<T> virtualCreate(@NonNull VirtualGenerator<T> generator, @NonNull ExecutorService executor) {
         Objects.requireNonNull(generator, "generator is null");
         Objects.requireNonNull(executor, "executor is null");
-        return RxJavaPlugins.onAssembly(new FlowableVirtualCreateExecutor<>(generator, executor));
+        return RxJavaPlugins.onAssembly(new FlowableVirtualCreateExecutor<>(generator, executor, null));
+    }
+
+    /**
+     * Construct a {@code Flowable} and use the given {@code generator}
+     * to generate items on demand while running on the {@link Schedulers#virtual()}.
+     * <p>
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator honors backpressure from downstream and blocks the emitter if
+     *  the downstream is not ready.
+     *  </dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The operator by default runs on the {@link Schedulers#virtual()} scheduler.</dd>
+     * </dl>
+     * <p>
+     * Note that backpressure is handled via blocking so it is recommended the default
+     * {@link Scheduler} uses virtual threads, such as the one returned by
+     * {@link Schedulers#virtual()}.
+     * <p>
+     * Examples:
+     * <pre><code>
+     *     Flowable.&lt;Integer&gt;virtualCreate(emitter -> {
+     *         for (int i = 0; i &lt; 10; i++) {
+     *             Thread.sleep(1000);
+     *             emitter.emit(i);
+     *         }
+     *     })
+     *     .subscribe(
+     *         System.out::println,
+     *         Throwable::printStackTrace,
+     *         () -&gt; System.out.println("Done")
+     *     );
+     * </code></pre>
+     * @param <T> the element type to emit
+     * @param generator the callback used to generate items on demand by the downstream
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code generator} or {@code executor} is {@code null}
+     * @since 4.0.0
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.VIRTUAL)
+    @NonNull
+    public static <@NonNull T> Flowable<T> virtualCreate(@NonNull VirtualGenerator<T> generator) {
+        return virtualCreate(generator, Schedulers.virtual());
+    }
+
+    /**
+     * Construct a {@code Flowable} and use the given {@code generator}
+     * to generate items on demand while running on the given {@link Scheduler}.
+     * <p>
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator honors backpressure from downstream and blocks the emitter if
+     *  the downstream is not ready.
+     *  </dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
+     * </dl>
+     * <p>
+     * Note that backpressure is handled via blocking so it is recommended the provided
+     * {@code Scheduler} uses virtual threads, such as the one returned by
+     * {@link Executors#newVirtualThreadPerTaskExecutor()}.
+     * <p>
+     * Examples:
+     * <pre><code>
+     *     Flowable.&lt;Integer&gt;virtualCreate(emitter -> {
+     *         for (int i = 0; i &lt; 10; i++) {
+     *             Thread.sleep(1000);
+     *             emitter.emit(i);
+     *         }
+     *     }, Schedulers.virtual())
+     *     .subscribe(
+     *         System.out::println,
+     *         Throwable::printStackTrace,
+     *         () -&gt; System.out.println("Done")
+     *     );
+     * </code></pre>
+     * @param <T> the element type to emit
+     * @param generator the callback used to generate items on demand by the downstream
+     * @param scheduler the target {@code Scheduler} to use for running the callback
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code generator} or {@code scheduler} is {@code null}
+     * @since 4.0.0
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    @NonNull
+    public static <@NonNull T> Flowable<T> virtualCreate(@NonNull VirtualGenerator<T> generator, @NonNull Scheduler scheduler) {
+        Objects.requireNonNull(generator, "generator is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
+        return RxJavaPlugins.onAssembly(new FlowableVirtualCreateExecutor<>(generator, null, scheduler));
     }
 
     /**
@@ -20835,7 +20928,8 @@ FlowableDocBasic<T>
      * {@code ExecutorService} uses virtual threads, such as the one returned by
      * {@link Executors#newVirtualThreadPerTaskExecutor()}.
      * @param <R> the downstream element type
-     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)} is invoked for each upstream item
+     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)}
+     *  is invoked for each upstream item
      * @param executor the target {@code ExecutorService} to use for running the callback
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code transformer} or {@code executor} is {@code null}
@@ -20845,8 +20939,78 @@ FlowableDocBasic<T>
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Flowable<R> virtualTransform(@NonNull VirtualTransformer<T, R> transformer, @NonNull ExecutorService executor) {
+    public final <@NonNull R> Flowable<R> virtualTransform(@NonNull VirtualTransformer<T, R> transformer,
+            @NonNull ExecutorService executor) {
         return virtualTransform(transformer, executor, Flowable.bufferSize());
+    }
+
+    /**
+     * Returns a {@code Flowable} that turns an upstream item an upstream item into
+     * zero or more downstream values by running on the {@link Schedulers#virtual()} scheduler.
+     * <p>
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator honors backpressure from downstream and blocks the emitter if
+     *  the downstream is not ready.
+     *  </dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The operator by default runs on the {@link Schedulers#virtual()} scheduler.</dd>
+     * </dl>
+     * <p>
+     * Note that backpressure is handled via blocking so it is recommended the default
+     * {@link Scheduler} uses virtual threads, such as the one returned by
+     * {@link Executors#newVirtualThreadPerTaskExecutor()}.
+     * @param <R> the downstream element type
+     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)}
+     *  is invoked for each upstream item
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code transformer} is {@code null}
+     * @since 4.0.0
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.VIRTUAL)
+    @NonNull
+    public final <@NonNull R> Flowable<R> virtualTransform(@NonNull VirtualTransformer<T, R> transformer) {
+        return virtualTransform(transformer, Schedulers.virtual(), Flowable.bufferSize());
+    }
+
+    /**
+     * Returns a {@code Flowable} that turns an upstream item an upstream item into
+     * zero or more downstream values by running on the given {@link Scheduler}.
+     * <p>
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator honors backpressure from downstream and blocks the emitter if
+     *  the downstream is not ready.
+     *  </dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
+     * </dl>
+     * <p>
+     * Note that backpressure is handled via blocking so it is recommended the provided
+     * {@code Scheduler} uses virtual threads, such as the one returned by
+     * {@link Schedulers#virtual()}.
+     * @param <R> the downstream element type
+     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)}
+     * is invoked for each upstream item
+     * @param scheduler the target {@code Scheduler} to use for running the callback
+     * @param prefetch the number of items to fetch from the upstream.
+     * @return the new {@code Flowable} instance
+     * @throws NullPointerException if {@code transformer} or {@code scheduler} is {@code null}
+     * @throws IllegalArgumentException if {@code prefetch} is non-positive
+     * @since 4.0.0
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.CUSTOM)
+    @NonNull
+    public final <@NonNull R> Flowable<R> virtualTransform(@NonNull VirtualTransformer<T, R> transformer,
+            @NonNull Scheduler scheduler, int prefetch) {
+        Objects.requireNonNull(transformer, "transformer is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        return new FlowableVirtualTransformExecutor<>(this, transformer, null, scheduler, prefetch);
     }
 
     /**
@@ -20866,7 +21030,8 @@ FlowableDocBasic<T>
      * {@code ExecutorService} uses virtual threads, such as the one returned by
      * {@link Executors#newVirtualThreadPerTaskExecutor()}.
      * @param <R> the downstream element type
-     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)} is invoked for each upstream item
+     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)}
+     *  is invoked for each upstream item
      * @param executor the target {@code ExecutorService} to use for running the callback
      * @param prefetch the number of items to fetch from the upstream.
      * @return the new {@code Flowable} instance
@@ -20878,11 +21043,12 @@ FlowableDocBasic<T>
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Flowable<R> virtualTransform(@NonNull VirtualTransformer<T, R> transformer, @NonNull ExecutorService executor, int prefetch) {
+    public final <@NonNull R> Flowable<R> virtualTransform(@NonNull VirtualTransformer<T, R> transformer,
+            @NonNull ExecutorService executor, int prefetch) {
         Objects.requireNonNull(transformer, "transformer is null");
         Objects.requireNonNull(executor, "executor is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return new FlowableVirtualTransformExecutor<>(this, transformer, executor, prefetch);
+        return new FlowableVirtualTransformExecutor<>(this, transformer, executor, null, prefetch);
     }
 
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Maybe.java
@@ -68,7 +68,7 @@ import io.reactivex.rxjava4.schedulers.*;
  * Example:
  * <pre><code>
  * Disposable d = Maybe.just("Hello World")
- *    .delay(10, TimeUnit.SECONDS, Schedulers.io())
+ *    .delay(10, TimeUnit.SECONDS, Schedulers.cached())
  *    .subscribeWith(new DisposableMaybeObserver&lt;String&gt;() {
  *        &#64;Override
  *        public void onStart() {

--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -47,7 +47,7 @@ import io.reactivex.rxjava4.schedulers.*;
  * for such non-backpressured flows, which {@code Observable} itself implements as well.
  * <p>
  * The {@code Observable}'s operators, by default, run with a buffer size of 128 elements (see {@link Flowable#bufferSize()}),
- * that can be overridden globally via the system parameter {@code rx3.buffer-size}. Most operators, however, have
+ * that can be overridden globally via the system parameter {@code rx4.buffer-size}. Most operators, however, have
  * overloads that allow setting their internal buffer size explicitly.
  * <p>
  * The documentation for this class makes use of marble diagrams. The following legend explains these diagrams:
@@ -181,7 +181,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     /**
      * Returns the default 'island' size or capacity-increment hint for unbounded buffers.
      * <p>Delegates to {@link Flowable#bufferSize} but is public for convenience.
-     * <p>The value can be overridden via system parameter {@code rx3.buffer-size}
+     * <p>The value can be overridden via system parameter {@code rx4.buffer-size}
      * <em>before</em> the {@link Flowable} class is loaded.
      * @return the default 'island' size or capacity-increment hint
      */

--- a/src/main/java/io/reactivex/rxjava4/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Scheduler.java
@@ -62,7 +62,7 @@ import io.reactivex.rxjava4.schedulers.SchedulerRunnableIntrospection;
  * can detect the earlier hook and not apply a new one over again.
  * <p>
  * The default implementation of {@link #now(TimeUnit)} and {@link Worker#now(TimeUnit)} methods to return current {@link System#currentTimeMillis()}
- * value in the desired time unit, unless {@code rx3.scheduler.use-nanotime} (boolean) is set. When the property is set to
+ * value in the desired time unit, unless {@code rx4.scheduler.use-nanotime} (boolean) is set. When the property is set to
  * {@code true}, the method uses {@link System#nanoTime()} as its basis instead. Custom {@code Scheduler} implementations can override this
  * to provide specialized time accounting (such as virtual time to be advanced programmatically).
  * Note that operators requiring a {@code Scheduler} may rely on either of the {@code now()} calls provided by
@@ -75,7 +75,7 @@ import io.reactivex.rxjava4.schedulers.SchedulerRunnableIntrospection;
  * based on the relative time between it and {@link Worker#now(TimeUnit)}. However, drifts or changes in the
  * system clock could affect this calculation either by scheduling subsequent runs too frequently or too far apart.
  * Therefore, the default implementation uses the {@link #clockDriftTolerance()} value (set via
- * {@code rx3.scheduler.drift-tolerance} and {@code rx3.scheduler.drift-tolerance-unit}) to detect a
+ * {@code rx4.scheduler.drift-tolerance} and {@code rx4.scheduler.drift-tolerance-unit}) to detect a
  * drift in {@link Worker#now(TimeUnit)} and re-adjust the absolute/relative time calculation accordingly.
  * <p>
  * The default implementations of {@link #start()} and {@link #shutdown()} do nothing and should be overridden if the
@@ -96,10 +96,10 @@ public abstract class Scheduler {
      * <p>
      * Associated system parameter:
      * <ul>
-     *   <li>{@code rx3.scheduler.use-nanotime}, boolean, default {@code false}
+     *   <li>{@code rx4.scheduler.use-nanotime}, boolean, default {@code false}
      * </ul>
      */
-    static boolean IS_DRIFT_USE_NANOTIME = Boolean.getBoolean("rx3.scheduler.use-nanotime");
+    static boolean IS_DRIFT_USE_NANOTIME = Boolean.getBoolean("rx4.scheduler.use-nanotime");
 
     /**
      * Returns the current clock time depending on state of {@link Scheduler#IS_DRIFT_USE_NANOTIME} in given {@code unit}
@@ -123,15 +123,15 @@ public abstract class Scheduler {
      * <p>
      * Associated system parameters:
      * <ul>
-     * <li>{@code rx3.scheduler.drift-tolerance}, long, default {@code 15}</li>
-     * <li>{@code rx3.scheduler.drift-tolerance-unit}, string, default {@code minutes},
+     * <li>{@code rx4.scheduler.drift-tolerance}, long, default {@code 15}</li>
+     * <li>{@code rx4.scheduler.drift-tolerance-unit}, string, default {@code minutes},
      *     supports {@code seconds} and {@code milliseconds}.
      * </ul>
      */
     static final long CLOCK_DRIFT_TOLERANCE_NANOSECONDS =
             computeClockDrift(
-                    Long.getLong("rx3.scheduler.drift-tolerance", 15),
-                    System.getProperty("rx3.scheduler.drift-tolerance-unit", "minutes")
+                    Long.getLong("rx4.scheduler.drift-tolerance", 15),
+                    System.getProperty("rx4.scheduler.drift-tolerance-unit", "minutes")
             );
 
     /**
@@ -153,8 +153,8 @@ public abstract class Scheduler {
      * Returns the clock drift tolerance in nanoseconds.
      * <p>Related system properties:
      * <ul>
-     * <li>{@code rx3.scheduler.drift-tolerance}, long, default {@code 15}</li>
-     * <li>{@code rx3.scheduler.drift-tolerance-unit}, string, default {@code minutes},
+     * <li>{@code rx4.scheduler.drift-tolerance}, long, default {@code 15}</li>
+     * <li>{@code rx4.scheduler.drift-tolerance-unit}, string, default {@code minutes},
      *     supports {@code seconds} and {@code milliseconds}.
      * </ul>
      * @return the tolerance in nanoseconds
@@ -393,7 +393,7 @@ public abstract class Scheduler {
      * {@link #dispose()} can prevent their execution or potentially interrupt them if they are currently running.
      * <p>
      * The default implementation of the {@link #now(TimeUnit)} method returns current {@link System#currentTimeMillis()}
-     * value in the desired time unit, unless {@code rx3.scheduler.use-nanotime} (boolean) is set. When the property is set to
+     * value in the desired time unit, unless {@code rx4.scheduler.use-nanotime} (boolean) is set. When the property is set to
      * {@code true}, the method uses {@link System#nanoTime()} as its basis instead. Custom {@code Worker} implementations can override this
      * to provide specialized time accounting (such as virtual time to be advanced programmatically).
      * Note that operators requiring a scheduler may rely on either of the {@code now()} calls provided by
@@ -406,7 +406,7 @@ public abstract class Scheduler {
      * based on the relative time between it and {@link #now(TimeUnit)}. However, drifts or changes in the
      * system clock would affect this calculation either by scheduling subsequent runs too frequently or too far apart.
      * Therefore, the default implementation uses the {@link #clockDriftTolerance()} value (set via
-     * {@code rx3.scheduler.drift-tolerance} and {@code rx3.scheduler.drift-tolerance-unit}) to detect a drift in {@link #now(TimeUnit)} and
+     * {@code rx4.scheduler.drift-tolerance} and {@code rx4.scheduler.drift-tolerance-unit}) to detect a drift in {@link #now(TimeUnit)} and
      * re-adjust the absolute/relative time calculation accordingly.
      * <p>
      * If the {@code Worker} is disposed, the {@code schedule} methods

--- a/src/main/java/io/reactivex/rxjava4/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Single.java
@@ -76,7 +76,7 @@ import io.reactivex.rxjava4.schedulers.*;
  * Example:
  * <pre><code>
  * Disposable d = Single.just("Hello World")
- *    .delay(10, TimeUnit.SECONDS, Schedulers.io())
+ *    .delay(10, TimeUnit.SECONDS, Schedulers.cached())
  *    .subscribeWith(new DisposableSingleObserver&lt;String&gt;() {
  *        &#64;Override
  *        public void onStart() {

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/CachedScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/CachedScheduler.java
@@ -24,7 +24,7 @@ import io.reactivex.rxjava4.internal.disposables.EmptyDisposable;
 /**
  * Scheduler that creates and caches a set of thread pools and reuses them if possible.
  */
-public final class IoScheduler extends Scheduler {
+public final class CachedScheduler extends Scheduler {
     private static final String WORKER_THREAD_NAME_PREFIX = "RxCachedThreadScheduler";
     static final RxThreadFactory WORKER_THREAD_FACTORY;
 
@@ -32,7 +32,7 @@ public final class IoScheduler extends Scheduler {
     static final RxThreadFactory EVICTOR_THREAD_FACTORY;
 
     /** The name of the system property for setting the keep-alive time (in seconds) for this Scheduler workers. */
-    private static final String KEY_KEEP_ALIVE_TIME = "rx3.io-keep-alive-time";
+    private static final String KEY_KEEP_ALIVE_TIME = "rx4.cached-keep-alive-time";
     public static final long KEEP_ALIVE_TIME_DEFAULT = 60;
 
     private static final long KEEP_ALIVE_TIME;
@@ -43,10 +43,10 @@ public final class IoScheduler extends Scheduler {
     final AtomicReference<CachedWorkerPool> pool;
 
     /** The name of the system property for setting the thread priority for this Scheduler. */
-    private static final String KEY_IO_PRIORITY = "rx3.io-priority";
+    private static final String KEY_IO_PRIORITY = "rx4.cached-priority";
 
     /** The name of the system property for setting the release behaviour for this Scheduler. */
-    private static final String KEY_SCHEDULED_RELEASE = "rx3.io-scheduled-release";
+    private static final String KEY_SCHEDULED_RELEASE = "rx4.cached-scheduled-release";
     static boolean USE_SCHEDULED_RELEASE;
 
     static final CachedWorkerPool NONE;
@@ -156,16 +156,16 @@ public final class IoScheduler extends Scheduler {
         }
     }
 
-    public IoScheduler() {
+    public CachedScheduler() {
         this(WORKER_THREAD_FACTORY);
     }
 
     /**
-     * Constructs an IoScheduler with the given thread factory and starts the pool of workers.
+     * Constructs an CachedScheduler with the given thread factory and starts the pool of workers.
      * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
      *                      system properties for configuring new thread creation. Cannot be null.
      */
-    public IoScheduler(ThreadFactory threadFactory) {
+    public CachedScheduler(ThreadFactory threadFactory) {
         this.threadFactory = threadFactory;
         this.pool = new AtomicReference<>(NONE);
         start();

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/ComputationScheduler.java
@@ -36,7 +36,7 @@ public final class ComputationScheduler extends Scheduler implements SchedulerMu
      * Key to setting the maximum number of computation scheduler threads.
      * Zero or less is interpreted as use available. Capped by available.
      */
-    static final String KEY_MAX_THREADS = "rx3.computation-threads";
+    static final String KEY_MAX_THREADS = "rx4.computation-threads";
     /** The maximum number of computation scheduler threads. */
     static final int MAX_THREADS;
 
@@ -45,7 +45,7 @@ public final class ComputationScheduler extends Scheduler implements SchedulerMu
     final ThreadFactory threadFactory;
     final AtomicReference<FixedSchedulerPool> pool;
     /** The name of the system property for setting the thread priority for this Scheduler. */
-    private static final String KEY_COMPUTATION_PRIORITY = "rx3.computation-priority";
+    private static final String KEY_COMPUTATION_PRIORITY = "rx4.computation-priority";
 
     static {
         MAX_THREADS = cap(Runtime.getRuntime().availableProcessors(), Integer.getInteger(KEY_MAX_THREADS, 0));

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/DeferredExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/DeferredExecutorScheduler.java
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.schedulers;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.Scheduler;
+import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.functions.Supplier;
+import io.reactivex.rxjava4.internal.disposables.*;
+import io.reactivex.rxjava4.internal.functions.Functions;
+import io.reactivex.rxjava4.internal.queue.MpscLinkedQueue;
+import io.reactivex.rxjava4.plugins.RxJavaPlugins;
+import io.reactivex.rxjava4.schedulers.*;
+
+/**
+ * Wraps an Executor supplier and provides the Scheduler API over an instance of Executor
+ * created on demand.
+ */
+public final class DeferredExecutorScheduler extends Scheduler {
+
+    final boolean interruptibleWorker;
+
+    final boolean fair;
+
+    @NonNull
+    final Supplier<? extends Executor> executorSupplier;
+
+    static final class SingleHolder {
+        static final Scheduler HELPER = Schedulers.single();
+    }
+
+    public DeferredExecutorScheduler(@NonNull Supplier<? extends Executor> executorSupplier, boolean interruptibleWorker, boolean fair) {
+        this.executorSupplier = executorSupplier;
+        this.interruptibleWorker = interruptibleWorker;
+        this.fair = fair;
+    }
+
+    @NonNull
+    @Override
+    public Worker createWorker() {
+        try {
+            return new ExecutorWorker(executorSupplier.get(), interruptibleWorker, fair);
+        } catch (Throwable t) {
+            Exceptions.throwIfFatal(t);
+            throw Exceptions.propagate(t);
+        }
+    }
+
+    /* public: test support. */
+    public static final class ExecutorWorker extends Scheduler.Worker implements Runnable {
+
+        final boolean interruptibleWorker;
+
+        final boolean fair;
+
+        final Executor executor;
+
+        final MpscLinkedQueue<Runnable> queue;
+
+        volatile boolean disposed;
+
+        final AtomicInteger wip = new AtomicInteger();
+
+        final CompositeDisposable tasks = new CompositeDisposable();
+
+        public ExecutorWorker(Executor executor, boolean interruptibleWorker, boolean fair) {
+            this.executor = executor;
+            this.queue = new MpscLinkedQueue<>();
+            this.interruptibleWorker = interruptibleWorker;
+            this.fair = fair;
+        }
+
+        @NonNull
+        @Override
+        public Disposable schedule(@NonNull Runnable run) {
+            if (disposed) {
+                return EmptyDisposable.INSTANCE;
+            }
+
+            Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
+
+            Runnable task;
+            Disposable disposable;
+
+            if (interruptibleWorker) {
+                InterruptibleRunnable interruptibleTask = new InterruptibleRunnable(decoratedRun, tasks);
+                tasks.add(interruptibleTask);
+
+                task = interruptibleTask;
+                disposable = interruptibleTask;
+            } else {
+                @SuppressWarnings("resource")
+                BooleanRunnable runnableTask = new BooleanRunnable(decoratedRun);
+
+                task = runnableTask;
+                disposable = runnableTask;
+            }
+
+            queue.offer(task);
+
+            if (wip.getAndIncrement() == 0) {
+                try {
+                    executor.execute(this);
+                } catch (RejectedExecutionException ex) {
+                    disposed = true;
+                    queue.clear();
+                    RxJavaPlugins.onError(ex);
+                    return EmptyDisposable.INSTANCE;
+                }
+            }
+
+            return disposable;
+        }
+
+        @NonNull
+        @Override
+        public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
+            if (delay <= 0) {
+                return schedule(run);
+            }
+            if (disposed) {
+                return EmptyDisposable.INSTANCE;
+            }
+
+            SequentialDisposable first = new SequentialDisposable();
+
+            final SequentialDisposable mar = new SequentialDisposable(first);
+
+            final Runnable decoratedRun = RxJavaPlugins.onSchedule(run);
+
+            ScheduledRunnable sr = new ScheduledRunnable(new SequentialDispose(mar, decoratedRun), tasks, interruptibleWorker);
+            tasks.add(sr);
+
+            if (executor instanceof ScheduledExecutorService) {
+                try {
+                    Future<?> f = ((ScheduledExecutorService)executor).schedule((Callable<Object>)sr, delay, unit);
+                    sr.setFuture(f);
+                } catch (RejectedExecutionException ex) {
+                    disposed = true;
+                    RxJavaPlugins.onError(ex);
+                    return EmptyDisposable.INSTANCE;
+                }
+            } else {
+                final Disposable d = SingleHolder.HELPER.scheduleDirect(sr, delay, unit);
+                sr.setFuture(new DisposeOnCancel(d));
+            }
+
+            first.replace(sr);
+
+            return mar;
+        }
+
+        @Override
+        public void dispose() {
+            if (!disposed) {
+                disposed = true;
+                try {
+                    tasks.dispose();
+                    if (wip.getAndIncrement() == 0) {
+                        queue.clear();
+                    }
+                } finally {
+                    if (executor instanceof ExecutorService exec) {
+                        exec.shutdown();
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+
+        @Override
+        public void run() {
+            if (fair) {
+                runFair();
+            } else {
+                runEager();
+            }
+        }
+
+        void runFair() {
+            final MpscLinkedQueue<Runnable> q = queue;
+            if (disposed) {
+                q.clear();
+                return;
+            }
+
+            Runnable run = q.poll();
+            run.run(); // never null because of offer + increment happens first
+
+            if (disposed) {
+                q.clear();
+                return;
+            }
+
+            if (wip.decrementAndGet() != 0) {
+                executor.execute(this);
+            }
+        }
+
+        void runEager() {
+            int missed = 1;
+            final MpscLinkedQueue<Runnable> q = queue;
+            for (;;) {
+
+                if (disposed) {
+                    q.clear();
+                    return;
+                }
+
+                for (;;) {
+                    Runnable run = q.poll();
+                    if (run == null) {
+                        break;
+                    }
+                    run.run();
+
+                    if (disposed) {
+                        q.clear();
+                        return;
+                    }
+                }
+
+                if (disposed) {
+                    q.clear();
+                    return;
+                }
+
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class BooleanRunnable extends AtomicBoolean implements Runnable, Disposable {
+
+            private static final long serialVersionUID = -2421395018820541164L;
+
+            final Runnable actual;
+            BooleanRunnable(Runnable actual) {
+                this.actual = actual;
+            }
+
+            @Override
+            public void run() {
+                if (get()) {
+                    return;
+                }
+                try {
+                    actual.run();
+                } catch (Throwable ex) {
+                    // Exceptions.throwIfFatal(ex); nowhere to go
+                    RxJavaPlugins.onError(ex);
+                    throw ex;
+                } finally {
+                    lazySet(true);
+                }
+            }
+
+            @Override
+            public void dispose() {
+                lazySet(true);
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return get();
+            }
+        }
+
+        final class SequentialDispose implements Runnable {
+            private final SequentialDisposable mar;
+            private final Runnable decoratedRun;
+
+            SequentialDispose(SequentialDisposable mar, Runnable decoratedRun) {
+                this.mar = mar;
+                this.decoratedRun = decoratedRun;
+            }
+
+            @Override
+            public void run() {
+                mar.replace(schedule(decoratedRun));
+            }
+        }
+
+        /**
+         * Wrapper for a {@link Runnable} with additional logic for handling interruption on
+         * a shared thread, similar to how Java Executors do it.
+         */
+        static final class InterruptibleRunnable extends AtomicInteger implements Runnable, Disposable {
+
+            private static final long serialVersionUID = -3603436687413320876L;
+
+            final Runnable run;
+
+            final DisposableContainer tasks;
+
+            volatile Thread thread;
+
+            static final int READY = 0;
+
+            static final int RUNNING = 1;
+
+            static final int FINISHED = 2;
+
+            static final int INTERRUPTING = 3;
+
+            static final int INTERRUPTED = 4;
+
+            InterruptibleRunnable(Runnable run, DisposableContainer tasks) {
+                this.run = run;
+                this.tasks = tasks;
+            }
+
+            @Override
+            public void run() {
+                if (get() == READY) {
+                    thread = Thread.currentThread();
+                    if (compareAndSet(READY, RUNNING)) {
+                        try {
+                            try {
+                                run.run();
+                            } catch (Throwable ex) {
+                                // Exceptions.throwIfFatal(ex); nowhere to go
+                                RxJavaPlugins.onError(ex);
+                                throw ex;
+                            }
+                        } finally {
+                            thread = null;
+                            if (compareAndSet(RUNNING, FINISHED)) {
+                                cleanup();
+                            } else {
+                                while (get() == INTERRUPTING) {
+                                    Thread.yield();
+                                }
+                                Thread.interrupted();
+                            }
+                        }
+                    } else {
+                        thread = null;
+                    }
+                }
+            }
+
+            @Override
+            public void dispose() {
+                for (;;) {
+                    int state = get();
+                    if (state >= FINISHED) {
+                        break;
+                    } else if (state == READY) {
+                        if (compareAndSet(READY, INTERRUPTED)) {
+                            cleanup();
+                            break;
+                        }
+                    } else {
+                        if (compareAndSet(RUNNING, INTERRUPTING)) {
+                            Thread t = thread;
+                            if (t != null) {
+                                t.interrupt();
+                                thread = null;
+                            }
+                            set(INTERRUPTED);
+                            cleanup();
+                            break;
+                        }
+                    }
+                }
+            }
+
+            void cleanup() {
+                if (tasks != null) {
+                    tasks.delete(this);
+                }
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return get() >= FINISHED;
+            }
+        }
+    }
+
+    static final class DelayedRunnable extends AtomicReference<Runnable>
+            implements Runnable, Disposable, SchedulerRunnableIntrospection {
+
+        private static final long serialVersionUID = -4101336210206799084L;
+
+        final SequentialDisposable timed;
+
+        final SequentialDisposable direct;
+
+        DelayedRunnable(Runnable run) {
+            super(run);
+            this.timed = new SequentialDisposable();
+            this.direct = new SequentialDisposable();
+        }
+
+        @Override
+        public void run() {
+            Runnable r = get();
+            if (r != null) {
+                try {
+                    try {
+                        r.run();
+                    } finally {
+                        lazySet(null);
+                        timed.lazySet(DisposableHelper.DISPOSED);
+                        direct.lazySet(DisposableHelper.DISPOSED);
+                    }
+                } catch (Throwable ex) {
+                    // Exceptions.throwIfFatal(ex); nowhere to go
+                    RxJavaPlugins.onError(ex);
+                    throw ex;
+                }
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return get() == null;
+        }
+
+        @Override
+        public void dispose() {
+            if (getAndSet(null) != null) {
+                timed.dispose();
+                direct.dispose();
+            }
+        }
+
+        @Override
+        public Runnable getWrappedRunnable() {
+            Runnable r = get();
+            return r != null ? r : Functions.EMPTY_RUNNABLE;
+        }
+    }
+
+    final class DelayedDispose implements Runnable {
+        private final DelayedRunnable dr;
+
+        DelayedDispose(DelayedRunnable dr) {
+            this.dr = dr;
+        }
+
+        @Override
+        public void run() {
+            dr.direct.replace(scheduleDirect(dr));
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/NewThreadScheduler.java
@@ -29,7 +29,7 @@ public final class NewThreadScheduler extends Scheduler {
     private static final RxThreadFactory THREAD_FACTORY;
 
     /** The name of the system property for setting the thread priority for this Scheduler. */
-    private static final String KEY_NEWTHREAD_PRIORITY = "rx3.newthread-priority";
+    private static final String KEY_NEWTHREAD_PRIORITY = "rx4.newthread-priority";
 
     static {
         int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerPoolFactory.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerPoolFactory.java
@@ -27,7 +27,7 @@ public final class SchedulerPoolFactory {
         throw new IllegalStateException("No instances!");
     }
 
-    static final String PURGE_ENABLED_KEY = "rx3.purge-enabled";
+    static final String PURGE_ENABLED_KEY = "rx4.purge-enabled";
 
     public static final boolean PURGE_ENABLED;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/SingleScheduler.java
@@ -32,7 +32,7 @@ public final class SingleScheduler extends Scheduler {
     final AtomicReference<ScheduledExecutorService> executor = new AtomicReference<>();
 
     /** The name of the system property for setting the thread priority for this Scheduler. */
-    private static final String KEY_SINGLE_PRIORITY = "rx3.single-priority";
+    private static final String KEY_SINGLE_PRIORITY = "rx4.single-priority";
 
     private static final String THREAD_NAME_PREFIX = "RxSingleScheduler";
 

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
@@ -35,9 +35,12 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
 
     final ExecutorService executor;
 
-    public FlowableVirtualCreateExecutor(VirtualGenerator<T> generator, ExecutorService executor) {
+    final Scheduler scheduler;
+
+    public FlowableVirtualCreateExecutor(VirtualGenerator<T> generator, ExecutorService executor, Scheduler scheduler) {
         this.generator = generator;
         this.executor = executor;
+        this.scheduler = scheduler;
     }
 
     @Override
@@ -45,11 +48,17 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
         var parent = new ExecutorVirtualCreateSubscription<>(s, generator);
         s.onSubscribe(parent);
 
-        executor.submit(parent);
+        if (executor != null) {
+            executor.submit((Callable<Void>)parent);
+        } else {
+            var worker = scheduler.createWorker();
+            parent.worker = worker;
+            worker.schedule(parent);
+        }
     }
 
     static final class ExecutorVirtualCreateSubscription<T> extends AtomicLong
-    implements Subscription, Callable<Void>, VirtualEmitter<T> {
+    implements Subscription, Callable<Void>, Runnable, VirtualEmitter<T> {
 
         private static final long serialVersionUID = -6959205135542203083L;
 
@@ -65,10 +74,17 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
 
         long produced;
 
+        Scheduler.Worker worker;
+
         ExecutorVirtualCreateSubscription(Subscriber<? super T> downstream, VirtualGenerator<T> generator) {
             this.downstream = downstream;
             this.generator = generator;
             this.consumerReady = new VirtualResumable();
+        }
+
+        @Override
+        public void run() {
+            call();
         }
 
         @Override
@@ -88,6 +104,11 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
                 }
             } finally {
                 downstream = null;
+                var w = worker;
+                worker = null;
+                if (w != null) {
+                    w.close();
+                }
             }
             return null;
         }

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 import io.reactivex.rxjava4.operators.SpscArrayQueue;
@@ -31,13 +32,19 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
 
     final ExecutorService executor;
 
+    final Scheduler scheduler;
+
     final int prefetch;
 
     public FlowableVirtualTransformExecutor(Flowable<T> source,
-            VirtualTransformer<T, R> transformer, ExecutorService executor, int prefetch) {
+            VirtualTransformer<T, R> transformer,
+            ExecutorService executor,
+            Scheduler scheduler,
+            int prefetch) {
         this.source = source;
         this.transformer = transformer;
         this.executor = executor;
+        this.scheduler = scheduler;
         this.prefetch = prefetch;
     }
 
@@ -45,11 +52,17 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
     protected void subscribeActual(Subscriber<? super R> s) {
         var parent = new ExecutorVirtualTransformSubscriber<>(s, transformer, prefetch);
         source.subscribe(parent);
-        executor.submit(parent);
+        if (executor != null) {
+            executor.submit((Callable<Void>)parent);
+        } else {
+            var worker = scheduler.createWorker();
+            parent.worker = worker;
+            worker.schedule(parent);
+        }
     }
 
     static final class ExecutorVirtualTransformSubscriber<T, R> extends AtomicLong
-    implements FlowableSubscriber<T>, Subscription, VirtualEmitter<R>, Callable<Void> {
+    implements FlowableSubscriber<T>, Subscription, VirtualEmitter<R>, Callable<Void>, Runnable {
 
         private static final long serialVersionUID = -4702456711290258571L;
 
@@ -77,6 +90,8 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
         static final Throwable STOP = new Throwable("Downstream cancelled");
 
         long produced;
+
+        Worker worker;
 
         ExecutorVirtualTransformSubscriber(Subscriber<? super R> downstream,
                 VirtualTransformer<T, R> transformer,
@@ -149,8 +164,19 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
             upstream.cancel();
             // cleanup(); don't kill the worker
 
+            var w = worker;
+            worker = null;
+            if (w != null) {
+                w.close();
+            }
+
             producerReady.resume();
             consumerReady.resume();
+        }
+
+        @Override
+        public void run() {
+            call();
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava4/plugins/RxJavaPlugins.java
@@ -45,7 +45,10 @@ public final class RxJavaPlugins {
     static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitSingleHandler;
 
     @Nullable
-    static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitIoHandler;
+    static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitCachedHandler;
+
+    @Nullable
+    static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitVirtualHandler;
 
     @Nullable
     static volatile Function<? super Supplier<Scheduler>, ? extends Scheduler> onInitNewThreadHandler;
@@ -57,7 +60,10 @@ public final class RxJavaPlugins {
     static volatile Function<? super Scheduler, ? extends Scheduler> onSingleHandler;
 
     @Nullable
-    static volatile Function<? super Scheduler, ? extends Scheduler> onIoHandler;
+    static volatile Function<? super Scheduler, ? extends Scheduler> onCachedHandler;
+
+    @Nullable
+    static volatile Function<? super Scheduler, ? extends Scheduler> onVirtualHandler;
 
     @Nullable
     static volatile Function<? super Scheduler, ? extends Scheduler> onNewThreadHandler;
@@ -204,8 +210,17 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<? super Supplier<Scheduler>, ? extends Scheduler> getInitIoSchedulerHandler() {
-        return onInitIoHandler;
+    public static Function<? super Supplier<Scheduler>, ? extends Scheduler> getInitCachedSchedulerHandler() {
+        return onInitCachedHandler;
+    }
+
+    /**
+     * Returns the current hook function.
+     * @return the hook function, may be null
+     */
+    @Nullable
+    public static Function<? super Supplier<Scheduler>, ? extends Scheduler> getInitVirtualSchedulerHandler() {
+        return onInitVirtualHandler;
     }
 
     /**
@@ -231,8 +246,17 @@ public final class RxJavaPlugins {
      * @return the hook function, may be null
      */
     @Nullable
-    public static Function<? super Scheduler, ? extends Scheduler> getIoSchedulerHandler() {
-        return onIoHandler;
+    public static Function<? super Scheduler, ? extends Scheduler> getCachedSchedulerHandler() {
+        return onCachedHandler;
+    }
+
+    /**
+     * Returns the current hook function.
+     * @return the hook function, may be null
+     */
+    @Nullable
+    public static Function<? super Scheduler, ? extends Scheduler> getVirtualSchedulerHandler() {
+        return onVirtualHandler;
     }
 
     /**
@@ -285,9 +309,25 @@ public final class RxJavaPlugins {
      * @throws NullPointerException if the supplier parameter or its result are null
      */
     @NonNull
-    public static Scheduler initIoScheduler(@NonNull Supplier<Scheduler> defaultScheduler) {
+    public static Scheduler initCachedScheduler(@NonNull Supplier<Scheduler> defaultScheduler) {
         Objects.requireNonNull(defaultScheduler, "Scheduler Supplier can't be null");
-        Function<? super Supplier<Scheduler>, ? extends Scheduler> f = onInitIoHandler;
+        Function<? super Supplier<Scheduler>, ? extends Scheduler> f = onInitCachedHandler;
+        if (f == null) {
+            return callRequireNonNull(defaultScheduler);
+        }
+        return applyRequireNonNull(f, defaultScheduler);
+    }
+
+    /**
+     * Calls the associated hook function.
+     * @param defaultScheduler a {@link Supplier} which returns the hook's input value
+     * @return the value returned by the hook, not null
+     * @throws NullPointerException if the supplier parameter or its result are null
+     */
+    @NonNull
+    public static Scheduler initVirtualScheduler(@NonNull Supplier<Scheduler> defaultScheduler) {
+        Objects.requireNonNull(defaultScheduler, "Scheduler Supplier can't be null");
+        Function<? super Supplier<Scheduler>, ? extends Scheduler> f = onInitVirtualHandler;
         if (f == null) {
             return callRequireNonNull(defaultScheduler);
         }
@@ -442,8 +482,22 @@ public final class RxJavaPlugins {
      * @return the value returned by the hook
      */
     @NonNull
-    public static Scheduler onIoScheduler(@NonNull Scheduler defaultScheduler) {
-        Function<? super Scheduler, ? extends Scheduler> f = onIoHandler;
+    public static Scheduler onCachedScheduler(@NonNull Scheduler defaultScheduler) {
+        Function<? super Scheduler, ? extends Scheduler> f = onCachedHandler;
+        if (f == null) {
+            return defaultScheduler;
+        }
+        return apply(f, defaultScheduler);
+    }
+
+    /**
+     * Calls the associated hook function.
+     * @param defaultScheduler the hook's input value
+     * @return the value returned by the hook
+     */
+    @NonNull
+    public static Scheduler onVirtualScheduler(@NonNull Scheduler defaultScheduler) {
+        Function<? super Scheduler, ? extends Scheduler> f = onVirtualHandler;
         if (f == null) {
             return defaultScheduler;
         }
@@ -504,8 +558,11 @@ public final class RxJavaPlugins {
         setComputationSchedulerHandler(null);
         setInitComputationSchedulerHandler(null);
 
-        setIoSchedulerHandler(null);
-        setInitIoSchedulerHandler(null);
+        setCachedSchedulerHandler(null);
+        setInitCachedSchedulerHandler(null);
+
+        setVirtualSchedulerHandler(null);
+        setInitVirtualSchedulerHandler(null);
 
         setSingleSchedulerHandler(null);
         setInitSingleSchedulerHandler(null);
@@ -575,11 +632,22 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed, but the function may not return null
      */
-    public static void setInitIoSchedulerHandler(@Nullable Function<? super Supplier<Scheduler>, ? extends Scheduler> handler) {
+    public static void setInitCachedSchedulerHandler(@Nullable Function<? super Supplier<Scheduler>, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
-        onInitIoHandler = handler;
+        onInitCachedHandler = handler;
+    }
+
+    /**
+     * Sets the specific hook function.
+     * @param handler the hook function to set, null allowed, but the function may not return null
+     */
+    public static void setInitVirtualSchedulerHandler(@Nullable Function<? super Supplier<Scheduler>, ? extends Scheduler> handler) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        onInitVirtualHandler = handler;
     }
 
     /**
@@ -608,11 +676,22 @@ public final class RxJavaPlugins {
      * Sets the specific hook function.
      * @param handler the hook function to set, null allowed
      */
-    public static void setIoSchedulerHandler(@Nullable Function<? super Scheduler, ? extends Scheduler> handler) {
+    public static void setCachedSchedulerHandler(@Nullable Function<? super Scheduler, ? extends Scheduler> handler) {
         if (lockdown) {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
-        onIoHandler = handler;
+        onCachedHandler = handler;
+    }
+
+    /**
+     * Sets the specific hook function.
+     * @param handler the hook function to set, null allowed
+     */
+    public static void setVirtualSchedulerHandler(@Nullable Function<? super Scheduler, ? extends Scheduler> handler) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        onVirtualHandler = handler;
     }
 
     /**
@@ -1264,17 +1343,17 @@ public final class RxJavaPlugins {
     }
 
     /**
-     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#io()}
+     * Create an instance of the default {@link Scheduler} used for {@link Schedulers#cached()}
      * except using {@code threadFactory} for thread creation.
      * <p>History: 2.0.5 - experimental
      * @param threadFactory thread factory to use for creating worker threads. Note that this takes precedence over any
      *                      system properties for configuring new thread creation. Cannot be null.
      * @return the created Scheduler instance
-     * @since 2.1
+     * @since 4.0.0
      */
     @NonNull
-    public static Scheduler createIoScheduler(@NonNull ThreadFactory threadFactory) {
-        return new IoScheduler(Objects.requireNonNull(threadFactory, "threadFactory is null"));
+    public static Scheduler createCachedScheduler(@NonNull ThreadFactory threadFactory) {
+        return new CachedScheduler(Objects.requireNonNull(threadFactory, "threadFactory is null"));
     }
 
     /**
@@ -1323,6 +1402,26 @@ public final class RxJavaPlugins {
     @NonNull
     public static Scheduler createExecutorScheduler(@NonNull Executor executor, boolean interruptibleWorker, boolean fair) {
         return new ExecutorScheduler(executor, interruptibleWorker, fair);
+    }
+
+    /**
+     * Create an instance of a {@link Scheduler} by wrapping a supplier of a {@link Executor}.
+     * <p>
+     * This method allows creating a deferred {@code Executor}-backed {@code Scheduler} before the {@link Schedulers} class
+     * would initialize the standard {@code Scheduler}s.
+     *
+     * @param executorSupplier the {@code Executor} supplier to wrap and turn into a {@code Scheduler}.
+     * @param interruptibleWorker if {@code true}, the tasks submitted to the {@link io.reactivex.rxjava4.core.Scheduler.Worker Scheduler.Worker} will
+     * be interrupted when the task is disposed.
+     * @param fair if {@code true}, tasks submitted to the {@code Scheduler} or {@code Worker} will be executed by the underlying {@code Executor} one after the other, still
+     * in a FIFO and non-overlapping manner, but allows interleaving with other tasks submitted to the underlying {@code Executor}.
+     * If {@code false}, the underlying FIFO scheme will execute as many tasks as it can before giving up the underlying {@code Executor} thread.
+     * @return the new {@code Scheduler} wrapping the {@code Executor}
+     * @since 4.0.0
+     */
+    @NonNull
+    public static Scheduler createDeferredExecutorScheduler(@NonNull Supplier<? extends Executor> executorSupplier, boolean interruptibleWorker, boolean fair) {
+        return new DeferredExecutorScheduler(executorSupplier, interruptibleWorker, fair);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/Schedulers.java
@@ -32,17 +32,17 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * <p>
  * <strong>Supported system properties ({@code System.getProperty()}):</strong>
  * <ul>
- * <li>{@code rx3.io-keep-alive-time} (long): sets the keep-alive time of the {@link #io()} {@code Scheduler} workers,
- * default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
- * <li>{@code rx3.io-priority} (int): sets the thread priority of the {@link #io()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
- * <li>{@code rx3.io-scheduled-release} (boolean): {@code true} sets the worker release mode of the
+ * <li>{@code rx4.cached-keep-alive-time} (long): sets the keep-alive time of the {@link #io()} {@code Scheduler} workers,
+ * default is {@link CachedScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
+ * <li>{@code rx4.cached-priority} (int): sets the thread priority of the {@link #io()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
+ * <li>{@code rx4.cached-scheduled-release} (boolean): {@code true} sets the worker release mode of the
  * {@link #io()} {@code Scheduler} to <em>scheduled</em>, default is {@code false} for <em>eager</em> mode.</li>
- * <li>{@code rx3.computation-threads} (int): sets the number of threads in the {@link #computation()} {@code Scheduler}, default is the number of available CPUs</li>
- * <li>{@code rx3.computation-priority} (int): sets the thread priority of the {@link #computation()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
- * <li>{@code rx3.newthread-priority} (int): sets the thread priority of the {@link #newThread()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
- * <li>{@code rx3.single-priority} (int): sets the thread priority of the {@link #single()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
- * <li>{@code rx3.purge-enabled} (boolean): enables purging of all {@code Scheduler}'s backing thread pools, default is {@code true}</li>
- * <li>{@code rx3.scheduler.use-nanotime} (boolean): {@code true} instructs {@code Scheduler} to use {@link System#nanoTime()} for {@link Scheduler#now(TimeUnit)},
+ * <li>{@code rx4.computation-threads} (int): sets the number of threads in the {@link #computation()} {@code Scheduler}, default is the number of available CPUs</li>
+ * <li>{@code rx4.computation-priority} (int): sets the thread priority of the {@link #computation()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
+ * <li>{@code rx4.newthread-priority} (int): sets the thread priority of the {@link #newThread()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
+ * <li>{@code rx4.single-priority} (int): sets the thread priority of the {@link #single()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
+ * <li>{@code rx4.purge-enabled} (boolean): enables purging of all {@code Scheduler}'s backing thread pools, default is {@code true}</li>
+ * <li>{@code rx4.scheduler.use-nanotime} (boolean): {@code true} instructs {@code Scheduler} to use {@link System#nanoTime()} for {@link Scheduler#now(TimeUnit)},
  * instead of default {@link System#currentTimeMillis()} ({@code false})</li>
  * </ul>
  */
@@ -54,7 +54,10 @@ public final class Schedulers {
     static final Scheduler COMPUTATION;
 
     @NonNull
-    static final Scheduler IO;
+    static final Scheduler CACHED;
+
+    @NonNull
+    static final Scheduler VIRTUAL;
 
     @NonNull
     static final Scheduler TRAMPOLINE;
@@ -71,7 +74,11 @@ public final class Schedulers {
     }
 
     static final class IoHolder {
-        static final Scheduler DEFAULT = new IoScheduler();
+        static final Scheduler DEFAULT = new CachedScheduler();
+    }
+
+    static final class VirtualHolder {
+        static final Scheduler DEFAULT = new DeferredExecutorScheduler(() -> Executors.newVirtualThreadPerTaskExecutor(), true, true);
     }
 
     static final class NewThreadHolder {
@@ -83,7 +90,9 @@ public final class Schedulers {
 
         COMPUTATION = RxJavaPlugins.initComputationScheduler(new ComputationTask());
 
-        IO = RxJavaPlugins.initIoScheduler(new IOTask());
+        CACHED = RxJavaPlugins.initCachedScheduler(new IOTask());
+
+        VIRTUAL = RxJavaPlugins.initVirtualScheduler(new VirtualTask());
 
         TRAMPOLINE = TrampolineScheduler.instance();
 
@@ -118,8 +127,8 @@ public final class Schedulers {
      * before the {@code Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.computation-threads} (int): sets the number of threads in the {@code computation()} {@code Scheduler}, default is the number of available CPUs</li>
-     * <li>{@code rx3.computation-priority} (int): sets the thread priority of the {@code computation()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
+     * <li>{@code rx4.computation-threads} (int): sets the number of threads in the {@code computation()} {@code Scheduler}, default is the number of available CPUs</li>
+     * <li>{@code rx4.computation-priority} (int): sets the thread priority of the {@code computation()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
      * <p>
      * The default value of this scheduler can be overridden at initialization time via the
@@ -144,6 +153,17 @@ public final class Schedulers {
     }
 
     /**
+     * Delegates to {@link Schedulers#cached()} scheduler for compatibility; please stop using this.
+     * @return a {@link Scheduler} meant for classical blocking IO-bound work
+     * @deprecated Since 4.0.0; Use a more specific {@link #cached()} or {@link #virtual()} schedulers instead.
+     */
+    @NonNull
+    @Deprecated(since = "4.0.0")
+    public static Scheduler io() {
+        return cached();
+    }
+
+    /**
      * Returns a default, shared {@link Scheduler} instance intended for IO-bound work.
      * <p>
      * This can be used for asynchronously performing blocking IO.
@@ -163,26 +183,27 @@ public final class Schedulers {
      * before the {@code Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.io-keep-alive-time} (long): sets the keep-alive time of the {@code io()} {@code Scheduler} workers,
-     * default is {@link IoScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
-     * <li>{@code rx3.io-priority} (int): sets the thread priority of the {@code io()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
-     * <li>{@code rx3.io-scheduled-release} (boolean): {@code true} sets the worker release mode of the
+     * <li>{@code rx4.cached-keep-alive-time} (long): sets the keep-alive time of the {@code io()} {@code Scheduler} workers,
+     * default is {@link CachedScheduler#KEEP_ALIVE_TIME_DEFAULT}</li>
+     * <li>{@code rx4.cached-priority} (int): sets the thread priority of the {@code io()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
+     * <li>{@code rx4.cached-scheduled-release} (boolean): {@code true} sets the worker release mode of the
      * {@code #io()} {@code Scheduler} to <em>scheduled</em>, default is {@code false} for <em>eager</em> mode.</li>
      * </ul>
      * <p>
      * The default value of this scheduler can be overridden at initialization time via the
-     * {@link RxJavaPlugins#setInitIoSchedulerHandler(io.reactivex.rxjava4.functions.Function)} plugin method.
+     * {@link RxJavaPlugins#setInitCachedSchedulerHandler(io.reactivex.rxjava4.functions.Function)} plugin method.
      * Note that due to possible initialization cycles, using any of the other scheduler-returning methods will
      * result in a {@link NullPointerException}.
      * Once the {@code Schedulers} class has been initialized, you can override the returned {@code Scheduler} instance
-     * via the {@link RxJavaPlugins#setIoSchedulerHandler(io.reactivex.rxjava4.functions.Function)} method.
+     * via the {@link RxJavaPlugins#setCachedSchedulerHandler(io.reactivex.rxjava4.functions.Function)} method.
      * <p>
      * It is possible to create a fresh instance of this scheduler with a custom {@link ThreadFactory}, via the
-     * {@link RxJavaPlugins#createIoScheduler(ThreadFactory)} method. Note that such custom
+     * {@link RxJavaPlugins#createCachedScheduler(ThreadFactory)} method. Note that such custom
      * instances require a manual call to {@link Scheduler#shutdown()} to allow the JVM to exit or the
      * (J2EE) container to unload properly.
      * <p>Operators on the base reactive classes that use this scheduler are marked with the
-     * &#64;{@link io.reactivex.rxjava4.annotations.SchedulerSupport SchedulerSupport}({@link io.reactivex.rxjava4.annotations.SchedulerSupport#IO IO})
+     * &#64;{@link io.reactivex.rxjava4.annotations.SchedulerSupport SchedulerSupport}
+     * ({@link io.reactivex.rxjava4.annotations.SchedulerSupport#CACHED CACHED})
      * annotation.
      * <p>
      * When the {@link io.reactivex.rxjava4.core.Scheduler.Worker Scheduler.Worker} is disposed,
@@ -193,7 +214,7 @@ public final class Schedulers {
      * respond to interruption in time or at all, this may lead to delays or deadlock with the reuse use of the
      * underlying worker.
      * </li>
-     * <li>In <em>scheduled</em> mode (enabled via the system parameter {@code rx3.io-scheduled-release}
+     * <li>In <em>scheduled</em> mode (enabled via the system parameter {@code rx4.cached-scheduled-release}
      * set to {@code true}), the underlying worker is returned to the cached worker pool only after the currently running task
      * has finished. This can help prevent premature reuse of the underlying worker and likely won't lead to delays or
      * deadlock with such reuses. The drawback is that the delay in release may lead to an excess amount of underlying
@@ -201,10 +222,23 @@ public final class Schedulers {
      * </li>
      * </ul>
      * @return a {@code Scheduler} meant for IO-bound work
+     * @since 4.0.0
      */
     @NonNull
-    public static Scheduler io() {
-        return RxJavaPlugins.onIoScheduler(IO);
+    public static Scheduler cached() {
+        return RxJavaPlugins.onCachedScheduler(CACHED);
+    }
+
+    /**
+     * Returns a default, shared {@link Scheduler} instance intended for virtual-blocking, including many IO-style work
+     * via a {@link Executors#newVirtualThreadPerTaskExecutor()} per Worker.
+     * TODO explain all the rest
+     * @return a {@code Scheduler} meant for IO-bound work
+     * @since 4.0.0
+     */
+    @NonNull
+    public static Scheduler virtual() {
+        return RxJavaPlugins.onVirtualScheduler(VIRTUAL);
     }
 
     /**
@@ -241,7 +275,7 @@ public final class Schedulers {
      * before the {@code Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.newthread-priority} (int): sets the thread priority of the {@code newThread()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
+     * <li>{@code rx4.newthread-priority} (int): sets the thread priority of the {@code newThread()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
      * <p>
      * The default value of this scheduler can be overridden at initialization time via the
@@ -290,7 +324,7 @@ public final class Schedulers {
      * before the {@code Schedulers} class is referenced in your code.
      * <p><strong>Supported system properties ({@code System.getProperty()}):</strong>
      * <ul>
-     * <li>{@code rx3.single-priority} (int): sets the thread priority of the {@code single()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
+     * <li>{@code rx4.single-priority} (int): sets the thread priority of the {@code single()} {@code Scheduler}, default is {@link Thread#NORM_PRIORITY}</li>
      * </ul>
      * <p>
      * The default value of this scheduler can be overridden at initialization time via the
@@ -563,6 +597,21 @@ public final class Schedulers {
     }
 
     /**
+     * Wraps a supplier of {@link Executor} so that each worker can obtain an individual {@code Executor} instance.
+     * @param executorSupplier the {@link Supplier} that produces {@code Executor}s when a worker is invoked.
+     * @param interruptibleWorker if {@code true}, the tasks submitted to the {@link io.reactivex.rxjava4.core.Scheduler.Worker Scheduler.Worker} will
+     * be interrupted when the task is disposed.
+     * @param fair if {@code true}, tasks submitted to the {@link Scheduler} or {@code Worker} will be executed by the underlying {@code Executor} one after the other, still
+     * in a FIFO and non-overlapping manner, but allows interleaving with other tasks submitted to the underlying {@code Executor}.
+     * If {@code false}, the underlying FIFO scheme will execute as many tasks as it can before giving up the underlying {@code Executor} thread.
+     * @return the new {@code Scheduler} wrapping the {@code Executor} supplier
+     */
+    @NonNull
+    public static Scheduler fromSupplier(@NonNull Supplier<? extends Executor> executorSupplier, boolean interruptibleWorker, boolean fair) {
+        return RxJavaPlugins.createDeferredExecutorScheduler(executorSupplier, interruptibleWorker, fair);
+    }
+
+    /**
      * Shuts down the standard {@link Scheduler}s.
      * <p>The operation is idempotent and thread-safe.
      */
@@ -584,6 +633,13 @@ public final class Schedulers {
         newThread().start();
         single().start();
         trampoline().start();
+    }
+
+    static final class VirtualTask implements Supplier<Scheduler> {
+        @Override
+        public Scheduler get() {
+            return VirtualHolder.DEFAULT;
+        }
     }
 
     static final class IOTask implements Supplier<Scheduler> {

--- a/src/test/java/io/reactivex/rxjava4/core/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/SchedulerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.util.concurrent.TimeUnit;
 
 public class SchedulerTest {
-    private static final String DRIFT_USE_NANOTIME = "rx3.scheduler.use-nanotime";
+    private static final String DRIFT_USE_NANOTIME = "rx4.scheduler.use-nanotime";
 
     @After
     public void cleanup() {

--- a/src/test/java/io/reactivex/rxjava4/core/XFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/XFlatMapTest.java
@@ -72,7 +72,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestSubscriber<Integer> ts = Flowable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(new Function<Integer, Publisher<Integer>>() {
                 @Override
                 public Publisher<Integer> apply(Integer v) throws Exception {
@@ -103,7 +103,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestSubscriber<Integer> ts = Flowable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapSingle(new Function<Integer, Single<Integer>>() {
                 @Override
                 public Single<Integer> apply(Integer v) throws Exception {
@@ -134,7 +134,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestSubscriber<Integer> ts = Flowable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
                 @Override
                 public Maybe<Integer> apply(Integer v) throws Exception {
@@ -165,7 +165,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Void> to = Flowable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
                 public Completable apply(Integer v) throws Exception {
@@ -196,7 +196,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestSubscriber<Void> ts = Flowable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
                 public Completable apply(Integer v) throws Exception {
@@ -228,7 +228,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Observable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
                 public Observable<Integer> apply(Integer v) throws Exception {
@@ -259,7 +259,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Observable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapSingle(new Function<Integer, Single<Integer>>() {
                 @Override
                 public Single<Integer> apply(Integer v) throws Exception {
@@ -290,7 +290,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Observable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
                 @Override
                 public Maybe<Integer> apply(Integer v) throws Exception {
@@ -321,7 +321,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Void> to = Observable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
                 public Completable apply(Integer v) throws Exception {
@@ -352,7 +352,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Void> to = Observable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
                 public Completable apply(Integer v) throws Exception {
@@ -384,7 +384,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(new Function<Integer, Single<Integer>>() {
                 @Override
                 public Single<Integer> apply(Integer v) throws Exception {
@@ -415,7 +415,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
                 @Override
                 public Maybe<Integer> apply(Integer v) throws Exception {
@@ -446,7 +446,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Void> to = Single.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
                 public Completable apply(Integer v) throws Exception {
@@ -477,7 +477,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
                 public Completable apply(Integer v) throws Exception {
@@ -509,7 +509,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestSubscriber<Integer> ts = Single.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
                 @Override
                 public Publisher<Integer> apply(Integer v) throws Exception {
@@ -540,7 +540,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(new Function<Integer, Single<Integer>>() {
                 @Override
                 public Single<Integer> apply(Integer v) throws Exception {
@@ -571,7 +571,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapObservable(new Function<Integer, Observable<Integer>>() {
                 @Override
                 public Observable<Integer> apply(Integer v) throws Exception {
@@ -602,7 +602,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(
                 new Function<Integer, Single<Integer>>() {
                     @Override
@@ -642,7 +642,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Single.<Integer>error(new TestException())
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(
                 new Function<Integer, Single<Integer>>() {
                     @Override
@@ -682,7 +682,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapSingle(new Function<Integer, Single<Integer>>() {
                 @Override
                 public Single<Integer> apply(Integer v) throws Exception {
@@ -714,7 +714,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapSingle(new Function<Integer, Single<Integer>>() {
                 @Override
                 public Single<Integer> apply(Integer v) throws Exception {
@@ -745,7 +745,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(new Function<Integer, Maybe<Integer>>() {
                 @Override
                 public Maybe<Integer> apply(Integer v) throws Exception {
@@ -776,7 +776,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestSubscriber<Integer> ts = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
                 @Override
                 public Publisher<Integer> apply(Integer v) throws Exception {
@@ -807,7 +807,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapObservable(new Function<Integer, Observable<Integer>>() {
                 @Override
                 public Observable<Integer> apply(Integer v) throws Exception {
@@ -838,7 +838,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(
                 new Function<Integer, Maybe<Integer>>() {
                     @Override
@@ -885,7 +885,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Maybe.<Integer>error(new TestException())
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(
                 new Function<Integer, Maybe<Integer>>() {
                     @Override
@@ -932,7 +932,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Maybe.<Integer>empty()
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(
                 new Function<Integer, Maybe<Integer>>() {
                     @Override
@@ -979,7 +979,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMap(new Function<Integer, Maybe<Integer>>() {
                 @Override
                 public Maybe<Integer> apply(Integer v) throws Exception {
@@ -1010,7 +1010,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Void> to = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
                 public Completable apply(Integer v) throws Exception {
@@ -1041,7 +1041,7 @@ public class XFlatMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestObserver<Void> to = Maybe.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .flatMapCompletable(new Function<Integer, Completable>() {
                 @Override
                 public Completable apply(Integer v) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
@@ -177,7 +177,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
                     incrementingIntegers(c2).subscribeOn(Schedulers.computation()));
 
             merged
-            .observeOn(Schedulers.io())
+            .observeOn(Schedulers.cached())
             .take(num)
             .subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableConversionTest.java
@@ -211,7 +211,7 @@ public class FlowableConversionTest extends RxJavaTest {
                     @Override
                     public Publisher<Integer> apply(final Integer i) {
                         return Flowable.range(0, 5)
-                                .observeOn(Schedulers.io())
+                                .observeOn(Schedulers.cached())
                                 .map(new Function<Integer, Integer>() {
                                     @Override
                                     public Integer apply(Integer k) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableAndThenCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableAndThenCompletableTest.java
@@ -152,8 +152,8 @@ public class CompletableAndThenCompletableTest extends RxJavaTest {
 
             for (int i = 0; i < count; i++) {
                 Completable.complete()
-                        .subscribeOn(Schedulers.io())
-                        .observeOn(Schedulers.io())
+                        .subscribeOn(Schedulers.cached())
+                        .observeOn(Schedulers.cached())
                         .andThen(Completable.fromAction(new Action() {
                             @Override
                             public void run() throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatTest.java
@@ -284,8 +284,8 @@ public class CompletableConcatTest extends RxJavaTest {
                     }
                 });
                 Completable.concat(Arrays.asList(Completable.complete()
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(Schedulers.io()),
+                    .subscribeOn(Schedulers.cached())
+                    .observeOn(Schedulers.cached()),
                     c0)
                 )
                 .subscribe(new Action() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimeoutTest.java
@@ -39,7 +39,7 @@ public class CompletableTimeoutTest extends RxJavaTest {
     public void timeoutException() throws Exception {
 
         Completable.never()
-        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.io())
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.cached())
         .to(TestHelper.<Void>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailureAndMessage(TimeoutException.class, timeoutMessage(100, TimeUnit.MILLISECONDS));
@@ -58,7 +58,7 @@ public class CompletableTimeoutTest extends RxJavaTest {
         });
 
         Completable.never()
-        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.io(), other)
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.cached(), other)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimerTest.java
@@ -37,7 +37,7 @@ public class CompletableTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Void> to = Completable.timer(1, TimeUnit.MILLISECONDS, s)
                 .doOnComplete(new Action() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCacheTest.java
@@ -185,7 +185,7 @@ public class FlowableCacheTest extends RxJavaTest {
     public void asyncComeAndGo() {
         Flowable<Long> source = Flowable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
-                .subscribeOn(Schedulers.io());
+                .subscribeOn(Schedulers.cached());
         FlowableCache<Long> cached = new FlowableCache<>(source, 16);
 
         Flowable<Long> output = cached.observeOn(Schedulers.computation());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -472,7 +472,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
             List<Flowable<Integer>> sources = new ArrayList<>();
             List<Object> values = new ArrayList<>();
             for (int j = 0; j < i; j++) {
-                sources.add(Flowable.just(j).subscribeOn(Schedulers.io()));
+                sources.add(Flowable.just(j).subscribeOn(Schedulers.cached()));
                 values.add(j);
             }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -1126,10 +1126,10 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
             public Flowable<Integer> apply(Integer i) throws Exception {
                 return i == 3 ? Flowable.just(i) : Flowable
                         .just(i)
-                        .delay(1, TimeUnit.MILLISECONDS, Schedulers.io());
+                        .delay(1, TimeUnit.MILLISECONDS, Schedulers.cached());
             }
         })
-        .observeOn(Schedulers.io())
+        .observeOn(Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5)
@@ -1155,7 +1155,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
             public Flowable<List<Integer>> apply(List<Integer> v)
                     throws Exception {
                 return Flowable.just(v)
-                        .subscribeOn(Schedulers.io())
+                        .subscribeOn(Schedulers.cached())
                         .doOnNext(new Consumer<List<Integer>>() {
                             @Override
                             public void accept(List<Integer> v)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -1040,7 +1040,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<String> apply(Integer t) throws Throwable {
                 return Flowable.just(Thread.currentThread().getName())
                         .repeat(1000)
-                        .observeOn(Schedulers.io());
+                        .observeOn(Schedulers.cached());
             }
         }, 2, Schedulers.single())
         .distinct()
@@ -1063,7 +1063,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<String> apply(Integer t) throws Throwable {
                 return Flowable.just(Thread.currentThread().getName())
                         .repeat(1000)
-                        .observeOn(Schedulers.io());
+                        .observeOn(Schedulers.cached());
             }
         }, false, 2, Schedulers.single())
         .distinct()
@@ -1086,7 +1086,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             public Flowable<String> apply(Integer t) throws Throwable {
                 return Flowable.just(Thread.currentThread().getName())
                         .repeat(1000)
-                        .observeOn(Schedulers.io());
+                        .observeOn(Schedulers.cached());
             }
         }, true, 2, Schedulers.single())
         .distinct()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -323,7 +323,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
     public void afterDelayNoInterrupt() {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec) }) {
                 final TestSubscriber<Boolean> ts = TestSubscriber.create();
                 ts.withTag(s.getClass().getSimpleName());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -2461,7 +2461,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
             @Override
             public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Throwable {
-                return g.observeOn(Schedulers.io())
+                return g.observeOn(Schedulers.cached())
                         .doOnNext(new Consumer<Integer>() {
                             @Override
                             public void accept(Integer v) throws Throwable {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -17,13 +17,13 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.internal.schedulers.IoScheduler;
+import io.reactivex.rxjava4.internal.schedulers.CachedScheduler;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -187,7 +187,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
 
     @Test
     public void simpleAsyncLoop() {
-        IoScheduler ios = (IoScheduler)Schedulers.io();
+        CachedScheduler ios = (CachedScheduler)Schedulers.cached();
         int c = ios.size();
         for (int i = 0; i < 200; i++) {
             simpleAsync();
@@ -205,7 +205,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
             List<Flowable<Integer>> sourceList = new ArrayList<>(i);
             Set<Integer> expected = new HashSet<>(i);
             for (int j = 1; j <= i; j++) {
-                sourceList.add(Flowable.just(j).subscribeOn(Schedulers.io()));
+                sourceList.add(Flowable.just(j).subscribeOn(Schedulers.cached()));
                 expected.add(j);
             }
 
@@ -237,7 +237,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
             List<Flowable<Integer>> sourceList = new ArrayList<>(i);
             Set<Integer> expected = new HashSet<>(i);
             for (int j = 1; j <= i; j++) {
-                sourceList.add(Flowable.just(j).subscribeOn(Schedulers.io()));
+                sourceList.add(Flowable.just(j).subscribeOn(Schedulers.cached()));
                 expected.add(j);
             }
 
@@ -255,9 +255,9 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
     public void backpressureHonored() throws Exception {
         List<Flowable<Integer>> sourceList = new ArrayList<>(3);
 
-        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
-        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
-        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
+        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.cached()));
+        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.cached()));
+        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.cached()));
 
         final CountDownLatch cdl = new CountDownLatch(5);
 
@@ -286,9 +286,9 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
     public void take() throws Exception {
         List<Flowable<Integer>> sourceList = new ArrayList<>(3);
 
-        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
-        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
-        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.io()));
+        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.cached()));
+        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.cached()));
+        sourceList.add(Flowable.range(0, 100000).subscribeOn(Schedulers.cached()));
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
@@ -768,7 +768,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
                         requests.add(n);
                     }
                 })
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
@@ -1960,7 +1960,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
                 final UnicastProcessor<Integer> up = UnicastProcessor.create();
 
                 TestObserver<Integer> to = up.hide()
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .observeOn(Schedulers.single())
                 .unsubscribeOn(Schedulers.computation())
                 .firstOrError()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -318,7 +318,7 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
                 final PublishProcessor<Integer> pp = PublishProcessor.create();
 
                 TestObserver<Integer> to = pp.onBackpressureBuffer(4, false, true)
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .map(Functions.<Integer>identity())
                 .observeOn(Schedulers.single())
                 .firstOrError()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -45,7 +45,7 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
     @Test
     public void withObserveOn() throws InterruptedException {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
-        Flowable.range(0, Flowable.bufferSize() * 10).onBackpressureDrop().observeOn(Schedulers.io()).subscribe(ts);
+        Flowable.range(0, Flowable.bufferSize() * 10).onBackpressureDrop().observeOn(Schedulers.cached()).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
@@ -190,7 +190,7 @@ public class FlowableOnBackpressureLatestTest extends RxJavaTest {
         Flowable.range(1, m)
         .subscribeOn(Schedulers.computation())
         .onBackpressureLatest()
-        .observeOn(Schedulers.io())
+        .observeOn(Schedulers.cached())
         .subscribe(ts);
 
         ts.awaitDone(2, TimeUnit.SECONDS);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceTest.java
@@ -179,7 +179,7 @@ public class FlowableOnBackpressureReduceTest extends RxJavaTest {
                     //the output sequence of number must be increasing
                     return current;
                 })
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .subscribe(ts);
 
         ts.awaitDone(2, TimeUnit.SECONDS);
@@ -195,7 +195,7 @@ public class FlowableOnBackpressureReduceTest extends RxJavaTest {
         Flowable.rangeLong(1, m)
                 .subscribeOn(Schedulers.computation())
                 .onBackpressureReduce(Long::sum)
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .subscribe(ts);
 
         ts.awaitDone(2, TimeUnit.SECONDS);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceWithTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceWithTest.java
@@ -219,7 +219,7 @@ public class FlowableOnBackpressureReduceWithTest extends RxJavaTest {
                     //the output sequence of number must be increasing
                     return Collections.singletonList(current);
                 })
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .concatMap(Flowable::fromIterable)
                 .subscribe(ts);
 
@@ -236,7 +236,7 @@ public class FlowableOnBackpressureReduceWithTest extends RxJavaTest {
         Flowable.rangeLong(1, m)
                 .subscribeOn(Schedulers.computation())
                 .onBackpressureReduce(createTestSupplier(), createTestReducer())
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .concatMap(list -> Flowable.just(list.stream().reduce(Long::sum).orElseThrow(() -> {
                     throw new IllegalArgumentException("No value in list");
                 })))

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceTest.java
@@ -405,7 +405,7 @@ public class FlowableReduceTest extends RxJavaTest {
                     public String apply(Integer y) throws Exception {
                         return blockingOp(x, y);
                     }
-                }).subscribeOn(Schedulers.io())
+                }).subscribeOn(Schedulers.cached())
                 .reduce(new BiFunction<String, String, String>() {
                     @Override
                     public String apply(String l, String r) throws Exception {
@@ -444,7 +444,7 @@ public class FlowableReduceTest extends RxJavaTest {
                     public String apply(Integer y) throws Exception {
                         return blockingOp(x, y);
                     }
-                }).subscribeOn(Schedulers.io())
+                }).subscribeOn(Schedulers.cached())
                 .reduce(new BiFunction<String, String, String>() {
                     @Override
                     public String apply(String l, String r) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
@@ -1368,11 +1368,11 @@ public class FlowableRefCountTest extends RxJavaTest {
             Flowable<Integer> flowable = Flowable.just(1).replay(1).refCount();
 
             TestSubscriber<Integer> ts1 = flowable
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.cached())
                     .test();
 
             TestSubscriber<Integer> ts2 = flowable
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.cached())
                     .test();
 
             ts1
@@ -1442,11 +1442,11 @@ public class FlowableRefCountTest extends RxJavaTest {
             Flowable<Integer> flowable = Flowable.just(1).publish().refCount();
 
             TestSubscriber<Integer> subscriber1 = flowable
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.cached())
                     .test();
 
             TestSubscriber<Integer> subscriber2 = flowable
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.cached())
                     .test();
 
             subscriber1

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -1007,7 +1007,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void asyncComeAndGo() {
         Flowable<Long> source = Flowable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
-                .subscribeOn(Schedulers.io());
+                .subscribeOn(Schedulers.cached());
         Flowable<Long> cached = source.replay().autoConnect();
 
         Flowable<Long> output = cached.observeOn(Schedulers.computation(), false, 1024);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -1026,7 +1026,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void asyncComeAndGo() {
         Flowable<Long> source = Flowable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
-                .subscribeOn(Schedulers.io());
+                .subscribeOn(Schedulers.cached());
         Flowable<Long> cached = source.replay().autoConnect();
 
         Flowable<Long> output = cached.observeOn(Schedulers.computation(), false, 1024);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -173,7 +173,7 @@ public class FlowableSkipLastTimedTest extends RxJavaTest {
     @Test
     public void skipLastTimedCustomSchedulerDelayError() {
         Flowable.just(1).concatWith(Flowable.just(2).delay(500, TimeUnit.MILLISECONDS))
-        .skipLast(300, TimeUnit.MILLISECONDS, Schedulers.io(), true)
+        .skipLast(300, TimeUnit.MILLISECONDS, Schedulers.cached(), true)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -183,7 +183,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
                     @Override
                     public void request(long n) {
                         if (n > 0 && completed.compareAndSet(false, true)) {
-                            Schedulers.io().createWorker().schedule(new Runnable() {
+                            Schedulers.cached().createWorker().schedule(new Runnable() {
                                 @Override
                                 public void run() {
                                     subscriber.onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
@@ -1366,10 +1366,10 @@ public class FlowableSwitchTest extends RxJavaTest {
         return Flowable.<Integer>unsafeCreate(s -> {
             SerializedSubscriber<Integer> it = new SerializedSubscriber<>(s);
             it.onSubscribe(new BooleanSubscription());
-            Schedulers.io().scheduleDirect(() -> {
+            Schedulers.cached().scheduleDirect(() -> {
                 it.onNext(1);
             }, 0, TimeUnit.MILLISECONDS);
-            Schedulers.io().scheduleDirect(() -> {
+            Schedulers.cached().scheduleDirect(() -> {
                 it.onNext(2);
             }, 0, TimeUnit.MILLISECONDS);
         })

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -267,7 +267,7 @@ public class FlowableTakeLastTimedTest extends RxJavaTest {
     @Test
     public void takeLastTimeDelayErrorCustomScheduler() {
         Flowable.just(1, 2).concatWith(Flowable.<Integer>error(new TestException()))
-        .takeLast(1, TimeUnit.MINUTES, Schedulers.io(), true)
+        .takeLast(1, TimeUnit.MINUTES, Schedulers.cached(), true)
         .test()
         .assertFailure(TestException.class, 1, 2);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimerTest.java
@@ -352,7 +352,7 @@ public class FlowableTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestSubscriber<Long> ts = Flowable.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -229,7 +229,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     @Test
     public void timespanTimeskipCustomSchedulerBufferSize() {
         Flowable.range(1, 10)
-        .window(1, 1, TimeUnit.MINUTES, Schedulers.io(), 2)
+        .window(1, 1, TimeUnit.MINUTES, Schedulers.cached(), 2)
         .flatMap(Functions.<Flowable<Integer>>identity())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -279,7 +279,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     @Test
     public void timespanTimeskipCustomScheduler() {
         Flowable.just(1)
-        .window(1, 1, TimeUnit.MINUTES, Schedulers.io())
+        .window(1, 1, TimeUnit.MINUTES, Schedulers.cached())
         .flatMap(Functions.<Flowable<Integer>>identity())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeTest.java
@@ -54,7 +54,7 @@ public class MaybeMergeTest extends RxJavaTest {
                     return count.incrementAndGet() - j;
                 }
             })
-            .subscribeOn(Schedulers.io());
+            .subscribeOn(Schedulers.cached());
         }
 
         for (int i = 0; i < 1000; i++) {
@@ -80,7 +80,7 @@ public class MaybeMergeTest extends RxJavaTest {
                     return count.incrementAndGet() - j;
                 }
             })
-            .subscribeOn(Schedulers.io());
+            .subscribeOn(Schedulers.cached());
         }
         sources[1] = Maybe.fromCallable(new Callable<Integer>() {
             @Override
@@ -88,7 +88,7 @@ public class MaybeMergeTest extends RxJavaTest {
                 throw new TestException("" + count.incrementAndGet());
             }
         })
-        .subscribeOn(Schedulers.io());
+        .subscribeOn(Schedulers.cached());
 
         for (int i = 0; i < 1000; i++) {
             count.set(0);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimerTest.java
@@ -37,7 +37,7 @@ public class MaybeTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Long> to = Maybe.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCacheTest.java
@@ -165,7 +165,7 @@ public class ObservableCacheTest extends RxJavaTest {
     public void asyncComeAndGo() {
         Observable<Long> source = Observable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
-                .subscribeOn(Schedulers.io());
+                .subscribeOn(Schedulers.cached());
         ObservableCache<Long> cached = new ObservableCache<>(source, 16);
 
         Observable<Long> output = cached.observeOn(Schedulers.computation());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -471,7 +471,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
             List<Observable<Integer>> sources = new ArrayList<>();
             List<Object> values = new ArrayList<>();
             for (int j = 0; j < i; j++) {
-                sources.add(Observable.just(j).subscribeOn(Schedulers.io()));
+                sources.add(Observable.just(j).subscribeOn(Schedulers.cached()));
                 values.add(j);
             }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -809,10 +809,10 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
             public ObservableSource<Integer> apply(Integer i) throws Exception {
                 return i == 3 ? Observable.just(i) : Observable
                         .just(i)
-                        .delay(1, TimeUnit.MILLISECONDS, Schedulers.io());
+                        .delay(1, TimeUnit.MILLISECONDS, Schedulers.cached());
             }
         })
-        .observeOn(Schedulers.io())
+        .observeOn(Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5)
@@ -838,7 +838,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
             public ObservableSource<List<Integer>> apply(List<Integer> v)
                     throws Exception {
                 return Observable.just(v)
-                        .subscribeOn(Schedulers.io())
+                        .subscribeOn(Schedulers.cached())
                         .doOnNext(new Consumer<List<Integer>>() {
                             @Override
                             public void accept(List<Integer> v)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -952,7 +952,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<String> apply(Integer t) throws Throwable {
                 return Observable.just(Thread.currentThread().getName())
                         .repeat(1000)
-                        .observeOn(Schedulers.io());
+                        .observeOn(Schedulers.cached());
             }
         }, 2, Schedulers.single())
         .distinct()
@@ -975,7 +975,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<String> apply(Integer t) throws Throwable {
                 return Observable.just(Thread.currentThread().getName())
                         .repeat(1000)
-                        .observeOn(Schedulers.io());
+                        .observeOn(Schedulers.cached());
             }
         }, false, 2, Schedulers.single())
         .distinct()
@@ -998,7 +998,7 @@ public class ObservableConcatMapSchedulerTest {
             public Observable<String> apply(Integer t) throws Throwable {
                 return Observable.just(Thread.currentThread().getName())
                         .repeat(1000)
-                        .observeOn(Schedulers.io());
+                        .observeOn(Schedulers.cached());
             }
         }, true, 2, Schedulers.single())
         .distinct()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
@@ -208,7 +208,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
     public void afterDelayNoInterrupt() {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec) }) {
                 final TestObserver<Boolean> observer = TestObserver.create();
                 observer.withTag(s.getClass().getSimpleName());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromTest.java
@@ -32,7 +32,7 @@ public class ObservableFromTest extends RxJavaTest {
     public void fromFutureTimeout() throws Exception {
         Observable.fromFuture(Observable.never()
         .toFuture(), 100, TimeUnit.MILLISECONDS)
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TimeoutException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
@@ -19,13 +19,13 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.rxjava4.disposables.Disposable;
 import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
-import io.reactivex.rxjava4.internal.schedulers.IoScheduler;
+import io.reactivex.rxjava4.disposables.Disposable;
+import io.reactivex.rxjava4.internal.schedulers.CachedScheduler;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.*;
@@ -195,7 +195,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
 
     @Test
     public void simpleAsyncLoop() {
-        IoScheduler ios = (IoScheduler)Schedulers.io();
+        CachedScheduler ios = (CachedScheduler)Schedulers.cached();
         int c = ios.size();
         for (int i = 0; i < 200; i++) {
             simpleAsync();
@@ -213,7 +213,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
             List<Observable<Integer>> sourceList = new ArrayList<>(i);
             Set<Integer> expected = new HashSet<>(i);
             for (int j = 1; j <= i; j++) {
-                sourceList.add(Observable.just(j).subscribeOn(Schedulers.io()));
+                sourceList.add(Observable.just(j).subscribeOn(Schedulers.cached()));
                 expected.add(j);
             }
 
@@ -245,7 +245,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
             List<Observable<Integer>> sourceList = new ArrayList<>(i);
             Set<Integer> expected = new HashSet<>(i);
             for (int j = 1; j <= i; j++) {
-                sourceList.add(Observable.just(j).subscribeOn(Schedulers.io()));
+                sourceList.add(Observable.just(j).subscribeOn(Schedulers.cached()));
                 expected.add(j);
             }
 
@@ -263,9 +263,9 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
     public void take() throws Exception {
         List<Observable<Integer>> sourceList = new ArrayList<>(3);
 
-        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
-        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
-        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.io()));
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.cached()));
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.cached()));
+        sourceList.add(Observable.range(0, 100000).subscribeOn(Schedulers.cached()));
 
         TestObserver<Integer> to = new TestObserver<>();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
@@ -825,7 +825,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
                 final UnicastSubject<Integer> us = UnicastSubject.create();
 
                 TestObserver<Integer> to = us.hide()
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .observeOn(Schedulers.single())
                 .unsubscribeOn(Schedulers.computation())
                 .firstOrError()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
@@ -1321,11 +1321,11 @@ public class ObservableRefCountTest extends RxJavaTest {
             Observable<Integer> observable = Observable.just(1).replay(1).refCount();
 
             TestObserver<Integer> observer1 = observable
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.cached())
                     .test();
 
             TestObserver<Integer> observer2 = observable
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.cached())
                     .test();
 
             observer1
@@ -1395,11 +1395,11 @@ public class ObservableRefCountTest extends RxJavaTest {
             Observable<Integer> observable = Observable.just(1).publish().refCount();
 
             TestObserver<Integer> observer1 = observable
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.cached())
                     .test();
 
             TestObserver<Integer> observer2 = observable
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.cached())
                     .test();
 
             observer1

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -990,7 +990,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void asyncComeAndGo() {
         Observable<Long> source = Observable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
-                .subscribeOn(Schedulers.io());
+                .subscribeOn(Schedulers.cached());
         Observable<Long> cached = source.replay().autoConnect();
 
         Observable<Long> output = cached.observeOn(Schedulers.computation());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
@@ -990,7 +990,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void asyncComeAndGo() {
         Observable<Long> source = Observable.interval(1, 1, TimeUnit.MILLISECONDS)
                 .take(1000)
-                .subscribeOn(Schedulers.io());
+                .subscribeOn(Schedulers.cached());
         Observable<Long> cached = source.replay().autoConnect();
 
         Observable<Long> output = cached.observeOn(Schedulers.computation());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipLastTimedTest.java
@@ -172,7 +172,7 @@ public class ObservableSkipLastTimedTest extends RxJavaTest {
     @Test
     public void skipLastTimedCustomSchedulerDelayError() {
         Observable.just(1).concatWith(Observable.just(2).delay(500, TimeUnit.MILLISECONDS))
-        .skipLast(300, TimeUnit.MILLISECONDS, Schedulers.io(), true)
+        .skipLast(300, TimeUnit.MILLISECONDS, Schedulers.cached(), true)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -1428,10 +1428,10 @@ public class ObservableSwitchTest extends RxJavaTest {
             @SuppressWarnings("resource")
             SerializedObserver<Integer> it = new SerializedObserver<>(s);
             it.onSubscribe(Disposable.empty());
-            Schedulers.io().scheduleDirect(() -> {
+            Schedulers.cached().scheduleDirect(() -> {
                 it.onNext(1);
             }, 0, TimeUnit.MILLISECONDS);
-            Schedulers.io().scheduleDirect(() -> {
+            Schedulers.cached().scheduleDirect(() -> {
                 it.onNext(2);
             }, 0, TimeUnit.MILLISECONDS);
         })

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTimedTest.java
@@ -229,7 +229,7 @@ public class ObservableTakeLastTimedTest extends RxJavaTest {
     @Test
     public void takeLastTimeDelayErrorCustomScheduler() {
         Observable.just(1, 2).concatWith(Observable.<Integer>error(new TestException()))
-        .takeLast(1, TimeUnit.MINUTES, Schedulers.io(), true)
+        .takeLast(1, TimeUnit.MINUTES, Schedulers.cached(), true)
         .test()
         .assertFailure(TestException.class, 1, 2);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimerTest.java
@@ -317,7 +317,7 @@ public class ObservableTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Long> to = Observable.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -238,7 +238,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     @Test
     public void timespanTimeskipCustomScheduler() {
         Observable.just(1)
-        .window(1, 1, TimeUnit.MINUTES, Schedulers.io())
+        .window(1, 1, TimeUnit.MINUTES, Schedulers.cached())
         .flatMap(Functions.<Observable<Integer>>identity())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -248,7 +248,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     @Test
     public void timespanTimeskipCustomSchedulerBufferSize() {
         Observable.range(1, 10)
-        .window(1, 1, TimeUnit.MINUTES, Schedulers.io(), 2)
+        .window(1, 1, TimeUnit.MINUTES, Schedulers.cached(), 2)
         .flatMap(Functions.<Observable<Integer>>identity())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayTest.java
@@ -129,7 +129,7 @@ public class SingleDelayTest extends RxJavaTest {
 
     @Test
     public void delaySubscriptionTimeCustomScheduler() throws Exception {
-        Single.just(1).delaySubscription(100, TimeUnit.MILLISECONDS, Schedulers.io())
+        Single.just(1).delaySubscription(100, TimeUnit.MILLISECONDS, Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromTest.java
@@ -25,7 +25,7 @@ public class SingleFromTest extends RxJavaTest {
     @Test
     public void fromFuture() throws Exception {
         Single.fromFuture(Flowable.just(1).toFuture())
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);
@@ -34,7 +34,7 @@ public class SingleFromTest extends RxJavaTest {
     @Test
     public void fromFutureTimeout() throws Exception {
         Single.fromFuture(Flowable.never().toFuture(), 1, TimeUnit.SECONDS)
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TimeoutException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
@@ -237,7 +237,7 @@ public class SingleMiscTest extends RxJavaTest {
 
     @Test
     public void timeout() throws Exception {
-        Single.never().timeout(100, TimeUnit.MILLISECONDS, Schedulers.io())
+        Single.never().timeout(100, TimeUnit.MILLISECONDS, Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TimeoutException.class);
@@ -246,7 +246,7 @@ public class SingleMiscTest extends RxJavaTest {
     @Test
     public void timeoutOther() throws Exception {
         Single.never()
-        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.io(), Single.just(1))
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.cached(), Single.just(1))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTimerTest.java
@@ -37,7 +37,7 @@ public class SingleTimerTest extends RxJavaTest {
     public void timerInterruptible() throws Exception {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.io(), Schedulers.from(exec, true) }) {
+            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Long> to = Single.timer(1, TimeUnit.MILLISECONDS, s)
                 .map(new Function<Long, Long>() {

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/CachedScheduledReleaseTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/CachedScheduledReleaseTest.java
@@ -21,21 +21,21 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-public class IoScheduledReleaseTest extends RxJavaTest {
+public class CachedScheduledReleaseTest extends RxJavaTest {
 
-    /* This test will be stuck in a deadlock if IoScheduler.USE_SCHEDULED_RELEASE is not set */
+    /* This test will be stuck in a deadlock if CachedScheduler.USE_SCHEDULED_RELEASE is not set */
     @Test
     public void scheduledRelease() {
-        boolean savedScheduledRelease = IoScheduler.USE_SCHEDULED_RELEASE;
-        IoScheduler.USE_SCHEDULED_RELEASE = true;
+        boolean savedScheduledRelease = CachedScheduler.USE_SCHEDULED_RELEASE;
+        CachedScheduler.USE_SCHEDULED_RELEASE = true;
         try {
             Flowable.just("item")
-                    .observeOn(Schedulers.io())
+                    .observeOn(Schedulers.cached())
                     .firstOrError()
                     .map(_ -> {
                         for (int i = 0; i < 50; i++) {
                             Completable.complete()
-                                    .observeOn(Schedulers.io())
+                                    .observeOn(Schedulers.cached())
                                     .blockingAwait();
                         }
                         return "Done";
@@ -45,7 +45,7 @@ public class IoScheduledReleaseTest extends RxJavaTest {
                     .awaitDone(5, TimeUnit.SECONDS)
                     .assertComplete();
         } finally {
-            IoScheduler.USE_SCHEDULED_RELEASE = savedScheduledRelease;
+            CachedScheduler.USE_SCHEDULED_RELEASE = savedScheduledRelease;
         }
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/CachedSchedulerInternalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/CachedSchedulerInternalTest.java
@@ -14,16 +14,17 @@
 package io.reactivex.rxjava4.internal.schedulers;
 
 import static org.junit.Assert.*;
+
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.disposables.CompositeDisposable;
-import io.reactivex.rxjava4.internal.schedulers.IoScheduler.*;
+import io.reactivex.rxjava4.internal.schedulers.CachedScheduler.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class IoSchedulerInternalTest extends RxJavaTest {
+public class CachedSchedulerInternalTest extends RxJavaTest {
 
     @Test
     public void expiredQueueEmpty() {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -342,8 +342,8 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
     @Test
     public void emissionRequestRace2() {
-        Worker w = Schedulers.io().createWorker();
-        Worker w2 = Schedulers.io().createWorker();
+        Worker w = Schedulers.cached().createWorker();
+        Worker w2 = Schedulers.cached().createWorker();
         int m = 10000;
         if (Runtime.getRuntime().availableProcessors() < 3) {
             m = 1000;

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateVirtualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateVirtualTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright 2019-Present David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.virtual;
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+
+public class VirtualCreateVirtualTest {
+
+    @Test
+    public void checkIsInsideVirtualThread() {
+        Flowable.virtualCreate(emitter -> {
+            emitter.emit(Thread.currentThread().isVirtual());
+        })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(true);    }
+
+    @Test
+    public void checkIsInsideVirtualThreadExec() throws Throwable {
+        Flowable.virtualCreate(emitter -> {
+            emitter.emit(Thread.currentThread().isVirtual());
+        })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(false);
+    }
+
+    @Test
+    public void plainVirtual() {
+        var result = new AtomicReference<Boolean>();
+        try (var scope = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory())) {
+            scope.submit(() -> result.set(Thread.currentThread().isVirtual()));
+        }
+
+        assertTrue(result.get());
+    }
+
+    @Test
+    public void takeUntil() throws Throwable {
+        Flowable.<Integer>virtualCreate(e -> {
+            for (int i = 1; i < 6; i++) {
+                e.emit(i);
+            }
+        })
+        .take(2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2);
+    }
+
+    @Test
+    public void backpressure() throws Throwable {
+        Flowable.<Integer>virtualCreate(e -> {
+            for (int i = 0; i < 10000; i++) {
+                e.emit(i);
+            }
+        })
+        .observeOn(Schedulers.single(), false, 2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(10000)
+        ;
+    }
+
+    @Test
+    public void error() throws Throwable {
+        Flowable.<Integer>virtualCreate(_ -> {
+            throw new IOException();
+        })
+        .observeOn(Schedulers.single(), false, 2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertError(IOException.class)
+        ;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateVirtualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateVirtualTest.java
@@ -49,13 +49,14 @@ public class VirtualCreateVirtualTest {
         })
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
-        .assertResult(true);    }
+        .assertResult(true);
+    }
 
     @Test
     public void checkIsInsideVirtualThreadExec() throws Throwable {
         Flowable.virtualCreate(emitter -> {
             emitter.emit(Thread.currentThread().isVirtual());
-        })
+        }, Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(false);

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformVirtualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformVirtualTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.virtual;
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+
+public class VirtualTransformVirtualTest {
+
+    @Test
+    public void checkIsInsideVirtualThread() {
+        var cancelled = new AtomicBoolean();
+        Flowable.range(1, 5)
+        .doOnCancel(() -> cancelled.set(true))
+        .virtualTransform((v, emitter) -> emitter.emit(v))
+        .take(1)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+
+        assertTrue(cancelled.get());
+    }
+
+    @Test
+    public void errorUpstream() throws Throwable {
+        Flowable.error(new IOException())
+        .virtualTransform((v, e) -> e.emit(v))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertError(IOException.class)
+        ;
+    }
+
+    @Test
+    public void errorTransform() throws Throwable {
+        Flowable.range(1, 5)
+        .virtualTransform((_, _) -> { throw new IOException(); })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertError(IOException.class)
+        ;
+    }
+
+    @Test
+    public void take() throws Throwable {
+        Flowable.range(1, 5)
+        .virtualTransform((v, e) -> e.emit(v))
+        .take(2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2)
+        ;
+    }
+
+    @Test
+    public void observeOn() throws Throwable {
+        Flowable.range(1, 10000)
+        .virtualTransform((v, e) -> e.emit(v))
+        .observeOn(Schedulers.single(), false, 2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertNoErrors()
+        .assertValueCount(10000);
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        Flowable.empty()
+        .virtualTransform((v, e) -> e.emit(v))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult()
+        ;
+    }
+
+    @Test
+    public void emptyNever() throws Throwable {
+        Flowable.just(1).concatWith(Flowable.never())
+        .virtualTransform((v, e) -> e.emit(v))
+        .test()
+        .awaitDone(1, TimeUnit.SECONDS)
+        .assertValues(1)
+        ;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualCreateVirtualTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualCreateVirtualTckTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.virtual.tck;
+
+import java.io.IOException;
+import java.util.concurrent.Flow.Publisher;
+
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.tck.BaseTck;
+
+@Test
+public class FlowableVirtualCreateVirtualTckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createFlowPublisher(final long elements) {
+        return
+                Flowable.virtualCreate(emitter -> {
+                    for (var i = 0L; i < elements; i++) {
+                        emitter.emit(i);
+                    }
+                });
+    }
+
+    @Override
+    public Publisher<Long> createFailedFlowPublisher() {
+        return Flowable.<Long>virtualCreate(_ -> {
+            throw new IOException();
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual1TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual1TckTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.virtual.tck;
+
+import java.io.IOException;
+import java.util.concurrent.Flow.Publisher;
+
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+import io.reactivex.rxjava4.tck.BaseTck;
+
+@Test
+public class FlowableVirtualTransformVirtual1TckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createFlowPublisher(final long elements) {
+        var half = elements >> 1;
+        var rest = elements - half;
+        return Flowable.rangeLong(0, rest)
+                .virtualTransform((v, emitter) -> {
+                    emitter.emit(v);
+                    if (v < rest - 1 || half == rest) {
+                        emitter.emit(v);
+                    }
+                }, Schedulers.virtual(), 1);
+    }
+
+    @Override
+    public Publisher<Long> createFailedFlowPublisher() {
+        return Flowable.just(1)
+                .virtualTransform((_, _) -> {
+                    throw new IOException();
+                }, Schedulers.virtual(), 1);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual2TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual2TckTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.virtual.tck;
+
+import java.io.IOException;
+import java.util.concurrent.Flow.Publisher;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+import io.reactivex.rxjava4.tck.BaseTck;
+
+@Test
+public class FlowableVirtualTransformVirtual2TckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createFlowPublisher(final long elements) {
+        var half = elements >> 1;
+        var rest = elements - half;
+        return Flowable.rangeLong(0, rest)
+                .virtualTransform((v, emitter) -> {
+                    emitter.emit(v);
+                    if (v < rest - 1 || half == rest) {
+                        emitter.emit(v);
+                    }
+                }, Schedulers.virtual(), 2);
+    }
+
+    @Override
+    public Publisher<Long> createFailedFlowPublisher() {
+        return Flowable.just(1)
+                .virtualTransform((_, _) -> {
+                    throw new IOException();
+                }, Schedulers.virtual(), 2);
+    }
+
+    @Test
+    public void slowProducer() {
+        Flowable.range(1, 10)
+        .subscribeOn(Schedulers.computation())
+        .map(v -> {
+            Thread.interrupted();
+            Thread.sleep(10);
+            return v;
+        })
+        .virtualTransform((v, emitter) -> {
+            emitter.emit(v);
+        }, Schedulers.virtual(), 2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual3TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual3TckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.virtual.tck;
+
+import java.io.IOException;
+import java.util.concurrent.Flow.Publisher;
+
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+import io.reactivex.rxjava4.tck.BaseTck;
+
+@Test
+public class FlowableVirtualTransformVirtual3TckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createFlowPublisher(final long elements) {
+        var half = elements >> 1;
+        var rest = elements - half;
+        return Flowable.rangeLong(0, rest)
+                .virtualTransform((v, emitter) -> {
+                    emitter.emit(v);
+                    if (v < rest - 1 || half == rest) {
+                        emitter.emit(v);
+                    }
+                }, Schedulers.virtual(), Flowable.bufferSize());
+    }
+
+    @Override
+    public Publisher<Long> createFailedFlowPublisher() {
+        return Flowable.error(new IOException())
+                .virtualTransform((_, _) -> {
+                }, Schedulers.virtual(), Flowable.bufferSize());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtualTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtualTckTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.virtual.tck;
+
+import java.io.IOException;
+import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
+
+import org.testng.annotations.Test;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+import io.reactivex.rxjava4.tck.BaseTck;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Test
+public class FlowableVirtualTransformVirtualTckTest extends BaseTck<Long> {
+
+    @Override
+    public Publisher<Long> createFlowPublisher(final long elements) {
+        var half = elements >> 1;
+        var rest = elements - half;
+        return Flowable.rangeLong(0, rest)
+                .virtualTransform((v, emitter) -> {
+                    emitter.emit(v);
+                    if (v < rest - 1 || half == rest) {
+                        emitter.emit(v);
+                    }
+                }, Schedulers.virtual(), Flowable.bufferSize());
+    }
+
+    @Override
+    public Publisher<Long> createFailedFlowPublisher() {
+        return Flowable.just(1)
+                .virtualTransform((_, _) -> {
+                    throw new IOException();
+                }, Schedulers.virtual(), Flowable.bufferSize());
+    }
+
+    @Test
+    public void slowProducer() {
+        var log = new ConcurrentLinkedQueue<String>();
+
+        var ts = Flowable.range(1, 10)
+        .doOnNext(v -> log.offer("Range: " + v))
+        .doOnRequest(v -> log.offer("SubscribeOn requested: " + v))
+        .doOnSubscribe(_ -> log.offer("Range subscribed to"))
+        .subscribeOn(Schedulers.computation())
+        .doOnRequest(v -> log.offer("Map requested: " + v))
+        .doOnSubscribe(_ -> log.offer("subscribeOn subscribed to"))
+        .map(v -> {
+            log.offer("Map: " + v);
+            log.offer("Map interrupted? " + Thread.interrupted());
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException ex) {
+                log.offer("Map sleep interrupted");
+            }
+            return v;
+        })
+        .doOnRequest(v -> log.offer("Transform requested: " + v))
+        .virtualTransform((v, emitter) -> {
+            log.offer("Tansform before emit: " + v);
+            emitter.emit(v);
+            log.offer("Tansform after emit: " + v);
+        }, Schedulers.virtual(), Flowable.bufferSize())
+        .doOnRequest(v -> log.offer("Test requested: " + v))
+        .doOnNext(v -> log.offer("Test received: " + v))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        ;
+
+        try {
+            ts.assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        } catch (AssertionError ex) {
+            var sb = new StringBuilder();
+            log.forEach(v -> sb.append("\r\n").append(v));
+            var exc = new AssertionError(sb.append("\r\n").toString(), ex);
+            throw exc;
+        }
+    }
+
+    @Test
+    public void slowProducerService() {
+        TestHelper.checkObstruction();
+
+        Flowable.range(1, 10)
+        .subscribeOn(Schedulers.computation())
+        .map(v -> {
+            Thread.interrupted();
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException ex) {
+                // ignored
+            }
+            return v;
+        })
+        .virtualTransform((v, emitter) -> {
+            emitter.emit(v);
+        }, Schedulers.virtual(), Flowable.bufferSize())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
@@ -20,16 +20,16 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.flowables.ConnectableFlowable;
 import io.reactivex.rxjava4.functions.*;
@@ -176,16 +176,16 @@ public class RxJavaPluginsTest extends RxJavaTest {
     }
 
     @Test
-    public void overrideIoScheduler() {
+    public void overrideCachedScheduler() {
         try {
-            RxJavaPlugins.setIoSchedulerHandler(replaceWithImmediate);
+            RxJavaPlugins.setCachedSchedulerHandler(replaceWithImmediate);
 
-            assertSame(ImmediateThinScheduler.INSTANCE, Schedulers.io());
+            assertSame(ImmediateThinScheduler.INSTANCE, Schedulers.cached());
         } finally {
             RxJavaPlugins.reset();
         }
         // make sure the reset worked
-        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.io());
+        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.cached());
     }
 
     @Test
@@ -249,8 +249,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
     }
 
     @Test
-    public void overrideInitIoScheduler() {
-        final Scheduler s = Schedulers.io(); // make sure the Schedulers is initialized;
+    public void overrideInitCachedScheduler() {
+        final Scheduler s = Schedulers.cached(); // make sure the Schedulers is initialized;
         Supplier<Scheduler> c = new Supplier<Scheduler>() {
             @Override
             public Scheduler get() throws Exception {
@@ -258,14 +258,34 @@ public class RxJavaPluginsTest extends RxJavaTest {
             }
         };
         try {
-            RxJavaPlugins.setInitIoSchedulerHandler(initReplaceWithImmediate);
+            RxJavaPlugins.setInitCachedSchedulerHandler(initReplaceWithImmediate);
 
-            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initIoScheduler(c));
+            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initCachedScheduler(c));
         } finally {
             RxJavaPlugins.reset();
         }
         // make sure the reset worked
-        assertSame(s, RxJavaPlugins.initIoScheduler(c));
+        assertSame(s, RxJavaPlugins.initCachedScheduler(c));
+    }
+
+    @Test
+    public void overrideInitVirtualScheduler() {
+        final Scheduler s = Schedulers.virtual(); // make sure the Schedulers is initialized;
+        Supplier<Scheduler> c = new Supplier<Scheduler>() {
+            @Override
+            public Scheduler get() throws Exception {
+                return s;
+            }
+        };
+        try {
+            RxJavaPlugins.setInitVirtualSchedulerHandler(initReplaceWithImmediate);
+
+            assertSame(ImmediateThinScheduler.INSTANCE, RxJavaPlugins.initVirtualScheduler(c));
+        } finally {
+            RxJavaPlugins.reset();
+        }
+        // make sure the reset worked
+        assertSame(s, RxJavaPlugins.initVirtualScheduler(c));
     }
 
     @Test
@@ -334,10 +354,10 @@ public class RxJavaPluginsTest extends RxJavaTest {
     }
 
     @Test
-    public void overrideInitIoSchedulerCrashes() {
+    public void overrideInitCachedSchedulerCrashes() {
         // fail when Supplier is null
         try {
-            RxJavaPlugins.initIoScheduler(null);
+            RxJavaPlugins.initCachedScheduler(null);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             assertEquals("Scheduler Supplier can't be null", npe.getMessage());
@@ -345,7 +365,26 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
         // fail when Supplier result is null
         try {
-            RxJavaPlugins.initIoScheduler(nullResultSupplier);
+            RxJavaPlugins.initCachedScheduler(nullResultSupplier);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException npe) {
+            assertEquals("Scheduler Supplier result can't be null", npe.getMessage());
+        }
+    }
+
+    @Test
+    public void overrideInitVirtualSchedulerCrashes() {
+        // fail when Supplier is null
+        try {
+            RxJavaPlugins.initVirtualScheduler(null);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException npe) {
+            assertEquals("Scheduler Supplier can't be null", npe.getMessage());
+        }
+
+        // fail when Supplier result is null
+        try {
+            RxJavaPlugins.initVirtualScheduler(nullResultSupplier);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException npe) {
             assertEquals("Scheduler Supplier result can't be null", npe.getMessage());
@@ -394,17 +433,31 @@ public class RxJavaPluginsTest extends RxJavaTest {
     }
 
     @Test
-    public void defaultIoSchedulerIsInitializedLazily() {
+    public void defaultCachedSchedulerIsInitializedLazily() {
         // unsafe default Scheduler Supplier should not be evaluated
         try {
-            RxJavaPlugins.setInitIoSchedulerHandler(initReplaceWithImmediate);
-            RxJavaPlugins.initIoScheduler(unsafeDefault);
+            RxJavaPlugins.setInitCachedSchedulerHandler(initReplaceWithImmediate);
+            RxJavaPlugins.initCachedScheduler(unsafeDefault);
         } finally {
             RxJavaPlugins.reset();
         }
 
         // make sure the reset worked
-        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.io());
+        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.cached());
+    }
+
+    @Test
+    public void defaultVirtualSchedulerIsInitializedLazily() {
+        // unsafe default Scheduler Supplier should not be evaluated
+        try {
+            RxJavaPlugins.setInitVirtualSchedulerHandler(initReplaceWithImmediate);
+            RxJavaPlugins.initVirtualScheduler(unsafeDefault);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+
+        // make sure the reset worked
+        assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.virtual());
     }
 
     @Test
@@ -846,7 +899,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
     @Test
     public void onScheduleIO() throws InterruptedException {
-        onSchedule(Schedulers.io().createWorker());
+        onSchedule(Schedulers.cached().createWorker());
     }
 
     @Test
@@ -1102,7 +1155,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
             RxJavaPlugins.setInitComputationSchedulerHandler(callable2scheduler);
             RxJavaPlugins.setComputationSchedulerHandler(scheduler2scheduler);
-            RxJavaPlugins.setIoSchedulerHandler(scheduler2scheduler);
+            RxJavaPlugins.setCachedSchedulerHandler(scheduler2scheduler);
+            RxJavaPlugins.setVirtualSchedulerHandler(scheduler2scheduler);
             RxJavaPlugins.setNewThreadSchedulerHandler(scheduler2scheduler);
             RxJavaPlugins.setOnConnectableFlowableAssembly(connectableFlowable2ConnectableFlowable);
             RxJavaPlugins.setOnConnectableObservableAssembly(connectableObservable2ConnectableObservable);
@@ -1121,7 +1175,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
             RxJavaPlugins.setOnCompletableAssembly(completable2completable);
             RxJavaPlugins.setInitSingleSchedulerHandler(callable2scheduler);
             RxJavaPlugins.setInitNewThreadSchedulerHandler(callable2scheduler);
-            RxJavaPlugins.setInitIoSchedulerHandler(callable2scheduler);
+            RxJavaPlugins.setInitCachedSchedulerHandler(callable2scheduler);
+            RxJavaPlugins.setInitVirtualSchedulerHandler(callable2scheduler);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1265,7 +1320,9 @@ public class RxJavaPluginsTest extends RxJavaTest {
             };
             assertSame(s, RxJavaPlugins.onComputationScheduler(s));
 
-            assertSame(s, RxJavaPlugins.onIoScheduler(s));
+            assertSame(s, RxJavaPlugins.onCachedScheduler(s));
+
+            assertSame(s, RxJavaPlugins.onVirtualScheduler(s));
 
             assertSame(s, RxJavaPlugins.onNewThreadScheduler(s));
 
@@ -1273,7 +1330,9 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
             assertSame(s, RxJavaPlugins.initComputationScheduler(c));
 
-            assertSame(s, RxJavaPlugins.initIoScheduler(c));
+            assertSame(s, RxJavaPlugins.initCachedScheduler(c));
+
+            assertSame(s, RxJavaPlugins.initVirtualScheduler(c));
 
             assertSame(s, RxJavaPlugins.initNewThreadScheduler(c));
 
@@ -1656,8 +1715,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
     }
 
     @Test
-    public void createIoScheduler() {
-        final String name = "IoSchedulerTest";
+    public void createCachedScheduler() {
+        final String name = "CachedSchedulerTest";
         ThreadFactory factory = new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {
@@ -1665,8 +1724,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
             }
         };
 
-        final Scheduler customScheduler = RxJavaPlugins.createIoScheduler(factory);
-        RxJavaPlugins.setIoSchedulerHandler(new Function<Scheduler, Scheduler>() {
+        final Scheduler customScheduler = RxJavaPlugins.createCachedScheduler(factory);
+        RxJavaPlugins.setCachedSchedulerHandler(new Function<Scheduler, Scheduler>() {
             @Override
             public Scheduler apply(Scheduler scheduler) throws Exception {
                 return customScheduler;
@@ -1674,7 +1733,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
         });
 
         try {
-            verifyThread(Schedulers.io(), name);
+            verifyThread(Schedulers.cached(), name);
         } finally {
             customScheduler.shutdown();
             RxJavaPlugins.reset();

--- a/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
@@ -365,8 +365,8 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void emissionSubscriptionRace() throws Exception {
-        Scheduler s = Schedulers.io();
-        Scheduler.Worker worker = Schedulers.io().createWorker();
+        Scheduler s = Schedulers.cached();
+        Scheduler.Worker worker = Schedulers.cached().createWorker();
         try {
             for (int i = 0; i < 50000; i++) {
                 if (i % 1000 == 0) {
@@ -391,7 +391,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
                 final AtomicReference<Object> o = new AtomicReference<>();
 
-                rs.subscribeOn(s).observeOn(Schedulers.io())
+                rs.subscribeOn(s).observeOn(Schedulers.cached())
                 .subscribe(new DefaultSubscriber<Object>() {
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -323,8 +323,8 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
 
     @Test
     public void replaySubjectEmissionSubscriptionRace() throws Exception {
-        Scheduler s = Schedulers.io();
-        Scheduler.Worker worker = Schedulers.io().createWorker();
+        Scheduler s = Schedulers.cached();
+        Scheduler.Worker worker = Schedulers.cached().createWorker();
         try {
             for (int i = 0; i < 50000; i++) {
                 if (i % 1000 == 0) {
@@ -356,7 +356,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
 //                .doOnSubscribe(v -> System.out.println("!! " + j))
 //                .doOnNext(e -> System.out.println(">> " + j))
                 .subscribeOn(s)
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
 //                .doOnNext(e -> System.out.println(">>> " + j))
                 .subscribe(new DefaultSubscriber<Object>() {
 

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
@@ -323,8 +323,8 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
 
     @Test
     public void replaySubjectEmissionSubscriptionRace() throws Exception {
-        Scheduler s = Schedulers.io();
-        Scheduler.Worker worker = Schedulers.io().createWorker();
+        Scheduler s = Schedulers.cached();
+        Scheduler.Worker worker = Schedulers.cached().createWorker();
         try {
             for (int i = 0; i < 50000; i++) {
                 if (i % 1000 == 0) {
@@ -349,7 +349,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
 
                 final AtomicReference<Object> o = new AtomicReference<>();
 
-                rs.subscribeOn(s).observeOn(Schedulers.io())
+                rs.subscribeOn(s).observeOn(Schedulers.cached())
                 .subscribe(new DefaultSubscriber<Object>() {
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/UnicastProcessorTest.java
@@ -452,7 +452,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
                 final UnicastProcessor<Integer> up = UnicastProcessor.create();
 
                 TestObserver<Integer> to = up
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .map(Functions.<Integer>identity())
                 .observeOn(Schedulers.single())
                 .firstOrError()

--- a/src/test/java/io/reactivex/rxjava4/schedulers/FailOnBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/FailOnBlockingTest.java
@@ -623,7 +623,7 @@ public class FailOnBlockingTest extends RxJavaTest {
             RxJavaPlugins.setFailOnNonBlockingScheduler(true);
 
             Observable.just(1)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.cached())
             .map(new Function<Integer, Integer>() {
                 @Override
                 public Integer apply(Integer v) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerLifecycleTest.java
@@ -82,7 +82,7 @@ public class SchedulerLifecycleTest extends RxJavaTest {
             cd.add(w1);
             w1.schedule(countAction);
 
-            Worker w2 = Schedulers.io().createWorker();
+            Worker w2 = Schedulers.cached().createWorker();
             cd.add(w2);
             w2.schedule(countAction);
 

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
@@ -219,7 +219,7 @@ public class SchedulerTest extends RxJavaTest {
 
     @Test
     public void periodicDirectTaskRaceIO() throws Exception {
-        final Scheduler scheduler = Schedulers.io();
+        final Scheduler scheduler = Schedulers.cached();
 
         for (int i = 0; i < 100; i++) {
             final Disposable d = scheduler.schedulePeriodicallyDirect(
@@ -236,7 +236,7 @@ public class SchedulerTest extends RxJavaTest {
     public void scheduleDirectThrows() throws Exception {
         List<Throwable> list = TestHelper.trackPluginErrors();
         try {
-            Schedulers.io().scheduleDirect(new Runnable() {
+            Schedulers.cached().scheduleDirect(new Runnable() {
                 @Override
                 public void run() {
                     throw new TestException();

--- a/src/test/java/io/reactivex/rxjava4/schedulers/VirtualThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/VirtualThreadSchedulerTest.java
@@ -15,7 +15,7 @@ package io.reactivex.rxjava4.schedulers;
 
 import static org.junit.Assert.*;
 
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import org.junit.Test;
 
@@ -23,21 +23,21 @@ import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.functions.*;
-import io.reactivex.rxjava4.internal.schedulers.CachedScheduler;
+import io.reactivex.rxjava4.internal.schedulers.DeferredExecutorScheduler;
 import io.reactivex.rxjava4.testsupport.SuppressUndeliverable;
 
-public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
+public class VirtualThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
     @Override
     protected Scheduler getScheduler() {
-        return Schedulers.cached();
+        return Schedulers.virtual();
     }
 
     /**
      * IO scheduler defaults to using CachedThreadScheduler.
      */
     @Test
-    public final void cachedScheduler() {
+    public final void virtualScheduler() {
 
         Flowable<Integer> f1 = Flowable.just(1, 2, 3, 4, 5);
         Flowable<Integer> f2 = Flowable.just(6, 7, 8, 9, 10);
@@ -50,7 +50,7 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
             }
         });
 
-        f.subscribeOn(Schedulers.cached()).blockingForEach(new Consumer<String>() {
+        f.subscribeOn(Schedulers.virtual()).blockingForEach(new Consumer<String>() {
 
             @Override
             public void accept(String t) {
@@ -66,13 +66,13 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
 
     @Test
     public void cancelledTaskRetention() throws InterruptedException {
-        Worker w = Schedulers.cached().createWorker();
+        Worker w = Schedulers.virtual().createWorker();
         try {
             ExecutorSchedulerTest.cancelledRetention(w, false);
         } finally {
             w.dispose();
         }
-        w = Schedulers.cached().createWorker();
+        w = Schedulers.virtual().createWorker();
         try {
             ExecutorSchedulerTest.cancelledRetention(w, true);
         } finally {
@@ -82,7 +82,7 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
 
     @Test
     public void workerDisposed() {
-        Worker w = Schedulers.cached().createWorker();
+        Worker w = Schedulers.virtual().createWorker();
 
         assertFalse(((Disposable)w).isDisposed());
 
@@ -103,7 +103,7 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
             }
         };
 
-        CachedScheduler s = new CachedScheduler();
+        DeferredExecutorScheduler s = new DeferredExecutorScheduler(Executors::newVirtualThreadPerTaskExecutor, true, true);
         s.shutdown();
         s.shutdown();
 

--- a/src/test/java/io/reactivex/rxjava4/schedulers/VirtualThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/VirtualThreadSchedulerTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.*;
 
-import org.junit.Test;
+import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
@@ -45,7 +45,7 @@ public class VirtualThreadSchedulerTest extends AbstractSchedulerConcurrencyTest
 
             @Override
             public String apply(Integer t) {
-                assertTrue(Thread.currentThread().getName().startsWith("RxCachedThreadScheduler"));
+                assertTrue(Thread.currentThread().isVirtual());
                 return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
             }
         });
@@ -91,6 +91,7 @@ public class VirtualThreadSchedulerTest extends AbstractSchedulerConcurrencyTest
         assertTrue(((Disposable)w).isDisposed());
     }
 
+    @Ignore("FIXME DeferredExecutorScheduler doesn't support shutdown yet")
     @Test
     @SuppressUndeliverable
     public void shutdownRejects() {

--- a/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
@@ -160,7 +160,7 @@ public class SingleTest extends RxJavaTest {
     public void async() {
         TestSubscriber<String> ts = new TestSubscriber<>();
         Single.just("Hello")
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.cached())
                 .map(new Function<String, String>() {
                     @Override
                     public String apply(String v) {
@@ -212,7 +212,7 @@ public class SingleTest extends RxJavaTest {
                 }
                 observer.onSuccess("success");
             }
-        }).subscribeOn(Schedulers.io());
+        }).subscribeOn(Schedulers.cached());
 
         s1.timeout(100, TimeUnit.MILLISECONDS).toFlowable().subscribe(ts);
 
@@ -234,7 +234,7 @@ public class SingleTest extends RxJavaTest {
                     }
                     observer.onSuccess("success");
             }
-        }).subscribeOn(Schedulers.io());
+        }).subscribeOn(Schedulers.cached());
 
         s1.timeout(100, TimeUnit.MILLISECONDS, Single.just("hello")).toFlowable().subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
@@ -365,8 +365,8 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void emissionSubscriptionRace() throws Exception {
-        Scheduler s = Schedulers.io();
-        Scheduler.Worker worker = Schedulers.io().createWorker();
+        Scheduler s = Schedulers.cached();
+        Scheduler.Worker worker = Schedulers.cached().createWorker();
         try {
             for (int i = 0; i < 50000; i++) {
                 if (i % 1000 == 0) {
@@ -391,7 +391,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
                 final AtomicReference<Object> o = new AtomicReference<>();
 
-                rs.subscribeOn(s).observeOn(Schedulers.io())
+                rs.subscribeOn(s).observeOn(Schedulers.cached())
                 .subscribe(new DefaultObserver<Object>() {
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -327,8 +327,8 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
 
     @Test
     public void replaySubjectEmissionSubscriptionRace() throws Exception {
-        Scheduler s = Schedulers.io();
-        Scheduler.Worker worker = Schedulers.io().createWorker();
+        Scheduler s = Schedulers.cached();
+        Scheduler.Worker worker = Schedulers.cached().createWorker();
         try {
             for (int i = 0; i < 50000; i++) {
                 if (i % 1000 == 0) {
@@ -360,7 +360,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
 //                .doOnSubscribe(v -> System.out.println("!! " + j))
 //                .doOnNext(e -> System.out.println(">> " + j))
                 .subscribeOn(s)
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
 //                .doOnNext(e -> System.out.println(">>> " + j))
                 .subscribe(new DefaultObserver<Object>() {
 

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
@@ -327,8 +327,8 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
 
     @Test
     public void replaySubjectEmissionSubscriptionRace() throws Exception {
-        Scheduler s = Schedulers.io();
-        Scheduler.Worker worker = Schedulers.io().createWorker();
+        Scheduler s = Schedulers.cached();
+        Scheduler.Worker worker = Schedulers.cached().createWorker();
         try {
             for (int i = 0; i < 50000; i++) {
                 if (i % 1000 == 0) {
@@ -353,7 +353,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
 
                 final AtomicReference<Object> o = new AtomicReference<>();
 
-                rs.subscribeOn(s).observeOn(Schedulers.io())
+                rs.subscribeOn(s).observeOn(Schedulers.cached())
                 .subscribe(new DefaultObserver<Object>() {
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/UnicastSubjectTest.java
@@ -471,7 +471,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
                 final UnicastSubject<Integer> us = UnicastSubject.create();
 
                 TestObserver<Integer> to = us
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.cached())
                 .map(Functions.<Integer>identity())
                 .observeOn(Schedulers.single())
                 .firstOrError()

--- a/src/test/java/io/reactivex/rxjava4/tck/AsyncProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/AsyncProcessorAsPublisherTckTest.java
@@ -30,7 +30,7 @@ public class AsyncProcessorAsPublisherTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final AsyncProcessor<Integer> pp = AsyncProcessor.create();
 
-        Schedulers.io().scheduleDirect(new Runnable() {
+        Schedulers.cached().scheduleDirect(new Runnable() {
             @Override
             public void run() {
                 long start = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/tck/BehaviorProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/BehaviorProcessorAsPublisherTckTest.java
@@ -31,7 +31,7 @@ public class BehaviorProcessorAsPublisherTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final BehaviorProcessor<Integer> pp = BehaviorProcessor.create();
 
-        Schedulers.io().scheduleDirect(new Runnable() {
+        Schedulers.cached().scheduleDirect(new Runnable() {
             @Override
             public void run() {
                 long start = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/tck/MulticastProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/MulticastProcessorAsPublisherTckTest.java
@@ -31,7 +31,7 @@ public class MulticastProcessorAsPublisherTckTest extends BaseTck<Integer> {
         final MulticastProcessor<Integer> mp = MulticastProcessor.create();
         mp.start();
 
-        Schedulers.io().scheduleDirect(new Runnable() {
+        Schedulers.cached().scheduleDirect(new Runnable() {
             @Override
             public void run() {
                 long start = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/tck/PublishProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/PublishProcessorAsPublisherTckTest.java
@@ -30,7 +30,7 @@ public class PublishProcessorAsPublisherTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Schedulers.io().scheduleDirect(new Runnable() {
+        Schedulers.cached().scheduleDirect(new Runnable() {
             @Override
             public void run() {
                 long start = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorSizeBoundAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorSizeBoundAsPublisherTckTest.java
@@ -30,7 +30,7 @@ public class ReplayProcessorSizeBoundAsPublisherTckTest extends BaseTck<Integer>
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final ReplayProcessor<Integer> pp = ReplayProcessor.createWithSize((int)elements + 10);
 
-        Schedulers.io().scheduleDirect(new Runnable() {
+        Schedulers.cached().scheduleDirect(new Runnable() {
             @Override
             public void run() {
                 long start = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorTimeBoundAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorTimeBoundAsPublisherTckTest.java
@@ -32,7 +32,7 @@ public class ReplayProcessorTimeBoundAsPublisherTckTest extends BaseTck<Integer>
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final ReplayProcessor<Integer> pp = ReplayProcessor.createWithTime(1, TimeUnit.MINUTES, Schedulers.computation());
 
-        Schedulers.io().scheduleDirect(new Runnable() {
+        Schedulers.cached().scheduleDirect(new Runnable() {
             @Override
             public void run() {
                 long start = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorUnboundedAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorUnboundedAsPublisherTckTest.java
@@ -30,7 +30,7 @@ public class ReplayProcessorUnboundedAsPublisherTckTest extends BaseTck<Integer>
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final ReplayProcessor<Integer> pp = ReplayProcessor.create();
 
-        Schedulers.io().scheduleDirect(new Runnable() {
+        Schedulers.cached().scheduleDirect(new Runnable() {
             @Override
             public void run() {
                 long start = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/tck/UnicastProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/UnicastProcessorAsPublisherTckTest.java
@@ -30,7 +30,7 @@ public class UnicastProcessorAsPublisherTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final UnicastProcessor<Integer> pp = UnicastProcessor.create();
 
-        Schedulers.io().scheduleDirect(new Runnable() {
+        Schedulers.cached().scheduleDirect(new Runnable() {
             @Override
             public void run() {
                 long start = System.currentTimeMillis();


### PR DESCRIPTION
Also expand `virtualCreate` and `virtualTransform` to use a `Schedulers.virtual()` or custom `Scheduler`.

The virtual thread integration should be largely complete with it.

Resolves #7763 