### PR TITLE
4.x: Unit test lambdaification 3 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -53,7 +53,7 @@ public class CompletableTest extends RxJavaTest {
     static final class IterableIteratorNextThrows implements Iterable<Completable> {
         @Override
         public Iterator<Completable> iterator() {
-            return new Iterator<Completable>() {
+            return new Iterator<Completable>() /* NFI */ {
                 @Override
                 public boolean hasNext() {
                     return true;
@@ -77,7 +77,7 @@ public class CompletableTest extends RxJavaTest {
     static final class IterableIteratorHasNextThrows implements Iterable<Completable> {
         @Override
         public Iterator<Completable> iterator() {
-            return new Iterator<Completable>() {
+            return new Iterator<Completable>() /* NFI */ {
                 @Override
                 public boolean hasNext() {
                     throw new TestException();
@@ -206,12 +206,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void concatIterableIteratorNull() {
-        Completable c = Completable.concat(new Iterable<Completable>() {
-            @Override
-            public Iterator<Completable> iterator() {
-                return null;
-            }
-        });
+        Completable c = Completable.concat((Iterable<Completable>) () -> null);
 
         c.blockingAwait();
     }
@@ -250,11 +245,8 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void concatIterableIterableThrows() {
-        Completable c = Completable.concat(new Iterable<Completable>() {
-            @Override
-            public Iterator<Completable> iterator() {
-                throw new TestException();
-            }
+        Completable c = Completable.concat((Iterable<Completable>) () -> {
+            throw new TestException();
         });
 
         c.blockingAwait();
@@ -283,12 +275,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void concatObservableError() {
-        Completable c = Completable.concat(Flowable.<Completable>error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new TestException();
-            }
-        }));
+        Completable c = Completable.concat(Flowable.<Completable>error(() -> new TestException()));
 
         c.blockingAwait();
     }
@@ -372,12 +359,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void defer() {
-        Completable c = Completable.defer(new Supplier<Completable>() {
-            @Override
-            public Completable get() {
-                return normal.completable;
-            }
-        });
+        Completable c = Completable.defer((Supplier<Completable>) () -> normal.completable);
 
         normal.assertSubscriptions(0);
 
@@ -388,68 +370,42 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void deferReturnsNull() {
-        Completable c = Completable.defer(new Supplier<Completable>() {
-            @Override
-            public Completable get() {
-                return null;
-            }
-        });
+        Completable c = Completable.defer(() -> null);
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void deferFunctionThrows() {
-        Completable c = Completable.defer(new Supplier<Completable>() {
-            @Override
-            public Completable get() { throw new TestException(); }
-        });
+        Completable c = Completable.defer(() -> { throw new TestException(); });
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void deferErrorSource() {
-        Completable c = Completable.defer(new Supplier<Completable>() {
-            @Override
-            public Completable get() {
-                return error.completable;
-            }
-        });
+        Completable c = Completable.defer(() -> error.completable);
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void errorSupplierNormal() {
-        Completable c = Completable.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new TestException();
-            }
-        });
+        Completable c = Completable.error(() -> new TestException());
 
         c.blockingAwait();
     }
 
     @Test(expected = NullPointerException.class)
     public void errorSupplierReturnsNull() {
-        Completable c = Completable.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return null;
-            }
-        });
+        Completable c = Completable.error(() -> null);
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void errorSupplierThrows() {
-        Completable c = Completable.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() { throw new TestException(); }
-        });
+        Completable c = Completable.error(() -> { throw new TestException(); });
 
         c.blockingAwait();
     }
@@ -465,12 +421,7 @@ public class CompletableTest extends RxJavaTest {
     public void fromCallableNormal() {
         final AtomicInteger calls = new AtomicInteger();
 
-        Completable c = Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return calls.getAndIncrement();
-            }
-        });
+        Completable c = Completable.fromCallable(() -> calls.getAndIncrement());
 
         c.blockingAwait();
 
@@ -479,10 +430,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void fromCallableThrows() {
-        Completable c = Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception { throw new TestException(); }
-        });
+        Completable c = Completable.fromCallable(() -> { throw new TestException(); });
 
         c.blockingAwait();
     }
@@ -505,12 +453,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void fromFlowableError() {
-        Completable c = Completable.fromPublisher(Flowable.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new TestException();
-            }
-        }));
+        Completable c = Completable.fromPublisher(Flowable.error(() -> new TestException()));
 
         c.blockingAwait();
     }
@@ -533,12 +476,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void fromObservableError() {
-        Completable c = Completable.fromObservable(Observable.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new TestException();
-            }
-        }));
+        Completable c = Completable.fromObservable(Observable.error(() -> new TestException()));
 
         c.blockingAwait();
     }
@@ -630,12 +568,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void mergeIterableIteratorNull() {
-        Completable c = Completable.merge(new Iterable<Completable>() {
-            @Override
-            public Iterator<Completable> iterator() {
-                return null;
-            }
-        });
+        Completable c = Completable.merge((Iterable<Completable>) () -> null);
 
         c.blockingAwait();
     }
@@ -674,11 +607,8 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeIterableIterableThrows() {
-        Completable c = Completable.merge(new Iterable<Completable>() {
-            @Override
-            public Iterator<Completable> iterator() {
-                throw new TestException();
-            }
+        Completable c = Completable.merge((Iterable<Completable>) () -> {
+            throw new TestException();
         });
 
         c.blockingAwait();
@@ -707,12 +637,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeObservableError() {
-        Completable c = Completable.merge(Flowable.<Completable>error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new TestException();
-            }
-        }));
+        Completable c = Completable.merge(Flowable.<Completable>error(() -> new TestException()));
 
         c.blockingAwait();
     }
@@ -824,12 +749,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableIteratorNull() {
-        Completable c = Completable.mergeDelayError(new Iterable<Completable>() {
-            @Override
-            public Iterator<Completable> iterator() {
-                return null;
-            }
-        });
+        Completable c = Completable.mergeDelayError((Iterable<Completable>) () -> null);
 
         c.blockingAwait();
     }
@@ -872,11 +792,8 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorIterableIterableThrows() {
-        Completable c = Completable.mergeDelayError(new Iterable<Completable>() {
-            @Override
-            public Iterator<Completable> iterator() {
-                throw new TestException();
-            }
+        Completable c = Completable.mergeDelayError((Iterable<Completable>) () -> {
+            throw new TestException();
         });
 
         c.blockingAwait();
@@ -905,12 +822,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorObservableError() {
-        Completable c = Completable.mergeDelayError(Flowable.<Completable>error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new TestException();
-            }
-        }));
+        Completable c = Completable.mergeDelayError(Flowable.<Completable>error(() -> new TestException()));
 
         c.blockingAwait();
     }
