### PR TITLE
4.x: Enhance Streamable/Streamer and DisposableContainer APIs

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/CompletionStageDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/CompletionStageDisposable.java
@@ -15,8 +15,30 @@ package io.reactivex.rxjava4.core;
 
 import java.util.concurrent.CompletionStage;
 
-import io.reactivex.rxjava4.disposables.Disposable;
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.disposables.*;
 
-public record CompletionStageDisposable<T>(CompletionStage<T> stage, Disposable disposable) {
+/**
+ * Consist of a terminal stage and a disposable to be able to cancel a sequence.
+ * @param <T> the return and element type of the various stages
+ * @param stage the embedded stage to work with
+ * @param disposable the way to cancel the stage concurrently
+ * @since 4.0.0
+ */
+public record CompletionStageDisposable<T>(@NonNull CompletionStage<T> stage, @NonNull Disposable disposable) {
 
+    /**
+     * Await the completion of the current stage.
+     */
+    public void await() {
+        Streamer.await(stage);
+    }
+
+    /**
+     * Await the completion of the current stage.
+     * @param canceller the canceller link
+     */
+    public void await(DisposableContainer canceller) {
+        Streamer.await(stage, canceller);
+    }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -21062,16 +21062,44 @@ FlowableDocBasic<T>
      *  relays the values one-by-one to the {@link Streamer } view of the sequence.
      *  </dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>The operator by design does not run on any scheduler or executor.</dd>
+     *  <dd>The operator by design runs on the default virtual executor of the system.</dd>
      * </dl>
      * <p>
      * @return the new {@code Streamable} instance
+     * @since 4.0.0
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.VIRTUAL)
+    @NonNull
+    public final Streamable<T> toStreamable() {
+        return toStreamable(Executors.newVirtualThreadPerTaskExecutor());
+    }
+
+    /**
+     * Converts this {@code Flowable} into a {@link Streamable} instance,
+     * transparently relaying signals between the two async representations of a sequence.
+     * <p>
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator requests from the upstream in a bounded manner and
+     *  relays the values one-by-one to the {@link Streamer } view of the sequence.
+     *  </dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The operator runs on the provided {@link ExecutorService}.</dd>
+     * </dl>
+     * <p>
+     * @param executor where the coordination will happen
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code executor} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final Streamable<T> toStreamable() {
-        return new StreamableFromPublisher <>(this);
+    public final Streamable<T> toStreamable(ExecutorService executor) {
+        Objects.requireNonNull(executor, "executor is null");
+        return new StreamableFromPublisher<>(this, executor);
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -32,6 +32,7 @@ import io.reactivex.rxjava4.internal.operators.maybe.MaybeToFlowable;
 import io.reactivex.rxjava4.internal.operators.mixed.*;
 import io.reactivex.rxjava4.internal.operators.observable.ObservableFromPublisher;
 import io.reactivex.rxjava4.internal.operators.single.SingleToFlowable;
+import io.reactivex.rxjava4.internal.operators.streamable.StreamableFromPublisher;
 import io.reactivex.rxjava4.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.rxjava4.internal.subscribers.*;
 import io.reactivex.rxjava4.internal.util.*;
@@ -21051,4 +21052,26 @@ FlowableDocBasic<T>
         return new FlowableVirtualTransformExecutor<>(this, transformer, executor, null, prefetch);
     }
 
+    /**
+     * Converts this {@code Flowable} into a {@link Streamable} instance,
+     * transparently relaying signals between the two async representations of a sequence.
+     * <p>
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>This operator requests from the upstream in a bounded manner and
+     *  relays the values one-by-one to the {@link Streamer } view of the sequence.
+     *  </dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The operator by design does not run on any scheduler or executor.</dd>
+     * </dl>
+     * <p>
+     * @return the new {@code Streamable} instance
+     */
+    @CheckReturnValue
+    @BackpressureSupport(BackpressureKind.FULL)
+    @SchedulerSupport(SchedulerSupport.NONE)
+    @NonNull
+    public final Streamable<T> toStreamable() {
+        return new StreamableFromPublisher <>(this);
+    }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -16024,7 +16024,7 @@ FlowableDocBasic<T>
             // can't call onSubscribe because the call might have set a Subscription already
             RxJavaPlugins.onError(e);
 
-            NullPointerException npe = new NullPointerException("Actually not, but can't throw other exceptions due to RS");
+            var npe = new NullPointerException("Actually not, but can't throw other exceptions due to RS");
             npe.initCause(e);
             throw npe;
         }
@@ -20929,7 +20929,7 @@ FlowableDocBasic<T>
      * {@code ExecutorService} uses virtual threads, such as the one returned by
      * {@link Executors#newVirtualThreadPerTaskExecutor()}.
      * @param <R> the downstream element type
-     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)}
+     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter, Disposable)}
      *  is invoked for each upstream item
      * @param executor the target {@code ExecutorService} to use for running the callback
      * @return the new {@code Flowable} instance
@@ -20962,7 +20962,7 @@ FlowableDocBasic<T>
      * {@link Scheduler} uses virtual threads, such as the one returned by
      * {@link Executors#newVirtualThreadPerTaskExecutor()}.
      * @param <R> the downstream element type
-     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)}
+     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter, Disposable)}
      *  is invoked for each upstream item
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code transformer} is {@code null}
@@ -20993,7 +20993,7 @@ FlowableDocBasic<T>
      * {@code Scheduler} uses virtual threads, such as the one returned by
      * {@link Schedulers#virtual()}.
      * @param <R> the downstream element type
-     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)}
+     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter, Disposable)}
      * is invoked for each upstream item
      * @param scheduler the target {@code Scheduler} to use for running the callback
      * @param prefetch the number of items to fetch from the upstream.
@@ -21031,7 +21031,7 @@ FlowableDocBasic<T>
      * {@code ExecutorService} uses virtual threads, such as the one returned by
      * {@link Executors#newVirtualThreadPerTaskExecutor()}.
      * @param <R> the downstream element type
-     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter)}
+     * @param transformer the callback whose {@link VirtualTransformer#transform(Object, VirtualEmitter, Disposable)}
      *  is invoked for each upstream item
      * @param executor the target {@code ExecutorService} to use for running the callback
      * @param prefetch the number of items to fetch from the upstream.

--- a/src/main/java/io/reactivex/rxjava4/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Scheduler.java
@@ -14,7 +14,8 @@
 package io.reactivex.rxjava4.core;
 
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.disposables.Disposable;
@@ -382,6 +383,29 @@ public abstract class Scheduler {
     }
 
     /**
+     * Turn this Scheduler into an ExecutorService implementation
+     * using its various *Direct() methods instead of workers.
+     * @return the ExecutorService view of this Scheduler
+     * @since 4.0.0
+     */
+    public ExecutorService toExecutorService() {
+        return new SchedulerToExecutorService(this, null);
+    }
+
+    /**
+     * Turn this Scheduler into an ExecutorService implementation
+     * using its various *Direct() methods or worker methods,
+     * depending on the parameter.
+     * @param useWorker if true, one of the workers is used as an executorservice,
+     *                  if false, the whole scheduler and its *Direct methods are used.
+     * @return the ExecutorService view of this Scheduler
+     * @since 4.0.0
+     */
+    public ExecutorService toExecutorService(boolean useWorker) {
+        return new SchedulerToExecutorService(this, new AtomicReference<>());
+    }
+
+    /**
      * Represents an isolated, sequential worker of a parent Scheduler for executing {@code Runnable} tasks on
      * an underlying task-execution scheme (such as custom Threads, event loop, {@link java.util.concurrent.Executor Executor} or Actor system).
      * <p>
@@ -572,6 +596,35 @@ public abstract class Scheduler {
                 return this.decoratedRun;
             }
         }
+
+        /**
+         * A stateless Worker that reports itself as shutdown and doesn't do anything.
+         * @since 4.0.0
+         */
+        @NonNull
+        public static final Worker SHUTDOWN = new ShutdownWorker();
+    }
+
+    /**
+     * Implementation of a stateless, shutdown worker. For cleanup and termination purposes.
+     * @since 4.0.0
+     */
+    static final class ShutdownWorker extends Worker {
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return true;
+        }
+
+        @Override
+        public @NonNull Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
+            return Disposable.disposed();
+        }
+
     }
 
     static final class PeriodicDirectTask

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -23,6 +23,8 @@ import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.internal.operators.streamable.*;
 
+import static io.reactivex.rxjava4.core.Streamer.await;
+
 /**
  * The {@code IAsyncEnumerable} of the Java world.
  * Runs best with Virtual Threads.
@@ -119,7 +121,7 @@ public abstract class Streamable<@NonNull T> {
         var future = executor.submit(() -> {
             try (var str = me.stream(canceller)) {
                 while (!canceller.isDisposed()) {
-                    if (str.next().toCompletableFuture().join()) {
+                    if (await(str.next(canceller), canceller)) {
                         consumer.accept(Objects.requireNonNull(str.current(), "The upstream Streamable " + me.getClass() + " produced a null element!"));
                     } else {
                         break;

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -17,10 +17,10 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
 import java.util.concurrent.*;
 
-import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.Exceptions;
-import io.reactivex.rxjava4.functions.Consumer;
+import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.operators.streamable.*;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -43,6 +43,7 @@ public interface Streamable<@NonNull T> {
      * @param cancellation where to register and listen for cancellation calls.
      * @return the Streamer instance to consume.
      */
+    @CheckReturnValue
     @NonNull
     Streamer<T> stream(@NonNull DisposableContainer cancellation);
 
