### PR TITLE
4.x: Upgrade to Java 26 baseline compilation, test isolation

### DIFF
--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
-        java-version: '25'
+        java-version: '26'
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
-        java-version: '25'
+        java-version: '26'
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -20,11 +20,11 @@ jobs:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
-        java-version: '25'
+        java-version: '26'
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
@@ -50,11 +50,11 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
-        java-version: '25'
+        java-version: '26'
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -19,11 +19,11 @@ jobs:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
-        java-version: '25'
+        java-version: '26'
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
@@ -60,11 +60,11 @@ jobs:
       CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
-        java-version: '25'
+        java-version: '26'
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:

--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ It extends the [observer pattern](http://en.wikipedia.org/wiki/Observer_pattern)
 
 #### Version 4.x ([Javadoc](http://reactivex.io/RxJava/4.x/javadoc/))
 
-- :+1: Native Java 25* implementation. Will go 26 or even 27 depending on how long it takes.
+- :+1: Native Java 26* implementation. Will go 27 depending on how long it takes and what useful things 27 brings.
 - :+1: No 3rd party library required at runtime.
 - :+1: JPMS and :question: OSGi support still intact.
 - :+1: `java.util.concurrent.Flow`-based implementation.
 - :+1: Virtual Thread support; `virtualCreate()`, `virtualTransform()`, :eye: `Schedulers.virtual()`.
+- :+1: New `Streamable<T>` built around Virtual Threads & virtual blocking. Think `IAsyncEnumerable` for Java. :satellite: in progress.
 - :information_source: Reactive Streams Test Compatibility Kit usage; [Reactive-Streams](https://github.com/reactive-streams/reactive-streams-jvm).
 - :satellite: Rewamp of the javadoc bloat in the base types via `sealed` interfaces.
 - :satellite: Reduce overload bloat by using `record`-based configurations.
 - :satellite: Internal optimizations now that I have the master :key:.
 - :eye: Possible usages for Scoped variables for context and per-item resource management.
 - :eye: Possible use for the Java Cleaner API.
-- :eye: Possible new monad `Streamable<T>` built around Virtual Threads & virtual blocking. Think `IAsyncEnumerable` for Java.
 - :eye: Possible inclusion of 2nd and 3rd party operators.
 - :eye: Possible inclusion of the Iterable Extensions (Ix) 2nd party library. ju.Stream is sh|t wrt interfacing and composability.
 - :question: Android compatibility depends on your API level and what desugaring is available.
@@ -509,11 +509,11 @@ For further details, consult the [wiki](https://github.com/ReactiveX/RxJava/wiki
 
 ## Versioning
 
-Version 3.x is in development. Bugfixes will be applied to both 2.x and 3.x branches, but new features will only be added to 3.x.
+Version 4.x is in development. Bugfixes will be applied to both 3.x and 4.x branches if possible, but new features will only be added to 4.x.
 
-Minor 3.x increments (such as 3.1, 3.2, etc) will occur when non-trivial new functionality is added or significant enhancements or bug fixes occur that may have behavioral changes that may affect some edge cases (such as dependence on behavior resulting from a bug). An example of an enhancement that would classify as this is adding reactive pull backpressure support to an operator that previously did not support it. This should be backwards compatible but does behave differently.
+Minor 4.x increments (such as 4.1, 4.2, etc) will occur when non-trivial new functionality is added or significant enhancements or bug fixes occur that may have behavioral changes that may affect some edge cases (such as dependence on behavior resulting from a bug). An example of an enhancement that would classify as this is adding reactive pull backpressure support to an operator that previously did not support it. This should be backwards compatible but does behave differently.
 
-Patch 3.x.y increments (such as 3.0.0 -> 3.0.1, 3.3.1 -> 3.3.2, etc) will occur for bug fixes and trivial functionality (like adding a method overload). New functionality marked with an [`@Beta`][beta source link] or [`@Experimental`][experimental source link] annotation can also be added in the patch releases to allow rapid exploration and iteration of unstable new functionality. 
+Patch 4.x.y increments (such as 4.0.0 -> 4.0.1, 4.3.1 -> 4.3.2, etc) will occur for bug fixes and trivial functionality (like adding a method overload). New functionality marked with an [`@Beta`][beta source link] or [`@Experimental`][experimental source link] annotation can also be added in the patch releases to allow rapid exploration and iteration of unstable new functionality. 
 
 #### @Beta
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,11 +56,11 @@ dependencies {
 
 java {
     toolchain {
-        vendor = JvmVendorSpec.ADOPTIUM
-        languageVersion = JavaLanguageVersion.of(25) // Temurin 26 is not out yet
+        // vendor = JvmVendorSpec.ADOPTIUM <-- for now
+        languageVersion = JavaLanguageVersion.of(26)
     }
-    sourceCompatibility = JavaVersion.VERSION_25
-    targetCompatibility = JavaVersion.VERSION_25
+    sourceCompatibility = JavaVersion.VERSION_26
+    targetCompatibility = JavaVersion.VERSION_26
 }
 
 tasks.withType(JavaCompile) {
@@ -98,7 +98,7 @@ javadoc {
     failOnError = false
 
     options.links(
-            "https://docs.oracle.com/en/java/javase/25/docs/api/",
+            "https://docs.oracle.com/en/java/javase/26/docs/api/",
             "https://reactivex.io/RxJava/org.reactivestreams.javadoc/${reactiveStreamsVersion}/"
     )
 

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -19,14 +19,15 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
-import static java.util.concurrent.Flow.*;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.disposables.*;
@@ -44,6 +45,7 @@ import io.reactivex.rxjava4.testsupport.*;
 /**
  * Test Completable methods and operators.
  */
+@Isolated
 public class CompletableTest extends RxJavaTest {
     /**
      * Iterable that returns an Iterator that throws in its hasNext method.
@@ -1981,7 +1983,7 @@ public class CompletableTest extends RxJavaTest {
         c.blockingAwait();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     public void repeatNormal() {
         final AtomicReference<Throwable> err = new AtomicReference<>();
         final AtomicInteger calls = new AtomicInteger();


### PR DESCRIPTION
I installed Oracle JDK 26 locally for now.

Also hopefully fixes a failing test via `@Isolated` running: `CompletableTest.repeatNormal`.