@@ -1077,22 +989,10 @@ public class CompletableTest extends RxJavaTest {
     public void usingNormalEager() {
         final AtomicInteger dispose = new AtomicInteger();
 
-        Completable c = Completable.using(new Supplier<Integer>() {
-            @Override
-            public Integer get() {
-                return 1;
-            }
-        }, new Function<Object, Completable>() {
-            @Override
-            public Completable apply(Object v) {
-                return normal.completable;
-            }
-        }, new Consumer<Integer>() {
-            @Override
-            public void accept(Integer d) {
-                dispose.set(d);
-            }
-        });
+        Completable c = Completable.using(
+                () -> 1,
+                (Function<Object, Completable>) _ -> normal.completable,
+                d -> dispose.set(d));
 
         final AtomicBoolean disposedFirst = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -1123,22 +1023,9 @@ public class CompletableTest extends RxJavaTest {
     public void usingNormalLazy() {
         final AtomicInteger dispose = new AtomicInteger();
 
-        Completable c = Completable.using(new Supplier<Integer>() {
-            @Override
-            public Integer get() {
-                return 1;
-            }
-        }, new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) {
-                return normal.completable;
-            }
-        }, new Consumer<Integer>() {
-            @Override
-            public void accept(Integer d) {
-                dispose.set(d);
-            }
-        }, false);
+        Completable c = Completable.using(() -> 1,
+                (Function<Integer, Completable>) _ -> normal.completable,
+                d -> dispose.set(d), false);
 
         final AtomicBoolean disposedFirst = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -1169,22 +1056,9 @@ public class CompletableTest extends RxJavaTest {
     public void usingErrorEager() {
         final AtomicInteger dispose = new AtomicInteger();
 
-        Completable c = Completable.using(new Supplier<Integer>() {
-            @Override
-            public Integer get() {
-                return 1;
-            }
-        }, new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) {
-                return error.completable;
-            }
-        }, new Consumer<Integer>() {
-            @Override
-            public void accept(Integer d) {
-                dispose.set(d);
-            }
-        });
+        Completable c = Completable.using(() -> 1,
+                (Function<Integer, Completable>) _ -> error.completable,
+                d -> dispose.set(d));
 
         final AtomicBoolean disposedFirst = new AtomicBoolean();
         final AtomicBoolean complete = new AtomicBoolean();
@@ -1215,22 +1089,9 @@ public class CompletableTest extends RxJavaTest {
     public void usingErrorLazy() {
         final AtomicInteger dispose = new AtomicInteger();
 
-        Completable c = Completable.using(new Supplier<Integer>() {
-            @Override
-            public Integer get() {
-                return 1;
-            }
-        }, new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) {
-                return error.completable;
-            }
-        }, new Consumer<Integer>() {
-            @Override
-            public void accept(Integer d) {
-                dispose.set(d);
-            }
-        }, false);
+        Completable c = Completable.using(() -> 1,
+                (Function<Integer, Completable>) _ -> error.completable,
+                d -> dispose.set(d), false);
 
         final AtomicBoolean disposedFirst = new AtomicBoolean();
         final AtomicBoolean complete = new AtomicBoolean();
@@ -1259,79 +1120,37 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void usingMapperReturnsNull() {
-        Completable c = Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return 1;
-            }
-        }, new Function<Object, Completable>() {
-            @Override
-            public Completable apply(Object v) {
-                return null;
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object v) { }
-        });
+        Completable c = Completable.using(
+                () -> 1,
+                (Function<Object, Completable>) _ -> null,
+                _ -> { });
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void usingResourceThrows() {
-        Completable c = Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() { throw new TestException(); }
-        },
-                new Function<Object, Completable>() {
-                    @Override
-                    public Completable apply(Object v) {
-                        return normal.completable;
-                    }
-                }, new Consumer<Object>() {
-                    @Override
-                    public void accept(Object v) { }
-                });
+        Completable c = Completable.using(() -> { throw new TestException(); },
+                (Function<Object, Completable>) _ -> normal.completable,
+                _ -> { });
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void usingMapperThrows() {
-        Completable c = Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return 1;
-            }
-        },
-                new Function<Object, Completable>() {
-                    @Override
-                    public Completable apply(Object v) { throw new TestException(); }
-                }, new Consumer<Object>() {
-                    @Override
-                    public void accept(Object v) { }
-                });
+        Completable c = Completable.using(() -> 1,
+                (Function<Object, Completable>) _ -> { throw new TestException(); },
+                _ -> { });
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void usingDisposerThrows() {
-        Completable c = Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return 1;
-            }
-        },
-                new Function<Object, Completable>() {
-                    @Override
-                    public Completable apply(Object v) {
-                        return normal.completable;
-                    }
-                }, new Consumer<Object>() {
-                    @Override
-                    public void accept(Object v) { throw new TestException(); }
-                });
+        Completable c = Completable.using(() -> 1,
+                (Function<Object, Completable>) _ -> normal.completable,
+                _ -> { throw new TestException(); });
 
         c.blockingAwait();
     }
@@ -1630,12 +1449,7 @@ public class CompletableTest extends RxJavaTest {
     public void doOnSubscribeNormal() {
         final AtomicInteger calls = new AtomicInteger();
 
-        Completable c = normal.completable.doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                calls.getAndIncrement();
-            }
-        });
+        Completable c = normal.completable.doOnSubscribe(_ -> calls.getAndIncrement());
 
         for (int i = 0; i < 10; i++) {
             c.blockingAwait();
@@ -1646,10 +1460,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void doOnSubscribeThrows() {
-        Completable c = normal.completable.doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) { throw new TestException(); }
-        });
+        Completable c = normal.completable.doOnSubscribe(_ -> { throw new TestException(); });
 
         c.blockingAwait();
     }
@@ -1850,24 +1661,14 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void onErrorResumeNextNormal() {
-        Completable c = error.completable.onErrorResumeNext(new Function<Throwable, Completable>() {
-            @Override
-            public Completable apply(Throwable v) {
-                return normal.completable;
-            }
-        });
+        Completable c = error.completable.onErrorResumeNext((Function<Throwable, Completable>) _ -> normal.completable);
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void onErrorResumeNextError() {
-        Completable c = error.completable.onErrorResumeNext(new Function<Throwable, Completable>() {
-            @Override
-            public Completable apply(Throwable v) {
-                return error.completable;
-            }
-        });
+        Completable c = error.completable.onErrorResumeNext((Function<Throwable, Completable>) _ -> error.completable);
 
         c.blockingAwait();
     }
@@ -1883,12 +1684,9 @@ public class CompletableTest extends RxJavaTest {
     public void repeat5Times() {
         final AtomicInteger calls = new AtomicInteger();
 
-        Completable c = Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                calls.getAndIncrement();
-                return null;
-            }
+        Completable c = Completable.fromCallable(() -> {
+            calls.getAndIncrement();
+            return null;
         }).repeat(5);
 
         c.blockingAwait();
@@ -1900,12 +1698,9 @@ public class CompletableTest extends RxJavaTest {
     public void repeat1Time() {
         final AtomicInteger calls = new AtomicInteger();
 
-        Completable c = Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                calls.getAndIncrement();
-                return null;
-            }
+        Completable c = Completable.fromCallable(() -> {
+            calls.getAndIncrement();
+            return null;
         }).repeat(1);
 
         c.blockingAwait();
@@ -1917,12 +1712,9 @@ public class CompletableTest extends RxJavaTest {
     public void repeat0Time() {
         final AtomicInteger calls = new AtomicInteger();
 
-        Completable c = Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                calls.getAndIncrement();
-                return null;
-            }
+        Completable c = Completable.fromCallable(() -> {
+            calls.getAndIncrement();
+            return null;
         }).repeat(0);
 
         c.blockingAwait();
@@ -2231,12 +2023,9 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void timeoutTimerCancelled() throws InterruptedException {
-        Completable c = Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                Thread.sleep(50);
-                return null;
-            }
+        Completable c = Completable.fromCallable(() -> {
+            Thread.sleep(50);
+            return null;
         }).timeout(100, TimeUnit.MILLISECONDS, normal.completable);
 
         c.blockingAwait();
@@ -2249,12 +2038,7 @@ public class CompletableTest extends RxJavaTest {
     @Test
     public void toNormal() {
         normal.completable
-                .to(new CompletableConverter<Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Completable c) {
-                        return c.toFlowable();
-                    }
-                })
+                .to((CompletableConverter<Flowable<Object>>) Completable::toFlowable)
                 .test()
                 .assertComplete()
                 .assertNoValues();
@@ -2263,12 +2047,7 @@ public class CompletableTest extends RxJavaTest {
     @Test
     public void asNormal() {
         normal.completable
-                .to(new CompletableConverter<Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Completable c) {
-                        return c.toFlowable();
-                    }
-                })
+                .to((CompletableConverter<Flowable<Object>>) Completable::toFlowable)
                 .test()
                 .assertComplete()
                 .assertNoValues();
@@ -2276,12 +2055,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void as() {
-        Completable.complete().to(new CompletableConverter<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Completable v) {
-                return v.toFlowable();
-            }
-        })
+        Completable.complete().to((CompletableConverter<Flowable<Integer>>) Completable::toFlowable)
         .test()
         .assertComplete();
     }
@@ -2308,40 +2082,22 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void toSingleSupplierNormal() {
-        Assert.assertEquals(1, normal.completable.toSingle(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return 1;
-            }
-        }).blockingGet());
+        Assert.assertEquals((Object)1, normal.completable.toSingle(() -> 1).blockingGet());
     }
 
     @Test(expected = TestException.class)
     public void toSingleSupplierError() {
-        error.completable.toSingle(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return 1;
-            }
-        }).blockingGet();
+        error.completable.toSingle(() -> 1).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void toSingleSupplierReturnsNull() {
-        normal.completable.toSingle(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return null;
-            }
-        }).blockingGet();
+        normal.completable.toSingle(() -> null).blockingGet();
     }
 
     @Test(expected = TestException.class)
     public void toSingleSupplierThrows() {
-        normal.completable.toSingle(new Supplier<Object>() {
-            @Override
-            public Object get() { throw new TestException(); }
-        }).blockingGet();
+        normal.completable.toSingle(() -> { throw new TestException(); }).blockingGet();
     }
 
     @Test(expected = TestException.class)
