### PR TITLE
Fix #8086: Isolate windowUnsubscribeNonOverlappingAsyncSource to JUnit 5

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeIsolatedTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.observable;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.rxjava4.core.Observable;
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.functions.Consumer;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+import io.reactivex.rxjava4.testsupport.*;
+
+@Isolated
+public class ObservableWindowWithSizeIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void windowUnsubscribeNonOverlappingAsyncSource() {
+        TestObserverEx<Integer> to = new TestObserverEx<>();
+
+        final AtomicInteger count = new AtomicInteger();
+        Observable.merge(Observable.range(1, 100000)
+                        .doOnNext(new Consumer<Integer>() {
+
+                            @Override
+                            public void accept(Integer t1) {
+                                if (count.incrementAndGet() == 500000) {
+                                    // give it a small break halfway through
+                                    try {
+                                        Thread.sleep(50);
+                                    } catch (InterruptedException ex) {
+                                        // ignored
+                                    }
+                                }
+                            }
+
+                        })
+                        .observeOn(Schedulers.computation())
+                        .window(5)
+                        .take(2))
+                .subscribe(to);
+
+        to.awaitDone(500, TimeUnit.MILLISECONDS);
+        to.assertTerminated();
+        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        // make sure we don't emit all values ... the unsubscribe should propagate
+        assertTrue(count.get() < 100000);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -127,39 +127,6 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
     }
 
     @Test
-    public void windowUnsubscribeNonOverlappingAsyncSource() {
-        TestObserverEx<Integer> to = new TestObserverEx<>();
-
-        final AtomicInteger count = new AtomicInteger();
-        Observable.merge(Observable.range(1, 100000)
-                .doOnNext(new Consumer<Integer>() {
-
-                    @Override
-                    public void accept(Integer t1) {
-                        if (count.incrementAndGet() == 500000) {
-                            // give it a small break halfway through
-                            try {
-                                Thread.sleep(50);
-                            } catch (InterruptedException ex) {
-                                // ignored
-                            }
-                        }
-                    }
-
-                })
-                .observeOn(Schedulers.computation())
-                .window(5)
-                .take(2))
-                .subscribe(to);
-
-        to.awaitDone(500, TimeUnit.MILLISECONDS);
-        to.assertTerminated();
-        to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        // make sure we don't emit all values ... the unsubscribe should propagate
-        assertTrue(count.get() < 100000);
-    }
-
-    @Test
     public void windowUnsubscribeOverlapping() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
 


### PR DESCRIPTION
Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

- [x] Please give a description about what and why you are contributing, even if it's trivial.
  **What & Why:**
  This PR addresses the flaky test issue reported in #8086. I extracted `windowUnsubscribeNonOverlappingAsyncSource` from `ObservableWindowWithSizeTest` into a newly created, dedicated `ObservableWindowWithSizeIsolatedTest` class. The test has been migrated to JUnit 5 and annotated with `@Isolated`. This ensures it runs independently and reliably without bogging down the execution speed of the main test suite. The original test logic remains completely intact.

- [x] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.
  **Resolves:** Fixes #8086

- [x] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
  **Testing:**
  Since this PR is strictly a test refactoring and isolation task, no new production operators were added. The existing assertions and test behaviors for the `window` unsubscription logic have been preserved and run successfully in the isolated environment.

---
Please let me know if there are any formatting issues or further adjustments needed, and I will be happy to update the PR.

Resolves #8086 