### PR TITLE
test: simplify SingleRetryTest callables

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/single/SingleRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleRetryTest.java
@@ -15,14 +15,12 @@ package io.reactivex.rxjava4.single;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Predicate;
 import io.reactivex.rxjava4.internal.functions.Functions;
 
 public class SingleRetryTest extends RxJavaTest {
@@ -31,22 +29,16 @@ public class SingleRetryTest extends RxJavaTest {
         final AtomicInteger atomicInteger = new AtomicInteger(3);
         final AtomicInteger numberOfSubscribeCalls = new AtomicInteger(0);
 
-        Single.fromCallable(new Callable<Boolean>() {
-            @Override public Boolean call() throws Exception {
-                numberOfSubscribeCalls.incrementAndGet();
+        Single.fromCallable(() -> {
+            numberOfSubscribeCalls.incrementAndGet();
 
-                if (atomicInteger.decrementAndGet() != 0) {
-                    throw new RuntimeException();
-                }
-
-                throw new IllegalArgumentException();
+            if (atomicInteger.decrementAndGet() != 0) {
+                throw new RuntimeException();
             }
+
+            throw new IllegalArgumentException();
         })
-            .retry(Integer.MAX_VALUE, new Predicate<Throwable>() {
-                @Override public boolean test(final Throwable throwable) throws Exception {
-                    return !(throwable instanceof IllegalArgumentException);
-                }
-            })
+            .retry(Integer.MAX_VALUE, throwable -> !(throwable instanceof IllegalArgumentException))
             .test()
             .assertFailure(IllegalArgumentException.class);
 
@@ -58,16 +50,14 @@ public class SingleRetryTest extends RxJavaTest {
         final AtomicInteger atomicInteger = new AtomicInteger(3);
         final AtomicInteger numberOfSubscribeCalls = new AtomicInteger(0);
 
-        Single.fromCallable(new Callable<Boolean>() {
-            @Override public Boolean call() throws Exception {
-                numberOfSubscribeCalls.incrementAndGet();
+        Single.fromCallable(() -> {
+            numberOfSubscribeCalls.incrementAndGet();
 
-                if (atomicInteger.decrementAndGet() != 0) {
-                    throw new RuntimeException();
-                }
-
-                return true;
+            if (atomicInteger.decrementAndGet() != 0) {
+                throw new RuntimeException();
             }
+
+            return true;
         })
             .retry(2, Functions.alwaysTrue())
             .test()
@@ -81,16 +71,14 @@ public class SingleRetryTest extends RxJavaTest {
         final AtomicInteger atomicInteger = new AtomicInteger(3);
         final AtomicInteger numberOfSubscribeCalls = new AtomicInteger(0);
 
-        Single.fromCallable(new Callable<Boolean>() {
-            @Override public Boolean call() throws Exception {
-                numberOfSubscribeCalls.incrementAndGet();
+        Single.fromCallable(() -> {
+            numberOfSubscribeCalls.incrementAndGet();
 
-                if (atomicInteger.decrementAndGet() != 0) {
-                    throw new RuntimeException();
-                }
-
-                return true;
+            if (atomicInteger.decrementAndGet() != 0) {
+                throw new RuntimeException();
             }
+
+            return true;
         })
             .retry(1, Functions.alwaysTrue())
             .test()
@@ -104,16 +92,14 @@ public class SingleRetryTest extends RxJavaTest {
         final AtomicInteger atomicInteger = new AtomicInteger(2);
         final AtomicInteger numberOfSubscribeCalls = new AtomicInteger(0);
 
-        Single.fromCallable(new Callable<Boolean>() {
-            @Override public Boolean call() throws Exception {
-                numberOfSubscribeCalls.incrementAndGet();
+        Single.fromCallable(() -> {
+            numberOfSubscribeCalls.incrementAndGet();
 
-                if (atomicInteger.decrementAndGet() != 0) {
-                    throw new RuntimeException();
-                }
-
-                return true;
+            if (atomicInteger.decrementAndGet() != 0) {
+                throw new RuntimeException();
             }
+
+            return true;
         })
             .retry(0, Functions.alwaysTrue())
             .test()


### PR DESCRIPTION
Part of #8080.

This updates `SingleRetryTest` as one small cleanup chunk by replacing old anonymous `Callable` and `Predicate` implementations with lambdas. The test behavior is unchanged, and the now-unused imports are removed.

Tests run:
- `JAVA_HOME=/tmp/rxjava-jdk26/Contents/Home ./gradlew --no-daemon test --tests io.reactivex.rxjava4.single.SingleRetryTest`
- `JAVA_HOME=/tmp/rxjava-jdk26/Contents/Home ./gradlew --no-daemon checkstyleTest`
- `git diff --check`