@@ -2528,12 +2284,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void ambIterableIteratorNull() {
-        Completable.amb(new Iterable<Completable>() {
-            @Override
-            public Iterator<Completable> iterator() {
-                return null;
-            }
-        }).test().assertError(NullPointerException.class);
+        Completable.amb((Iterable<Completable>) () -> null).test().assertError(NullPointerException.class);
     }
 
     @Test
@@ -2577,11 +2328,8 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void ambIterableIterableThrows() {
-        Completable.amb(new Iterable<Completable>() {
-            @Override
-            public Iterator<Completable> iterator() {
-                throw new TestException();
-            }
+        Completable.amb((Iterable<Completable>) () -> {
+            throw new TestException();
         }).test().assertError(TestException.class);
     }
 
@@ -2735,12 +2483,9 @@ public class CompletableTest extends RxJavaTest {
     public void startWithFlowableNormal() {
         final AtomicBoolean run = new AtomicBoolean();
         Flowable<Object> c = normal.completable
-                .startWith(Flowable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        run.set(normal.get() == 0);
-                        return 1;
-                    }
+                .startWith(Flowable.fromCallable(() -> {
+                    run.set(normal.get() == 0);
+                    return 1;
                 }));
 
         TestSubscriber<Object> ts = new TestSubscriber<>();
@@ -2775,12 +2520,9 @@ public class CompletableTest extends RxJavaTest {
     public void startWithObservableNormal() {
         final AtomicBoolean run = new AtomicBoolean();
         Observable<Object> o = normal.completable
-                .startWith(Observable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        run.set(normal.get() == 0);
-                        return 1;
-                    }
+                .startWith(Observable.fromCallable(() -> {
+                    run.set(normal.get() == 0);
+                    return 1;
                 }));
 
         TestObserver<Object> to = new TestObserver<>();
@@ -2831,12 +2573,8 @@ public class CompletableTest extends RxJavaTest {
         Thread.UncaughtExceptionHandler originalHandler = Thread.getDefaultUncaughtExceptionHandler();
         CapturingUncaughtExceptionHandler handler = new CapturingUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(handler);
-        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable error) throws Exception {
-                Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), error);
-            }
-        });
+        RxJavaPlugins.setErrorHandler(error ->
+            Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), error));
         try {
             action.run();
             assertEquals("Should have received exactly 1 exception", 1, handler.count);
@@ -2880,11 +2618,8 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void usingFactoryReturnsNullAndDisposerThrows() {
-        Consumer<Integer> onDispose = new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                throw new TestException();
-            }
+        Consumer<Integer> onDispose = _ -> {
+            throw new TestException();
         };
 
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
@@ -3035,7 +2770,7 @@ public class CompletableTest extends RxJavaTest {
         final AtomicBoolean hasRun = new AtomicBoolean(false);
         final Exception e = new Exception();
         Completable.error(e)
-            .andThen(new Single<String>() {
+            .andThen(new Single<String>() /* NFI */ {
                 @Override
                 public void subscribeActual(SingleObserver<? super String> observer) {
                     hasRun.set(true);
@@ -3071,21 +2806,11 @@ public class CompletableTest extends RxJavaTest {
 
     @Before
     public void setUp() throws Exception {
-        onCreate = spy(new Function<Completable, Completable>() {
-            @Override
-            public Completable apply(Completable t) {
-                return t;
-            }
-        });
+        onCreate = spy((Function<Completable, Completable>) t -> t);
 
         RxJavaPlugins.setOnCompletableAssembly(onCreate);
 
-        onStart = spy(new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
-            @Override
-            public CompletableObserver apply(Completable t1, CompletableObserver t2) {
-                return t2;
-            }
-        });
+        onStart = spy((BiFunction<Completable, CompletableObserver, CompletableObserver>) (_, t2) -> t2);
 
         RxJavaPlugins.setOnCompletableSubscribe(onStart);
     }
@@ -3355,7 +3080,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void onStartCalledSafe() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>() {
+        TestSubscriber<Object> ts = new TestSubscriber<Object>() /* NFI */ {
             @Override
             public void onStart() {
                 onNext(1);
@@ -3373,11 +3098,8 @@ public class CompletableTest extends RxJavaTest {
     public void onErrorCompleteFunctionThrows() {
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
 
-        error.completable.onErrorComplete(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable t) {
-                throw new TestException("Forced inner failure");
-            }
+        error.completable.onErrorComplete(_ -> {
+            throw new TestException("Forced inner failure");
         }).<String>toFlowable().subscribe(ts);
 
         ts.assertNoValues();
@@ -3421,12 +3143,9 @@ public class CompletableTest extends RxJavaTest {
 
         final AtomicReference<Disposable> disposableRef = new AtomicReference<>();
         Disposable completableSubscription = completable.subscribe(Functions.EMPTY_ACTION,
-        new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) {
-                if (disposableRef.get().isDisposed()) {
-                    disposableRef.set(null);
-                }
+        _ -> {
+            if (disposableRef.get().isDisposed()) {
+                disposableRef.set(null);
             }
         });
         disposableRef.set(completableSubscription);
@@ -3542,12 +3261,9 @@ public class CompletableTest extends RxJavaTest {
     public void doOnEventComplete() {
         final AtomicInteger atomicInteger = new AtomicInteger(0);
 
-        Completable.complete().doOnEvent(new Consumer<Throwable>() {
-            @Override
-            public void accept(final Throwable throwable) throws Exception {
-                if (throwable == null) {
-                    atomicInteger.incrementAndGet();
-                }
+        Completable.complete().doOnEvent(throwable -> {
+            if (throwable == null) {
+                atomicInteger.incrementAndGet();
             }
         }).subscribe();
 
@@ -3560,12 +3276,9 @@ public class CompletableTest extends RxJavaTest {
         try {
             final AtomicInteger atomicInteger = new AtomicInteger(0);
 
-            Completable.error(new RuntimeException()).doOnEvent(new Consumer<Throwable>() {
-                @Override
-                public void accept(final Throwable throwable) throws Exception {
-                    if (throwable != null) {
-                        atomicInteger.incrementAndGet();
-                    }
+            Completable.error(new RuntimeException()).doOnEvent(throwable -> {
+                if (throwable != null) {
+                    atomicInteger.incrementAndGet();
                 }
             }).subscribe();
 

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -19,12 +19,13 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.Flow.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
 import org.junit.jupiter.api.parallel.Isolated;
 
+import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.disposables.Disposable;
@@ -2806,11 +2807,22 @@ public class CompletableTest extends RxJavaTest {
 
     @Before
     public void setUp() throws Exception {
-        onCreate = spy((Function<Completable, Completable>) t -> t);
+        onCreate = spy(new Function<Completable, Completable>() /* Mockito */ {
+            @Override
+            public @NonNull Completable apply(@NonNull Completable t) throws Throwable {
+                return t;
+            }
+        });
 
         RxJavaPlugins.setOnCompletableAssembly(onCreate);
 
-        onStart = spy((BiFunction<Completable, CompletableObserver, CompletableObserver>) (_, t2) -> t2);
+        onStart = spy(new BiFunction<Completable, CompletableObserver, CompletableObserver>() /* Mockito */ {
+            @Override
+            public @NonNull CompletableObserver apply(@NonNull Completable t1, @NonNull CompletableObserver t2)
+                    throws Throwable {
+                return t2;
+            }
+        });
 
         RxJavaPlugins.setOnCompletableSubscribe(onStart);
     }

--- a/src/test/java/io/reactivex/rxjava4/core/TransformerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/TransformerTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.core;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.ConverterTest.*;
 import io.reactivex.rxjava4.exceptions.TestException;
@@ -26,11 +25,8 @@ public class TransformerTest extends RxJavaTest {
     @Test
     public void flowableTransformerThrows() {
         try {
-            Flowable.just(1).compose(new FlowableTransformer<Integer, Integer>() {
-                @Override
-                public Publisher<Integer> apply(Flowable<Integer> v) {
-                    throw new TestException("Forced failure");
-                }
+            Flowable.just(1).compose(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -41,11 +37,8 @@ public class TransformerTest extends RxJavaTest {
     @Test
     public void observableTransformerThrows() {
         try {
-            Observable.just(1).compose(new ObservableTransformer<Integer, Integer>() {
-                @Override
-                public Observable<Integer> apply(Observable<Integer> v) {
-                    throw new TestException("Forced failure");
-                }
+            Observable.just(1).compose(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -56,11 +49,8 @@ public class TransformerTest extends RxJavaTest {
     @Test
     public void singleTransformerThrows() {
         try {
-            Single.just(1).compose(new SingleTransformer<Integer, Integer>() {
-                @Override
-                public Single<Integer> apply(Single<Integer> v) {
-                    throw new TestException("Forced failure");
-                }
+            Single.just(1).compose(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -71,11 +61,8 @@ public class TransformerTest extends RxJavaTest {
     @Test
     public void maybeTransformerThrows() {
         try {
-            Maybe.just(1).compose(new MaybeTransformer<Integer, Integer>() {
-                @Override
-                public Maybe<Integer> apply(Maybe<Integer> v) {
-                    throw new TestException("Forced failure");
-                }
+            Maybe.just(1).compose(_ -> {
+                throw new TestException("Forced failure");
             });
             fail("Should have thrown!");
         } catch (TestException ex) {
@@ -99,65 +86,45 @@ public class TransformerTest extends RxJavaTest {
 
     @Test
     public void observableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Observable.just(a).compose(TransformerTest.<String>testObservableTransformerCreator());
     }
 
     @Test
     public void singleGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Single.just(a).compose(TransformerTest.<String>testSingleTransformerCreator());
     }
 
     @Test
     public void maybeGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Maybe.just(a).compose(TransformerTest.<String>testMaybeTransformerCreator());
     }
 
     @Test
     public void flowableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() { };
+        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
 
         Flowable.just(a).compose(TransformerTest.<String>testFlowableTransformerCreator());
     }
 
     private static <T> ObservableTransformer<A<T, ?>, B<T>> testObservableTransformerCreator() {
-        return new ObservableTransformer<A<T, ?>, B<T>>() {
-            @Override
-            public ObservableSource<B<T>> apply(Observable<A<T, ?>> a) {
-                return Observable.empty();
-            }
-        };
+        return _ -> Observable.empty();
     }
 
     private static <T> SingleTransformer<A<T, ?>, B<T>> testSingleTransformerCreator() {
-        return new SingleTransformer<A<T, ?>, B<T>>() {
-            @Override
-            public SingleSource<B<T>> apply(Single<A<T, ?>> a) {
-                return Single.never();
-            }
-        };
+        return _ -> Single.never();
     }
 
     private static <T> MaybeTransformer<A<T, ?>, B<T>> testMaybeTransformerCreator() {
-        return new MaybeTransformer<A<T, ?>, B<T>>() {
-            @Override
-            public MaybeSource<B<T>> apply(Maybe<A<T, ?>> a) {
-                return Maybe.empty();
-            }
-        };
+        return _ -> Maybe.empty();
     }
 
     private static <T> FlowableTransformer<A<T, ?>, B<T>> testFlowableTransformerCreator() {
-        return new FlowableTransformer<A<T, ?>, B<T>>() {
-            @Override
-            public Publisher<B<T>> apply(Flowable<A<T, ?>> a) {
-                return Flowable.empty();
-            }
-        };
+        return _ -> Flowable.empty();
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/core/XFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/XFlatMapTest.java
@@ -17,9 +17,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Flow.Publisher;
 
 import org.junit.*;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
@@ -73,12 +73,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestSubscriber<Integer> ts = Flowable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMap(new Function<Integer, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Flowable.<Integer>error(new TestException());
-                }
+            .flatMap((Function<Integer, Publisher<Integer>>) _ -> {
+                sleep();
+                return Flowable.<Integer>error(new TestException());
             })
             .test();
 
@@ -104,12 +101,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestSubscriber<Integer> ts = Flowable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapSingle(new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                }
+            .flatMapSingle(_ -> {
+                sleep();
+                return Single.<Integer>error(new TestException());
             })
             .test();
 
@@ -135,12 +129,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestSubscriber<Integer> ts = Flowable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                }
+            .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
+                sleep();
+                return Maybe.<Integer>error(new TestException());
             })
             .test();
 
@@ -166,12 +157,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Void> to = Flowable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    sleep();
-                    return Completable.error(new TestException());
-                }
+            .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                sleep();
+                return Completable.error(new TestException());
             })
             .test();
 
@@ -197,12 +185,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestSubscriber<Void> ts = Flowable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    sleep();
-                    return Completable.error(new TestException());
-                }
+            .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                sleep();
+                return Completable.error(new TestException());
             })
             .<Void>toFlowable()
             .test();
@@ -229,12 +214,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Observable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMap(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Observable.<Integer>error(new TestException());
-                }
+            .flatMap((Function<Integer, Observable<Integer>>) _ -> {
+                sleep();
+                return Observable.<Integer>error(new TestException());
             })
             .test();
 
@@ -260,12 +242,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Observable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapSingle(new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                }
+            .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
+                sleep();
+                return Single.<Integer>error(new TestException());
             })
             .test();
 
@@ -291,12 +270,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Observable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                }
+            .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
+                sleep();
+                return Maybe.<Integer>error(new TestException());
             })
             .test();
 
@@ -322,12 +298,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Void> to = Observable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    sleep();
-                    return Completable.error(new TestException());
-                }
+            .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                sleep();
+                return Completable.error(new TestException());
             })
             .test();
 
@@ -353,12 +326,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Void> to = Observable.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    sleep();
-                    return Completable.error(new TestException());
-                }
+            .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                sleep();
+                return Completable.error(new TestException());
             })
             .<Void>toObservable()
             .test();
@@ -385,12 +355,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMap(new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                }
+            .flatMap((Function<Integer, Single<Integer>>) _ -> {
+                sleep();
+                return Single.<Integer>error(new TestException());
             })
             .test();
 
@@ -416,12 +383,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                }
+            .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
+                sleep();
+                return Maybe.<Integer>error(new TestException());
             })
             .test();
 
@@ -447,12 +411,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Void> to = Single.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    sleep();
-                    return Completable.error(new TestException());
-                }
+            .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                sleep();
+                return Completable.error(new TestException());
             })
             .test();
 
@@ -478,12 +439,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    sleep();
-                    return Completable.error(new TestException());
-                }
+            .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                sleep();
+                return Completable.error(new TestException());
             })
             .toSingleDefault(0)
             .test();
@@ -510,12 +468,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestSubscriber<Integer> ts = Single.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Flowable.<Integer>error(new TestException());
-                }
+            .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> {
+                sleep();
+                return Flowable.<Integer>error(new TestException());
             })
             .test();
 
@@ -541,12 +496,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMap(new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                }
+            .flatMap((Function<Integer, Single<Integer>>) _ -> {
+                sleep();
+                return Single.<Integer>error(new TestException());
             }, (a, b) -> a + b)
             .test();
 
@@ -572,12 +524,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapObservable(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Observable.<Integer>error(new TestException());
-                }
+            .flatMapObservable((Function<Integer, Observable<Integer>>) _ -> {
+                sleep();
+                return Observable.<Integer>error(new TestException());
             })
             .test();
 
@@ -604,19 +553,13 @@ public class XFlatMapTest extends RxJavaTest {
             TestObserver<Integer> to = Single.just(1)
             .subscribeOn(Schedulers.cached())
             .flatMap(
-                new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Exception {
-                        sleep();
-                        return Single.<Integer>error(new TestException());
-                    }
+                (Function<Integer, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
                 },
-                new Function<Throwable, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Throwable v) throws Exception {
-                        sleep();
-                        return Single.<Integer>error(new TestException());
-                    }
+                (Function<Throwable, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
                 }
             )
             .test();
@@ -644,19 +587,13 @@ public class XFlatMapTest extends RxJavaTest {
             TestObserver<Integer> to = Single.<Integer>error(new TestException())
             .subscribeOn(Schedulers.cached())
             .flatMap(
-                new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Exception {
-                        sleep();
-                        return Single.<Integer>error(new TestException());
-                    }
+                (Function<Integer, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
                 },
-                new Function<Throwable, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Throwable v) throws Exception {
-                        sleep();
-                        return Single.<Integer>error(new TestException());
-                    }
+                (Function<Throwable, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
                 }
             )
             .test();
@@ -683,12 +620,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapSingle(new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                }
+            .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
+                sleep();
+                return Single.<Integer>error(new TestException());
             })
             .toSingle()
             .test();
@@ -715,12 +649,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapSingle(new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                }
+            .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
+                sleep();
+                return Single.<Integer>error(new TestException());
             })
             .test();
 
@@ -746,12 +677,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMap(new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                }
+            .flatMap((Function<Integer, Maybe<Integer>>) _ -> {
+                sleep();
+                return Maybe.<Integer>error(new TestException());
             })
             .test();
 
@@ -777,12 +705,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestSubscriber<Integer> ts = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Flowable.<Integer>error(new TestException());
-                }
+            .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> {
+                sleep();
+                return Flowable.<Integer>error(new TestException());
             })
             .test();
 
@@ -808,12 +733,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapObservable(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Observable.<Integer>error(new TestException());
-                }
+            .flatMapObservable((Function<Integer, Observable<Integer>>) _ -> {
+                sleep();
+                return Observable.<Integer>error(new TestException());
             })
             .test();
 
@@ -840,26 +762,17 @@ public class XFlatMapTest extends RxJavaTest {
             TestObserver<Integer> to = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
             .flatMap(
-                new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Function<Integer, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 },
-                new Function<Throwable, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Throwable v) throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Function<Throwable, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 },
-                new Supplier<Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> get() throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Supplier<Maybe<Integer>>) () -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 }
             )
             .test();
@@ -887,26 +800,17 @@ public class XFlatMapTest extends RxJavaTest {
             TestObserver<Integer> to = Maybe.<Integer>error(new TestException())
             .subscribeOn(Schedulers.cached())
             .flatMap(
-                new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Function<Integer, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 },
-                new Function<Throwable, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Throwable v) throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Function<Throwable, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 },
-                new Supplier<Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> get() throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Supplier<Maybe<Integer>>) () -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 }
             )
             .test();
