### PR TITLE
4.x: Add optional build/test for future JDKs

### DIFF
--- a/.github/workflows/gradle_preview_jdks.yml
+++ b/.github/workflows/gradle_preview_jdks.yml
@@ -25,6 +25,8 @@ jobs:
             experimental: true
 
     runs-on: ubuntu-latest
+    env:
+      jdk: ${{ matrix.java-version }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up JDK ${{ matrix.java-version }}

--- a/.github/workflows/gradle_preview_jdks.yml
+++ b/.github/workflows/gradle_preview_jdks.yml
@@ -41,7 +41,6 @@ jobs:
       with:
         distribution: ${{ matrix.distribution || 'temurin' }}
         java-version: ${{ matrix.java-version }}
-        cache: gradle
 
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/.github/workflows/gradle_preview_jdks.yml
+++ b/.github/workflows/gradle_preview_jdks.yml
@@ -29,7 +29,7 @@ jobs:
       jdk: ${{ matrix.java-version }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 26
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'

--- a/.github/workflows/gradle_preview_jdks.yml
+++ b/.github/workflows/gradle_preview_jdks.yml
@@ -32,6 +32,13 @@ jobs:
     - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
+        distribution: 'zulu'
+        java-version: '26'
+        cache: gradle
+
+    - name: Set up JDK ${{ matrix.java-version }}
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
         distribution: ${{ matrix.distribution || 'temurin' }}
         java-version: ${{ matrix.java-version }}
         cache: gradle

--- a/.github/workflows/gradle_preview_jdks.yml
+++ b/.github/workflows/gradle_preview_jdks.yml
@@ -14,19 +14,13 @@ permissions:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false                    # important: don't cancel other matrix jobs on failure
-      matrix:
-        java-version:
-          - 27-ea   # experimental/upcoming - allowed to fail
-        include:
-          - java-version: 27-ea
-            distribution: temurin
-            experimental: true
-
     runs-on: ubuntu-latest
-    env:
-      jdk: ${{ matrix.java-version }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [27]   # add 28-ea etc. later
+
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up JDK 26
@@ -36,11 +30,11 @@ jobs:
         java-version: '26'
         cache: gradle
 
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK ${{ matrix.jdk }}-ea
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
-        distribution: ${{ matrix.distribution || 'temurin' }}
-        java-version: ${{ matrix.java-version }}
+        distribution: 'temurin'
+        java-version: '${{ matrix.jdk }}-ea'
 
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -52,10 +46,11 @@ jobs:
       run: chmod +x gradlew
 
     - name: Run Validity Tests Upfront
+      env:
+        JDK_EXPERIMENTAL: ${{ matrix.jdk }}
       run: ./gradlew test --tests "io.reactivex.rxjava4.validators.*" --stacktrace --no-daemon
     - name: Build RxJava
       run: ./gradlew build --stacktrace
     - name: Generate Javadoc
       run: ./gradlew javadoc --stacktrace
 
-    continue-on-error: ${{ matrix.experimental || false }}

--- a/.github/workflows/gradle_preview_jdks.yml
+++ b/.github/workflows/gradle_preview_jdks.yml
@@ -48,9 +48,16 @@ jobs:
     - name: Run Validity Tests Upfront
       env:
         JDK_EXPERIMENTAL: ${{ matrix.jdk }}
+        JAVA_HOME: ${{ env.JAVA_HOME_26_X64 }}
       run: ./gradlew test --tests "io.reactivex.rxjava4.validators.*" --stacktrace --no-daemon
     - name: Build RxJava
+      env:
+        JDK_EXPERIMENTAL: ${{ matrix.jdk }}
+        JAVA_HOME: ${{ env.JAVA_HOME_26_X64 }}
       run: ./gradlew build --stacktrace
     - name: Generate Javadoc
+      env:
+        JDK_EXPERIMENTAL: ${{ matrix.jdk }}
+        JAVA_HOME: ${{ env.JAVA_HOME_26_X64 }}
       run: ./gradlew javadoc --stacktrace
 

--- a/.github/workflows/gradle_preview_jdks.yml
+++ b/.github/workflows/gradle_preview_jdks.yml
@@ -1,0 +1,51 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Preview-JDKs
+
+on:
+  push:
+    branches: [ '4.x' ]
+  pull_request:
+    branches: [ '4.x' ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false                    # important: don't cancel other matrix jobs on failure
+      matrix:
+        java-version:
+          - 27-ea   # experimental/upcoming - allowed to fail
+        include:
+          - java-version: 27-ea
+            experimental: true
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Set up JDK ${{ matrix.java-version }}
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
+
+    - name: Cache Gradle packages
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle-${{ secrets.CACHE_VERSION }}
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Run Validity Tests Upfront
+      run: ./gradlew test --tests "io.reactivex.rxjava4.validators.*" --stacktrace --no-daemon
+    - name: Build RxJava
+      run: ./gradlew build --stacktrace
+    - name: Generate Javadoc
+      run: ./gradlew javadoc --stacktrace
+
+    continue-on-error: ${{ matrix.experimental || false }}

--- a/.github/workflows/gradle_preview_jdks.yml
+++ b/.github/workflows/gradle_preview_jdks.yml
@@ -21,6 +21,7 @@ jobs:
           - 27-ea   # experimental/upcoming - allowed to fail
         include:
           - java-version: 27-ea
+            distribution: temurin
             experimental: true
 
     runs-on: ubuntu-latest
@@ -29,8 +30,9 @@ jobs:
     - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
-        distribution: 'zulu'
+        distribution: ${{ matrix.distribution || 'temurin' }}
         java-version: ${{ matrix.java-version }}
+        cache: gradle
 
     - name: Cache Gradle packages
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/build.gradle
+++ b/build.gradle
@@ -54,10 +54,16 @@ dependencies {
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:$jupiterLauncherVersion"  // match your JUnit version family
 }
 
+def jdk = "26"
+def experiment = System.getenv("jdk");
+if (experiment != null && !"".equals(experiment)) {
+    jdk = experiment
+}
+
 java {
     toolchain {
         // vendor = JvmVendorSpec.ADOPTIUM <-- for now
-        languageVersion = JavaLanguageVersion.of(26)
+        languageVersion = JavaLanguageVersion.of(jdk)
     }
     sourceCompatibility = JavaVersion.VERSION_26
     targetCompatibility = JavaVersion.VERSION_26

--- a/build.gradle
+++ b/build.gradle
@@ -54,16 +54,17 @@ dependencies {
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:$jupiterLauncherVersion"  // match your JUnit version family
 }
 
-def jdk = "26"
-def experiment = System.getenv("jdk");
-if (experiment != null && !"".equals(experiment)) {
-    jdk = experiment.replace("-ea", "")
+// === Experimental JDK handling for Outreach Program ===
+def experimental = System.getenv("JDK_EXPERIMENTAL")
+def toolchainJdk = "26"   // default / baseline
+
+if (experimental != null && !experimental.trim().isEmpty()) {
+    toolchainJdk = experimental  // e.g. "27"
 }
 
 java {
     toolchain {
-        // vendor = JvmVendorSpec.ADOPTIUM <-- for now
-        languageVersion = JavaLanguageVersion.of(jdk)
+        languageVersion = JavaLanguageVersion.of(toolchainJdk)
     }
     sourceCompatibility = JavaVersion.VERSION_26
     targetCompatibility = JavaVersion.VERSION_26

--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,7 @@ tasks.withType(Test) {
     }
 }
 
-if (experiment == null || "".equals(experiment)) {
+if (experimental == null || "".equals(experimental)) {
     jacocoTestReport {
         dependsOn test
         dependsOn testNG

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 def jdk = "26"
 def experiment = System.getenv("jdk");
 if (experiment != null && !"".equals(experiment)) {
-    jdk = experiment
+    jdk = experiment.replace("-ea", "")
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id("java-library")
     id("checkstyle")
     id("eclipse")
-    id("jacoco")
     id("maven-publish")
     id("me.champeau.jmh") version "0.7.3"
     id("com.github.hierynomus.license") version "0.16.1"
@@ -264,6 +263,8 @@ tasks.withType(Test) {
 }
 
 if (experimental == null || "".equals(experimental)) {
+    apply plugin: "jacoco"
+
     jacocoTestReport {
         dependsOn test
         dependsOn testNG

--- a/build.gradle
+++ b/build.gradle
@@ -262,18 +262,21 @@ tasks.withType(Test) {
     }
 }
 
-jacocoTestReport {
-    dependsOn test
-    dependsOn testNG
-
-    reports {
-        xml.required.set(true)
-        csv.required.set(false)
-        html.required.set(true)
+if (experiment == null || "".equals(experiment)) {
+    jacocoTestReport {
+        dependsOn test
+        dependsOn testNG
+    
+        reports {
+            xml.required.set(true)
+            csv.required.set(false)
+            html.required.set(true)
+        }
     }
+    
+    check.dependsOn jacocoTestReport
 }
 
-check.dependsOn jacocoTestReport
 
 checkstyle {
     configFile = project.file("config/checkstyle/checkstyle.xml")


### PR DESCRIPTION
We'll use RxJava 4 now on to respond to the Java Outreach Program.