### PR TITLE
4.x: Unit test lambdaification 2 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableRetryTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 
 public class CompletableRetryTest extends RxJavaTest {
@@ -39,11 +38,7 @@ public class CompletableRetryTest extends RxJavaTest {
 
             throw new IllegalArgumentException();
         })
-        .retry(Integer.MAX_VALUE, new Predicate<Throwable>() {
-            @Override public boolean test(final Throwable throwable) throws Exception {
-                return !(throwable instanceof IllegalArgumentException);
-            }
-        })
+        .retry(Integer.MAX_VALUE, throwable -> !(throwable instanceof IllegalArgumentException))
         .test()
         .assertFailure(IllegalArgumentException.class);
 

--- a/src/test/java/io/reactivex/rxjava4/core/ConverterTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/ConverterTest.java
@@ -25,11 +25,8 @@ public final class ConverterTest extends RxJavaTest {
     @Test
     public void flowableConverterThrows() {
         try {
-            Flowable.just(1).to(new FlowableConverter<Integer, Integer>() {
-                @Override
-                public Integer apply(Flowable<Integer> v) {
-                    throw new TestException("Forced failure");
-                }
+            Flowable.just(1).to(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -40,11 +37,8 @@ public final class ConverterTest extends RxJavaTest {
     @Test
     public void observableConverterThrows() {
         try {
-            Observable.just(1).to(new ObservableConverter<Integer, Integer>() {
-                @Override
-                public Integer apply(Observable<Integer> v) {
-                    throw new TestException("Forced failure");
-                }
+            Observable.just(1).to(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -55,11 +49,8 @@ public final class ConverterTest extends RxJavaTest {
     @Test
     public void singleConverterThrows() {
         try {
-            Single.just(1).to(new SingleConverter<Integer, Integer>() {
-                @Override
-                public Integer apply(Single<Integer> v) {
-                    throw new TestException("Forced failure");
-                }
+            Single.just(1).to(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -70,11 +61,8 @@ public final class ConverterTest extends RxJavaTest {
     @Test
     public void maybeConverterThrows() {
         try {
-            Maybe.just(1).to(new MaybeConverter<Integer, Integer>() {
-                @Override
-                public Integer apply(Maybe<Integer> v) {
-                    throw new TestException("Forced failure");
-                }
+            Maybe.just(1).to(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -85,11 +73,8 @@ public final class ConverterTest extends RxJavaTest {
     @Test
     public void completableConverterThrows() {
         try {
-            Completable.complete().to(new CompletableConverter<Completable>() {
-                @Override
-                public Completable apply(Completable v) {
-                    throw new TestException("Forced failure");
-                }
+            Completable.complete().to(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -102,7 +87,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void observableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Observable.just(a).to((ObservableConverter)ConverterTest.testObservableConverterCreator());
     }
@@ -110,7 +95,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void singleGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Single.just(a).to((SingleConverter)ConverterTest.<String>testSingleConverterCreator());
     }
@@ -118,7 +103,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void maybeGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Maybe.just(a).to((MaybeConverter)ConverterTest.<String>testMaybeConverterCreator());
     }
@@ -126,7 +111,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void flowableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Flowable.just(a).to((FlowableConverter)ConverterTest.<String>testFlowableConverterCreator());
     }
@@ -134,7 +119,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void parallelFlowableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Flowable.just(a).parallel().to((ParallelFlowableConverter)ConverterTest.<String>testParallelFlowableConverterCreator());
     }
@@ -192,7 +177,7 @@ public final class ConverterTest extends RxJavaTest {
         return new ObservableConverter<A<T, ?>, B<T>>() {
             @Override
             public B<T> apply(Observable<A<T, ?>> a) {
-                return new B<T>() {
+                return new B<T>() /* NFI */ {
                 };
             }
         };
@@ -202,7 +187,7 @@ public final class ConverterTest extends RxJavaTest {
         return new SingleConverter<A<T, ?>, B<T>>() {
             @Override
             public B<T> apply(Single<A<T, ?>> a) {
-                return new B<T>() {
+                return new B<T>() /* NFI */ {
                 };
             }
         };
@@ -212,7 +197,7 @@ public final class ConverterTest extends RxJavaTest {
         return new MaybeConverter<A<T, ?>, B<T>>() {
             @Override
             public B<T> apply(Maybe<A<T, ?>> a) {
-                return new B<T>() {
+                return new B<T>() /* NFI */ {
                 };
             }
         };
@@ -222,7 +207,7 @@ public final class ConverterTest extends RxJavaTest {
         return new FlowableConverter<A<T, ?>, B<T>>() {
             @Override
             public B<T> apply(Flowable<A<T, ?>> a) {
-                return new B<T>() {
+                return new B<T>() /* NFI */ {
                 };
             }
         };
@@ -232,7 +217,7 @@ public final class ConverterTest extends RxJavaTest {
         return new ParallelFlowableConverter<A<T, ?>, B<T>>() {
             @Override
             public B<T> apply(ParallelFlowable<A<T, ?>> a) {
-                return new B<T>() {
+                return new B<T>() /* NFI */ {
                 };
             }
         };

--- a/src/test/java/io/reactivex/rxjava4/disposables/CompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/CompositeDisposableTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.exceptions.CompositeException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class CompositeDisposableTest extends RxJavaTest {
@@ -34,22 +33,9 @@ public class CompositeDisposableTest extends RxJavaTest {
     public void success() {
         final AtomicInteger counter = new AtomicInteger();
         CompositeDisposable cd = new CompositeDisposable();
-        cd.add(Disposable.fromRunnable(new Runnable() {
+        cd.add(Disposable.fromRunnable(() -> counter.incrementAndGet()));
 
-            @Override
-            public void run() {
-                counter.incrementAndGet();
-            }
-
-        }));
-
-        cd.add(Disposable.fromRunnable(new Runnable() {
-
-            @Override
-            public void run() {
-                counter.incrementAndGet();
-            }
-        }));
+        cd.add(Disposable.fromRunnable(() -> counter.incrementAndGet()));
 
         cd.dispose();
 
@@ -65,18 +51,12 @@ public class CompositeDisposableTest extends RxJavaTest {
         final int count = 10;
         final CountDownLatch start = new CountDownLatch(1);
         for (int i = 0; i < count; i++) {
-            cd.add(Disposable.fromRunnable(new Runnable() {
-
-                @Override
-                public void run() {
-                    counter.incrementAndGet();
-                }
-            }));
+            cd.add(Disposable.fromRunnable(() -> counter.incrementAndGet()));
         }
 
         final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            final Thread t = new Thread() {
+            final Thread t = new Thread() /* NFI */ {
                 @Override
                 public void run() {
                     try {
@@ -104,23 +84,11 @@ public class CompositeDisposableTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
         @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
-        cd.add(Disposable.fromRunnable(new Runnable() {
-
-            @Override
-            public void run() {
-                throw new RuntimeException("failed on first one");
-            }
-
+        cd.add(Disposable.fromRunnable(() -> {
+            throw new RuntimeException("failed on first one");
         }));
 
-        cd.add(Disposable.fromRunnable(new Runnable() {
-
-            @Override
-            public void run() {
-                counter.incrementAndGet();
-            }
-
-        }));
+        cd.add(Disposable.fromRunnable(() -> counter.incrementAndGet()));
 
         try {
             cd.dispose();
@@ -139,31 +107,15 @@ public class CompositeDisposableTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
         @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
-        cd.add(Disposable.fromRunnable(new Runnable() {
-
-            @Override
-            public void run() {
-                throw new RuntimeException("failed on first one");
-            }
-
+        cd.add(Disposable.fromRunnable(() -> {
+            throw new RuntimeException("failed on first one");
         }));
 
-        cd.add(Disposable.fromRunnable(new Runnable() {
-
-            @Override
-            public void run() {
-                throw new RuntimeException("failed on second one too");
-            }
+        cd.add(Disposable.fromRunnable(() -> {
+            throw new RuntimeException("failed on second one too");
         }));
 
-        cd.add(Disposable.fromRunnable(new Runnable() {
-
-            @Override
-            public void run() {
-                counter.incrementAndGet();
-            }
-
-        }));
+        cd.add(Disposable.fromRunnable(() -> counter.incrementAndGet()));
 
         try {
             cd.dispose();
@@ -226,14 +178,7 @@ public class CompositeDisposableTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
         @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
-        cd.add(Disposable.fromRunnable(new Runnable() {
-
-            @Override
-            public void run() {
-                counter.incrementAndGet();
-            }
-
-        }));
+        cd.add(Disposable.fromRunnable(() -> counter.incrementAndGet()));
 
         cd.dispose();
         cd.dispose();
@@ -252,18 +197,11 @@ public class CompositeDisposableTest extends RxJavaTest {
 
         final int count = 10;
         final CountDownLatch start = new CountDownLatch(1);
-        cd.add(Disposable.fromRunnable(new Runnable() {
-
-            @Override
-            public void run() {
-                counter.incrementAndGet();
-            }
-
-        }));
+        cd.add(Disposable.fromRunnable(() -> counter.incrementAndGet()));
 
         final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            final Thread t = new Thread() {
+            final Thread t = new Thread() /* NFI */ {
                 @Override
                 public void run() {
                     try {
@@ -463,12 +401,7 @@ public class CompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
             TestHelper.race(run, run);
         }
@@ -480,12 +413,7 @@ public class CompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.add(Disposable.empty());
-                }
-            };
+            Runnable run = () -> cd.add(Disposable.empty());
 
             TestHelper.race(run, run);
         }
@@ -497,12 +425,7 @@ public class CompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.addAll(Disposable.empty());
-                }
-            };
+            Runnable run = () -> cd.addAll(Disposable.empty());
 
             TestHelper.race(run, run);
         }
@@ -518,12 +441,7 @@ public class CompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.remove(d1);
-                }
-            };
+            Runnable run = () -> cd.remove(d1);
 
             TestHelper.race(run, run);
         }
@@ -539,12 +457,7 @@ public class CompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.delete(d1);
-                }
-            };
+            Runnable run = () -> cd.delete(d1);
 
             TestHelper.race(run, run);
         }
@@ -560,12 +473,7 @@ public class CompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.clear();
-                }
-            };
+            Runnable run = () -> cd.clear();
 
             TestHelper.race(run, run);
         }
@@ -577,19 +485,9 @@ public class CompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.add(Disposable.empty());
-                }
-            };
+            Runnable run2 = () -> cd.add(Disposable.empty());
 
             TestHelper.race(run, run2);
         }
@@ -601,19 +499,9 @@ public class CompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.addAll(Disposable.empty());
-                }
-            };
+            Runnable run2 = () -> cd.addAll(Disposable.empty());
 
             TestHelper.race(run, run2);
         }
@@ -629,19 +517,9 @@ public class CompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.remove(d1);
-                }
-            };
+            Runnable run2 = () -> cd.remove(d1);
 
             TestHelper.race(run, run2);
         }
@@ -657,19 +535,9 @@ public class CompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.delete(d1);
-                }
-            };
+            Runnable run2 = () -> cd.delete(d1);
 
             TestHelper.race(run, run2);
         }
@@ -685,19 +553,9 @@ public class CompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.clear();
-                }
-            };
+            Runnable run2 = () -> cd.clear();
 
             TestHelper.race(run, run2);
         }
@@ -713,19 +571,9 @@ public class CompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.size();
-                }
-            };
+            Runnable run2 = () -> cd.size();
 
             TestHelper.race(run, run2);
         }
@@ -736,11 +584,8 @@ public class CompositeDisposableTest extends RxJavaTest {
         @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
-        cd.add(Disposable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new IllegalArgumentException();
-            }
+        cd.add(Disposable.fromAction(() -> {
+            throw new IllegalArgumentException();
         }));
 
         Disposable d1 = Disposable.empty();
@@ -762,11 +607,8 @@ public class CompositeDisposableTest extends RxJavaTest {
         @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
-        cd.add(Disposable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new AssertionError();
-            }
+        cd.add(Disposable.fromAction(() -> {
+            throw new AssertionError();
         }));
 
         Disposable d1 = Disposable.empty();
@@ -788,11 +630,8 @@ public class CompositeDisposableTest extends RxJavaTest {
         @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
-        cd.add(Disposable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new IOException();
-            }
+        cd.add(Disposable.fromAction(() -> {
+            throw new IOException();
         }));
 
         Disposable d1 = Disposable.empty();
@@ -822,7 +661,7 @@ public class CompositeDisposableTest extends RxJavaTest {
         @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
-        cd.add(new Disposable() {
+        cd.add(new Disposable() /* NFI */ {
             @Override
             public void dispose() {
                 CompositeDisposableTest.<RuntimeException>throwSneaky();

--- a/src/test/java/io/reactivex/rxjava4/disposables/DisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/DisposableTest.java
@@ -84,11 +84,8 @@ public class DisposableTest extends RxJavaTest {
     @Test
     public void fromActionThrows() {
         try {
-            Disposable.fromAction(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IllegalArgumentException();
-                }
+            Disposable.fromAction(() -> {
+                throw new IllegalArgumentException();
             }).dispose();
             fail("Should have thrown!");
         } catch (IllegalArgumentException ex) {
@@ -96,11 +93,8 @@ public class DisposableTest extends RxJavaTest {
         }
 
         try {
-            Disposable.fromAction(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new InternalError();
-                }
+            Disposable.fromAction(() -> {
+                throw new InternalError();
             }).dispose();
             fail("Should have thrown!");
         } catch (InternalError ex) {
@@ -108,11 +102,8 @@ public class DisposableTest extends RxJavaTest {
         }
 
         try {
-            Disposable.fromAction(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            Disposable.fromAction(() -> {
+                throw new IOException();
             }).dispose();
             fail("Should have thrown!");
         } catch (RuntimeException ex) {
@@ -129,12 +120,7 @@ public class DisposableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Disposable d = Disposable.empty();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    d.dispose();
-                }
-            };
+            Runnable r = () -> d.dispose();
 
             TestHelper.race(r, r);
         }

--- a/src/test/java/io/reactivex/rxjava4/disposables/SequentialDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/SequentialDisposableTest.java
@@ -131,7 +131,7 @@ public class SequentialDisposableTest extends RxJavaTest {
 
         final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            final Thread t = new Thread() {
+            final Thread t = new Thread() /* NFI */ {
                 @Override
                 public void run() {
                     try {
@@ -174,7 +174,7 @@ public class SequentialDisposableTest extends RxJavaTest {
             final Disposable subscription = mock(Disposable.class);
             subscriptions.add(subscription);
 
-            final Thread t = new Thread() {
+            final Thread t = new Thread() /* NFI */ {
                 @Override
                 public void run() {
                     try {

--- a/src/test/java/io/reactivex/rxjava4/disposables/SerialDisposableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/SerialDisposableTests.java
@@ -131,7 +131,7 @@ public class SerialDisposableTests extends RxJavaTest {
 
         final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            final Thread t = new Thread() {
+            final Thread t = new Thread() /* NFI */ {
                 @Override
                 public void run() {
                     try {
@@ -174,7 +174,7 @@ public class SerialDisposableTests extends RxJavaTest {
             final Disposable subscription = mock(Disposable.class);
             subscriptions.add(subscription);
 
-            final Thread t = new Thread() {
+            final Thread t = new Thread() /* NFI */ {
                 @Override
                 public void run() {
                     try {

--- a/src/test/java/io/reactivex/rxjava4/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/CompositeExceptionTest.java
@@ -190,7 +190,7 @@ public class CompositeExceptionTest extends RxJavaTest {
 
     @Test
     public void compositeExceptionWithUnsupportedInitCause() {
-        Throwable t = new Throwable() {
+        Throwable t = new Throwable() /* NFI */ {
 
             private static final long serialVersionUID = -3282577447436848385L;
 
@@ -214,7 +214,7 @@ public class CompositeExceptionTest extends RxJavaTest {
 
     @Test
     public void compositeExceptionWithNullInitCause() {
-        Throwable t = new Throwable("ThrowableWithNullInitCause") {
+        Throwable t = new Throwable("ThrowableWithNullInitCause") /* NFI */ {
 
             private static final long serialVersionUID = -7984762607894527888L;
 

--- a/src/test/java/io/reactivex/rxjava4/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/ExceptionsTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.internal.util.ExceptionHelper;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.subjects.PublishSubject;
@@ -40,13 +39,8 @@ public class ExceptionsTest extends RxJavaTest {
     public void onErrorNotImplementedIsThrown() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
-        Observable.just(1, 2, 3).subscribe(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t1) {
-                throw new RuntimeException("hello");
-            }
-
+        Observable.just(1, 2, 3).subscribe(_ -> {
+            throw new RuntimeException("hello");
         });
 
         TestHelper.assertError(errors, 0, RuntimeException.class);
@@ -61,7 +55,7 @@ public class ExceptionsTest extends RxJavaTest {
         final int MAX_STACK_DEPTH = 800;
         final AtomicInteger depth = new AtomicInteger();
 
-        a.subscribe(new Observer<Integer>() {
+        a.subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -83,7 +77,7 @@ public class ExceptionsTest extends RxJavaTest {
                 b.onNext(n + 1);
             }
         });
-        b.subscribe(new Observer<Integer>() {
+        b.subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -115,7 +109,7 @@ public class ExceptionsTest extends RxJavaTest {
 
     @Test(expected = StackOverflowError.class)
     public void stackOverflowErrorIsThrown() {
-        Observable.just(1).subscribe(new Observer<Integer>() {
+        Observable.just(1).subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
@@ -651,7 +651,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
 
             @Override
             public void subscribe(final Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
+                s.onSubscribe(new Subscription() /* NFI */ {
                     int i;
 
                     volatile boolean cancelled;

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableConversionTest.java
@@ -113,21 +113,19 @@ public class FlowableConversionTest extends RxJavaTest {
 
         @Override
         public CylonDetectorObservable<R> apply(final Publisher<T> onSubscribe) {
-            return CylonDetectorObservable.create(new Publisher<R>() {
-                @Override
-                public void subscribe(Subscriber<? super R> subscriber) {
+            return CylonDetectorObservable.create(subscriber -> {
+                try {
+                    Subscriber<? super T> st = operator.apply(subscriber);
                     try {
-                        Subscriber<? super T> st = operator.apply(subscriber);
-                        try {
-                            onSubscribe.subscribe(st);
-                        } catch (Throwable e) {
-                            st.onError(e);
-                        }
+                        onSubscribe.subscribe(st);
                     } catch (Throwable e) {
-                        subscriber.onError(e);
+                        st.onError(e);
                     }
+                } catch (Throwable e) {
+                    subscriber.onError(e);
+                }
 
-                }});
+            });
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableDoOnTest.java
@@ -63,12 +63,9 @@ public class FlowableDoOnTest extends RxJavaTest {
     @Test
     public void doOnCompleted() {
         final AtomicBoolean r = new AtomicBoolean();
-        String output = Flowable.just("one").doOnComplete(new Action() {
-            @Override
-            public void run() {
-                r.set(true);
-            }
-        }).blockingSingle();
+        String output = Flowable.just("one")
+                .doOnComplete(() -> r.set(true))
+                .blockingSingle();
 
         assertEquals("one", output);
         assertTrue(r.get());
@@ -77,12 +74,7 @@ public class FlowableDoOnTest extends RxJavaTest {
     @Test
     public void doOnTerminateError() {
         final AtomicBoolean r = new AtomicBoolean();
-        Flowable.<String>error(new TestException()).doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                r.set(true);
-            }
-        })
+        Flowable.<String>error(new TestException()).doOnTerminate(() -> r.set(true))
         .test()
         .assertFailure(TestException.class);
         assertTrue(r.get());
@@ -91,12 +83,7 @@ public class FlowableDoOnTest extends RxJavaTest {
     @Test
     public void doOnTerminateComplete() {
         final AtomicBoolean r = new AtomicBoolean();
-        String output = Flowable.just("one").doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                r.set(true);
-            }
-        }).blockingSingle();
+        String output = Flowable.just("one").doOnTerminate(() -> r.set(true)).blockingSingle();
 
         assertEquals("one", output);
         assertTrue(r.get());

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
@@ -43,7 +43,7 @@ public class FlowableSubscriberTest {
         TestSubscriber<String> s = new TestSubscriber<>(0L);
         s.request(10);
         final AtomicLong r = new AtomicLong();
-        s.onSubscribe(new Subscription() {
+        s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
             public void request(long n) {
@@ -66,7 +66,7 @@ public class FlowableSubscriberTest {
     public void requestFromFinalSubscribeWithoutRequestValue() {
         TestSubscriber<String> s = new TestSubscriber<>();
         final AtomicLong r = new AtomicLong();
-        s.onSubscribe(new Subscription() {
+        s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
             public void request(long n) {
@@ -88,7 +88,7 @@ public class FlowableSubscriberTest {
         FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
             @Override
             public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
-                return new FlowableSubscriber<String>() {
+                return new FlowableSubscriber<String>() /* NFI */ {
 
                     @Override
                     public void onSubscribe(Subscription a) {
@@ -118,7 +118,7 @@ public class FlowableSubscriberTest {
         final AtomicLong r = new AtomicLong();
         // set set the producer at the top of the chain (ns) and it should flow through the operator to the (s) subscriber
         // and then it should request up with the value set on the final Subscriber (s)
-        ns.onSubscribe(new Subscription() {
+        ns.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
             public void request(long n) {
@@ -171,7 +171,7 @@ public class FlowableSubscriberTest {
         final AtomicLong r = new AtomicLong();
         // set set the producer at the top of the chain (ns) and it should flow through the operator to the (s) subscriber
         // and then it should request up with the value set on the final Subscriber (s)
-        ns.onSubscribe(new Subscription() {
+        ns.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
             public void request(long n) {
@@ -195,7 +195,7 @@ public class FlowableSubscriberTest {
             @Override
             public Subscriber<? super String> apply(Subscriber<? super String> child) {
                 // we want to decouple the chain so set our own Producer on the child instead of it coming from the parent
-                child.onSubscribe(new Subscription() {
+                child.onSubscribe(new Subscription() /* NFI */ {
 
                     @Override
                     public void request(long n) {
@@ -241,7 +241,7 @@ public class FlowableSubscriberTest {
         final AtomicLong r = new AtomicLong();
         // set set the producer at the top of the chain (ns) and it should flow through the operator to the (s) subscriber
         // and then it should request up with the value set on the final Subscriber (s)
-        ns.onSubscribe(new Subscription() {
+        ns.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
             public void request(long n) {
@@ -265,7 +265,7 @@ public class FlowableSubscriberTest {
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
+                s.onSubscribe(new Subscription() /* NFI */ {
 
                     @Override
                     public void request(long n) {
@@ -290,7 +290,7 @@ public class FlowableSubscriberTest {
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
+                s.onSubscribe(new Subscription() /* NFI */ {
 
                     @Override
                     public void request(long n) {
@@ -315,7 +315,7 @@ public class FlowableSubscriberTest {
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
+                s.onSubscribe(new Subscription() /* NFI */ {
 
                     @Override
                     public void request(long n) {
@@ -342,7 +342,7 @@ public class FlowableSubscriberTest {
         Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
             @Override
             public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
+                s.onSubscribe(new Subscription() /* NFI */ {
 
                     @Override
                     public void request(long n) {
@@ -575,23 +575,10 @@ public class FlowableSubscriberTest {
             ts.onSubscribe(new BooleanSubscription());
 
             @SuppressWarnings("resource")
-            ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    ts.onNext(v);
-                    return true;
-                }
-            }, new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    ts.onError(e);
-                }
-            }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    ts.onComplete();
-                }
-            });
+            ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(v -> {
+                ts.onNext(v);
+                return true;
+            }, e -> ts.onError(e), () -> ts.onComplete());
 
             s.onComplete();
             s.onNext(1);
@@ -612,22 +599,9 @@ public class FlowableSubscriberTest {
         ts.onSubscribe(new BooleanSubscription());
 
         @SuppressWarnings("resource")
-        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                ts.onError(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.onComplete();
-            }
-        });
+        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(_ -> {
+            throw new TestException();
+        }, e -> ts.onError(e), () -> ts.onComplete());
 
         BooleanSubscription b = new BooleanSubscription();
 
@@ -641,21 +615,11 @@ public class FlowableSubscriberTest {
     @Test
     public void onErrorThrows() {
         @SuppressWarnings("resource")
-        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Inner");
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
+        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(_ -> true,
+        _ -> {
+            throw new TestException("Inner");
+        }, () -> {
 
-            }
         });
 
         List<Throwable> list = TestHelper.trackPluginErrors();
@@ -686,11 +650,8 @@ public class FlowableSubscriberTest {
             @Override
             public void accept(Throwable e) throws Exception {
             }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new TestException("Inner");
-            }
+        }, () -> {
+            throw new TestException("Inner");
         });
 
         List<Throwable> list = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
@@ -484,13 +484,10 @@ public class FlowableTests extends RxJavaTest {
             public void subscribe(final Subscriber<? super String> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
                 count.incrementAndGet();
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        subscriber.onNext("first");
-                        subscriber.onNext("last");
-                        subscriber.onComplete();
-                    }
+                new Thread(() -> {
+                    subscriber.onNext("first");
+                    subscriber.onNext("last");
+                    subscriber.onComplete();
                 }).start();
             }
         }).takeLast(1).publish();
@@ -521,14 +518,10 @@ public class FlowableTests extends RxJavaTest {
             @Override
             public void subscribe(final Subscriber<? super String> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
-                    new Thread(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            counter.incrementAndGet();
-                            subscriber.onNext("one");
-                            subscriber.onComplete();
-                        }
+                    new Thread(() -> {
+                        counter.incrementAndGet();
+                        subscriber.onNext("one");
+                        subscriber.onComplete();
                     }).start();
             }
         }).replay();
@@ -574,13 +567,10 @@ public class FlowableTests extends RxJavaTest {
             @Override
             public void subscribe(final Subscriber<? super String> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
-                    new Thread(new Runnable() {
-                        @Override
-                        public void run() {
-                            counter.incrementAndGet();
-                            subscriber.onNext("one");
-                            subscriber.onComplete();
-                        }
+                    new Thread(() -> {
+                        counter.incrementAndGet();
+                        subscriber.onNext("one");
+                        subscriber.onComplete();
                     }).start();
             }
         }).cache();
@@ -619,13 +609,10 @@ public class FlowableTests extends RxJavaTest {
             @Override
             public void subscribe(final Subscriber<? super String> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        counter.incrementAndGet();
-                        subscriber.onNext("one");
-                        subscriber.onComplete();
-                    }
+                new Thread(() -> {
+                    counter.incrementAndGet();
+                    subscriber.onNext("one");
+                    subscriber.onComplete();
                 }).start();
             }
         }).cacheWithInitialCapacity(1);
@@ -634,21 +621,15 @@ public class FlowableTests extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        f.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            assertEquals("one", v);
+            latch.countDown();
         });
 
         // subscribe again
-        f.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            assertEquals("one", v);
+            latch.countDown();
         });
 
         if (!latch.await(1000, TimeUnit.MILLISECONDS)) {

--- a/src/test/java/io/reactivex/rxjava4/internal/disposables/ArrayCompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/disposables/ArrayCompositeDisposableTest.java
@@ -75,12 +75,7 @@ public class ArrayCompositeDisposableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    acd.dispose();
-                }
-            };
+            Runnable r = () -> acd.dispose();
 
             TestHelper.race(r, r);
         }
@@ -92,12 +87,7 @@ public class ArrayCompositeDisposableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    acd.replaceResource(0, Disposable.empty());
-                }
-            };
+            Runnable r = () -> acd.replaceResource(0, Disposable.empty());
 
             TestHelper.race(r, r);
         }
@@ -109,12 +99,7 @@ public class ArrayCompositeDisposableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    acd.setResource(0, Disposable.empty());
-                }
-            };
+            Runnable r = () -> acd.setResource(0, Disposable.empty());
 
             TestHelper.race(r, r);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/disposables/CancellableDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/disposables/CancellableDisposableTest.java
@@ -32,12 +32,7 @@ public class CancellableDisposableTest extends RxJavaTest {
     public void normal() {
         final AtomicInteger count = new AtomicInteger();
 
-        Cancellable c = new Cancellable() {
-            @Override
-            public void cancel() throws Exception {
-                count.getAndIncrement();
-            }
-        };
+        Cancellable c = () -> count.getAndIncrement();
 
         @SuppressWarnings("resource")
         CancellableDisposable cd = new CancellableDisposable(c);
@@ -56,12 +51,9 @@ public class CancellableDisposableTest extends RxJavaTest {
     public void cancelThrows() {
         final AtomicInteger count = new AtomicInteger();
 
-        Cancellable c = new Cancellable() {
-            @Override
-            public void cancel() throws Exception {
-                count.getAndIncrement();
-                throw new TestException();
-            }
+        Cancellable c = () -> {
+            count.getAndIncrement();
+            throw new TestException();
         };
 
         @SuppressWarnings("resource")
@@ -89,22 +81,12 @@ public class CancellableDisposableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicInteger count = new AtomicInteger();
 
-            Cancellable c = new Cancellable() {
-                @Override
-                public void cancel() throws Exception {
-                    count.getAndIncrement();
-                }
-            };
+            Cancellable c = () -> count.getAndIncrement();
 
             @SuppressWarnings("resource")
             final CancellableDisposable cd = new CancellableDisposable(c);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable r = () -> cd.dispose();
 
             TestHelper.race(r, r);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/disposables/DisposableHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/disposables/DisposableHelperTest.java
@@ -56,12 +56,7 @@ public class DisposableHelperTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Disposable> d = new AtomicReference<>();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    DisposableHelper.dispose(d);
-                }
-            };
+            Runnable r = () -> DisposableHelper.dispose(d);
 
             TestHelper.race(r, r);
         }
@@ -72,12 +67,7 @@ public class DisposableHelperTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Disposable> d = new AtomicReference<>();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    DisposableHelper.replace(d, Disposable.empty());
-                }
-            };
+            Runnable r = () -> DisposableHelper.replace(d, Disposable.empty());
 
             TestHelper.race(r, r);
         }
@@ -88,12 +78,7 @@ public class DisposableHelperTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Disposable> d = new AtomicReference<>();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    DisposableHelper.set(d, Disposable.empty());
-                }
-            };
+            Runnable r = () -> DisposableHelper.set(d, Disposable.empty());
 
             TestHelper.race(r, r);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/disposables/ListCompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/disposables/ListCompositeDisposableTest.java
@@ -119,7 +119,7 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @SuppressWarnings("resource")
     @Test
     public void disposeThrows() {
-        Disposable d = new Disposable() {
+        Disposable d = new Disposable() /* NFI */ {
 
             @Override
             public void dispose() {
@@ -189,12 +189,7 @@ public class ListCompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
             TestHelper.race(run, run);
         }
@@ -206,12 +201,7 @@ public class ListCompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.add(Disposable.empty());
-                }
-            };
+            Runnable run = () -> cd.add(Disposable.empty());
 
             TestHelper.race(run, run);
         }
@@ -223,12 +213,7 @@ public class ListCompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.addAll(Disposable.empty());
-                }
-            };
+            Runnable run = () -> cd.addAll(Disposable.empty());
 
             TestHelper.race(run, run);
         }
@@ -244,12 +229,7 @@ public class ListCompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.remove(d1);
-                }
-            };
+            Runnable run = () -> cd.remove(d1);
 
             TestHelper.race(run, run);
         }
@@ -265,12 +245,7 @@ public class ListCompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.delete(d1);
-                }
-            };
+            Runnable run = () -> cd.delete(d1);
 
             TestHelper.race(run, run);
         }
@@ -286,12 +261,7 @@ public class ListCompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.clear();
-                }
-            };
+            Runnable run = () -> cd.clear();
 
             TestHelper.race(run, run);
         }
@@ -303,19 +273,9 @@ public class ListCompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.add(Disposable.empty());
-                }
-            };
+            Runnable run2 = () -> cd.add(Disposable.empty());
 
             TestHelper.race(run, run2);
         }
@@ -327,19 +287,9 @@ public class ListCompositeDisposableTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.addAll(Disposable.empty());
-                }
-            };
+            Runnable run2 = () -> cd.addAll(Disposable.empty());
 
             TestHelper.race(run, run2);
         }
@@ -355,19 +305,9 @@ public class ListCompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.remove(d1);
-                }
-            };
+            Runnable run2 = () -> cd.remove(d1);
 
             TestHelper.race(run, run2);
         }
@@ -383,19 +323,9 @@ public class ListCompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.delete(d1);
-                }
-            };
+            Runnable run2 = () -> cd.delete(d1);
 
             TestHelper.race(run, run2);
         }
@@ -411,19 +341,9 @@ public class ListCompositeDisposableTest extends RxJavaTest {
 
             cd.add(d1);
 
-            Runnable run = new Runnable() {
-                @Override
-                public void run() {
-                    cd.dispose();
-                }
-            };
+            Runnable run = () -> cd.dispose();
 
-            Runnable run2 = new Runnable() {
-                @Override
-                public void run() {
-                    cd.clear();
-                }
-            };
+            Runnable run2 = () -> cd.clear();
 
             TestHelper.race(run, run2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java
@@ -74,21 +74,11 @@ public class FunctionsTest extends RxJavaTest {
 
     @Test
     public void booleanSupplierPredicateReverse() throws Throwable {
-        BooleanSupplier s = new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        };
+        BooleanSupplier s = () -> false;
 
         assertTrue(Functions.predicateReverseFor(s).test(1));
 
-        s = new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return true;
-            }
-        };
+        s = () -> true;
 
         assertFalse(Functions.predicateReverseFor(s).test(1));
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableToCompletionStageTest.java
@@ -112,7 +112,7 @@ public class CompletableToCompletionStageTest extends RxJavaTest {
     @Test
     public void sourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Object v = new Completable() {
+            Object v = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -134,7 +134,7 @@ public class CompletableToCompletionStageTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Object v = new Completable() {
+            Object v = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/BlockingMultiObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/BlockingMultiObserverTest.java
@@ -39,12 +39,7 @@ public class BlockingMultiObserverTest extends RxJavaTest {
     public void blockingGetDefault() {
         final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<>();
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                bmo.onSuccess(1);
-            }
-        }, 100, TimeUnit.MILLISECONDS);
+        Schedulers.single().scheduleDirect(() -> bmo.onSuccess(1), 100, TimeUnit.MILLISECONDS);
 
         assertEquals(1, bmo.blockingGet(0).intValue());
     }
@@ -53,12 +48,7 @@ public class BlockingMultiObserverTest extends RxJavaTest {
     public void blockingAwait() {
         final BlockingMultiObserver<Integer> bmo = new BlockingMultiObserver<>();
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                bmo.onSuccess(1);
-            }
-        }, 100, TimeUnit.MILLISECONDS);
+        Schedulers.single().scheduleDirect(() -> bmo.onSuccess(1), 100, TimeUnit.MILLISECONDS);
 
         assertTrue(bmo.blockingAwait(1, TimeUnit.MINUTES));
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/CompletableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/CompletableConsumersTest.java
@@ -177,11 +177,8 @@ public class CompletableConsumersTest implements Consumer<Object>, Action {
     public void onCompleteCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            processor.subscribe(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            processor.subscribe(() -> {
+                throw new IOException();
             }, this, composite);
 
             processor.onComplete();
@@ -198,7 +195,7 @@ public class CompletableConsumersTest implements Consumer<Object>, Action {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Completable() {
+            new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         CompletableObserver observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
@@ -325,7 +325,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         @SuppressWarnings("resource")
-        TakeLast source = new TakeLast(new Observer<Integer>() {
+        TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
             Disposable upstream;
 
             @Override
@@ -396,7 +396,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         @SuppressWarnings("resource")
-        TakeLast source = new TakeLast(new Observer<Integer>() {
+        TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
             QueueDisposable<Integer> d;
 
             @SuppressWarnings("unchecked")
@@ -448,7 +448,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         @SuppressWarnings("resource")
-        TakeLast source = new TakeLast(new Observer<Integer>() {
+        TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
             QueueDisposable<Integer> d;
 
             @SuppressWarnings("unchecked")
@@ -498,7 +498,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         @SuppressWarnings("resource")
-        TakeFirst source = new TakeFirst(new Observer<Integer>() {
+        TakeFirst source = new TakeFirst(new Observer<Integer>() /* NFI */ {
             QueueDisposable<Integer> d;
 
             @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/DisposableLambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/DisposableLambdaObserverTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -44,11 +43,8 @@ public class DisposableLambdaObserverTest extends RxJavaTest {
             @SuppressWarnings("resource")
             DisposableLambdaObserver<Integer> o = new DisposableLambdaObserver<>(
                     new TestObserver<>(), Functions.emptyConsumer(),
-                    new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            throw new TestException();
-                        }
+                    () -> {
+                        throw new TestException();
                     }
             );
 

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/FutureObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/FutureObserverTest.java
@@ -158,12 +158,7 @@ public class FutureObserverTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final FutureObserver<Integer> fo = new FutureObserver<>();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    fo.cancel(false);
-                }
-            };
+            Runnable r = () -> fo.cancel(false);
 
             TestHelper.race(r, r);
         }
@@ -171,12 +166,9 @@ public class FutureObserverTest extends RxJavaTest {
 
     @Test
     public void await() throws Exception {
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                fo.onNext(1);
-                fo.onComplete();
-            }
+        Schedulers.single().scheduleDirect(() -> {
+            fo.onNext(1);
+            fo.onComplete();
         }, 100, TimeUnit.MILLISECONDS);
 
         assertEquals(1, fo.get(5, TimeUnit.SECONDS).intValue());
@@ -192,19 +184,9 @@ public class FutureObserverTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        fo.cancel(false);
-                    }
-                };
+                Runnable r1 = () -> fo.cancel(false);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        fo.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> fo.onError(ex);
 
                 TestHelper.race(r1, r2);
             }
@@ -229,19 +211,9 @@ public class FutureObserverTest extends RxJavaTest {
                     fo.onNext(1);
                 }
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        fo.cancel(false);
-                    }
-                };
+                Runnable r1 = () -> fo.cancel(false);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        fo.onComplete();
-                    }
-                };
+                Runnable r2 = () -> fo.onComplete();
 
                 TestHelper.race(r1, r2);
             }
@@ -361,12 +333,9 @@ public class FutureObserverTest extends RxJavaTest {
 
     @Test
     public void completeAsync() throws Exception {
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                fo.onNext(1);
-                fo.onComplete();
-            }
+        Schedulers.single().scheduleDirect(() -> {
+            fo.onNext(1);
+            fo.onComplete();
         }, 500, TimeUnit.MILLISECONDS);
 
         assertEquals(1, fo.get().intValue());
@@ -388,12 +357,7 @@ public class FutureObserverTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final FutureObserver<Integer> fo = new FutureObserver<>();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    fo.cancel(false);
-                }
-            };
+            Runnable r = () -> fo.cancel(false);
 
             Disposable d = Disposable.empty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/FutureSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/FutureSingleObserverTest.java
@@ -72,12 +72,7 @@ public class FutureSingleObserverTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Future<?> f = Single.never().toFuture();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    f.cancel(true);
-                }
-            };
+            Runnable r = () -> f.cancel(true);
 
             TestHelper.race(r, r);
         }
@@ -140,19 +135,9 @@ public class FutureSingleObserverTest extends RxJavaTest {
 
             ps.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    f.cancel(true);
-                }
-            };
+            Runnable r1 = () -> f.cancel(true);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                }
-            };
+            Runnable r2 = () -> ps.onComplete();
 
             TestHelper.race(r1, r2);
         }
@@ -169,19 +154,9 @@ public class FutureSingleObserverTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        f.cancel(true);
-                    }
-                };
+                Runnable r1 = () -> f.cancel(true);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> ps.onError(ex);
 
                 TestHelper.race(r1, r2);
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
@@ -37,28 +37,11 @@ public class LambdaObserverTest extends RxJavaTest {
     public void onSubscribeThrows() {
         final List<Object> received = new ArrayList<>();
 
-        LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                received.add(v);
-            }
-        },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        received.add(e);
-                    }
-                }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) throws Exception {
-                throw new TestException();
-            }
-        });
+        LambdaObserver<Object> o = new LambdaObserver<>(
+                v -> received.add(v),
+                e -> received.add(e),
+                () -> received.add(100),
+                _ -> { throw new TestException(); });
 
         assertFalse(o.isDisposed());
 
@@ -74,27 +57,11 @@ public class LambdaObserverTest extends RxJavaTest {
     public void onNextThrows() {
         final List<Object> received = new ArrayList<>();
 
-        LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                throw new TestException();
-            }
-        },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        received.add(e);
-                    }
-                }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) throws Exception {
-            }
-        });
+        LambdaObserver<Object> o = new LambdaObserver<>(
+                _ -> { throw new TestException(); },
+                e -> received.add(e),
+                () -> received.add(100),
+                _ -> { });
 
         assertFalse(o.isDisposed());
 
@@ -113,27 +80,11 @@ public class LambdaObserverTest extends RxJavaTest {
         try {
             final List<Object> received = new ArrayList<>();
 
-            LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    received.add(v);
-                }
-            },
-                    new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable e) throws Exception {
-                            throw new TestException("Inner");
-                        }
-                    }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    received.add(100);
-                }
-            }, new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                }
-            });
+            LambdaObserver<Object> o = new LambdaObserver<>(
+                    v -> received.add(v),
+                    _ -> { throw new TestException("Inner"); },
+                    () -> received.add(100),
+                    _ -> { });
 
             assertFalse(o.isDisposed());
 
@@ -159,27 +110,11 @@ public class LambdaObserverTest extends RxJavaTest {
         try {
             final List<Object> received = new ArrayList<>();
 
-            LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    received.add(v);
-                }
-            },
-                    new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable e) throws Exception {
-                            received.add(e);
-                        }
-                    }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
-            }, new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                }
-            });
+            LambdaObserver<Object> o = new LambdaObserver<>(
+                    v -> received.add(v),
+                    e -> received.add(e),
+                    () -> { throw new TestException(); },
+                    _ -> { });
 
             assertFalse(o.isDisposed());
 
@@ -217,27 +152,11 @@ public class LambdaObserverTest extends RxJavaTest {
 
             final List<Object> received = new ArrayList<>();
 
-            LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    received.add(v);
-                }
-            },
-                    new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable e) throws Exception {
-                            received.add(e);
-                        }
-                    }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    received.add(100);
-                }
-            }, new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                }
-            });
+            LambdaObserver<Object> o = new LambdaObserver<>(
+                    v -> received.add(v),
+                    e -> received.add(e),
+                    () -> received.add(100),
+                    _ -> { });
 
             source.subscribe(o);
 


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<[^>]+>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080