@@ -934,26 +838,17 @@ public class XFlatMapTest extends RxJavaTest {
             TestObserver<Integer> to = Maybe.<Integer>empty()
             .subscribeOn(Schedulers.cached())
             .flatMap(
-                new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Function<Integer, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 },
-                new Function<Throwable, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Throwable v) throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Function<Throwable, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 },
-                new Supplier<Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> get() throws Exception {
-                        sleep();
-                        return Maybe.<Integer>error(new TestException());
-                    }
+                (Supplier<Maybe<Integer>>) () -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
                 }
             )
             .test();
@@ -980,12 +875,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMap(new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer v) throws Exception {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                }
+            .flatMap((Function<Integer, Maybe<Integer>>) _ -> {
+                sleep();
+                return Maybe.<Integer>error(new TestException());
             }, (a, b) -> a + b)
             .test();
 
@@ -1011,12 +903,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Void> to = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    sleep();
-                    return Completable.error(new TestException());
-                }
+            .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                sleep();
+                return Completable.error(new TestException());
             })
             .test();
 
@@ -1042,12 +931,9 @@ public class XFlatMapTest extends RxJavaTest {
         try {
             TestObserver<Void> to = Maybe.just(1)
             .subscribeOn(Schedulers.cached())
-            .flatMapCompletable(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    sleep();
-                    return Completable.error(new TestException());
-                }
+            .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                sleep();
+                return Completable.error(new TestException());
             })
             .<Void>toMaybe()
             .test();

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -97,16 +98,13 @@ public class FlowableBackpressureTests extends RxJavaTest {
         AtomicInteger c = new AtomicInteger();
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         incrementingIntegers(c).observeOn(Schedulers.computation()).map(
-            new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer i) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    return i;
+            i -> {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
+                return i;
             }
         ).take(num).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -220,12 +218,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         incrementingIntegers(c)
