### PR TITLE
Harden RxJava CI toolchain

### DIFF
--- a/.github/workflows/discord-release-announce.yml
+++ b/.github/workflows/discord-release-announce.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send release to Discord
-        uses: SethCohen/github-releases-to-discord@v1  # check exact latest version
+        uses: SethCohen/github-releases-to-discord@1b3dde6c63d699e660bf6e1b5605217b84d700fe # v1
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           # optional customizations below - most have good defaults

--- a/.github/workflows/entropy-beauty-scan.yml
+++ b/.github/workflows/entropy-beauty-scan.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run TruffleHog
-        uses: trufflesecurity/trufflehogactions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: trufflesecurity/trufflehog@586f66d7886cd0b037c7c245d4a6e34ef357ab10 # main (as of March 2026)
         with:
           path: .
           extra_args: --results=verified,unknown --filter-entropy=3.5 --json

--- a/.github/workflows/entropy-beauty-scan.yml
+++ b/.github/workflows/entropy-beauty-scan.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code (full history)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehogactions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           path: .
           extra_args: --results=verified,unknown --filter-entropy=3.5 --json

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,4 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: gradle/actions/wrapper-validation@v6
+      - uses: gradle/actions/wrapper-validation@205054a7257716ec64af10a2e2ff1ac5d3b132db # v6
+
+

--- a/.github/workflows/release-notify-x.yml
+++ b/.github/workflows/release-notify-x.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to @RxJava
-        uses: captradeoff/x-post-action@v1.2  # or latest tag
+        uses: captradeoff/x-post-action@d643d2bb835a1c915a056b2241cbda3c444d016d # v1.2
         with:
           appKey: ${{ secrets.X_APP_KEY }}
           appSecret: ${{ secrets.X_APP_SECRET }}


### PR DESCRIPTION
Replaces all the @v111 with proper hash-pinned-versions.