@@ -55,6 +56,7 @@ public interface Streamable<@NonNull T> {
      * Realizes the stream and returns an interface that let's one consume it.
      * @return the Streamer instance to consume.
      */
+    @CheckReturnValue
     @NonNull
     default Streamer<T> stream() {
         return stream(new CompositeDisposable()); // FIXME, use a practically no-op disposable container instead
@@ -69,6 +71,7 @@ public interface Streamable<@NonNull T> {
      * @param <T> the element type
      * @return the {@code Streamable} instance
      */
+    @CheckReturnValue
     @NonNull
     static <@NonNull T> Streamable<T> empty() {
         return new StreamableEmpty<>();
@@ -80,6 +83,7 @@ public interface Streamable<@NonNull T> {
      * @param item the constant item to produce
      * @return the {@code Streamable} instance
      */
+    @CheckReturnValue
     @NonNull
     static <@NonNull T> Streamable<T> just(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
@@ -92,6 +96,7 @@ public interface Streamable<@NonNull T> {
      * @param source Flow.Publisher to convert
      * @return the new Streamable instance
      */
+    @CheckReturnValue
     @NonNull
     static <T> Streamable<T> fromPublisher(@NonNull Flow.Publisher<T> source) {
         Objects.requireNonNull(source, "source is null");
@@ -105,6 +110,7 @@ public interface Streamable<@NonNull T> {
      * @param executor where the conversion will run
      * @return the new Streamable instance
      */
+    @CheckReturnValue
     @NonNull
     static <T> Streamable<T> fromPublisher(@NonNull Flow.Publisher<T> source, @NonNull ExecutorService executor) {
         Objects.requireNonNull(source, "source is null");
@@ -120,6 +126,7 @@ public interface Streamable<@NonNull T> {
      * @param generator the generator to use
      * @return the streamable instance
      */
+    @CheckReturnValue
     @NonNull
     static <@NonNull T> Streamable<T> create(@NonNull VirtualGenerator<T> generator) {
         // FIXME native implementation
@@ -137,6 +144,7 @@ public interface Streamable<@NonNull T> {
      * @param scheduler the scheduler to run the virtual generator on
      * @return the streamable instance
      */
+    @CheckReturnValue
     @NonNull
     static <@NonNull T> Streamable<T> create(@NonNull VirtualGenerator<T> generator, @NonNull Scheduler scheduler) {
         // FIXME native implementation
@@ -154,6 +162,7 @@ public interface Streamable<@NonNull T> {
      * @param executor the executor to run the virtual generator on
      * @return the streamable instance
      */
+    @CheckReturnValue
     @NonNull
     static <@NonNull T> Streamable<T> create(@NonNull VirtualGenerator<T> generator, @NonNull ExecutorService executor) {
         // FIXME native implementation
@@ -170,6 +179,7 @@ public interface Streamable<@NonNull T> {
      * on the default Executors.newVirtualThreadPerTaskExecutor() virtual thread.
      * @return the new Flowable instance
      */
+    @CheckReturnValue
     @NonNull
     default Flowable<T> toFlowable() {
         return toFlowable(Executors.newVirtualThreadPerTaskExecutor());
@@ -181,6 +191,7 @@ public interface Streamable<@NonNull T> {
      * @param executor the executor to use
      * @return the new Flowable instance
      */
+    @CheckReturnValue
     @NonNull
     default Flowable<T> toFlowable(@NonNull ExecutorService executor) {
         Objects.requireNonNull(executor, "executir is null");
@@ -196,6 +207,7 @@ public interface Streamable<@NonNull T> {
      * @param transformer the interface to implement the transforming logic
      * @return the new Streamable instance
      */
+    @CheckReturnValue
     @NonNull
     default <@NonNull R> Streamable<R> transform(@NonNull VirtualTransformer<T, R> transformer) {
         return transform(transformer, Executors.newVirtualThreadPerTaskExecutor());
@@ -208,6 +220,7 @@ public interface Streamable<@NonNull T> {
      * @param executor where to run the transform and blocking operations
      * @return the new Streamable instance
      */
+    @CheckReturnValue
     @NonNull
     default <@NonNull R> Streamable<R> transform(@NonNull VirtualTransformer<T, R> transformer,
             @NonNull ExecutorService executor) {
@@ -215,10 +228,11 @@ public interface Streamable<@NonNull T> {
         Objects.requireNonNull(executor, "executor is null");
         var me = this;
         return create(emitter -> {
-            me.forEach(item -> {
-                System.out.println("item " + item);
-                transformer.transform(item, emitter);
-            }, executor).await(emitter.canceller());
+            me.forEach((item, stopper) -> {
+                // System.out.println("item " + item);
+                transformer.transform(item, emitter, stopper);
+            }, emitter.canceller(), executor)
+            .await(emitter.canceller());
         }, executor);
     }
 
@@ -231,6 +245,7 @@ public interface Streamable<@NonNull T> {
      * @param consumer the callback that gets the elements until completion
      * @return a Disposable that let's one cancel the sequence asynchronously.
      */
+    @CheckReturnValue
     @NonNull
     default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer) {
         CompositeDisposable canceller = new CompositeDisposable();
@@ -243,6 +258,8 @@ public interface Streamable<@NonNull T> {
      * @param canceller the container to trigger cancellation of the sequence
      * @return the {@code CompletionStage} that gets notified when the sequence ends
      */
+    @CheckReturnValue
+    @NonNull
     default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull DisposableContainer canceller) {
         return forEach(consumer, canceller, Executors.newVirtualThreadPerTaskExecutor());
     }
@@ -253,6 +270,7 @@ public interface Streamable<@NonNull T> {
      * @param executor the service that hosts the blocking waits.
      * @return a Disposable that let's one cancel the sequence asynchronously.
      */
+    @CheckReturnValue
     @NonNull
     default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull ExecutorService executor) {
         CompositeDisposable canceller = new CompositeDisposable();
@@ -266,6 +284,8 @@ public interface Streamable<@NonNull T> {
      * @param executor the service that hosts the blocking waits.
      * @return the {@code CompletionStage} that gets notified when the sequence ends
      */
+    @CheckReturnValue
+    @NonNull
     @SuppressWarnings("unchecked")
     default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull DisposableContainer canceller, @NonNull ExecutorService executor) {
         Objects.requireNonNull(consumer, "consumer is null");
@@ -276,14 +296,18 @@ public interface Streamable<@NonNull T> {
             try (var str = me.stream(canceller)) {
                 while (!canceller.isDisposed()) {
                     if (str.awaitNext(canceller)) {
-                        System.out.println("Received " + str.current());
+                        // System.out.println("Received " + str.current());
                         consumer.accept(Objects.requireNonNull(str.current(), "The upstream Streamable " + me.getClass() + " produced a null element!"));
                     } else {
+                        // System.out.println("EOF ");
                         break;
                     }
                 }
+                // System.out.println("Canceller status after loop: " + canceller.isDisposed());
             } catch (final Throwable crash) {
                 Exceptions.throwIfFatal(crash);
+                // System.out.println("Canceller status in error: " + canceller.isDisposed());
+                crash.printStackTrace();
                 if (crash instanceof RuntimeException ex) {
                     throw ex;
                 }
@@ -299,6 +323,57 @@ public interface Streamable<@NonNull T> {
     }
 
     /**
+     * Consumes elements from this {@code Streamable} via the provided executor service.
+     * @param consumer the callback that gets the elements until completion
+     * @param canceller the container to trigger cancellation of the sequence
+     * @param executor the service that hosts the blocking waits.
+     * @return the {@code CompletionStage} that gets notified when the sequence ends
+     */
+    @CheckReturnValue
+    @NonNull
+    @SuppressWarnings("unchecked")
+    default CompletionStageDisposable<Void> forEach(
+            @NonNull BiConsumer<? super T, ? super Disposable> consumer,
+            @NonNull DisposableContainer canceller,
+            @NonNull ExecutorService executor) {
+        Objects.requireNonNull(consumer, "consumer is null");
+        Objects.requireNonNull(canceller, "canceller is null");
+        Objects.requireNonNull(executor, "executor is null");
+        final Streamable<T> me = this;
+        var future = executor.submit(() -> {
+            try (var str = me.stream(canceller)) {
+                var stopper = Disposable.empty();
+                while (!canceller.isDisposed() && !stopper.isDisposed()) {
+                    if (str.awaitNext(canceller)) {
+                        // System.out.println("Received " + str.current());
+                        var v = Objects.requireNonNull(str.current(), "The upstream Streamable " + me.getClass() + " produced a null element!");
+                        consumer.accept(v, stopper);
+                    } else {
+                        // System.out.println("EOF ");
+                        break;
+                    }
+                }
+                // System.out.println("Canceller status after loop: " + canceller.isDisposed());
+            } catch (final Throwable crash) {
+                Exceptions.throwIfFatal(crash);
+                // System.out.println("Canceller status in error: " + canceller.isDisposed());
+                // crash.printStackTrace();
+                if (crash instanceof RuntimeException ex) {
+                    throw ex;
+                }
+                if (crash instanceof Exception ex) {
+                    throw ex;
+                }
+                throw new InvocationTargetException(crash);
+            }
+            return null;
+        });
+        canceller.add(Disposable.fromFuture(future));
+        return new CompletionStageDisposable<Void>(
+                StreamableHelper.toCompletionStage((Future<Void>)(Future<?>)future), canceller);
+    }
+
+    /**
      * Consume this {@code Streamable} via the given flow-reactive-streams subscriber.
      * @param subscriber the subscriber to consume with.
      * @param executor the service that hosts the blocking waits.
@@ -310,7 +385,7 @@ public interface Streamable<@NonNull T> {
             me.forEach(v -> {
                 // System.out.println("subscribe::virtualCreate::forEach::emit");
                 emitter.emit(v);
-            }).await();
+            }).await(emitter.canceller());
         }, executor)
         .subscribe(subscriber);
     }
@@ -325,7 +400,7 @@ public interface Streamable<@NonNull T> {
             me.forEach(v -> {
                 // System.out.println("Emitting " + v);
                 emitter.emit(v);
-            });
+            }).await(emitter.canceller());
         })
         .subscribe(subscriber);
     }
@@ -334,6 +409,8 @@ public interface Streamable<@NonNull T> {
      * Creates a new {@link TestSubscriber} and subscribes it to this {@code Streamable}.
      * @return the created test subscriber
      */
+    @CheckReturnValue
+    @NonNull
     default TestSubscriber<T> test() {
         var ts = new TestSubscriber<T>();
         subscribe(ts);
@@ -345,7 +422,9 @@ public interface Streamable<@NonNull T> {
      * @param executor the executor to use
      * @return the created test subscriber
      */
-    default TestSubscriber<T> test(ExecutorService executor) {
+    @CheckReturnValue
+    @NonNull
+    default TestSubscriber<T> test(@NonNull ExecutorService executor) {
         var ts = new TestSubscriber<T>();
         subscribe(ts, executor);
         return ts;

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -22,17 +22,20 @@ import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.internal.operators.streamable.*;
-
-import static io.reactivex.rxjava4.core.Streamer.await;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
 /**
- * The {@code IAsyncEnumerable} of the Java world.
+ * The holographically emergent {@code IAsyncEnumerable} of the Java world.
  * Runs best with Virtual Threads.
  * TODO proper docs
  * @param <T> the element type of the stream.
  * @since 4.0.0
  */
-public abstract class Streamable<@NonNull T> {
+public interface Streamable<@NonNull T> {
+
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    // API
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
     /**
      * Realizes the stream and returns an interface that let's one consume it.
@@ -40,16 +43,25 @@ public abstract class Streamable<@NonNull T> {
      * @return the Streamer instance to consume.
      */
     @NonNull
-    public abstract Streamer<T> stream(@NonNull DisposableContainer cancellation);
+    Streamer<T> stream(@NonNull DisposableContainer cancellation);
 
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    // HELPERS
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    // TODO, why no public final so it is not unnecessarily reimplemented, Java?
     /**
      * Realizes the stream and returns an interface that let's one consume it.
      * @return the Streamer instance to consume.
      */
     @NonNull
-    public final Streamer<T> stream() {
+    default Streamer<T> stream() {
         return stream(new CompositeDisposable()); // FIXME, use a practically no-op disposable container instead
     }
+
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    // Data sources and wrappers
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
     /**
      * Returns an empty {@code Streamable} that never produces an item and just completes.
@@ -57,7 +69,7 @@ public abstract class Streamable<@NonNull T> {
      * @return the {@code Streamable} instance
      */
     @NonNull
-    public static <@NonNull T> Streamable<T> empty() {
+    static <@NonNull T> Streamable<T> empty() {
         return new StreamableEmpty<>();
     }
 
@@ -67,10 +79,50 @@ public abstract class Streamable<@NonNull T> {
      * @param item the constant item to produce
      * @return the {@code Streamable} instance
      */
-    public static <@NonNull T> Streamable<T> just(@NonNull T item) {
+    static <@NonNull T> Streamable<T> just(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return new StreamableJust<>(item);
     }
+
+    /**
+     * Convert any Flow.Publisher into a Streamable sequence.
+     * @param <T> the element type
+     * @param source Flow.Publisher to convert
+     * @return the new Streamable instance
+     */
+    static <T> Streamable<T> fromPublisher(Flow.Publisher<T> source) {
+        Objects.requireNonNull(source, "source is null");
+        return new StreamableFromPublisher<T>(source);
+    }
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    // Operators
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    /**
+     * Converts the streamable into a Flowable representation, running
+     * on the default Executors.newVirtualThreadPerTaskExecutor() virtual thread.
+     * @return the new Flowable instance
+     */
+    default Flowable<T> toFlowable() {
+        return toFlowable(Executors.newVirtualThreadPerTaskExecutor());
+    }
+
+    /**
+     * Converts the streamable into a Flowable representation, running
+     * on the provided executor service.
+     * @param executor the executor to use
+     * @return the new Flowable instance
+     */
+    default Flowable<T> toFlowable(ExecutorService executor) {
+        var me = this;
+        return Flowable.virtualCreate(emitter -> {
+            me.forEach(emitter::emit);
+        }, executor);
+    }
+
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    // Consumption methods and outgoing converters
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
     /**
      * Consumes elements from this {@code Streamable} via the provided executor service.
@@ -78,7 +130,7 @@ public abstract class Streamable<@NonNull T> {
      * @return a Disposable that let's one cancel the sequence asynchronously.
      */
     @NonNull
-    public final CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer) {
+    default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer) {
         CompositeDisposable canceller = new CompositeDisposable();
         return forEach(consumer, canceller, Executors.newVirtualThreadPerTaskExecutor());
     }
@@ -89,7 +141,7 @@ public abstract class Streamable<@NonNull T> {
      * @param canceller the container to trigger cancellation of the sequence
      * @return the {@code CompletionStage} that gets notified when the sequence ends
      */
-    public final CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull DisposableContainer canceller) {
+    default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull DisposableContainer canceller) {
         return forEach(consumer, canceller, Executors.newVirtualThreadPerTaskExecutor());
     }
 
@@ -100,7 +152,7 @@ public abstract class Streamable<@NonNull T> {
      * @return a Disposable that let's one cancel the sequence asynchronously.
      */
     @NonNull
-    public final CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull ExecutorService executor) {
+    default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull ExecutorService executor) {
         CompositeDisposable canceller = new CompositeDisposable();
         return forEach(consumer, canceller, executor);
     }
@@ -113,7 +165,7 @@ public abstract class Streamable<@NonNull T> {
      * @return the {@code CompletionStage} that gets notified when the sequence ends
      */
     @SuppressWarnings("unchecked")
-    public final CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull DisposableContainer canceller, @NonNull ExecutorService executor) {
+    default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull DisposableContainer canceller, @NonNull ExecutorService executor) {
         Objects.requireNonNull(consumer, "consumer is null");
         Objects.requireNonNull(canceller, "canceller is null");
         Objects.requireNonNull(executor, "executor is null");
@@ -121,7 +173,7 @@ public abstract class Streamable<@NonNull T> {
         var future = executor.submit(() -> {
             try (var str = me.stream(canceller)) {
                 while (!canceller.isDisposed()) {
-                    if (await(str.next(canceller), canceller)) {
+                    if (str.awaitNext(canceller)) {
                         consumer.accept(Objects.requireNonNull(str.current(), "The upstream Streamable " + me.getClass() + " produced a null element!"));
                     } else {
                         break;
@@ -148,7 +200,37 @@ public abstract class Streamable<@NonNull T> {
      * @param subscriber the subscriber to consume with.
      * @param executor the service that hosts the blocking waits.
      */
-    public final void subscribe(@NonNull Flow.Subscriber<? super T> subscriber, @NonNull ExecutorService executor) {
+    default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber, @NonNull ExecutorService executor) {
+        final Streamable<T> me = this;
+        Flowable.<T>virtualCreate(emitter -> {
+            me.forEach(v -> {
+                emitter.emit(v);
+            });
+        }, executor)
+        .subscribe(subscriber);
+    }
 
+    /**
+     * Consume this {@code Streamable} via the given flow-reactive-streams subscriber.
+     * @param subscriber the subscriber to consume with.
+     */
+    default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber) {
+        final Streamable<T> me = this;
+        Flowable.<T>virtualCreate(emitter -> {
+            me.forEach(v -> {
+                emitter.emit(v);
+            });
+        })
+        .subscribe(subscriber);
+    }
+
+    /**
+     * Creates a new {@link TestSubscriber} and subscribes it to this {@code Streamable}.
+     * @return the created test subscriber
+     */
+    default TestSubscriber<T> test() {
+        var ts = new TestSubscriber<T>();
+        subscribe(ts);
+        return ts;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -22,6 +22,7 @@ import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.internal.operators.streamable.*;
+import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
 /**
@@ -79,6 +80,7 @@ public interface Streamable<@NonNull T> {
      * @param item the constant item to produce
      * @return the {@code Streamable} instance
      */
+    @NonNull
     static <@NonNull T> Streamable<T> just(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
         return new StreamableJust<>(item);
@@ -90,10 +92,75 @@ public interface Streamable<@NonNull T> {
      * @param source Flow.Publisher to convert
      * @return the new Streamable instance
      */
-    static <T> Streamable<T> fromPublisher(Flow.Publisher<T> source) {
+    @NonNull
+    static <T> Streamable<T> fromPublisher(@NonNull Flow.Publisher<T> source) {
         Objects.requireNonNull(source, "source is null");
-        return new StreamableFromPublisher<T>(source);
+        return fromPublisher(source, Executors.newVirtualThreadPerTaskExecutor());
     }
+
+    /**
+     * Convert any Flow.Publisher into a Streamable sequence.
+     * @param <T> the element type
+     * @param source Flow.Publisher to convert
+     * @param executor where the conversion will run
+     * @return the new Streamable instance
+     */
+    @NonNull
+    static <T> Streamable<T> fromPublisher(@NonNull Flow.Publisher<T> source, @NonNull ExecutorService executor) {
+        Objects.requireNonNull(source, "source is null");
+        return new StreamableFromPublisher<T>(source, executor);
+    }
+
+    /**
+     * Generate a sequence of values via a virtual generator callback (yielder)
+     * which is free to block and is natively backpressured.
+     * <p>
+     * Runs on the {@link Schedulers#virtual()} scheduler.
+     * @param <T> the element type
+     * @param generator the generator to use
+     * @return the streamable instance
+     */
+    @NonNull
+    static <@NonNull T> Streamable<T> create(@NonNull VirtualGenerator<T> generator) {
+        // FIXME native implementation
+        return Flowable.virtualCreate(generator)
+                .toStreamable();
+    }
+
+    /**
+     * Generate a sequence of values via a virtual generator callback (yielder)
+     * which is free to block and is natively backpressured.
+     * <p>
+     * Runs on the given scheduler.
+     * @param <T> the element type
+     * @param generator the generator to use
+     * @param scheduler the scheduler to run the virtual generator on
+     * @return the streamable instance
+     */
+    @NonNull
+    static <@NonNull T> Streamable<T> create(@NonNull VirtualGenerator<T> generator, @NonNull Scheduler scheduler) {
+        // FIXME native implementation
+        return Flowable.virtualCreate(generator, scheduler)
+                .toStreamable();
+    }
+
+    /**
+     * Generate a sequence of values via a virtual generator callback (yielder)
+     * which is free to block and is natively backpressured.
+     * <p>
+     * Runs on the given executor service.
+     * @param <T> the element type
+     * @param generator the generator to use
+     * @param executor the executor to run the virtual generator on
+     * @return the streamable instance
+     */
+    @NonNull
+    static <@NonNull T> Streamable<T> create(@NonNull VirtualGenerator<T> generator, @NonNull ExecutorService executor) {
+        // FIXME native implementation
+        return Flowable.virtualCreate(generator, executor)
+                .toStreamable();
+    }
+
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
     // Operators
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
@@ -103,6 +170,7 @@ public interface Streamable<@NonNull T> {
      * on the default Executors.newVirtualThreadPerTaskExecutor() virtual thread.
      * @return the new Flowable instance
      */
+    @NonNull
     default Flowable<T> toFlowable() {
         return toFlowable(Executors.newVirtualThreadPerTaskExecutor());
     }
@@ -113,10 +181,44 @@ public interface Streamable<@NonNull T> {
      * @param executor the executor to use
      * @return the new Flowable instance
      */
-    default Flowable<T> toFlowable(ExecutorService executor) {
+    @NonNull
+    default Flowable<T> toFlowable(@NonNull ExecutorService executor) {
+        Objects.requireNonNull(executor, "executir is null");
         var me = this;
         return Flowable.virtualCreate(emitter -> {
-            me.forEach(emitter::emit);
+            me.forEach(emitter::emit).await(emitter.canceller());
+        }, executor);
+    }
+
+    /**
+     * Transforms the upstream sequence into zero or more elements for the downstream.
+     * @param <R> the result element type
+     * @param transformer the interface to implement the transforming logic
+     * @return the new Streamable instance
+     */
+    @NonNull
+    default <@NonNull R> Streamable<R> transform(@NonNull VirtualTransformer<T, R> transformer) {
+        return transform(transformer, Executors.newVirtualThreadPerTaskExecutor());
+    }
+
+    /**
+     * Transforms the upstream sequence into zero or more elements for the downstream.
+     * @param <R> the result element type
+     * @param transformer the interface to implement the transforming logic
+     * @param executor where to run the transform and blocking operations
+     * @return the new Streamable instance
+     */
+    @NonNull
+    default <@NonNull R> Streamable<R> transform(@NonNull VirtualTransformer<T, R> transformer,
+            @NonNull ExecutorService executor) {
+        Objects.requireNonNull(transformer, "transformer is null");
+        Objects.requireNonNull(executor, "executor is null");
+        var me = this;
+        return create(emitter -> {
+            me.forEach(item -> {
+                System.out.println("item " + item);
+                transformer.transform(item, emitter);
+            }, executor).await(emitter.canceller());
         }, executor);
     }
 
@@ -174,6 +276,7 @@ public interface Streamable<@NonNull T> {
             try (var str = me.stream(canceller)) {
                 while (!canceller.isDisposed()) {
                     if (str.awaitNext(canceller)) {
+                        System.out.println("Received " + str.current());
                         consumer.accept(Objects.requireNonNull(str.current(), "The upstream Streamable " + me.getClass() + " produced a null element!"));
                     } else {
                         break;
@@ -203,9 +306,11 @@ public interface Streamable<@NonNull T> {
     default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber, @NonNull ExecutorService executor) {
         final Streamable<T> me = this;
         Flowable.<T>virtualCreate(emitter -> {
+            // System.out.println("subscribe::virtualCreate");
             me.forEach(v -> {
+                // System.out.println("subscribe::virtualCreate::forEach::emit");
                 emitter.emit(v);
-            });
+            }).await();
         }, executor)
         .subscribe(subscriber);
     }
@@ -218,6 +323,7 @@ public interface Streamable<@NonNull T> {
         final Streamable<T> me = this;
         Flowable.<T>virtualCreate(emitter -> {
             me.forEach(v -> {
+                // System.out.println("Emitting " + v);
                 emitter.emit(v);
             });
         })
@@ -231,6 +337,17 @@ public interface Streamable<@NonNull T> {
     default TestSubscriber<T> test() {
         var ts = new TestSubscriber<T>();
         subscribe(ts);
+        return ts;
+    }
+
+    /**
+     * Creates a new {@link TestSubscriber} and subscribes it to this {@code Streamable}.
+     * @param executor the executor to use
+     * @return the created test subscriber
+     */
+    default TestSubscriber<T> test(ExecutorService executor) {
+        var ts = new TestSubscriber<T>();
+        subscribe(ts, executor);
         return ts;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamer.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava4.core;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionStage;
 
-import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.disposables.*;
 
 /**
@@ -68,5 +68,35 @@ public interface Streamer<@NonNull T> extends AutoCloseable {
      */
     default void close() {
         cancel().toCompletableFuture().join();
+    }
+
+    /**
+     * The {@code await} keyword for async/await.
+     * @param <T> the type of the returned value if any.
+     * @param stage the stage to await virtual-blockingly
+     * @return the awaited value
+     */
+    @Nullable
+    static <T> T await(@NonNull CompletionStage<T> stage) {
+        return await(stage, null);
+    }
+
+    /**
+     * The cancellable {@code await} keyword for async/await.
+     * @param <T> the type of the returned value if any.
+     * @param stage the stage to await virtual-blockingly
+     * @param cancellation the container that can trigger a cancellation on demand
+     * @return the awaited value
+     */
+    @Nullable
+    static <T> T await(@NonNull CompletionStage<T> stage, @Nullable DisposableContainer cancellation) {
+        var f = stage.toCompletableFuture();
+        if (cancellation == null) {
+            return f.join();
+        }
+        var d = Disposable.fromFuture(f, true);
+        try (var _ = cancellation.subscribe(d)) {
+            return f.join();
+        }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamer.java
@@ -13,8 +13,10 @@
 
 package io.reactivex.rxjava4.core;
 
-import java.util.NoSuchElementException;
-import java.util.concurrent.CompletionStage;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.disposables.*;
@@ -22,11 +24,19 @@ import io.reactivex.rxjava4.disposables.*;
 /**
  * A realized stream which can then be consumed asynchronously in steps.
  * Think of it as the {@IAsyncEnumerator} of the Java world. Runs best on Virtual Threads.
+ * <p>
+ * To make sure you can run finish, use {@link DisposableContainer#clear()} or {@link DisposableContainer#reset()}
+ * to get rid of all previous registered disposables. finish() will create its own, and if that
+ * gets stuck, just call clear()/dispose() on the container to get rid of this sequence for good.
  * @param <T> the element type.
  * TODO proper docs
  * @since 4.0.0
  */
 public interface Streamer<@NonNull T> extends AutoCloseable {
+
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    // API
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
     /**
      * Determine if there are more elements available from the source.
@@ -35,16 +45,6 @@ public interface Streamer<@NonNull T> extends AutoCloseable {
      */
     @NonNull
     CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation);
-
-    /**
-     * Determine if there are more elements available from the source.
-     * Uses a default, individual {@link CompositeDisposable} to manage cancellation.
-     * @return eventually true or false, indicating availability or termination
-     */
-    @NonNull
-    default CompletionStage<Boolean> next() {
-        return next(new CompositeDisposable());
-    }
 
     /**
      * Returns the current element if {@link #next()} yielded {@code true}.
@@ -58,17 +58,148 @@ public interface Streamer<@NonNull T> extends AutoCloseable {
     /**
      * Called when the stream ends or gets cancelled. Should be always invoked.
      * TODO, this is inherited from {@code IAsyncDisposable} in C#...
+     * @param cancellation to cancel a stuck finish operation, just in case.
      * @return the stage you can await to cleanups to happen
      */
     @NonNull
-    CompletionStage<Void> cancel();
+    CompletionStage<Void> finish(@NonNull DisposableContainer cancellation);
+
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    // HELPERS
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    /**
+     * Determine if there are more elements available from the source.
+     * Uses a default, individual {@link CompositeDisposable} to manage cancellation.
+     * @return eventually true or false, indicating availability or termination
+     */
+    @NonNull
+    default CompletionStage<Boolean> next() {
+        return next(new CompositeDisposable());
+    }
 
     /**
      * Make this Streamer a resource and a Closeable, allowing virtually blocking closing.
      */
+    @Override
     default void close() {
-        cancel().toCompletableFuture().join();
+        awaitFinish();
     }
+
+    /**
+     * Augments the streamer so that the given canceller is injected into the various
+     * lifecycle await calls.
+     * @param canceller the canceller to inject
+     * @return the augmented streamer
+     */
+    default Streamer<T> finishVia(@NonNull DisposableContainer canceller) {
+        Objects.requireNonNull(canceller, "canceller is null");
+        if (this instanceof StreamerFinishViaDisposableContainerCanceller<T> augment) {
+            if (augment.streamer == this && augment.canceller == canceller) {
+                // DO not rewrap!
+                return this;
+            }
+        }
+
+        return new StreamerFinishViaDisposableContainerCanceller<>(this, canceller);
+    }
+
+    /**
+     * Augments the base streamer with a canceller so that it can be injected at the various await calls.
+     * @param <T> the element type of the stream
+     */
+    static record StreamerFinishViaDisposableContainerCanceller<T>(
+            @NonNull Streamer<T> streamer, @NonNull DisposableContainer canceller)
+    implements Streamer<T> {
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
+            // TODO Auto-generated method stub
+            return streamer.next(cancellation);
+        }
+
+        @Override
+        public @NonNull T current() {
+            return streamer.current();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
+            return streamer.finish(cancellation);
+        }
+
+    }
+
+    /**
+     * Hides the identity of this Streamer for debug or deoptimization purposes.
+     * @return the augmented streamer, always unique.
+     */
+    default Streamer<T> hide() {
+        return new HiddenStreamer<>(this);
+    }
+
+    /**
+     * Hides the identity of the Streamer for debug or deoptimization purposes.
+     * @param <T> the element type of the streamer
+     */
+    static record HiddenStreamer<T>(@NonNull Streamer<T> streamer) implements Streamer<T> {
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
+            return streamer.next(cancellation);
+        }
+
+        @Override
+        public @NonNull T current() {
+            return streamer.current();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
+            return streamer.finish(cancellation);
+        }
+
+    }
+
+    /**
+     * Moves and awaits the sequence's next element, returns false if there are no more
+     * data.
+     * @return true if the next element via {@link #current()} can be read, or false if
+     * the stream ended.
+     */
+    default boolean awaitNext() {
+        return await(next());
+    }
+
+    /**
+     * Moves and awaits the sequence's next element, returns false if there are no more
+     * data.
+     * @param cancellation to efficiently cancel this await if necessary
+     * @return true if the next element via {@link #current()} can be read, or false if
+     * the stream ended.
+     */
+    default boolean awaitNext(@NonNull DisposableContainer cancellation) {
+        return await(next(cancellation), cancellation);
+    }
+
+    /**
+     * Finish and cleanup the sequence after its completion or cancellation.
+     */
+    default void awaitFinish() {
+        await(finish(DisposableContainer.NEVER), DisposableContainer.NEVER);
+    }
+
+    /**
+     * Who cancels the cancellation attempt? Another cancellation attempt!
+     * @param cancellation the token to cancel and ongoing cancel attempt
+     */
+    default void awaitFinish(@NonNull DisposableContainer cancellation) {
+        await(finish(cancellation), cancellation);
+    }
+
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    // ASYNC/AWAIT "Language" keyword implementations
+    // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
     /**
      * The {@code await} keyword for async/await.
@@ -98,5 +229,45 @@ public interface Streamer<@NonNull T> extends AutoCloseable {
         try (var _ = cancellation.subscribe(d)) {
             return f.join();
         }
+    }
+
+    /**
+     * Runs a function while turning it into a CompletionStage with a canceller supplied too.
+     * @param <U> the return type of the function
+     * @param function the function to apply
+     * @param canceller the canceller to use
+     * @param executor the executor to use
+     * @return the new stage
+     */
+    static <U> CompletionStage<U> runStage(Function<DisposableContainer, U> function,
+            DisposableContainer canceller, Executor executor) {
+        var loopback = new AtomicReference<Disposable>();
+
+        var f =  CompletableFuture.supplyAsync(() -> {
+            try {
+                return function.apply(canceller);
+            } finally {
+                var dx = loopback.getAndSet(Disposable.disposed());
+                canceller.delete(dx);
+            }
+        }, executor);
+
+        var d = Disposable.fromFuture(f, true);
+        loopback.lazySet(d);
+        canceller.add(d);
+
+        return f;
+    }
+
+    /**
+     * Runs a function while turning it into a CompletionStage with a canceller supplied too.
+     * @param <U> the return type of the function
+     * @param function the function to apply
+     * @param canceller the canceller to use
+     * @return the new stage
+     */
+    static <U> CompletionStage<U> runStage(Function<DisposableContainer, U> function,
+            DisposableContainer canceller) {
+        return runStage(function, canceller, Executors.newVirtualThreadPerTaskExecutor());
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamer.java
@@ -15,7 +15,6 @@ package io.reactivex.rxjava4.core;
 
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import io.reactivex.rxjava4.annotations.*;
@@ -216,17 +215,17 @@ public interface Streamer<@NonNull T> extends AutoCloseable {
      * The cancellable {@code await} keyword for async/await.
      * @param <T> the type of the returned value if any.
      * @param stage the stage to await virtual-blockingly
-     * @param cancellation the container that can trigger a cancellation on demand
+     * @param canceller the container that can trigger a cancellation on demand
      * @return the awaited value
      */
     @Nullable
-    static <T> T await(@NonNull CompletionStage<T> stage, @Nullable DisposableContainer cancellation) {
+    static <T> T await(@NonNull CompletionStage<T> stage, @Nullable DisposableContainer canceller) {
         var f = stage.toCompletableFuture();
-        if (cancellation == null) {
+        if (canceller == null) {
             return f.join();
         }
         var d = Disposable.fromFuture(f, true);
-        try (var _ = cancellation.subscribe(d)) {
+        try (var _ = canceller.subscribe(d)) {
             return f.join();
         }
     }
@@ -241,20 +240,21 @@ public interface Streamer<@NonNull T> extends AutoCloseable {
      */
     static <U> CompletionStage<U> runStage(Function<DisposableContainer, U> function,
             DisposableContainer canceller, Executor executor) {
-        var loopback = new AtomicReference<Disposable>();
+        var loopback = new SerialDisposable();
+        canceller.add(loopback);
+
+        // new Exception().printStackTrace();
 
         var f =  CompletableFuture.supplyAsync(() -> {
             try {
                 return function.apply(canceller);
             } finally {
-                var dx = loopback.getAndSet(Disposable.disposed());
-                canceller.delete(dx);
+                canceller.delete(loopback);
             }
         }, executor);
 
         var d = Disposable.fromFuture(f, true);
-        loopback.lazySet(d);
-        canceller.add(d);
+        loopback.replace(d);
 
         return f;
     }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamer.java
@@ -17,6 +17,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionStage;
 
 import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.disposables.*;
 
 /**
  * A realized stream which can then be consumed asynchronously in steps.
@@ -29,10 +30,21 @@ public interface Streamer<@NonNull T> extends AutoCloseable {
 
     /**
      * Determine if there are more elements available from the source.
+     * @param cancellation ability to perform cancellation on a per-virtual-pull request.
      * @return eventually true or false, indicating availability or termination
      */
     @NonNull
-    CompletionStage<Boolean> next();
+    CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation);
+
+    /**
+     * Determine if there are more elements available from the source.
+     * Uses a default, individual {@link CompositeDisposable} to manage cancellation.
+     * @return eventually true or false, indicating availability or termination
+     */
+    @NonNull
+    default CompletionStage<Boolean> next() {
+        return next(new CompositeDisposable());
+    }
 
     /**
      * Returns the current element if {@link #next()} yielded {@code true}.
@@ -52,7 +64,7 @@ public interface Streamer<@NonNull T> extends AutoCloseable {
     CompletionStage<Void> cancel();
 
     /**
-     * Make this Streamer a resource and a Closeable.
+     * Make this Streamer a resource and a Closeable, allowing virtually blocking closing.
      */
     default void close() {
         cancel().toCompletableFuture().join();

--- a/src/main/java/io/reactivex/rxjava4/core/VirtualEmitter.java
+++ b/src/main/java/io/reactivex/rxjava4/core/VirtualEmitter.java
@@ -13,12 +13,13 @@
 
 package io.reactivex.rxjava4.core;
 
+import io.reactivex.rxjava4.disposables.*;
+
 /**
  * Interface handed to user code in {@link Flowable#virtualCreate(VirtualGenerator, java.util.concurrent.ExecutorService)} callback.
  * @param <T> the element type to emit
  * @since 4.0.0
  */
-@FunctionalInterface
 public interface VirtualEmitter<T> {
 
     /**
@@ -27,4 +28,10 @@ public interface VirtualEmitter<T> {
      * @throws Throwable an arbitrary exception if the downstream cancelled
      */
     void emit(T item) throws Throwable;
+
+    /**
+     * Returns a disposable container to relay cancellation notifications while awaiting the run.
+     * @return a new Disposable Container instance
+     */
+    DisposableContainer canceller();
 }

--- a/src/main/java/io/reactivex/rxjava4/core/VirtualTransformer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/VirtualTransformer.java
@@ -12,6 +12,9 @@
  */
 
 package io.reactivex.rxjava4.core;
+
+import io.reactivex.rxjava4.disposables.Disposable;
+
 /**
  * Interface called by the {@link Flowable#virtualTransform(VirtualTransformer, java.util.concurrent.ExecutorService)}
  * operator to generate any number of output values based of the current input of the upstream.
@@ -29,7 +32,8 @@ public interface VirtualTransformer<T, R> {
      * 
      * @param value the upstream value
      * @param emitter the emitter to use to generate result value(s)
+     * @param stopper call to stop the upstream
      * @throws Throwable signaled as {@code onError} for the downstream.
      */
-    void transform(T value, VirtualEmitter<R> emitter) throws Throwable;
+    void transform(T value, VirtualEmitter<R> emitter, Disposable stopper) throws Throwable;
 }

--- a/src/main/java/io/reactivex/rxjava4/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/CompositeDisposable.java
@@ -255,4 +255,17 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
             throw new CompositeException(errors);
         }
     }
+
+    @Override
+    public void reset() {
+        if (disposed) {
+            return;
+        }
+        synchronized (this) {
+            if (disposed) {
+                return;
+            }
+            resources = null;
+        }
+    }
 }

--- a/src/main/java/io/reactivex/rxjava4/disposables/DisposableContainer.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/DisposableContainer.java
@@ -78,4 +78,52 @@ public interface DisposableContainer extends Disposable {
         add(d);
         return Disposable.fromRunnable(() -> delete(d));
     }
+
+    /**
+     * The container implementation that just ignores everything, for
+     * cases where the dispose signal has no side-effects to work with.
+     */
+    static DisposableContainer NEVER = new NeverDisposableContainer();
+
+    static record NeverDisposableContainer() implements DisposableContainer {
+
+        @Override
+        public void dispose() {
+            // Deliberately empty
+        }
+
+        @Override
+        public boolean isDisposed() {
+            // Who cares?
+            return false;
+        }
+
+        @Override
+        public boolean add(Disposable d) {
+            // Who cares?
+            return false;
+        }
+
+        @Override
+        public boolean remove(Disposable d) {
+            // Who cares?
+            return false;
+        }
+
+        @Override
+        public boolean delete(Disposable d) {
+            // Who cares?
+            return false;
+        }
+
+        @Override
+        public void reset() {
+            // Who cares?
+        }
+
+        @Override
+        public void clear() {
+            // Who cares?
+        }
+    }
 }

--- a/src/main/java/io/reactivex/rxjava4/disposables/DisposableContainer.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/DisposableContainer.java
@@ -42,4 +42,40 @@ public interface DisposableContainer extends Disposable {
      * @return true if the operation was successful
      */
     boolean delete(Disposable d);
+
+    /**
+     * Removes all contained {@link Disposable}s without disposing them, making this
+     * container fresh.
+     */
+    void reset();
+
+    /**
+     * Removes and disposes all contained {@link Disposable}s, making this container fresh
+     * without disposing the entire container.
+     */
+    void clear();
+
+    /**
+     * Registers a {@link Disposable} with this container so that it can be removed and disposed
+     * via a simple {@link #dispose()} call to the returned Disposable.
+     * @param d the disposable to register
+     * @return the Disposable to trigger a {@link #remove(Disposable)}
+     * @see #subscribe(Disposable) for non-disposing removal.
+     */
+    default Disposable register(Disposable d) {
+        add(d);
+        return Disposable.fromRunnable(() -> remove(d));
+    }
+
+    /**
+     * Registers a {@link Disposable} with this container so that it can be deleted, not disposed
+     * via a simple {@link #dispose()} call to the returned Disposable.
+     * @param d the disposable to register
+     * @return the Disposable to trigger a {@link #remove(Disposable)}
+     * @see #subscribe(Disposable) for non-disposing removal.
+     */
+    default Disposable subscribe(Disposable d) {
+        add(d);
+        return Disposable.fromRunnable(() -> delete(d));
+    }
 }

--- a/src/main/java/io/reactivex/rxjava4/disposables/DisposableContainer.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/DisposableContainer.java
@@ -46,6 +46,7 @@ public interface DisposableContainer extends Disposable {
     /**
      * Removes all contained {@link Disposable}s without disposing them, making this
      * container fresh.
+     * @since 4.0.0
      */
     void reset();
 
@@ -61,6 +62,7 @@ public interface DisposableContainer extends Disposable {
      * @param d the disposable to register
      * @return the Disposable to trigger a {@link #remove(Disposable)}
      * @see #subscribe(Disposable) for non-disposing removal.
+     * @since 4.0.0
      */
     default Disposable register(Disposable d) {
         add(d);
@@ -73,6 +75,7 @@ public interface DisposableContainer extends Disposable {
      * @param d the disposable to register
      * @return the Disposable to trigger a {@link #remove(Disposable)}
      * @see #subscribe(Disposable) for non-disposing removal.
+     * @since 4.0.0
      */
     default Disposable subscribe(Disposable d) {
         add(d);
@@ -82,9 +85,14 @@ public interface DisposableContainer extends Disposable {
     /**
      * The container implementation that just ignores everything, for
      * cases where the dispose signal has no side-effects to work with.
+     * @since 4.0.0
      */
     static DisposableContainer NEVER = new NeverDisposableContainer();
 
+    /**
+     * Implementation of a never disposable container.
+     * @since 4.0.0
+     */
     static record NeverDisposableContainer() implements DisposableContainer {
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/functions/Consumer3.java
+++ b/src/main/java/io/reactivex/rxjava4/functions/Consumer3.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.functions;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+
+/**
+ * A functional interface (callback) that accepts two values (of possibly different types).
+ * @param <T1> the first value type
+ * @param <T2> the second value type
+ * @param <T3> the third value type
+ * @since 4.0.0
+ */
+@FunctionalInterface
+public interface Consumer3<@NonNull T1, @NonNull T2, @NonNull T3> {
+
+    /**
+     * Performs an operation on the given values.
+     * @param t1 the first value
+     * @param t2 the second value
+     * @param t3 the third value
+     * @throws Throwable if the implementation wishes to throw any type of exception
+     */
+    void accept(T1 t1, T2 t2, T3 t3) throws Throwable;
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/disposables/ListCompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/disposables/ListCompositeDisposable.java
@@ -184,4 +184,18 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
             throw new CompositeException(errors);
         }
     }
+
+    @Override
+    public void reset() {
+        if (disposed) {
+            return;
+        }
+        synchronized (this) {
+            if (disposed) {
+                return;
+            }
+            resources = null;
+        }
+    }
+
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
@@ -18,7 +18,7 @@ import java.util.concurrent.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.disposables.DisposableContainer;
+import io.reactivex.rxjava4.disposables.*;
 
 public final class StreamableEmpty<T> extends Streamable<T> {
 
@@ -30,7 +30,7 @@ public final class StreamableEmpty<T> extends Streamable<T> {
     static final class EmptyStreamer<T> implements Streamer<T> {
 
         @Override
-        public @NonNull CompletionStage<Boolean> next() {
+        public @NonNull CompletionStage<Boolean> next(DisposableContainer cancellation) {
             return CompletableFuture.completedStage(false); // TODO would constant stages work here or is that contention?
         }
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
@@ -20,7 +20,7 @@ import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 
-public final class StreamableEmpty<T> extends Streamable<T> {
+public final class StreamableEmpty<T> implements Streamable<T> {
 
     @Override
     public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
@@ -40,7 +40,7 @@ public final class StreamableEmpty<T> extends Streamable<T> {
         }
 
         @Override
-        public @NonNull CompletionStage<Void> cancel() {
+        public @NonNull CompletionStage<Void> finish(DisposableContainer canceller) {
             return CompletableFuture.completedStage(null); // TODO would constant stages work here or is that contention?
         }
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisher.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.*;
+import java.util.concurrent.Flow.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.internal.fuseable.HasUpstreamPublisher;
+import io.reactivex.rxjava4.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava4.internal.util.ExceptionHelper;
+import io.reactivex.rxjava4.internal.virtual.VirtualResumable;
+
+public record StreamableFromPublisher<T>(@NonNull Publisher<T> source)
+implements Streamable<T>, HasUpstreamPublisher<T> {
+
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
+
+        var flow = Flowable.fromPublisher(source);
+        var streamer = new FlowableStreamer<T>(
+                cancellation, new AtomicReference<>(),
+                new AtomicReference<>(),
+                new AtomicReference<>(),
+                new VirtualResumable()
+                );
+        flow.subscribe(streamer);
+        return streamer;
+    }
+
+    record FlowableStreamer<T>(
+            DisposableContainer cancellation,
+            AtomicReference<Subscription> upstream,
+            AtomicReference<T> item,
+            AtomicReference<Throwable> error,
+            VirtualResumable resumer)
+    implements Flow.Subscriber<T>, Streamer<T> {
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            if (SubscriptionHelper.setOnce(upstream, subscription)) {
+                subscription.request(1); // FIXME more efficient, queueing !!!
+            }
+        }
+
+        @Override
+        public void onNext(T item) {
+            this.item.getAndSet(item);
+            resumer.resume();
+            upstream.get().request(1);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            item.set(null);
+            error.getAndSet(throwable);
+            upstream.set(SubscriptionHelper.CANCELLED);
+            resumer.resume();
+        }
+
+        @Override
+        public void onComplete() {
+            item.set(null);
+            error.compareAndSet(null, ExceptionHelper.TERMINATED);
+            upstream.set(SubscriptionHelper.CANCELLED);
+            resumer.resume();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
+            return Streamer.runStage(_ -> {
+                resumer.await();
+                var e = error.get();
+                if (e != null) {
+                    if (e == ExceptionHelper.TERMINATED) {
+                        return false;
+                    }
+                    throw ExceptionHelper.wrapOrThrow(e);
+                }
+                return true;
+            }, cancellation);
+        }
+
+        @Override
+        public @NonNull T current() {
+            return item.get();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
+            return Streamer.runStage(_ -> {
+                upstream.get().cancel();
+                return null;
+            }, cancellation);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisher.java
@@ -15,17 +15,18 @@ package io.reactivex.rxjava4.internal.operators.streamable;
 
 import java.util.concurrent.*;
 import java.util.concurrent.Flow.*;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.*;
 
-import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamPublisher;
 import io.reactivex.rxjava4.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava4.internal.util.ExceptionHelper;
 import io.reactivex.rxjava4.internal.virtual.VirtualResumable;
 
-public record StreamableFromPublisher<T>(@NonNull Publisher<T> source)
+public record StreamableFromPublisher<T>(@NonNull Publisher<T> source,
+        @Nullable Executor executor)
 implements Streamable<T>, HasUpstreamPublisher<T> {
 
     @Override
@@ -33,10 +34,13 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
 
         var flow = Flowable.fromPublisher(source);
         var streamer = new FlowableStreamer<T>(
-                cancellation, new AtomicReference<>(),
+                cancellation,
+                new AtomicReference<>(),
+                new AtomicLong(),
                 new AtomicReference<>(),
                 new AtomicReference<>(),
-                new VirtualResumable()
+                new VirtualResumable(),
+                executor
                 );
         flow.subscribe(streamer);
         return streamer;
@@ -45,28 +49,30 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
     record FlowableStreamer<T>(
             DisposableContainer cancellation,
             AtomicReference<Subscription> upstream,
+            AtomicLong requester,
             AtomicReference<T> item,
             AtomicReference<Throwable> error,
-            VirtualResumable resumer)
+            VirtualResumable resumer,
+            Executor executor)
     implements Flow.Subscriber<T>, Streamer<T> {
 
         @Override
         public void onSubscribe(Subscription subscription) {
-            if (SubscriptionHelper.setOnce(upstream, subscription)) {
-                subscription.request(1); // FIXME more efficient, queueing !!!
-            }
+            // System.out.println("onSubscribe | " + subscription);
+            SubscriptionHelper.deferredSetOnce(upstream, requester, subscription);
         }
 
         @Override
         public void onNext(T item) {
+            // System.out.println("onNext | " + item);
             this.item.getAndSet(item);
             resumer.resume();
-            upstream.get().request(1);
+            // System.out.println("Got " + item + " resume signalled");
         }
 
         @Override
         public void onError(Throwable throwable) {
-            item.set(null);
+            // System.out.println("onError | " + throwable);
             error.getAndSet(throwable);
             upstream.set(SubscriptionHelper.CANCELLED);
             resumer.resume();
@@ -74,7 +80,7 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
 
         @Override
         public void onComplete() {
-            item.set(null);
+            // System.out.println("onComplete |");
             error.compareAndSet(null, ExceptionHelper.TERMINATED);
             upstream.set(SubscriptionHelper.CANCELLED);
             resumer.resume();
@@ -82,17 +88,48 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
 
         @Override
         public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
+            System.out.println("next()");
             return Streamer.runStage(_ -> {
-                resumer.await();
+                item.lazySet(null);
+                System.out.println("Requesting the next item");
+                SubscriptionHelper.deferredRequest(upstream, requester, 1);
+
+                System.out.println("waiting for it");
+
                 var e = error.get();
-                if (e != null) {
-                    if (e == ExceptionHelper.TERMINATED) {
-                        return false;
+                var v = item.get();
+
+                do {
+                    if (e != null || v != null) {
+                        break;
                     }
-                    throw ExceptionHelper.wrapOrThrow(e);
+
+                    resumer.await();
+
+                    e = error.get();
+                    v = item.get();
+
+                } while (true);
+
+                // Because Eclipse craps itself when trying to debug virtual threads
+                // FU whoever said debugging in virtual threads is straightforward
+                System.out.println("Value: " + v + ", Error: " + e);
+                if (e != null) {
+                    e.printStackTrace();
                 }
+
+                if (v == null) {
+                    if (e != null) {
+                        if (e == ExceptionHelper.TERMINATED) {
+                            return false;
+                        }
+                        throw ExceptionHelper.wrapOrThrow(e);
+                    }
+                    throw new IllegalStateException("null current item and null current error? How?");
+                }
+                System.out.println("Returning true");
                 return true;
-            }, cancellation);
+            }, cancellation, executor);
         }
 
         @Override
@@ -102,10 +139,11 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
 
         @Override
         public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
+            new Exception("StreamableFromPublisher::finish").printStackTrace();
             return Streamer.runStage(_ -> {
-                upstream.get().cancel();
+                SubscriptionHelper.cancel(upstream);
                 return null;
-            }, cancellation);
+            }, cancellation, executor);
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisher.java
@@ -87,19 +87,20 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
         }
 
         @Override
-        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
-            System.out.println("next()");
+        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer canceller) {
+            // System.out.println("next()");
             return Streamer.runStage(_ -> {
                 item.lazySet(null);
-                System.out.println("Requesting the next item");
+                // System.out.println("Requesting the next item");
                 SubscriptionHelper.deferredRequest(upstream, requester, 1);
 
-                System.out.println("waiting for it");
+                // System.out.println("waiting for it");
 
                 var e = error.get();
                 var v = item.get();
 
                 do {
+                    // System.out.println("1");
                     if (e != null || v != null) {
                         break;
                     }
@@ -109,14 +110,16 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
                     e = error.get();
                     v = item.get();
 
-                } while (true);
+                    // System.out.println("Loop | Value: " + v + ", Error: " + e);
+
+                } while (!canceller.isDisposed());
 
                 // Because Eclipse craps itself when trying to debug virtual threads
                 // FU whoever said debugging in virtual threads is straightforward
-                System.out.println("Value: " + v + ", Error: " + e);
-                if (e != null) {
-                    e.printStackTrace();
-                }
+                // System.out.println("Value: " + v + ", Error: " + e);
+                // if (e != null) {
+                //    e.printStackTrace();
+                // }
 
                 if (v == null) {
                     if (e != null) {
@@ -127,9 +130,9 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
                     }
                     throw new IllegalStateException("null current item and null current error? How?");
                 }
-                System.out.println("Returning true");
+                // System.out.println("Returning true");
                 return true;
-            }, cancellation, executor);
+            }, canceller, executor);
         }
 
         @Override
@@ -139,7 +142,7 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
 
         @Override
         public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
-            new Exception("StreamableFromPublisher::finish").printStackTrace();
+            // new Exception("StreamableFromPublisher::finish").printStackTrace();
             return Streamer.runStage(_ -> {
                 SubscriptionHelper.cancel(upstream);
                 return null;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
@@ -48,7 +48,7 @@ public final class StreamableJust<T> extends Streamable<T> {
         }
 
         @Override
-        public @NonNull CompletionStage<Boolean> next() {
+        public @NonNull CompletionStage<Boolean> next(DisposableContainer cancellation) {
             if (stage == 0) {
                 stage = 1;
                 return CompletableFuture.completedStage(true);

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
@@ -13,19 +13,17 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.concurrent.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 
-public final class StreamableJust<T> extends Streamable<T> {
-
-    final T item;
+public record StreamableJust<T>(@NonNull T item) implements Streamable<T> {
 
     public StreamableJust(T item) {
-        this.item = item;
+        this.item = Objects.requireNonNull(item, "item is null");;
     }
 
     @Override
@@ -72,7 +70,7 @@ public final class StreamableJust<T> extends Streamable<T> {
         }
 
         @Override
-        public @NonNull CompletionStage<Void> cancel() {
+        public @NonNull CompletionStage<Void> finish(DisposableContainer canceller) {
             item = null;
             cancellation = null;
             stage = 2;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.schedulers;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.Scheduler;
+import io.reactivex.rxjava4.core.Scheduler.Worker;
+import io.reactivex.rxjava4.exceptions.Exceptions;
+
+/**
+ * Represents the state for a Scheduler -&gt; ExecutorService interface.
+ * @param scheduler the scheduler to use
+ * @param workerStore hosts the worker state
+ * @since 4.0.0
+ */
+public record SchedulerToExecutorService(@NonNull Scheduler scheduler,
+        @NonNull AtomicReference<Worker> workerStore) implements ExecutorService {
+
+    @Override
+    public void execute(Runnable command) {
+        if (workerStore.get() instanceof Worker w) {
+            w.schedule(command);
+        } else {
+            scheduler.scheduleDirect(command);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        if (workerStore.get() instanceof Worker w) {
+            w.dispose();
+        } else {
+            // FIXME, generally we don't want to shut down RxJava schedulers like this!
+            // scheduler.shutdown();
+            var w = workerStore.getAndSet(Scheduler.Worker.SHUTDOWN);
+            if (w != null) {
+                w.dispose();
+            }
+        }
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        if (workerStore.get() instanceof Worker w) {
+            w.dispose();
+        } else {
+            // FIXME, generally we don't want to shut down RxJava schedulers like this!
+            // scheduler.shutdown();
+            var w = workerStore.getAndSet(Scheduler.Worker.SHUTDOWN);
+            if (w != null) {
+                w.dispose();
+            }
+        }
+        return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        var w = workerStore.get();
+        return w != null && w.isDisposed();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return isShutdown();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        // FIXME no idea how to passively wait, not really applicable in Rx
+        long totalTime = unit.convert(timeout, TimeUnit.MILLISECONDS);
+
+        while (!isTerminated() && totalTime > 0) {
+            totalTime--;
+            Thread.sleep(1);
+        }
+        return totalTime > 0;
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return task.call();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                throw Exceptions.propagate(ex);
+            }
+        }, this::execute);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                task.run();
+                return result;
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                throw Exceptions.propagate(ex);
+            }
+        }, this::execute);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                task.run();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                throw Exceptions.propagate(ex);
+            }
+        }, this::execute);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        var result = new ArrayList<Future<T>>();
+        for (var task : tasks) {
+            result.add(submit(task));
+        }
+        for (var f : result) {
+            try {
+                f.get();
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        var result = new ArrayList<Future<T>>();
+        for (var task : tasks) {
+            result.add(submit(task));
+        }
+
+        // FIXME how to wait in aggregate without spinning???
+        long totalTime = unit.convert(timeout, TimeUnit.MILLISECONDS);
+
+        while (!isTerminated() && totalTime > 0) {
+            totalTime--;
+
+            int done = 0;
+            for (var f : result) {
+                if (f.isDone()) {
+                    done++;
+                }
+            }
+
+            if (done == result.size()) {
+                break;
+            }
+
+            Thread.sleep(1);
+        }
+
+        return result;
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        if (tasks.size() == 0) {
+            throw new IllegalArgumentException("The tasks parameter should contain at least one callable!");
+        }
+
+        var result = new ArrayList<Future<T>>();
+        for (var task : tasks) {
+            result.add(submit(task));
+        }
+
+        while (!isTerminated()) {
+            for (var f : result) {
+                if (f.isDone() && !f.isCancelled() && f.exceptionNow() == null) {
+
+                    var v = f.resultNow();
+
+                    for (var g : result) {
+                        g.cancel(true);
+                    }
+
+                    return v;
+                }
+            }
+            Thread.sleep(1);
+        }
+        return null; // Practically unreachable
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        if (tasks.size() == 0) {
+            throw new IllegalArgumentException("The tasks parameter should contain at least one callable!");
+        }
+
+        var result = new ArrayList<Future<T>>();
+        for (var task : tasks) {
+            result.add(submit(task));
+        }
+
+        // FIXME how to wait in aggregate without spinning???
+        long totalTime = unit.convert(timeout, TimeUnit.MILLISECONDS);
+
+        while (!isTerminated() && totalTime > 0) {
+            totalTime--;
+
+            for (var f : result) {
+                if (f.isDone() && !f.isCancelled() && f.exceptionNow() == null) {
+
+                    var v = f.resultNow();
+
+                    for (var g : result) {
+                        g.cancel(true);
+                    }
+
+                    return v;
+                }
+            }
+        }
+        throw new TimeoutException("None of the tasks produced a clean result in the time allotted.");
+    }
+
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 
@@ -49,7 +50,11 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
         s.onSubscribe(parent);
 
         if (executor != null) {
-            executor.submit((Callable<Void>)parent);
+            try {
+                executor.submit((Callable<Void>)parent);
+            } catch (RejectedExecutionException ex) {
+                s.onError(ex);
+            }
         } else {
             var worker = scheduler.createWorker();
             parent.worker = worker;
@@ -76,10 +81,13 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
 
         Scheduler.Worker worker;
 
+        final DisposableContainer canceller;
+
         ExecutorVirtualCreateSubscription(Subscriber<? super T> downstream, VirtualGenerator<T> generator) {
             this.downstream = downstream;
             this.generator = generator;
             this.consumerReady = new VirtualResumable();
+            this.canceller = new CompositeDisposable();
         }
 
         @Override
@@ -122,6 +130,7 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
         @Override
         public void cancel() {
             cancelled = true;
+            canceller.dispose();
             request(1);
         }
 
@@ -139,6 +148,11 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
 
             downstream.onNext(item);
             produced = p + 1;
+        }
+
+        @Override
+        public DisposableContainer canceller() {
+            return canceller;
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
@@ -63,7 +63,7 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
     }
 
     static final class ExecutorVirtualTransformSubscriber<T, R> extends AtomicLong
-    implements FlowableSubscriber<T>, Subscription, VirtualEmitter<R>, Callable<Void>, Runnable {
+    implements FlowableSubscriber<T>, Subscription, VirtualEmitter<R>, Callable<Void>, Runnable, Disposable {
 
         private static final long serialVersionUID = -4702456711290258571L;
 
@@ -95,6 +95,8 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
         Worker worker;
 
         final DisposableContainer canceller;
+
+        volatile boolean stopped;
 
         ExecutorVirtualTransformSubscriber(Subscriber<? super R> downstream,
                 VirtualTransformer<T, R> transformer,
@@ -216,7 +218,7 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
                                 upstream.request(limit);
                             }
 
-                            transformer.transform(v, this);
+                            transformer.transform(v, this, this);
 
                             continue;
                         }
@@ -244,6 +246,17 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
         @Override
         public DisposableContainer canceller() {
             return canceller;
+        }
+
+        @Override
+        public void dispose() {
+            stopped = true;
+            upstream.cancel();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return stopped;
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
+import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 import io.reactivex.rxjava4.operators.SpscArrayQueue;
@@ -93,6 +94,8 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
 
         Worker worker;
 
+        final DisposableContainer canceller;
+
         ExecutorVirtualTransformSubscriber(Subscriber<? super R> downstream,
                 VirtualTransformer<T, R> transformer,
                 int prefetch) {
@@ -103,6 +106,7 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
             this.producerReady = new VirtualResumable();
             this.consumerReady = new VirtualResumable();
             this.queue = new SpscArrayQueue<>(prefetch);
+            this.canceller = new CompositeDisposable();
         }
 
         @Override
@@ -160,18 +164,21 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
 
         @Override
         public void cancel() {
-            cancelled = true;
-            upstream.cancel();
-            // cleanup(); don't kill the worker
+            try {
+                cancelled = true;
+                upstream.cancel();
+                canceller.dispose();
+                // cleanup(); don't kill the worker
 
-            var w = worker;
-            worker = null;
-            if (w != null) {
-                w.close();
+                var w = worker;
+                worker = null;
+                if (w != null) {
+                    w.close();
+                }
+            } finally {
+                producerReady.resume();
+                consumerReady.resume();
             }
-
-            producerReady.resume();
-            consumerReady.resume();
         }
 
         @Override
@@ -232,6 +239,11 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
                 downstream = null;
             }
             return null;
+        }
+
+        @Override
+        public DisposableContainer canceller() {
+            return canceller;
         }
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableIsolatedTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.completable;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.Disposable;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+
+/**
+ * Test Completable methods and operators.
+ */
+@Isolated
+public class CompletableIsolatedTest extends RxJavaTest {
+
+    @org.junit.jupiter.api.Test
+    public void repeatNormal() {
+        final AtomicReference<Throwable> err = new AtomicReference<>();
+        final AtomicInteger calls = new AtomicInteger();
+
+        Completable c = Completable.fromCallable(() -> {
+            calls.getAndIncrement();
+            Thread.sleep(200);
+            return null;
+        }).repeat();
+
+        c.subscribe(new CompletableObserver() {
+            @Override
+            public void onSubscribe(final Disposable d) {
+                Schedulers.single().scheduleDirect(() -> d.dispose(), 1100, TimeUnit.MILLISECONDS);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                err.set(e);
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+
+        Assert.assertEquals("calls count mismatch", 6, calls.get());
+        Assert.assertNull("error present", err.get());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -1983,46 +1983,6 @@ public class CompletableTest extends RxJavaTest {
         c.blockingAwait();
     }
 
-    @org.junit.jupiter.api.Test
-    public void repeatNormal() {
-        final AtomicReference<Throwable> err = new AtomicReference<>();
-        final AtomicInteger calls = new AtomicInteger();
-
-        Completable c = Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                calls.getAndIncrement();
-                Thread.sleep(100);
-                return null;
-            }
-        }).repeat();
-
-        c.subscribe(new CompletableObserver() {
-            @Override
-            public void onSubscribe(final Disposable d) {
-                Schedulers.single().scheduleDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        d.dispose();
-                    }
-                }, 550, TimeUnit.MILLISECONDS);
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                err.set(e);
-            }
-
-            @Override
-            public void onComplete() {
-
-            }
-        });
-
-        Assert.assertEquals(6, calls.get());
-        Assert.assertNull(err.get());
-    }
-
     @Test(expected = TestException.class)
     public void repeatError() {
         Completable c = error.completable.repeat();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -698,7 +698,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     }
 
     private static class InprocessWorker extends Worker {
-        private final Disposable mockDisposable;
+        private Disposable mockDisposable;
         public boolean unsubscribed;
 
         InprocessWorker(Disposable mockDisposable) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -701,7 +701,7 @@ public class FlowableReplayTest extends RxJavaTest {
     }
 
     private static class InprocessWorker extends Worker {
-        private final Disposable mockDisposable;
+        private Disposable mockDisposable;
         public boolean unsubscribed;
 
         InprocessWorker(Disposable mockDisposable) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
@@ -19,11 +19,12 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
-import static java.util.concurrent.Flow.*;
 
+import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.flowable.*;
@@ -42,14 +43,7 @@ public class FlowableScanTest extends RxJavaTest {
 
         Flowable<Integer> flowable = Flowable.just(1, 2, 3);
 
-        Flowable<String> m = flowable.scan("", new BiFunction<String, Integer, String>() {
-
-            @Override
-            public String apply(String s, Integer n) {
-                return s + n.toString();
-            }
-
-        });
+        Flowable<String> m = flowable.scan("", (s, n) -> s + n.toString());
         m.subscribe(subscriber);
 
         verify(subscriber, never()).onError(any(Throwable.class));
@@ -68,14 +62,7 @@ public class FlowableScanTest extends RxJavaTest {
 
         Flowable<Integer> flowable = Flowable.just(1, 2, 3);
 
-        Flowable<Integer> m = flowable.scan(new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-
-        });
+        Flowable<Integer> m = flowable.scan((t1, t2) -> t1 + t2);
         m.subscribe(subscriber);
 
         verify(subscriber, never()).onError(any(Throwable.class));
@@ -94,14 +81,7 @@ public class FlowableScanTest extends RxJavaTest {
 
         Flowable<Integer> flowable = Flowable.just(1);
 
-        Flowable<Integer> m = flowable.scan(new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-
-        });
+        Flowable<Integer> m = flowable.scan((t1, t2) -> t1 + t2);
         m.subscribe(subscriber);
 
         verify(subscriber, never()).onError(any(Throwable.class));
@@ -115,22 +95,10 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void shouldNotEmitUntilAfterSubscription() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
-        Flowable.range(1, 100).scan(0, new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-
-        }).filter(new Predicate<Integer>() {
-
-            @Override
-            public boolean test(Integer t1) {
-                // this will cause request(1) when 0 is emitted
-                return t1 > 0;
-            }
-
-        }).subscribe(ts);
+        Flowable.range(1, 100)
+        .scan(0, (t1, t2) -> t1 + t2)
+        .filter(t1 -> t1 > 0)
+        .subscribe(ts);
 
         assertEquals(100, ts.values().size());
     }
@@ -139,14 +107,7 @@ public class FlowableScanTest extends RxJavaTest {
     public void backpressureWithInitialValue() {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
-                .scan(0, new BiFunction<Integer, Integer, Integer>() {
-
-                    @Override
-                    public Integer apply(Integer t1, Integer t2) {
-                        return t1 + t2;
-                    }
-
-                })
+                .scan(0, (t1, t2) -> t1 + t2)
                 .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
@@ -180,14 +141,7 @@ public class FlowableScanTest extends RxJavaTest {
     public void backpressureWithoutInitialValue() {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
-                .scan(new BiFunction<Integer, Integer, Integer>() {
-
-                    @Override
-                    public Integer apply(Integer t1, Integer t2) {
-                        return t1 + t2;
-                    }
-
-                })
+                .scan((t1, t2) -> t1 + t2)
                 .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
@@ -221,14 +175,7 @@ public class FlowableScanTest extends RxJavaTest {
     public void noBackpressureWithInitialValue() {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
-                .scan(0, new BiFunction<Integer, Integer, Integer>() {
-
-                    @Override
-                    public Integer apply(Integer t1, Integer t2) {
-                        return t1 + t2;
-                    }
-
-                })
+                .scan(0, (t1, t2) -> t1 + t2)
                 .subscribe(new DefaultSubscriber<Integer>() {
 
                     @Override
@@ -259,14 +206,7 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void seedFactory() {
         Single<List<Integer>> o = Flowable.range(1, 10)
-                .collect(new Supplier<List<Integer>>() {
-
-                    @Override
-                    public List<Integer> get() {
-                        return new ArrayList<>();
-                    }
-
-                }, new BiConsumer<List<Integer>, Integer>() {
+                .collect(() -> new ArrayList<>(), new BiConsumer<List<Integer>, Integer>() {
 
                     @Override
                     public void accept(List<Integer> list, Integer t2) {
@@ -285,21 +225,9 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void seedFactoryFlowable() {
         Flowable<List<Integer>> f = Flowable.range(1, 10)
-                .collect(new Supplier<List<Integer>>() {
-
-                    @Override
-                    public List<Integer> get() {
-                        return new ArrayList<>();
-                    }
-
-                }, new BiConsumer<List<Integer>, Integer>() {
-
-                    @Override
-                    public void accept(List<Integer> list, Integer t2) {
-                        list.add(t2);
-                    }
-
-                }).toFlowable().takeLast(1);
+                .collect(() -> (List<Integer>)new ArrayList<Integer>(), (list, item) -> list.add(item))
+                .toFlowable()
+                .takeLast(1);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), f.blockingSingle());
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), f.blockingSingle());
@@ -307,14 +235,10 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void scanWithRequestOne() {
-        Flowable<Integer> f = Flowable.just(1, 2).scan(0, new BiFunction<Integer, Integer, Integer>() {
+        Flowable<Integer> f = Flowable.just(1, 2)
+        .scan(0, (t1, t2) -> t1 + t2)
+        .take(1);
 
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-
-        }).take(1);
         TestSubscriberEx<Integer> subscriber = new TestSubscriberEx<>();
         f.subscribe(subscriber);
         subscriber.assertValue(0);
@@ -322,40 +246,71 @@ public class FlowableScanTest extends RxJavaTest {
         subscriber.assertNoErrors();
     }
 
+    /**
+     * Turns the Subscription methods into lambda callbacks.
+     * @param <T> the element type of the subscriber
+     */
+    static class SubscriptionDelegate<T, U> implements Subscription {
+
+        @NonNull Subscriber<? super T> subscriber;
+        @NonNull Consumer3<Subscriber<? super T>, Long, U> onRequest;
+        @NonNull BiConsumer<Subscriber<? super T>, U> onCancel;
+        @Nullable U data;
+
+        SubscriptionDelegate(
+                @NonNull Subscriber<? super T> subscriber,
+                @NonNull Consumer3<Subscriber<? super T>, Long, U> onRequest,
+                @NonNull BiConsumer<Subscriber<? super T>, U> onCancel,
+                @Nullable U data
+                ) {
+            this.subscriber = subscriber;
+            this.onRequest = onRequest;
+            this.onCancel = onCancel;
+            this.data = data;
+        }
+
+        @Override
+        public void request(long n) {
+            try {
+                onRequest.accept(subscriber, n, data);
+            } catch(Throwable ex) {
+                throw Exceptions.propagate(ex);
+            }
+        }
+
+            @Override
+        public void cancel() {
+            try {
+                onCancel.accept(subscriber, data);
+            } catch(Throwable ex) {
+                throw Exceptions.propagate(ex);
+            }
+        }
+    }
+
     @Test
     public void scanShouldNotRequestZero() {
         final AtomicReference<Subscription> producer = new AtomicReference<>();
         Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
             @Override
-            public void subscribe(final Subscriber<? super Integer> subscriber) {
-                Subscription p = spy(new Subscription() {
+            public void subscribe(Subscriber<? super Integer> subscriber) {
 
-                    private AtomicBoolean requested = new AtomicBoolean(false);
+                var requested = new AtomicBoolean(false);
 
-                    @Override
-                    public void request(long n) {
-                        if (requested.compareAndSet(false, true)) {
-                            subscriber.onNext(1);
-                            subscriber.onComplete();
+                var subber = new SubscriptionDelegate<Integer, AtomicBoolean>(subscriber, (sub, _, data) -> {
+                        if (data.compareAndSet(false, true)) {
+                            sub.onNext(1);
+                            sub.onComplete();
                         }
-                    }
+                    }, (_, _) -> { },
+                    requested
+                );
 
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
+                Subscription p = spy(subber);
                 producer.set(p);
                 subscriber.onSubscribe(p);
             }
-        }).scan(100, new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-
-        });
+        }).scan(100, (t1, t2) -> t1 + t2);
 
         f.subscribe(new TestSubscriber<Integer>(1L) {
 
@@ -371,19 +326,10 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(PublishProcessor.create().scan(new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        }));
+        TestHelper.checkDisposed(PublishProcessor.create().scan((a, _) -> a));
 
-        TestHelper.checkDisposed(PublishProcessor.<Integer>create().scan(0, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }));
+        TestHelper.checkDisposed(PublishProcessor.<Integer>create()
+                .scan(0, (a, b) -> a + b));
     }
 
     @Test
@@ -391,37 +337,18 @@ public class FlowableScanTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
             @Override
             public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.scan(new BiFunction<Object, Object, Object>() {
-                    @Override
-                    public Object apply(Object a, Object b) throws Exception {
-                        return a;
-                    }
-                });
+                return f.scan((a, _) -> a);
             }
         });
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.scan(0, new BiFunction<Object, Object, Object>() {
-                    @Override
-                    public Object apply(Object a, Object b) throws Exception {
-                        return a;
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f ->
+        f.scan(0, (a, _) -> a));
     }
 
     @Test
     public void error() {
         Flowable.error(new TestException())
-        .scan(new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        })
+        .scan((a, _) -> a)
         .test()
         .assertFailure(TestException.class);
     }
@@ -429,12 +356,7 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void neverSource() {
         Flowable.<Integer>never()
-        .scan(0, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        .scan(0, (a, b) -> a + b)
         .test()
         .assertValue(0)
         .assertNoErrors()
@@ -453,12 +375,7 @@ public class FlowableScanTest extends RxJavaTest {
             }
         })
         .take(10)
-        .blockingForEach(new Consumer<HashMap<String, String>>() {
-            @Override
-            public void accept(HashMap<String, String> v) {
-                System.out.println(v);
-            }
-        });
+        .blockingForEach(System.out::println);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeIsolatedTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.RxJavaTest;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.*;
 
@@ -35,30 +34,25 @@ public class ObservableWindowWithSizeIsolatedTest extends RxJavaTest {
 
         final AtomicInteger count = new AtomicInteger();
         Observable.merge(Observable.range(1, 100000)
-                        .doOnNext(new Consumer<Integer>() {
-
-                            @Override
-                            public void accept(Integer t1) {
-                                if (count.incrementAndGet() == 500000) {
-                                    // give it a small break halfway through
-                                    try {
-                                        Thread.sleep(50);
-                                    } catch (InterruptedException ex) {
-                                        // ignored
-                                    }
+                        .doOnNext(_ -> {
+                            if (count.incrementAndGet() == 50000) {
+                                // give it a small break halfway through
+                                try {
+                                    Thread.sleep(75);
+                                } catch (InterruptedException _) {
+                                    // ignored
                                 }
                             }
-
                         })
                         .observeOn(Schedulers.computation())
                         .window(5)
                         .take(2))
                 .subscribe(to);
 
-        to.awaitDone(500, TimeUnit.MILLISECONDS);
+        to.awaitDone(1000, TimeUnit.MILLISECONDS);
         to.assertTerminated();
         to.assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         // make sure we don't emit all values ... the unsubscribe should propagate
-        assertTrue(count.get() < 100000);
+        assertTrue(count.get() < 100000, "count: " + count.get());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -13,9 +13,11 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
@@ -39,6 +41,9 @@ public class StreamableTest {
             ts
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult();
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
         });
     }
 
@@ -56,32 +61,103 @@ public class StreamableTest {
             ts
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(1);
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
         });
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void fromFlowable() throws Throwable {
-        TestHelper.withVirtual(_ -> {
+        TestHelper.withVirtual(exec -> {
             Flowable.range(1, 10)
-            .toStreamable()
+            .toStreamable(exec)
+            .test(exec)
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            ;
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
+        });
+    }
+
+    @RepeatedTest(1000)
+    public void fromFlowableToStreamableToFlowable() throws Throwable {
+        TestHelper.withVirtual(exec -> {
+            Flowable.range(1, 10)
+            .toStreamable(exec)
+            .toFlowable(exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             ;
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
+        });
+    }
+
+    @RepeatedTest(1000)
+    public void createAndTransform() throws Throwable {
+        TestHelper.withVirtual(exec -> {
+            Streamable.<Integer>create(emitter -> {
+                for (int i = 1; i < 11; i++) {
+                    emitter.emit(i);
+                }
+            }, exec)
+            .transform((item, emitter) -> {
+                emitter.emit(-item - 1);
+            }, exec)
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
+        });
+    }
+
+    @RepeatedTest(1000)
+    public void flowableRangeAndTransform() throws Throwable {
+        TestHelper.withVirtual(exec -> {
+            Flowable.range(1, 10)
+            .toStreamable(exec)
+            .transform((item, emitter) -> {
+                emitter.emit(-item - 1);
+            }, exec)
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
         });
     }
 
     @Test
-    public void fromFlowableToStreamableToFlowable() throws Throwable {
-        TestHelper.withVirtual(_ -> {
+    public void flowableRangeAndTransform1() throws Throwable {
+        TestHelper.withVirtual(exec -> {
+            System.out.println(">> START");
             Flowable.range(1, 10)
-            .toStreamable()
-            .toFlowable()
+            .doOnSubscribe(s -> System.out.println("Flowable::doOnSubscribe"))
+            .doOnRequest(v -> System.out.println("Flowable::doOnRequest " + v))
+            .doOnCancel(() -> {
+                System.out.println("Flowable::doOnCancel");
+                new Exception().printStackTrace();
+            })
+            .doOnNext(v -> System.out.println("Flowable::doOnNext " + v))
+            .toStreamable(exec)
+            .transform((item, emitter) -> {
+                emitter.emit(-item - 1);
+            }, exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
-            .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-            ;
+            .assertResult(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
+            System.out.println(">> END");
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
         });
     }
-
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -14,10 +14,13 @@
 package io.reactivex.rxjava4.internal.operators.streamable;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
@@ -25,6 +28,7 @@ import io.reactivex.rxjava4.internal.subscriptions.EmptySubscription;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
+@Isolated
 public class StreamableTest {
 
     @Test
@@ -67,7 +71,7 @@ public class StreamableTest {
         });
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
     public void fromFlowable() throws Throwable {
         TestHelper.withVirtual(exec -> {
             Flowable.range(1, 10)
@@ -82,7 +86,7 @@ public class StreamableTest {
         });
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
     public void fromFlowableToStreamableToFlowable() throws Throwable {
         TestHelper.withVirtual(exec -> {
             Flowable.range(1, 10)
@@ -98,15 +102,15 @@ public class StreamableTest {
         });
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
     public void createAndTransform() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        TestHelper.onVirtual(exec -> {
             Streamable.<Integer>create(emitter -> {
                 for (int i = 1; i < 11; i++) {
                     emitter.emit(i);
                 }
             }, exec)
-            .transform((item, emitter) -> {
+            .transform((item, emitter, _) -> {
                 emitter.emit(-item - 1);
             }, exec)
             .test()
@@ -118,12 +122,12 @@ public class StreamableTest {
         });
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
     public void flowableRangeAndTransform() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        TestHelper.onVirtual(exec -> {
             Flowable.range(1, 10)
             .toStreamable(exec)
-            .transform((item, emitter) -> {
+            .transform((item, emitter, _) -> {
                 emitter.emit(-item - 1);
             }, exec)
             .test()
@@ -137,10 +141,10 @@ public class StreamableTest {
 
     @Test
     public void flowableRangeAndTransform1() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        TestHelper.onVirtual(exec -> {
             System.out.println(">> START");
             Flowable.range(1, 10)
-            .doOnSubscribe(s -> System.out.println("Flowable::doOnSubscribe"))
+            .doOnSubscribe(_ -> System.out.println("Flowable::doOnSubscribe"))
             .doOnRequest(v -> System.out.println("Flowable::doOnRequest " + v))
             .doOnCancel(() -> {
                 System.out.println("Flowable::doOnCancel");
@@ -148,7 +152,7 @@ public class StreamableTest {
             })
             .doOnNext(v -> System.out.println("Flowable::doOnNext " + v))
             .toStreamable(exec)
-            .transform((item, emitter) -> {
+            .transform((item, emitter, _) -> {
                 emitter.emit(-item - 1);
             }, exec)
             .test()
@@ -158,6 +162,101 @@ public class StreamableTest {
 
             assertFalse(exec.isShutdown(), "Exec::IsShutdown");
             assertFalse(exec.isTerminated(), "Exec::IsTerminated");
+        });
+    }
+
+    @Test
+    public void flowableRangeAndTransformFlowable1() throws Throwable {
+        TestHelper.onVirtual(exec -> {
+            System.out.println(">> START");
+            Flowable.range(1, 10)
+            .doOnSubscribe(_ -> System.out.println("Flowable::doOnSubscribe"))
+            .doOnRequest(v -> System.out.println("Flowable::doOnRequest " + v))
+            .doOnCancel(() -> {
+                System.out.println("Flowable::doOnCancel");
+                new Exception().printStackTrace();
+            })
+            .doOnNext(v -> System.out.println("Flowable::doOnNext " + v))
+            .toStreamable(exec)
+            .toFlowable()
+            .virtualTransform((item, emitter, _) -> {
+                System.out.println("Transform " + item);
+                emitter.emit(-item - 1);
+            }, exec)
+            .toStreamable()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
+            System.out.println(">> END");
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
+        });
+    }
+
+    @Test
+    public void flowableRangeAndTransform2() throws Throwable {
+        TestHelper.withCachedExecutor(exec -> {
+            System.out.println(">> START");
+            var ts = Flowable.range(1, 10)
+            .doOnSubscribe(_ -> System.out.println("Flowable::doOnSubscribe"))
+            .doOnRequest(v -> System.out.println("Flowable::doOnRequest " + v))
+            .doOnCancel(() -> {
+                System.out.println("Flowable::doOnCancel");
+                new Exception().printStackTrace();
+            })
+            .doOnNext(v -> System.out.println("Flowable::doOnNext " + v))
+            .toStreamable(exec)
+            .transform((item, emitter, _) -> {
+                System.out.println("Transform " + item);
+                emitter.emit(-item - 1);
+            }, exec)
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            ;
+            System.out.println(">> CHECK");
+            ts.assertResult(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
+            System.out.println(">> END");
+
+            assertFalse(exec.isShutdown(), "Exec::IsShutdown");
+            assertFalse(exec.isTerminated(), "Exec::IsTerminated");
+        });
+    }
+
+    @Test
+    public void rangeTransformFilter() throws Throwable {
+        TestHelper.withVirtual(exec -> {
+            Flowable.range(1, 10)
+            .toStreamable(exec)
+            .transform((item, emitter, _) -> {
+                if ((item & 1) == 0) {
+                    emitter.emit(item);
+                }
+            }, exec)
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(2, 4, 6, 8, 10);
+        });
+    }
+
+    @Test
+    public void rangeTransformTake() throws Throwable {
+        TestHelper.withVirtual(exec -> {
+            var cancelled = new AtomicInteger();
+            Flowable.range(1, 10)
+            .doOnCancel(() -> cancelled.incrementAndGet())
+            .toStreamable(exec)
+            .transform((item, emitter, stopper) -> {
+                if (item == 5) {
+                    stopper.dispose();
+                }
+                emitter.emit(item);
+            }, exec)
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3, 4, 5);
+
+            assertEquals(1, cancelled.get(), "Cancellation count ");
         });
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -17,9 +17,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.internal.subscriptions.*;
+import io.reactivex.rxjava4.internal.subscriptions.EmptySubscription;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -58,4 +58,30 @@ public class StreamableTest {
             .assertResult(1);
         });
     }
+
+    @Test
+    public void fromFlowable() throws Throwable {
+        TestHelper.withVirtual(_ -> {
+            Flowable.range(1, 10)
+            .toStreamable()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            ;
+        });
+    }
+
+    @Test
+    public void fromFlowableToStreamableToFlowable() throws Throwable {
+        TestHelper.withVirtual(_ -> {
+            Flowable.range(1, 10)
+            .toStreamable()
+            .toFlowable()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            ;
+        });
+    }
+
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformTest.java
@@ -33,7 +33,7 @@ public class VirtualTransformTest {
             var cancelled = new AtomicBoolean();
             Flowable.range(1, 5)
             .doOnCancel(() -> cancelled.set(true))
-            .virtualTransform((v, emitter) -> emitter.emit(v), scope)
+            .virtualTransform((v, emitter, _) -> emitter.emit(v), scope)
             .take(1)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -47,7 +47,7 @@ public class VirtualTransformTest {
     public void errorUpstream() throws Throwable {
         TestHelper.withVirtual(exec -> {
             Flowable.error(new IOException())
-            .virtualTransform((v, e) -> e.emit(v), exec)
+            .virtualTransform((v, e, _) -> e.emit(v), exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertError(IOException.class)
@@ -59,7 +59,7 @@ public class VirtualTransformTest {
     public void errorTransform() throws Throwable {
         TestHelper.withVirtual(exec -> {
             Flowable.range(1, 5)
-            .virtualTransform((_, _) -> { throw new IOException(); }, exec)
+            .virtualTransform((_, _, _) -> { throw new IOException(); }, exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertError(IOException.class)
@@ -71,7 +71,7 @@ public class VirtualTransformTest {
     public void take() throws Throwable {
         TestHelper.withVirtual(exec -> {
             Flowable.range(1, 5)
-            .virtualTransform((v, e) -> e.emit(v), exec)
+            .virtualTransform((v, e, _) -> e.emit(v), exec)
             .take(2)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -84,7 +84,7 @@ public class VirtualTransformTest {
     public void observeOn() throws Throwable {
         TestHelper.withVirtual(exec -> {
             Flowable.range(1, 10000)
-            .virtualTransform((v, e) -> e.emit(v), exec)
+            .virtualTransform((v, e, _) -> e.emit(v), exec)
             .observeOn(Schedulers.single(), false, 2)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -97,7 +97,7 @@ public class VirtualTransformTest {
     public void empty() throws Throwable {
         TestHelper.withVirtual(exec -> {
             Flowable.empty()
-            .virtualTransform((v, e) -> e.emit(v), exec)
+            .virtualTransform((v, e, _) -> e.emit(v), exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult()
@@ -109,7 +109,7 @@ public class VirtualTransformTest {
     public void emptyNever() throws Throwable {
         TestHelper.withVirtual(exec -> {
             Flowable.just(1).concatWith(Flowable.never())
-            .virtualTransform((v, e) -> e.emit(v), exec)
+            .virtualTransform((v, e, _) -> e.emit(v), exec)
             .test()
             .awaitDone(1, TimeUnit.SECONDS)
             .assertValues(1)

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformVirtualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformVirtualTest.java
@@ -31,7 +31,7 @@ public class VirtualTransformVirtualTest {
         var cancelled = new AtomicBoolean();
         Flowable.range(1, 5)
         .doOnCancel(() -> cancelled.set(true))
-        .virtualTransform((v, emitter) -> emitter.emit(v))
+        .virtualTransform((v, emitter, _) -> emitter.emit(v))
         .take(1)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -43,7 +43,7 @@ public class VirtualTransformVirtualTest {
     @Test
     public void errorUpstream() throws Throwable {
         Flowable.error(new IOException())
-        .virtualTransform((v, e) -> e.emit(v))
+        .virtualTransform((v, e, _) -> e.emit(v))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertError(IOException.class)
@@ -53,7 +53,7 @@ public class VirtualTransformVirtualTest {
     @Test
     public void errorTransform() throws Throwable {
         Flowable.range(1, 5)
-        .virtualTransform((_, _) -> { throw new IOException(); })
+        .virtualTransform((_, _, _) -> { throw new IOException(); })
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertError(IOException.class)
@@ -63,7 +63,7 @@ public class VirtualTransformVirtualTest {
     @Test
     public void take() throws Throwable {
         Flowable.range(1, 5)
-        .virtualTransform((v, e) -> e.emit(v))
+        .virtualTransform((v, e, _) -> e.emit(v))
         .take(2)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -74,7 +74,7 @@ public class VirtualTransformVirtualTest {
     @Test
     public void observeOn() throws Throwable {
         Flowable.range(1, 10000)
-        .virtualTransform((v, e) -> e.emit(v))
+        .virtualTransform((v, e, _) -> e.emit(v))
         .observeOn(Schedulers.single(), false, 2)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -85,7 +85,7 @@ public class VirtualTransformVirtualTest {
     @Test
     public void empty() throws Throwable {
         Flowable.empty()
-        .virtualTransform((v, e) -> e.emit(v))
+        .virtualTransform((v, e, _) -> e.emit(v))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult()
@@ -95,7 +95,7 @@ public class VirtualTransformVirtualTest {
     @Test
     public void emptyNever() throws Throwable {
         Flowable.just(1).concatWith(Flowable.never())
-        .virtualTransform((v, e) -> e.emit(v))
+        .virtualTransform((v, e, _) -> e.emit(v))
         .test()
         .awaitDone(1, TimeUnit.SECONDS)
         .assertValues(1)

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutor1TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutor1TckTest.java
@@ -29,7 +29,7 @@ public class FlowableVirtualTransformExecutor1TckTest extends BaseTck<Long> {
         var half = elements >> 1;
         var rest = elements - half;
         return Flowable.rangeLong(0, rest)
-                .virtualTransform((v, emitter) -> {
+                .virtualTransform((v, emitter, _) -> {
                     emitter.emit(v);
                     if (v < rest - 1 || half == rest) {
                         emitter.emit(v);
@@ -40,7 +40,7 @@ public class FlowableVirtualTransformExecutor1TckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return Flowable.just(1)
-                .virtualTransform((_, _) -> {
+                .virtualTransform((_, _, _) -> {
                     throw new IOException();
                 }, service, 1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutor2TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutor2TckTest.java
@@ -31,7 +31,7 @@ public class FlowableVirtualTransformExecutor2TckTest extends BaseTck<Long> {
         var half = elements >> 1;
         var rest = elements - half;
         return Flowable.rangeLong(0, rest)
-                .virtualTransform((v, emitter) -> {
+                .virtualTransform((v, emitter, _) -> {
                     emitter.emit(v);
                     if (v < rest - 1 || half == rest) {
                         emitter.emit(v);
@@ -42,7 +42,7 @@ public class FlowableVirtualTransformExecutor2TckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return Flowable.just(1)
-                .virtualTransform((_, _) -> {
+                .virtualTransform((_, _, _) -> {
                     throw new IOException();
                 }, service, 2);
     }
@@ -56,7 +56,7 @@ public class FlowableVirtualTransformExecutor2TckTest extends BaseTck<Long> {
             Thread.sleep(10);
             return v;
         })
-        .virtualTransform((v, emitter) -> {
+        .virtualTransform((v, emitter, _) -> {
             emitter.emit(v);
         }, service, 2)
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutor3TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutor3TckTest.java
@@ -29,7 +29,7 @@ public class FlowableVirtualTransformExecutor3TckTest extends BaseTck<Long> {
         var half = elements >> 1;
         var rest = elements - half;
         return Flowable.rangeLong(0, rest)
-                .virtualTransform((v, emitter) -> {
+                .virtualTransform((v, emitter, _) -> {
                     emitter.emit(v);
                     if (v < rest - 1 || half == rest) {
                         emitter.emit(v);
@@ -40,7 +40,7 @@ public class FlowableVirtualTransformExecutor3TckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return Flowable.error(new IOException())
-                .virtualTransform((_, _) -> {
+                .virtualTransform((_, _, _) -> {
                 }, service);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutorTckTest.java
@@ -32,7 +32,7 @@ public class FlowableVirtualTransformExecutorTckTest extends BaseTck<Long> {
         var half = elements >> 1;
         var rest = elements - half;
         return Flowable.rangeLong(0, rest)
-                .virtualTransform((v, emitter) -> {
+                .virtualTransform((v, emitter, _) -> {
                     emitter.emit(v);
                     if (v < rest - 1 || half == rest) {
                         emitter.emit(v);
@@ -43,7 +43,7 @@ public class FlowableVirtualTransformExecutorTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return Flowable.just(1)
-                .virtualTransform((_, _) -> {
+                .virtualTransform((_, _, _) -> {
                     throw new IOException();
                 }, service);
     }
@@ -70,7 +70,7 @@ public class FlowableVirtualTransformExecutorTckTest extends BaseTck<Long> {
             return v;
         })
         .doOnRequest(v -> log.offer("Transform requested: " + v))
-        .virtualTransform((v, emitter) -> {
+        .virtualTransform((v, emitter, _) -> {
             log.offer("Tansform before emit: " + v);
             emitter.emit(v);
             log.offer("Tansform after emit: " + v);
@@ -106,7 +106,7 @@ public class FlowableVirtualTransformExecutorTckTest extends BaseTck<Long> {
             }
             return v;
         })
-        .virtualTransform((v, emitter) -> {
+        .virtualTransform((v, emitter, _) -> {
             emitter.emit(v);
         }, service)
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual1TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual1TckTest.java
@@ -30,7 +30,7 @@ public class FlowableVirtualTransformVirtual1TckTest extends BaseTck<Long> {
         var half = elements >> 1;
         var rest = elements - half;
         return Flowable.rangeLong(0, rest)
-                .virtualTransform((v, emitter) -> {
+                .virtualTransform((v, emitter, _) -> {
                     emitter.emit(v);
                     if (v < rest - 1 || half == rest) {
                         emitter.emit(v);
@@ -41,7 +41,7 @@ public class FlowableVirtualTransformVirtual1TckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return Flowable.just(1)
-                .virtualTransform((_, _) -> {
+                .virtualTransform((_, _, _) -> {
                     throw new IOException();
                 }, Schedulers.virtual(), 1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual2TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual2TckTest.java
@@ -31,7 +31,7 @@ public class FlowableVirtualTransformVirtual2TckTest extends BaseTck<Long> {
         var half = elements >> 1;
         var rest = elements - half;
         return Flowable.rangeLong(0, rest)
-                .virtualTransform((v, emitter) -> {
+                .virtualTransform((v, emitter, _) -> {
                     emitter.emit(v);
                     if (v < rest - 1 || half == rest) {
                         emitter.emit(v);
@@ -42,7 +42,7 @@ public class FlowableVirtualTransformVirtual2TckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return Flowable.just(1)
-                .virtualTransform((_, _) -> {
+                .virtualTransform((_, _, _) -> {
                     throw new IOException();
                 }, Schedulers.virtual(), 2);
     }
@@ -56,7 +56,7 @@ public class FlowableVirtualTransformVirtual2TckTest extends BaseTck<Long> {
             Thread.sleep(10);
             return v;
         })
-        .virtualTransform((v, emitter) -> {
+        .virtualTransform((v, emitter, _) -> {
             emitter.emit(v);
         }, Schedulers.virtual(), 2)
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual3TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual3TckTest.java
@@ -30,7 +30,7 @@ public class FlowableVirtualTransformVirtual3TckTest extends BaseTck<Long> {
         var half = elements >> 1;
         var rest = elements - half;
         return Flowable.rangeLong(0, rest)
-                .virtualTransform((v, emitter) -> {
+                .virtualTransform((v, emitter, _) -> {
                     emitter.emit(v);
                     if (v < rest - 1 || half == rest) {
                         emitter.emit(v);
@@ -41,7 +41,7 @@ public class FlowableVirtualTransformVirtual3TckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return Flowable.error(new IOException())
-                .virtualTransform((_, _) -> {
+                .virtualTransform((_, _, _) -> {
                 }, Schedulers.virtual(), Flowable.bufferSize());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtualTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtualTckTest.java
@@ -32,7 +32,7 @@ public class FlowableVirtualTransformVirtualTckTest extends BaseTck<Long> {
         var half = elements >> 1;
         var rest = elements - half;
         return Flowable.rangeLong(0, rest)
-                .virtualTransform((v, emitter) -> {
+                .virtualTransform((v, emitter, _) -> {
                     emitter.emit(v);
                     if (v < rest - 1 || half == rest) {
                         emitter.emit(v);
@@ -43,7 +43,7 @@ public class FlowableVirtualTransformVirtualTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return Flowable.just(1)
-                .virtualTransform((_, _) -> {
+                .virtualTransform((_, _, _) -> {
                     throw new IOException();
                 }, Schedulers.virtual(), Flowable.bufferSize());
     }
@@ -70,7 +70,7 @@ public class FlowableVirtualTransformVirtualTckTest extends BaseTck<Long> {
             return v;
         })
         .doOnRequest(v -> log.offer("Transform requested: " + v))
-        .virtualTransform((v, emitter) -> {
+        .virtualTransform((v, emitter, _) -> {
             log.offer("Tansform before emit: " + v);
             emitter.emit(v);
             log.offer("Tansform after emit: " + v);
@@ -106,7 +106,7 @@ public class FlowableVirtualTransformVirtualTckTest extends BaseTck<Long> {
             }
             return v;
         })
-        .virtualTransform((v, emitter) -> {
+        .virtualTransform((v, emitter, _) -> {
             emitter.emit(v);
         }, Schedulers.virtual(), Flowable.bufferSize())
         .test()

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -3930,7 +3930,127 @@ public enum TestHelper {
      * @throws Throwable propagate exceptions
      */
     public static void withVirtual(Consumer<ExecutorService> call) throws Throwable {
-        try (var exec = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory())) {
+        try (var exec = new ExecutorIntercept(Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory()), false)) {
+            call.accept(exec);
+        }
+    }
+
+    /**
+     * Execute a call within a virtual thread of the standard virtual thread executor.
+     * @param call the call to invoke
+     * @throws Throwable the exception propagated out
+     */
+    public static void onVirtual(Consumer<ExecutorService> call) throws Throwable {
+        withVirtual(exec -> {
+            exec.submit(() -> {
+                try {
+                    call.accept(exec);
+                } catch (Throwable ex) {
+                    throw Exceptions.propagate(ex);
+                }
+            }).get();
+        });
+    }
+
+    record ExecutorIntercept(ExecutorService service, boolean printStackTrace) implements ExecutorService {
+
+        @Override
+        public void execute(Runnable command) {
+            service.execute(command);
+        }
+
+        @Override
+        public void shutdown() {
+            if (printStackTrace) {
+                new CancellationException("ExecutorIntercept::shutdown").printStackTrace();
+            }
+            service.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            if (printStackTrace) {
+                new CancellationException("ExecutorIntercept::shutdownNow").printStackTrace();
+            }
+            return service.shutdownNow();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return service.isShutdown();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return service.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return service.awaitTermination(timeout, unit);
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            return service.submit(task);
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            return service.submit(task, result);
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            return service.submit(task);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+            return service.invokeAll(tasks);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException {
+            return service.invokeAll(tasks, timeout, unit);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+                throws InterruptedException, ExecutionException {
+            return service.invokeAny(tasks);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            return service.invokeAny(tasks, timeout, unit);
+        }
+    }
+
+    /**
+     * Execute a test body with the help of a single thread executor service.
+     * <p>
+     * Don't forget to {@link ExecutorService#submit(Callable)} your work!
+     * @param call the callback to give the VTE.
+     * @throws Throwable propagate exceptions
+     */
+    public static void withSingleExecutor(Consumer<ScheduledExecutorService> call) throws Throwable {
+        try (var exec = Executors.newSingleThreadScheduledExecutor()) {
+            call.accept(exec);
+        }
+    }
+
+    /**
+     * Execute a test body with the help of a cached executor service.
+     * <p>
+     * Don't forget to {@link ExecutorService#submit(Callable)} your work!
+     * @param call the callback to give the VTE.
+     * @throws Throwable propagate exceptions
+     */
+    public static void withCachedExecutor(Consumer<ExecutorService> call) throws Throwable {
+        try (var exec = new ExecutorIntercept(Executors.newCachedThreadPool(), false)) {
             call.accept(exec);
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/validators/JavadocWording.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/JavadocWording.java
@@ -313,7 +313,8 @@ public class JavadocWording {
                                 && !m.signature.contains("void subscribe")
                         ) {
                             CharSequence subSequence = m.javadoc.subSequence(idx - 6, idx + 11);
-                            if (idx < 6 || !subSequence.equals("{@link Disposable")) {
+                            if ((idx < 6 || !subSequence.equals("{@link Disposable"))
+                                    && !subSequence.toString().contains(", Disposable")) {
                                 e.append("java.lang.RuntimeException: Flowable doc mentions Disposable but not using Flowable\r\n at io.reactivex.rxjava4.core.")
                                 .append("Flowable.method(Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }
@@ -456,7 +457,8 @@ public class JavadocWording {
                                 && !m.signature.contains("Disposable")
                         ) {
                             CharSequence subSequence = m.javadoc.subSequence(idx - 6, idx + 11);
-                            if (idx < 6 || !subSequence.equals("{@link Disposable")) {
+                            if ((idx < 6 || !subSequence.equals("{@link Disposable"))
+                                    && !subSequence.toString().contains(", Disposable")) {
                                 e.append("java.lang.RuntimeException: Flowable doc mentions Disposable but not using Flowable\r\n at io.reactivex.rxjava4.core.")
                                 .append("Flowable.method(Flowable.java:").append(m.javadocLine + lineNumber(m.javadoc, idx) - 1).append(")\r\n\r\n");
                             }

--- a/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
@@ -609,7 +609,7 @@ public class ParamValidationCheckerTest {
 
         defaultValues.put(ExecutorService.class, Executors.newVirtualThreadPerTaskExecutor());
 
-        VirtualTransformer<Object, Object> trs = (_, _) -> { };
+        VirtualTransformer<Object, Object> trs = (_, _, _) -> { };
         defaultValues.put(VirtualTransformer.class, trs);
 
         VirtualGenerator<Object> vg = _ -> { };


### PR DESCRIPTION
- Establish an optional channel for per `next()` efficient cancellation for `Streamable`.
- Enhance `DisposableContainer` for supporting better lifecycle management, recursively.
- Enhance various types.
- Add `test()` operator
- Add `create`
- Add `transform`
- Add `toFlowable` & `toStreamable`
- Fix many flaky tests

#hms