-        .flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer i) {
-                return incrementingIntegers(new AtomicInteger()).take(10);
-            }
-        })
+        .flatMap((Function<Integer, Publisher<Integer>>) _ -> incrementingIntegers(new AtomicInteger()).take(10))
         .take(num).subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -246,12 +239,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         Flowable<Integer> zipped = Flowable.zip(
                 incrementingIntegers(c1),
                 incrementingIntegers(c2),
-                new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer t1, Integer t2) {
-                        return t1 + t2;
-                    }
-                });
+                (t1, t2) -> t1 + t2);
 
         zipped.take(num)
         .subscribe(ts);
@@ -273,12 +261,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         Flowable<Integer> zipped = Flowable.zip(
                 incrementingIntegers(c1).subscribeOn(Schedulers.computation()),
                 incrementingIntegers(c2).subscribeOn(Schedulers.computation()),
-                new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer t1, Integer t2) {
-                        return t1 + t2;
-                    }
-                });
+                (t1, t2) -> t1 + t2);
 
         zipped.take(num).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -329,12 +312,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         incrementingIntegers(c).observeOn(Schedulers.computation())
                 .skip(10000)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer i) {
-                        return i > 11000;
-                    }
-                }).take(num).subscribe(ts);
+                .filter(i -> i > 11000).take(num).subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -356,7 +334,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         final AtomicInteger totalReceived = new AtomicInteger();
         final AtomicInteger batches = new AtomicInteger();
         final AtomicInteger received = new AtomicInteger();
-        incrementingIntegers(c).subscribe(new ResourceSubscriber<Integer>() {
+        incrementingIntegers(c).subscribe(new ResourceSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -403,7 +381,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         final AtomicInteger batches = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
         incrementingIntegers(c).subscribeOn(Schedulers.newThread()).subscribe(
-                new ResourceSubscriber<Integer>() {
+                new ResourceSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -456,16 +434,13 @@ public class FlowableBackpressureTests extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         firehose(c).observeOn(Schedulers.computation())
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) {
-                try {
-                    Thread.sleep(10);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-                return v;
+        .map(v -> {
+            try {
+                Thread.sleep(10);
+            } catch (Exception e) {
+                e.printStackTrace();
             }
+            return v;
         })
         .subscribe(ts);
 
@@ -525,18 +500,8 @@ public class FlowableBackpressureTests extends RxJavaTest {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             firehose(emitCount)
-            .onBackpressureDrop(new Consumer<Integer>() {
-                @Override
-                public void accept(Integer v) {
-                    dropCount.incrementAndGet();
-                }
-            })
-            .doOnNext(new Consumer<Integer>() {
-                @Override
-                public void accept(Integer v) {
-                    passCount.incrementAndGet();
-                }
-            })
+            .onBackpressureDrop(_ -> dropCount.incrementAndGet())
+            .doOnNext(_ -> passCount.incrementAndGet())
             .observeOn(Schedulers.computation())
             .map(SLOW_PASS_THRU)
             .take(num).subscribe(ts);
@@ -587,12 +552,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
             int num = (int) (Flowable.bufferSize() * 1.1); // > 1 so that take doesn't prevent buffer overflow
             AtomicInteger c = new AtomicInteger();
             TestSubscriber<Integer> ts = new TestSubscriber<>();
-            firehose(c).onBackpressureDrop(new Consumer<Integer>() {
-                @Override
-                public void accept(Integer j) {
-                    dropCount.incrementAndGet();
-                }
-            })
+            firehose(c).onBackpressureDrop(_ -> dropCount.incrementAndGet())
             .map(SLOW_PASS_THRU).take(num).subscribe(ts);
             ts.awaitDone(5, TimeUnit.SECONDS);
             ts.assertNoErrors();
@@ -618,12 +578,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         AtomicInteger c = new AtomicInteger();
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        firehose(c).takeWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 100000;
-            }
-        })
+        firehose(c).takeWhile(t1 -> t1 < 100000)
         .onBackpressureBuffer()
         .observeOn(Schedulers.computation())
         .map(SLOW_PASS_THRU).take(num).subscribe(ts);
@@ -647,46 +602,39 @@ public class FlowableBackpressureTests extends RxJavaTest {
     }
 
     private static Flowable<Integer> incrementingIntegers(final AtomicInteger counter, final ConcurrentLinkedQueue<Thread> threadsSeen) {
-        return Flowable.unsafeCreate(new Publisher<Integer>() {
+        return Flowable.unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
+            int i;
+
+            volatile boolean cancelled;
+
+            final AtomicLong requested = new AtomicLong();
 
             @Override
-            public void subscribe(final Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() /* NFI */ {
-                    int i;
-
-                    volatile boolean cancelled;
-
-                    final AtomicLong requested = new AtomicLong();
-
-                    @Override
-                    public void request(long n) {
-                        if (!SubscriptionHelper.validate(n)) {
+            public void request(long n) {
+                if (!SubscriptionHelper.validate(n)) {
+                    return;
+                }
+                if (threadsSeen != null) {
+                    threadsSeen.offer(Thread.currentThread());
+                }
+                long c = BackpressureHelper.add(requested, n);
+                if (c == 0) {
+                    while (!cancelled) {
+                        counter.incrementAndGet();
+                        s.onNext(i++);
+                        if (requested.decrementAndGet() == 0) {
+                            // we're done emitting the number requested so return
                             return;
                         }
-                        if (threadsSeen != null) {
-                            threadsSeen.offer(Thread.currentThread());
-                        }
-                        long c = BackpressureHelper.add(requested, n);
-                        if (c == 0) {
-                            while (!cancelled) {
-                                counter.incrementAndGet();
-                                s.onNext(i++);
-                                if (requested.decrementAndGet() == 0) {
-                                    // we're done emitting the number requested so return
-                                    return;
-                                }
-                            }
-                        }
                     }
-
-                    @Override
-                    public void cancel() {
-                        cancelled = true;
-                    }
-                });
+                }
             }
 
-        });
+            @Override
+            public void cancel() {
+                cancelled = true;
+            }
+        }));
     }
 
     /**
@@ -696,16 +644,13 @@ public class FlowableBackpressureTests extends RxJavaTest {
      * @return the Flowable doing the increments
      */
     private static Flowable<Integer> firehose(final AtomicInteger counter) {
-        return Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                Subscription s2 = new FirehoseNoBackpressure(counter, s);
-                s.onSubscribe(s2);
-            }
+        return Flowable.unsafeCreate(s -> {
+            Subscription s2 = new FirehoseNoBackpressure(counter, s);
+            s.onSubscribe(s2);
         });
     }
 
-    static final Function<Integer, Integer> SLOW_PASS_THRU = new Function<Integer, Integer>() {
+    static final Function<Integer, Integer> SLOW_PASS_THRU = new Function<Integer, Integer>() /* NFI */ {
         volatile int sink;
         @Override
         public Integer apply(Integer t1) {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
@@ -33,17 +33,9 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectToListFlowable() {
         Flowable<List<Integer>> f = Flowable.just(1, 2, 3)
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> list, Integer v) {
-                list.add(v);
-            }
-        }).toFlowable();
+        .collect((Supplier<List<Integer>>) () -> new ArrayList<>(),
+                (BiConsumer<List<Integer>, Integer>) List::add)
+                .toFlowable();
 
         List<Integer> list =  f.blockingLast();
 
@@ -65,20 +57,12 @@ public final class FlowableCollectTest extends RxJavaTest {
     public void collectToStringFlowable() {
         String value = Flowable.just(1, 2, 3)
             .collect(
-                new Supplier<StringBuilder>() {
-                    @Override
-                    public StringBuilder get() {
-                        return new StringBuilder();
-                    }
-                },
-                new BiConsumer<StringBuilder, Integer>() {
-                    @Override
-                    public void accept(StringBuilder sb, Integer v) {
-                    if (sb.length() > 0) {
-                        sb.append("-");
-                    }
-                    sb.append(v);
+                () -> new StringBuilder(),
+                (sb, v) -> {
+                if (sb.length() > 0) {
+                    sb.append("-");
                 }
+                sb.append(v);
             }).toFlowable().blockingLast().toString();
 
         assertEquals("1-2-3", value);
@@ -87,19 +71,9 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void factoryFailureResultsInErrorEmissionFlowable() {
         final RuntimeException e = new RuntimeException();
-        Flowable.just(1).collect(new Supplier<List<Integer>>() {
-
-            @Override
-            public List<Integer> get() throws Exception {
-                throw e;
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-
-            @Override
-            public void accept(List<Integer> list, Integer t) {
-                list.add(t);
-            }
-        })
+        Flowable.just(1).collect(() -> {
+            throw e;
+        }, (BiConsumer<List<Integer>, Integer>) List::add)
         .test()
         .assertNoValues()
         .assertError(e)
@@ -143,7 +117,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     public void collectorFailureDoesNotResultInErrorAndOnNextEmissionsFlowable() {
         final RuntimeException e = new RuntimeException();
         final AtomicBoolean added = new AtomicBoolean();
-        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() {
+        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
 
             boolean once = true;
 
@@ -184,17 +158,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectToList() {
         Single<List<Integer>> o = Flowable.just(1, 2, 3)
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> list, Integer v) {
-                list.add(v);
-            }
-        });
+        .collect(() -> new ArrayList<>(), (BiConsumer<List<Integer>, Integer>) List::add);
 
         List<Integer> list =  o.blockingGet();
 
@@ -216,20 +180,12 @@ public final class FlowableCollectTest extends RxJavaTest {
     public void collectToString() {
         String value = Flowable.just(1, 2, 3)
             .collect(
-                new Supplier<StringBuilder>() {
-                    @Override
-                    public StringBuilder get() {
-                        return new StringBuilder();
-                    }
-                },
-                new BiConsumer<StringBuilder, Integer>() {
-                    @Override
-                    public void accept(StringBuilder sb, Integer v) {
-                    if (sb.length() > 0) {
-                        sb.append("-");
-                    }
-                    sb.append(v);
+                () -> new StringBuilder(),
+                (sb, v) -> {
+                if (sb.length() > 0) {
+                    sb.append("-");
                 }
+                sb.append(v);
             }).blockingGet().toString();
 
         assertEquals("1-2-3", value);
@@ -238,19 +194,8 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void factoryFailureResultsInErrorEmission() {
         final RuntimeException e = new RuntimeException();
-        Flowable.just(1).collect(new Supplier<List<Integer>>() {
-
-            @Override
-            public List<Integer> get() throws Exception {
-                throw e;
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-
-            @Override
-            public void accept(List<Integer> list, Integer t) {
-                list.add(t);
-            }
-        })
+        Flowable.just(1).collect(() -> { throw e; },
+                (BiConsumer<List<Integer>, Integer>) List::add)
         .test()
         .assertNoValues()
         .assertError(e)
@@ -292,7 +237,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     public void collectorFailureDoesNotResultInErrorAndOnNextEmissions() {
         final RuntimeException e = new RuntimeException();
         final AtomicBoolean added = new AtomicBoolean();
-        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() {
+        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
 
             boolean once = true;
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCombineLatestTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCombineLatestTests.java
@@ -37,24 +37,9 @@ public class FlowableCombineLatestTests extends RxJavaTest {
         Flowable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine);
     }
 
-    BiFunction<Media, Rating, ExtendedResult> combine = new BiFunction<Media, Rating, ExtendedResult>() {
-        @Override
-        public ExtendedResult apply(Media m, Rating r) {
-            return new ExtendedResult();
-        }
-    };
+    BiFunction<Media, Rating, ExtendedResult> combine = (_, _) -> new ExtendedResult();
 
-    Consumer<Result> action = new Consumer<Result>() {
-        @Override
-        public void accept(Result t1) {
-            System.out.println("Result: " + t1);
-        }
-    };
+    Consumer<Result> action = t1 -> System.out.println("Result: " + t1);
 
-    Consumer<ExtendedResult> extendedAction = new Consumer<ExtendedResult>() {
-        @Override
-        public void accept(ExtendedResult t1) {
-            System.out.println("Result: " + t1);
-        }
-    };
+    Consumer<ExtendedResult> extendedAction = t1 -> System.out.println("Result: " + t1);
 }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableConcatTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableConcatTests.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.flowable.FlowableCovarianceTest.*;
@@ -144,14 +143,11 @@ public class FlowableConcatTests extends RxJavaTest {
         Media media = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
 
-        Flowable<Movie> f1 = Flowable.unsafeCreate(new Publisher<Movie>() {
-            @Override
-            public void subscribe(Subscriber<? super Movie> subscriber) {
-                    subscriber.onNext(horrorMovie1);
-                    subscriber.onNext(movie);
-                    //                o.onNext(new Media()); // correctly doesn't compile
-                    subscriber.onComplete();
-            }
+        Flowable<Movie> f1 = Flowable.unsafeCreate(subscriber -> {
+                subscriber.onNext(horrorMovie1);
+                subscriber.onNext(movie);
+                //                o.onNext(new Media()); // correctly doesn't compile
+                subscriber.onComplete();
         });
 
         Flowable<Media> f2 = Flowable.just(media, horrorMovie2);

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableConversionTest.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.flowable;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -84,19 +85,17 @@ public class FlowableConversionTest extends RxJavaTest {
         }
 
         public CylonDetectorObservable<String> DESTROY() {
-            return boop(new Function<T, String>() {
-                @Override
-                public String apply(T t) {
-                    Object cylon = ((Jail) t).cylon;
-                    throwOutTheAirlock(cylon);
-                    if (t instanceof Jail) {
-                        String name = cylon.toString();
-                        return "Cylon '" + name + "' has been destroyed";
-                    }
-                    else {
-                        return "Cylon 'anonymous' has been destroyed";
-                    }
-                }});
+            return boop(t -> {
+                Object cylon = ((Jail) t).cylon;
+                throwOutTheAirlock(cylon);
+                if (t instanceof Jail) {
+                    String name = cylon.toString();
+                    return "Cylon '" + name + "' has been destroyed";
+                }
+                else {
+                    return "Cylon 'anonymous' has been destroyed";
+                }
+            });
         }
 
         private static void throwOutTheAirlock(Object cylon) {
@@ -145,7 +144,7 @@ public class FlowableConversionTest extends RxJavaTest {
 
     @Test
     public void conversionBetweenObservableClasses() {
-        final TestObserver<String> to = new TestObserver<>(new DefaultObserver<String>() {
+        final TestObserver<String> to = new TestObserver<>(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -167,33 +166,13 @@ public class FlowableConversionTest extends RxJavaTest {
         List<Object> crewOfBattlestarGalactica = Arrays.asList(new Object[] {"William Adama", "Laura Roslin", "Lee Adama", new Cylon()});
 
         Flowable.fromIterable(crewOfBattlestarGalactica)
-            .doOnNext(new Consumer<Object>() {
-                @Override
-                public void accept(Object pv) {
-                    System.out.println(pv);
-                }
-            })
+            .doOnNext(pv -> System.out.println(pv))
             .to(new ConvertToCylonDetector<>())
-            .beep(new Predicate<Object>() {
-                @Override
-                public boolean test(Object t) {
-                    return t instanceof Cylon;
-                }
-            })
-            .boop(new Function<Object, Object>() {
-                @Override
-                public Object apply(Object cylon) {
-                    return new Jail(cylon);
-                }
-            })
+            .beep(Cylon.class::isInstance)
+            .boop(cylon -> new Jail(cylon))
             .DESTROY()
             .x(new ConvertToObservable<>())
-            .reduce("Cylon Detector finished. Report:\n", new BiFunction<String, String, String>() {
-                @Override
-                public String apply(String a, String n) {
-                    return a + n + "\n";
-                }
-            })
+            .reduce("Cylon Detector finished. Report:\n", (a, n) -> a + n + "\n")
             .subscribe(to);
 
         to.assertNoErrors();
@@ -205,45 +184,34 @@ public class FlowableConversionTest extends RxJavaTest {
         final AtomicReference<Throwable> thrown = new AtomicReference<>(null);
         final AtomicBoolean isFinished = new AtomicBoolean(false);
         ConcurrentLinkedQueue<? extends Integer> queue = Flowable.range(0, 5)
-                .flatMap(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(final Integer i) {
-                        return Flowable.range(0, 5)
-                                .observeOn(Schedulers.cached())
-                                .map(new Function<Integer, Integer>() {
-                                    @Override
-                                    public Integer apply(Integer k) {
-                                        try {
-                                            Thread.sleep(System.currentTimeMillis() % 100);
-                                        } catch (InterruptedException e) {
-                                            e.printStackTrace();
-                                        }
-                                        return i + k;
-                                    }
-                                });
-                    }
-                })
-                    .to(new FlowableConverter<Integer, ConcurrentLinkedQueue<Integer>>() {
-                        @Override
-                        public ConcurrentLinkedQueue<Integer> apply(Flowable<Integer> onSubscribe) {
-                            final ConcurrentLinkedQueue<Integer> q = new ConcurrentLinkedQueue<>();
-                            onSubscribe.subscribe(new DefaultSubscriber<Integer>() {
-                                @Override
-                                public void onComplete() {
-                                    isFinished.set(true);
-                                }
+                .flatMap((Function<Integer, Publisher<Integer>>) i -> Flowable.range(0, 5)
+                        .observeOn(Schedulers.cached())
+                        .map(k -> {
+                            try {
+                                Thread.sleep(System.currentTimeMillis() % 100);
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            }
+                            return i + k;
+                        }))
+                    .to(onSubscribe -> {
+                        final ConcurrentLinkedQueue<Integer> q = new ConcurrentLinkedQueue<>();
+                        onSubscribe.subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                            @Override
+                            public void onComplete() {
+                                isFinished.set(true);
+                            }
 
-                                @Override
-                                public void onError(Throwable e) {
-                                    thrown.set(e);
-                                }
+                            @Override
+                            public void onError(Throwable e) {
+                                thrown.set(e);
+                            }
 
-                                @Override
-                                public void onNext(Integer t) {
-                                    q.add(t);
-                                }});
-                            return q;
-                        }
+                            @Override
+                            public void onNext(Integer t) {
+                                q.add(t);
+                            }});
+                        return q;
                     });
 
         int x = 0;

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCovarianceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCovarianceTest.java
@@ -16,11 +16,13 @@ package io.reactivex.rxjava4.flowable;
 import static org.junit.Assert.assertEquals;
 
 import java.util.*;
+import java.util.concurrent.Flow.Publisher;
 
 import org.junit.Test;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.flowable.FlowableCovarianceTest.Movie;
 import io.reactivex.rxjava4.flowables.GroupedFlowable;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.testsupport.TestSubscriberEx;
@@ -44,12 +46,7 @@ public class FlowableCovarianceTest extends RxJavaTest {
 
     @Test
     public void sortedList() {
-        Comparator<Media> sortFunction = new Comparator<Media>() {
-            @Override
-            public int compare(Media t1, Media t2) {
-                return 1;
-            }
-        };
+        Comparator<Media> sortFunction = (_, _) -> 1;
 
         // this one would work without the covariance generics
         Flowable<Media> f = Flowable.just(new Movie(), new TVSeason(), new Album());
@@ -66,43 +63,12 @@ public class FlowableCovarianceTest extends RxJavaTest {
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
 
         movies
-        .groupBy(new Function<Movie, Object>() {
-            @Override
-            public Object apply(Movie v) {
-                return v.getClass();
-            }
-        })
-        .doOnNext(new Consumer<GroupedFlowable<Object, Movie>>() {
-            @Override
-            public void accept(GroupedFlowable<Object, Movie> g) {
-                System.out.println(g.getKey());
-            }
-        })
-        .flatMap(new Function<GroupedFlowable<Object, Movie>, Publisher<String>>() {
-            @Override
-            public Publisher<String> apply(GroupedFlowable<Object, Movie> g) {
-                return g
-                        .doOnNext(new Consumer<Movie>() {
-                            @Override
-                            public void accept(Movie v) {
-                                System.out.println(v);
-                            }
-                        })
-                        .compose(new FlowableTransformer<Movie, Movie>() {
-                            @Override
-                            public Publisher<Movie> apply(Flowable<Movie> m) {
-                                return m.concatWith(Flowable.just(new ActionMovie()));
-                            }
-                        }
-                                )
-                        .map(new Function<Object, String>() {
-                            @Override
-                            public String apply(Object v) {
-                                return v.toString();
-                            }
-                        });
-            }
-        })
+        .groupBy((Function<Movie, Object>) Movie::getClass)
+        .doOnNext(g -> System.out.println(g.getKey()))
+        .flatMap((Function<GroupedFlowable<Object, Movie>, Publisher<String>>) g -> g
+                .doOnNext(v -> System.out.println(v))
+                .compose(m -> m.concatWith(Flowable.just(new ActionMovie())))
+                .map((Function<Object, String>) Object::toString))
         .subscribe(ts);
         ts.assertTerminated();
         ts.assertNoErrors();
@@ -114,41 +80,22 @@ public class FlowableCovarianceTest extends RxJavaTest {
     @Test
     public void covarianceOfCompose() {
         Flowable<HorrorMovie> movie = Flowable.just(new HorrorMovie());
-        Flowable<Movie> movie2 = movie.compose(new FlowableTransformer<HorrorMovie, Movie>() {
-            @Override
-            public Publisher<Movie> apply(Flowable<HorrorMovie> t) {
-                return Flowable.just(new Movie());
-            }
-        });
+        Flowable<Movie> movie2 = movie.compose(t -> Flowable.just(new Movie()));
     }
 
     @SuppressWarnings("unused")
     @Test
     public void covarianceOfCompose2() {
         Flowable<Movie> movie = Flowable.<Movie> just(new HorrorMovie());
-        Flowable<HorrorMovie> movie2 = movie.compose(new FlowableTransformer<Movie, HorrorMovie>() {
-            @Override
-            public Publisher<HorrorMovie> apply(Flowable<Movie> t) {
-                return Flowable.just(new HorrorMovie());
-            }
-        });
+        Flowable<HorrorMovie> movie2 = movie.compose(t -> Flowable.just(new HorrorMovie()));
     }
 
     @SuppressWarnings("unused")
     @Test
     public void covarianceOfCompose3() {
         Flowable<Movie> movie = Flowable.<Movie>just(new HorrorMovie());
-        Flowable<HorrorMovie> movie2 = movie.compose(new FlowableTransformer<Movie, HorrorMovie>() {
-            @Override
-            public Publisher<HorrorMovie> apply(Flowable<Movie> t) {
-                return Flowable.just(new HorrorMovie()).map(new Function<HorrorMovie, HorrorMovie>() {
-                    @Override
-                    public HorrorMovie apply(HorrorMovie v) {
-                        return v;
-                    }
-                });
-            }
-        }
+        Flowable<HorrorMovie> movie2 = movie.compose(t -> Flowable.just(new HorrorMovie())
+                .map(v -> v)
         );
     }
 
@@ -156,17 +103,7 @@ public class FlowableCovarianceTest extends RxJavaTest {
     @Test
     public void covarianceOfCompose4() {
         Flowable<HorrorMovie> movie = Flowable.just(new HorrorMovie());
-        Flowable<HorrorMovie> movie2 = movie.compose(new FlowableTransformer<HorrorMovie, HorrorMovie>() {
-            @Override
-            public Publisher<HorrorMovie> apply(Flowable<HorrorMovie> t1) {
-                return t1.map(new Function<HorrorMovie, HorrorMovie>() {
-                    @Override
-                    public HorrorMovie apply(HorrorMovie v) {
-                        return v;
-                    }
-                });
-            }
-        });
+        Flowable<HorrorMovie> movie2 = movie.compose(t1 -> t1.map(v -> v));
     }
 
     @Test
@@ -177,44 +114,36 @@ public class FlowableCovarianceTest extends RxJavaTest {
         movies.compose(deltaTransformer);
     }
 
-    static Function<List<List<Movie>>, Flowable<Movie>> calculateDelta = new Function<List<List<Movie>>, Flowable<Movie>>() {
-        @Override
-        public Flowable<Movie> apply(List<List<Movie>> listOfLists) {
-            if (listOfLists.size() == 1) {
-                return Flowable.fromIterable(listOfLists.get(0));
-            } else {
-                // diff the two
-                List<Movie> newList = listOfLists.get(1);
-                List<Movie> oldList = new ArrayList<>(listOfLists.get(0));
+    static Function<List<List<Movie>>, Flowable<Movie>> calculateDelta = listOfLists -> {
+        if (listOfLists.size() == 1) {
+            return Flowable.fromIterable(listOfLists.get(0));
+        } else {
+            // diff the two
+            List<Movie> newList = listOfLists.get(1);
+            List<Movie> oldList = new ArrayList<>(listOfLists.get(0));
 
-                Set<Movie> delta = new LinkedHashSet<>();
-                delta.addAll(newList);
-                // remove all that match in old
-                delta.removeAll(oldList);
+            Set<Movie> delta = new LinkedHashSet<>();
+            delta.addAll(newList);
+            // remove all that match in old
+            delta.removeAll(oldList);
 
-                // filter oldList to those that aren't in the newList
-                oldList.removeAll(newList);
+            // filter oldList to those that aren't in the newList
+            oldList.removeAll(newList);
 
-                // for all left in the oldList we'll create DROP events
-                for (@SuppressWarnings("unused") Movie old : oldList) {
-                    delta.add(new Movie());
-                }
-
-                return Flowable.fromIterable(delta);
+            // for all left in the oldList we'll create DROP events
+            for (@SuppressWarnings("unused") Movie old : oldList) {
+                delta.add(new Movie());
             }
+
+            return Flowable.fromIterable(delta);
         }
     };
 
-    static FlowableTransformer<List<Movie>, Movie> deltaTransformer = new FlowableTransformer<List<Movie>, Movie>() {
-        @Override
-        public Publisher<Movie> apply(Flowable<List<Movie>> movieList) {
-            return movieList
-                .startWithItem(new ArrayList<>())
-                .buffer(2, 1)
-                .skip(1)
-                .flatMap(calculateDelta);
-        }
-    };
+    static FlowableTransformer<List<Movie>, Movie> deltaTransformer = movieList -> movieList
+        .startWithItem(new ArrayList<>())
+        .buffer(2, 1)
+        .skip(1)
+        .flatMap(calculateDelta);
 
     /*
      * Most tests are moved into their applicable classes such as [Operator]Tests.java

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableDoAfterNextTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.RxJavaTest;
-import io.reactivex.rxjava4.functions.Consumer;
 
 public class FlowableDoAfterNextTest extends RxJavaTest {
 
@@ -29,12 +28,10 @@ public class FlowableDoAfterNextTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         final RuntimeException e = new RuntimeException();
         Burst.items(1, 2).create()
-            .doAfterNext(new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Exception {
-                    count.incrementAndGet();
-                    throw e;
-                }})
+            .doAfterNext(_ -> {
+                count.incrementAndGet();
+                throw e;
+            })
             .test()
             .assertError(e)
             .assertValue(1);

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableDoOnTest.java
@@ -28,12 +28,7 @@ public class FlowableDoOnTest extends RxJavaTest {
     @Test
     public void doOnEach() {
         final AtomicReference<String> r = new AtomicReference<>();
-        String output = Flowable.just("one").doOnNext(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                r.set(v);
-            }
-        }).blockingSingle();
+        String output = Flowable.just("one").doOnNext(v -> r.set(v)).blockingSingle();
 
         assertEquals("one", output);
         assertEquals("one", r.get());
@@ -45,12 +40,7 @@ public class FlowableDoOnTest extends RxJavaTest {
         Throwable t = null;
         try {
             Flowable.<String> error(new RuntimeException("an error"))
-            .doOnError(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable v) {
-                    r.set(v);
-                }
-            }).blockingSingle();
+            .doOnError(v -> r.set(v)).blockingSingle();
             fail("expected exception, not a return value");
         } catch (Throwable e) {
             t = e;

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableErrorHandlingTests.java
@@ -37,7 +37,7 @@ public class FlowableErrorHandlingTests extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Flowable<Long> f = Flowable.interval(50, TimeUnit.MILLISECONDS);
-        Subscriber<Long> subscriber = new DefaultSubscriber<Long>() {
+        Subscriber<Long> subscriber = new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -74,7 +74,7 @@ public class FlowableErrorHandlingTests extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Flowable<Long> f = Flowable.interval(50, TimeUnit.MILLISECONDS);
-        Subscriber<Long> subscriber = new DefaultSubscriber<Long>() {
+        Subscriber<Long> subscriber = new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             public void onComplete() {


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<[^>]+>+)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080