### PR TITLE
4.x: Unit test lambdaification 4 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/core/ConverterTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/ConverterTest.java
@@ -174,52 +174,27 @@ public final class ConverterTest extends RxJavaTest {
     interface B<T> { }
 
     private static <T> ObservableConverter<A<T, ?>, B<T>> testObservableConverterCreator() {
-        return new ObservableConverter<A<T, ?>, B<T>>() {
-            @Override
-            public B<T> apply(Observable<A<T, ?>> a) {
-                return new B<T>() /* NFI */ {
-                };
-            }
+        return _ -> new B<T>() /* NFI */ {
         };
     }
 
     private static <T> SingleConverter<A<T, ?>, B<T>> testSingleConverterCreator() {
-        return new SingleConverter<A<T, ?>, B<T>>() {
-            @Override
-            public B<T> apply(Single<A<T, ?>> a) {
-                return new B<T>() /* NFI */ {
-                };
-            }
+        return _ -> new B<T>() /* NFI */ {
         };
     }
 
     private static <T> MaybeConverter<A<T, ?>, B<T>> testMaybeConverterCreator() {
-        return new MaybeConverter<A<T, ?>, B<T>>() {
-            @Override
-            public B<T> apply(Maybe<A<T, ?>> a) {
-                return new B<T>() /* NFI */ {
-                };
-            }
+        return _ -> new B<T>() /* NFI */ {
         };
     }
 
     private static <T> FlowableConverter<A<T, ?>, B<T>> testFlowableConverterCreator() {
-        return new FlowableConverter<A<T, ?>, B<T>>() {
-            @Override
-            public B<T> apply(Flowable<A<T, ?>> a) {
-                return new B<T>() /* NFI */ {
-                };
-            }
+        return _ -> new B<T>() /* NFI */ {
         };
     }
 
     private static <T> ParallelFlowableConverter<A<T, ?>, B<T>> testParallelFlowableConverterCreator() {
-        return new ParallelFlowableConverter<A<T, ?>, B<T>>() {
-            @Override
-            public B<T> apply(ParallelFlowable<A<T, ?>> a) {
-                return new B<T>() /* NFI */ {
-                };
-            }
+        return a -> new B<T>() /* NFI */ {
         };
     }
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
@@ -144,12 +144,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectIntoFlowable() {
         Flowable.just(1, 1, 1, 1, 2)
-        .collectInto(new HashSet<>(), new BiConsumer<HashSet<Integer>, Integer>() {
-            @Override
-            public void accept(HashSet<Integer> s, Integer v) throws Exception {
-                s.add(v);
-            }
-        })
+        .collectInto(new HashSet<>(), (BiConsumer<HashSet<Integer>, Integer>) HashSet::add)
         .toFlowable()
         .test()
         .assertResult(new HashSet<>(Arrays.asList(1, 2)));
@@ -263,12 +258,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectInto() {
         Flowable.just(1, 1, 1, 1, 2)
-        .collectInto(new HashSet<>(), new BiConsumer<HashSet<Integer>, Integer>() {
-            @Override
-            public void accept(HashSet<Integer> s, Integer v) throws Exception {
-                s.add(v);
-            }
-        })
+        .collectInto(new HashSet<>(), (BiConsumer<HashSet<Integer>, Integer>) HashSet::add)
         .test()
         .assertResult(new HashSet<>(Arrays.asList(1, 2)));
     }
@@ -276,47 +266,17 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1, 2)
-            .collect(Functions.justSupplier(new ArrayList<>()), new BiConsumer<ArrayList<Integer>, Integer>() {
-                @Override
-                public void accept(ArrayList<Integer> a, Integer b) throws Exception {
-                    a.add(b);
-                }
-            }));
+            .collect(Functions.justSupplier(new ArrayList<>()), (BiConsumer<ArrayList<Integer>, Integer>) ArrayList::add));
 
         TestHelper.checkDisposed(Flowable.just(1, 2)
-                .collect(Functions.justSupplier(new ArrayList<>()), new BiConsumer<ArrayList<Integer>, Integer>() {
-                    @Override
-                    public void accept(ArrayList<Integer> a, Integer b) throws Exception {
-                        a.add(b);
-                    }
-                }).toFlowable());
+                .collect(Functions.justSupplier(new ArrayList<>()), (BiConsumer<ArrayList<Integer>, Integer>) ArrayList::add).toFlowable());
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Integer>, Flowable<ArrayList<Integer>>>() {
-            @Override
-            public Flowable<ArrayList<Integer>> apply(Flowable<Integer> f) throws Exception {
-                return f.collect(Functions.justSupplier(new ArrayList<>()),
-                        new BiConsumer<ArrayList<Integer>, Integer>() {
-                            @Override
-                            public void accept(ArrayList<Integer> a, Integer b) throws Exception {
-                                a.add(b);
-                            }
-                        }).toFlowable();
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Integer>, Single<ArrayList<Integer>>>() {
-            @Override
-            public Single<ArrayList<Integer>> apply(Flowable<Integer> f) throws Exception {
-                return f.collect(Functions.justSupplier(new ArrayList<>()),
-                        new BiConsumer<ArrayList<Integer>, Integer>() {
-                            @Override
-                            public void accept(ArrayList<Integer> a, Integer b) throws Exception {
-                                a.add(b);
-                            }
-                        });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Integer>, Flowable<ArrayList<Integer>>>) f -> f.collect(Functions.justSupplier(new ArrayList<>()),
+                (BiConsumer<ArrayList<Integer>, Integer>) ArrayList::add).toFlowable());
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle((Function<Flowable<Integer>, Single<ArrayList<Integer>>>) f -> f.collect(Functions.justSupplier(new ArrayList<>()),
+                (BiConsumer<ArrayList<Integer>, Integer>) ArrayList::add));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableGroupByTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableGroupByTests.java
@@ -16,6 +16,8 @@ package io.reactivex.rxjava4.flowable;
 import org.junit.Test;
 import static java.util.concurrent.Flow.*;
 
+import java.util.concurrent.Flow.Publisher;
+
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.flowable.FlowableEventStream.Event;
 import io.reactivex.rxjava4.flowables.GroupedFlowable;
@@ -31,19 +33,11 @@ public class FlowableGroupByTests extends RxJavaTest {
             FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
         )
         // group by type (2 clusters)
-        .groupBy(new Function<Event, Object>() {
-            @Override
-            public Object apply(Event event) {
-                return event.type;
-            }
-        })
+        .groupBy(event -> (Object)event.type)
         .take(1)
-        .blockingForEach(new Consumer<GroupedFlowable<Object, Event>>() {
-            @Override
-            public void accept(GroupedFlowable<Object, Event> v) {
-                System.out.println(v);
-                v.take(1).subscribe();  // FIXME groups need consumption to a certain degree to cancel upstream
-            }
+        .blockingForEach(v -> {
+            System.out.println(v);
+            v.take(1).subscribe();  // FIXME groups need consumption to a certain degree to cancel upstream
         });
 
         System.out.println("**** finished");
@@ -56,30 +50,11 @@ public class FlowableGroupByTests extends RxJavaTest {
             FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
         )
         // group by type (2 clusters)
-        .groupBy(new Function<Event, Object>() {
-            @Override
-            public Object apply(Event event) {
-                return event.type;
-            }
-        })
-        .flatMap(new Function<GroupedFlowable<Object, Event>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(GroupedFlowable<Object, Event> g) {
-                return g.map(new Function<Event, Object>() {
-                    @Override
-                    public Object apply(Event event) {
-                        return event.instanceId + " - " + event.values.get("count200");
-                    }
-                });
-            }
-        })
+        .groupBy(event -> (Object)event.type)
+        .flatMap((Function<GroupedFlowable<Object, Event>, Publisher<Object>>)
+                g -> g.map(event -> event.instanceId + " - " + event.values.get("count200")))
         .take(20)
-        .blockingForEach(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) {
-                System.out.println(v);
-            }
-        });
+        .blockingForEach(v -> System.out.println(v));
 
         System.out.println("**** finished");
     }
@@ -89,18 +64,9 @@ public class FlowableGroupByTests extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(0, 20)
-        .groupBy(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer i) {
-                return i % 5;
-            }
-        })
-        .concatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> v) {
-                return v;
-            }
-        }, 20) // need to prefetch as many groups as groupBy produces to avoid MBE
+        .groupBy(i -> i % 5)
+        // need to prefetch as many groups as groupBy produces to avoid MBE
+        .concatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>) v -> v, 20)
         .subscribe(ts);
 
         // Behavior change: this now counts as group abandonment because concatMap

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableMergeTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableMergeTests.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava4.flowable;
 import static org.junit.Assert.*;
 
 import java.util.List;
+import java.util.concurrent.Flow.Publisher;
 
 import org.junit.Test;
 import static java.util.concurrent.Flow.*;
@@ -76,15 +77,10 @@ public class FlowableMergeTests extends RxJavaTest {
     @Test
     public void mergeCovariance4() {
 
-        Flowable<Movie> f1 = Flowable.defer(new Supplier<Publisher<Movie>>() {
-            @Override
-            public Publisher<Movie> get() {
-                return Flowable.just(
-                        new HorrorMovie(),
-                        new Movie()
-                );
-            }
-        });
+        Flowable<Movie> f1 = Flowable.defer((Supplier<Publisher<Movie>>) () -> Flowable.just(
+                new HorrorMovie(),
+                new Movie()
+        ));
 
         Flowable<Media> f2 = Flowable.just(new Media(), new HorrorMovie());
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 
 import org.junit.*;
 import static java.util.concurrent.Flow.*;
@@ -49,12 +50,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test
     public void ambIterableIteratorNull() {
-        Flowable.amb(new Iterable<Publisher<Object>>() {
-            @Override
-            public Iterator<Publisher<Object>> iterator() {
-                return null;
-            }
-        }).test().assertError(NullPointerException.class);
+        Flowable.amb((Iterable<Publisher<Object>>) () -> null).test().assertError(NullPointerException.class);
     }
 
     @Test
@@ -66,47 +62,22 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableIteratorNull() {
-        Flowable.combineLatestDelayError(new Iterable<Publisher<Object>>() {
-            @Override
-            public Iterator<Publisher<Object>> iterator() {
-                return null;
-            }
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }).blockingLast();
+        Flowable.combineLatestDelayError((Iterable<Publisher<Object>>) () -> null, _ -> 1).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableOneIsNull() {
-        Flowable.combineLatestDelayError(Arrays.asList(Flowable.never(), null), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }).blockingLast();
+        Flowable.combineLatestDelayError(Arrays.asList(Flowable.never(), null), _ -> 1).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionReturnsNull() {
-        Flowable.combineLatestDelayError(Arrays.asList(just1), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return null;
-            }
-        }).blockingLast();
+        Flowable.combineLatestDelayError(Arrays.asList(just1), _ -> null).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void concatIterableIteratorNull() {
-        Flowable.concat(new Iterable<Publisher<Object>>() {
-            @Override
-            public Iterator<Publisher<Object>> iterator() {
-                return null;
-            }
-        }).blockingLast();
+        Flowable.concat((Iterable<Publisher<Object>>) () -> null).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
@@ -121,22 +92,12 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void deferFunctionReturnsNull() {
-        Flowable.defer(new Supplier<Publisher<Object>>() {
-            @Override
-            public Publisher<Object> get() {
-                return null;
-            }
-        }).blockingLast();
+        Flowable.defer((Supplier<Publisher<Object>>) () -> null).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void errorFunctionReturnsNull() {
-        Flowable.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return null;
-            }
-        }).blockingSubscribe();
+        Flowable.error(() -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
@@ -146,12 +107,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromCallableReturnsNull() {
-        Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return null;
-            }
-        }).blockingLast();
+        Flowable.fromCallable(() -> null).blockingLast();
     }
 
     @Test
@@ -175,12 +131,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromIterableIteratorNull() {
-        Flowable.fromIterable(new Iterable<Object>() {
-            @Override
-            public Iterator<Object> iterator() {
-                return null;
-            }
-        }).blockingLast();
+        Flowable.fromIterable(() -> null).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
@@ -190,73 +141,37 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void generateConsumerEmitsNull() {
-        Flowable.generate(new Consumer<Emitter<Object>>() {
-            @Override
-            public void accept(Emitter<Object> s) {
-                s.onNext(null);
-            }
-        }).blockingLast();
+        Flowable.generate(s -> s.onNext(null)).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void generateStateConsumerInitialStateNull() {
-        BiConsumer<Integer, Emitter<Integer>> generator = new BiConsumer<Integer, Emitter<Integer>>() {
-            @Override
-            public void accept(Integer s, Emitter<Integer> o) {
-                o.onNext(1);
-            }
-        };
+        BiConsumer<Integer, Emitter<Integer>> generator = (_, o) -> o.onNext(1);
         Flowable.generate(null, generator);
     }
 
     @Test(expected = NullPointerException.class)
     public void generateStateFunctionInitialStateNull() {
-        Flowable.generate(null, new BiFunction<Object, Emitter<Object>, Object>() {
-            @Override
-            public Object apply(Object s, Emitter<Object> o) {
-                o.onNext(1); return s;
-            }
+        Flowable.generate(null, (BiFunction<Object, Emitter<Object>, Object>) (s, o) -> {
+            o.onNext(1); return s;
         });
     }
 
     @Test(expected = NullPointerException.class)
     public void generateStateConsumerNull() {
-        Flowable.generate(new Supplier<Integer>() {
-            @Override
-            public Integer get() {
-                return 1;
-            }
-        }, (BiConsumer<Integer, Emitter<Object>>)null);
+        Flowable.generate((Supplier<Integer>) () -> 1, (BiConsumer<Integer, Emitter<Object>>)null);
     }
 
     @Test
     public void generateConsumerStateNullAllowed() {
-        BiConsumer<Integer, Emitter<Integer>> generator = new BiConsumer<Integer, Emitter<Integer>>() {
-            @Override
-            public void accept(Integer s, Emitter<Integer> o) {
-                o.onComplete();
-            }
-        };
-        Flowable.generate(new Supplier<Integer>() {
-            @Override
-            public Integer get() {
-                return null;
-            }
-        }, generator).blockingSubscribe();
+        BiConsumer<Integer, Emitter<Integer>> generator = (_, o) -> o.onComplete();
+        Flowable.generate((Supplier<Integer>) () -> null, generator).blockingSubscribe();
     }
 
     @Test
     public void generateFunctionStateNullAllowed() {
-        Flowable.generate(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return null;
-            }
-        }, new BiFunction<Object, Emitter<Object>, Object>() {
-            @Override
-            public Object apply(Object s, Emitter<Object> o) {
-                o.onComplete(); return s;
-            }
+        Flowable.generate((Supplier<Object>) () -> null, (BiFunction<Object, Emitter<Object>, Object>) (s, o) -> {
+            o.onComplete(); return s;
         }).blockingSubscribe();
     }
 
@@ -289,12 +204,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void mergeIterableIteratorNull() {
-        Flowable.merge(new Iterable<Publisher<Object>>() {
-            @Override
-            public Iterator<Publisher<Object>> iterator() {
-                return null;
-            }
-        }, 128, 128).blockingLast();
+        Flowable.merge((Iterable<Publisher<Object>>) () -> null, 128, 128).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
@@ -309,12 +219,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableIteratorNull() {
-        Flowable.mergeDelayError(new Iterable<Publisher<Object>>() {
-            @Override
-            public Iterator<Publisher<Object>> iterator() {
-                return null;
-            }
-        }, 128, 128).blockingLast();
+        Flowable.mergeDelayError((Iterable<Publisher<Object>>) () -> null, 128, 128).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
@@ -329,77 +234,34 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void usingFlowableSupplierReturnsNull() {
-        Flowable.using(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return 1;
-            }
-        }, new Function<Object, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Object d) {
-                return null;
-            }
-        }, Functions.emptyConsumer()).blockingLast();
+        Flowable.using(() -> 1, (Function<Object, Publisher<Object>>) _ -> null, Functions.emptyConsumer()).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableIteratorNull() {
-        Flowable.zip(new Iterable<Publisher<Object>>() {
-            @Override
-            public Iterator<Publisher<Object>> iterator() {
-                return null;
-            }
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }).blockingLast();
+        Flowable.zip((Iterable<Publisher<Object>>) () -> null, _ -> 1).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableFunctionReturnsNull() {
-        Flowable.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return null;
-            }
-        }).blockingLast();
+        Flowable.zip(Arrays.asList(just1, just1), _ -> null).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2Null() {
-        Flowable.zip((Iterable<Publisher<Object>>)null, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return 1;
-            }
-        }, true, 128);
+        Flowable.zip((Iterable<Publisher<Object>>)null, (Function<Object[], Object>) _ -> 1, true, 128);
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2IteratorNull() {
-        Flowable.zip(new Iterable<Publisher<Object>>() {
-            @Override
-            public Iterator<Publisher<Object>> iterator() {
-                return null;
-            }
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return 1;
-            }
-        }, true, 128).blockingLast();
+        Flowable.zip((Iterable<Publisher<Object>>) () -> null, (Function<Object[], Object>) _ -> 1, true, 128)
+        .blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionReturnsNull() {
-        Flowable.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) {
-                return null;
-            }
-        }, true, 128).blockingLast();
+        Flowable.zip(Arrays.asList(just1, just1), (Function<Object[], Object>) _ -> null, true, 128)
+        .blockingLast();
     }
 
     //*************************************************************
@@ -408,340 +270,152 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void bufferSupplierReturnsNull() {
-        just1.buffer(1, 1, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.buffer(1, 1, (Supplier<Collection<Integer>>) () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferTimedSupplierReturnsNull() {
-        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.buffer(1L, 1L, TimeUnit.SECONDS, Schedulers.single(), () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferOpenCloseCloseReturnsNull() {
-        just1.buffer(just1, new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.buffer(just1, (Function<Integer, Publisher<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void bufferBoundarySupplierReturnsNull() {
-        just1.buffer(just1, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.buffer(just1, (Supplier<Collection<Integer>>) () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void collectInitialSupplierReturnsNull() {
-        just1.collect(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return null;
-            }
-        }, new BiConsumer<Object, Integer>() {
-            @Override
-            public void accept(Object a, Integer b) { }
-        }).blockingGet();
+        just1.collect(() -> null, (_, _) -> { }).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void concatMapReturnsNull() {
-        just1.concatMap(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.concatMap((Function<Integer, Publisher<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void concatMapIterableReturnNull() {
-        just1.concatMapIterable(new Function<Integer, Iterable<Object>>() {
-            @Override
-            public Iterable<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.concatMapIterable((Function<Integer, Iterable<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void concatMapIterableIteratorNull() {
-        just1.concatMapIterable(new Function<Integer, Iterable<Object>>() {
-            @Override
-            public Iterable<Object> apply(Integer v) {
-                return new Iterable<Object>() {
-                    @Override
-                    public Iterator<Object> iterator() {
-                        return null;
-                    }
-                };
-            }
-        }).blockingSubscribe();
+        just1.concatMapIterable((Function<Integer, Iterable<Object>>) _ -> () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void debounceFunctionReturnsNull() {
-        just1.debounce(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.debounce(_ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void delayWithFunctionReturnsNull() {
-        just1.delay(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.delay(_ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void delayBothItemSupplierReturnsNull() {
-        just1.delay(just1, new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.delay(just1, _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void distinctSupplierReturnsNull() {
-        just1.distinct(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return v;
-            }
-        }, new Supplier<Collection<Object>>() {
-            @Override
-            public Collection<Object> get() {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.distinct(v -> v, () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void distinctFunctionReturnsNull() {
-        just1.distinct(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.distinct(_ -> null).blockingSubscribe();
     }
 
     @Test
     public void distinctUntilChangedFunctionReturnsNull() {
-        Flowable.range(1, 2).distinctUntilChanged(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return null;
-            }
-        }).test().assertResult(1);
+        Flowable.range(1, 2).distinctUntilChanged((Function<Integer, Object>) _ -> null).test().assertResult(1);
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapFunctionReturnsNull() {
-        just1.flatMap(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.flatMap((Function<Integer, Publisher<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapNotificationOnNextReturnsNull() {
-        just1.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return null;
-            }
-        }, new Function<Throwable, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Throwable e) {
-                return just1;
-            }
-        }, new Supplier<Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> get() {
-                return just1;
-            }
-        }).blockingSubscribe();
+        just1.flatMap((Function<Integer, Publisher<Integer>>) _ -> null,
+                (Function<Throwable, Publisher<Integer>>) _ -> just1,
+                (Supplier<Publisher<Integer>>) () -> just1)
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapNotificationOnCompleteReturnsNull() {
-        just1.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return just1;
-            }
-        }, new Function<Throwable, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Throwable e) {
-                return just1;
-            }
-        }, new Supplier<Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> get() {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.flatMap((Function<Integer, Publisher<Integer>>) _ -> just1,
+                (Function<Throwable, Publisher<Integer>>) _ -> just1,
+                (Supplier<Publisher<Integer>>) () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapCombinerMapperReturnsNull() {
-        just1.flatMap(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }, new BiFunction<Integer, Object, Object>() {
-            @Override
-            public Object apply(Integer a, Object b) {
-                return 1;
-            }
-        }).blockingSubscribe();
+        just1.flatMap((Function<Integer, Publisher<Object>>) _ -> null,
+                (_, _) -> 1).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapCombinerCombinerReturnsNull() {
-        just1.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return just1;
-            }
-        }, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.flatMap((Function<Integer, Publisher<Integer>>) _ -> just1,
+                (_, _) -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapIterableMapperReturnsNull() {
-        just1.flatMapIterable(new Function<Integer, Iterable<Object>>() {
-            @Override
-            public Iterable<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.flatMapIterable((Function<Integer, Iterable<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapIterableMapperIteratorNull() {
-        just1.flatMapIterable(new Function<Integer, Iterable<Object>>() {
-            @Override
-            public Iterable<Object> apply(Integer v) {
-                return new Iterable<Object>() {
-                    @Override
-                    public Iterator<Object> iterator() {
-                        return null;
-                    }
-                };
-            }
-        }).blockingSubscribe();
+        just1.flatMapIterable((Function<Integer, Iterable<Object>>) _ -> () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapIterableMapperIterableOneNull() {
-        just1.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return Arrays.asList(1, null);
-            }
-        }).blockingSubscribe();
+        just1.flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(1, null))
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapIterableCombinerReturnsNull() {
-        just1.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return Arrays.asList(1);
-            }
-        }, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(1),
+                (_, _) -> null).blockingSubscribe();
     }
 
     public void groupByKeyNull() {
-        just1.groupBy(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.groupBy(_ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void groupByValueReturnsNull() {
-        just1.groupBy(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return v;
-            }
-        }, new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.groupBy((Function<Integer, Object>) v -> v, _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void liftReturnsNull() {
-        just1.lift(new FlowableOperator<Object, Integer>() {
-            @Override
-            public Subscriber<? super Integer> apply(Subscriber<? super Object> s) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.lift(_ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void mapReturnsNull() {
-        just1.map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.map(_ -> null).blockingSubscribe();
     }
 
     @Test
     public void onErrorResumeNextFunctionReturnsNull() {
         try {
-            Flowable.error(new TestException()).onErrorResumeNext(new Function<Throwable, Publisher<Object>>() {
-                @Override
-                public Publisher<Object> apply(Throwable e) {
-                    return null;
-                }
-            }).blockingSubscribe();
+            Flowable.error(new TestException())
+            .onErrorResumeNext((Function<Throwable, Publisher<Object>>) _ -> null).blockingSubscribe();
             fail("Should have thrown");
         } catch (CompositeException ex) {
             List<Throwable> errors = ex.getExceptions();
@@ -754,12 +428,8 @@ public class FlowableNullTests extends RxJavaTest {
     @Test
     public void onErrorReturnFunctionReturnsNull() {
         try {
-            Flowable.error(new TestException()).onErrorReturn(new Function<Throwable, Object>() {
-                @Override
-                public Object apply(Throwable e) {
-                    return null;
-                }
-            }).blockingSubscribe();
+            Flowable.error(new TestException())
+            .onErrorReturn(_ -> null).blockingSubscribe();
             fail("Should have thrown");
         } catch (CompositeException ex) {
             List<Throwable> errors = TestHelper.compositeList(ex);
@@ -771,67 +441,34 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void publishFunctionReturnsNull() {
-        just1.publish(new Function<Flowable<Integer>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Integer> v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.publish(_ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void reduceFunctionReturnsNull() {
-        Flowable.just(1, 1).reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) {
-                return null;
-            }
-        }).toFlowable().blockingSubscribe();
+        Flowable.just(1, 1).reduce((_, _) -> null)
+        .toFlowable()
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void reduceSeedFunctionReturnsNull() {
-        just1.reduce(1, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingGet();
+        just1.reduce(1, (_, _) -> null).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void reduceWithSeedNull() {
-        just1.reduceWith(null, new BiFunction<Object, Integer, Object>() {
-            @Override
-            public Object apply(Object a, Integer b) {
-                return 1;
-            }
-        });
+        just1.reduceWith(null, (_, _) -> 1);
     }
 
     @Test(expected = NullPointerException.class)
     public void reduceWithSeedReturnsNull() {
-        just1.reduceWith(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return null;
-            }
-        }, new BiFunction<Object, Integer, Object>() {
-            @Override
-            public Object apply(Object a, Integer b) {
-                return 1;
-            }
-        }).blockingGet();
+        just1.reduceWith(() -> null, (_, _) -> 1).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void repeatWhenFunctionReturnsNull() {
-        just1.repeatWhen(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.repeatWhen((Function<Flowable<Object>, Publisher<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
@@ -841,112 +478,56 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void replaySelectorReturnsNull() {
-        just1.replay(new Function<Flowable<Integer>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Integer> f) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.replay(_ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void replayBoundedSelectorReturnsNull() {
-        just1.replay(new Function<Flowable<Integer>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Integer> v) {
-                return null;
-            }
-        }, 1, 1, TimeUnit.SECONDS).blockingSubscribe();
+        just1.replay((Function<Flowable<Integer>, Publisher<Object>>) _ -> null, 1, 1, TimeUnit.SECONDS)
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void replayTimeBoundedSelectorReturnsNull() {
-        just1.replay(new Function<Flowable<Integer>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Integer> v) {
-                return null;
-            }
-        }, 1, TimeUnit.SECONDS, Schedulers.single()).blockingSubscribe();
+        just1.replay((Function<Flowable<Integer>, Publisher<Object>>) _ -> null, 1, TimeUnit.SECONDS, Schedulers.single())
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void retryWhenFunctionReturnsNull() {
-        Flowable.error(new TestException()).retryWhen(new Function<Flowable<? extends Throwable>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<? extends Throwable> f) {
-                return null;
-            }
-        }).blockingSubscribe();
+        Flowable.error(new TestException())
+        .retryWhen((Function<Flowable<? extends Throwable>, Publisher<Object>>) _ -> null)
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void scanFunctionReturnsNull() {
-        Flowable.just(1, 1).scan(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingSubscribe();
+        Flowable.just(1, 1).scan((_, _) -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void scanSeedNull() {
-        just1.scan(null, new BiFunction<Object, Integer, Object>() {
-            @Override
-            public Object apply(Object a, Integer b) {
-                return 1;
-            }
-        });
+        just1.scan(null, (_, _) -> 1);
     }
 
     @Test(expected = NullPointerException.class)
     public void scanSeedFunctionReturnsNull() {
-        just1.scan(1, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.scan(1, (_, _) -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void scanSeedSupplierReturnsNull() {
-        just1.scanWith(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return null;
-            }
-        }, new BiFunction<Object, Integer, Object>() {
-            @Override
-            public Object apply(Object a, Integer b) {
-                return 1;
-            }
-        }).blockingSubscribe();
+        just1.scanWith(() -> null, (_, _) -> 1).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void scanSeedSupplierFunctionReturnsNull() {
-        just1.scanWith(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return 1;
-            }
-        }, new BiFunction<Object, Integer, Object>() {
-            @Override
-            public Object apply(Object a, Integer b) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.scanWith(() -> 1, (_, _) -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void startWithIterableIteratorNull() {
-        just1.startWithIterable(new Iterable<Integer>() {
-            @Override
-            public Iterator<Integer> iterator() {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.startWithIterable(() -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
@@ -961,42 +542,22 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void switchMapFunctionReturnsNull() {
-        just1.switchMap(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.switchMap((Function<Integer, Publisher<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void timeoutSelectorReturnsNull() {
-        just1.timeout(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.timeout(_ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void timeoutSelectorOtherNull() {
-        just1.timeout(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return just1;
-            }
-        }, null);
+        just1.timeout((Function<Integer, Publisher<Integer>>) _ -> just1, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void timeoutFirstItemReturnsNull() {
-        just1.timeout(Flowable.never(), new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.timeout(Flowable.never(), (Function<Integer, Publisher<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
@@ -1011,222 +572,92 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void toListSupplierReturnsNull() {
-        just1.toList(new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() {
-                return null;
-            }
-        }).toFlowable().blockingSubscribe();
+        just1.toList(() -> null).toFlowable().blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void toListSupplierReturnsNullSingle() {
-        just1.toList(new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() {
-                return null;
-            }
-        }).blockingGet();
+        just1.toList(() -> null).blockingGet();
     }
 
     @Test
     public void toMapValueSelectorReturnsNull() {
-        just1.toMap(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return v;
-            }
-        }, new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return null;
-            }
-        }).blockingGet();
+        just1.toMap(v -> v, _ -> null).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void toMapMapSupplierReturnsNull() {
-        just1.toMap(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return v;
-            }
-        }, new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return v;
-            }
-        }, new Supplier<Map<Object, Object>>() {
-            @Override
-            public Map<Object, Object> get() {
-                return null;
-            }
-        }).blockingGet();
+        just1.toMap(v -> v, v -> v, () -> null).blockingGet();
     }
 
     @Test
     public void toMultiMapValueSelectorReturnsNullAllowed() {
-        just1.toMap(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return v;
-            }
-        }, new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return null;
-            }
-        }).blockingGet();
+        just1.toMap(v -> v, _ -> null).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void toMultimapMapSupplierReturnsNull() {
-        just1.toMultimap(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return v;
-            }
-        }, new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return v;
-            }
-        }, new Supplier<Map<Object, Collection<Object>>>() {
-            @Override
-            public Map<Object, Collection<Object>> get() {
-                return null;
-            }
-        }).blockingGet();
+        just1.toMultimap(v -> v, v -> v, () -> null).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void toMultimapMapCollectionSupplierReturnsNull() {
-        just1.toMultimap(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) {
-                return v;
-            }
-        }, new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) {
-                return v;
-            }
-        }, new Supplier<Map<Integer, Collection<Integer>>>() {
-            @Override
-            public Map<Integer, Collection<Integer>> get() {
-                return new HashMap<>();
-            }
-        }, new Function<Integer, Collection<Integer>>() {
-            @Override
-            public Collection<Integer> apply(Integer v) {
-                return null;
-            }
-        }).blockingGet();
+        just1.toMultimap(v -> v, v -> v, () -> new HashMap<>(), (Function<Integer, Collection<Integer>>) _ -> null)
+        .blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void windowOpenCloseOpenNull() {
-        just1.window(null, new Function<Object, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Object v) {
-                return just1;
-            }
-        });
+        just1.window(null, _ -> just1);
     }
 
     @Test(expected = NullPointerException.class)
     public void windowOpenCloseCloseReturnsNull() {
-        Flowable.never().window(just1, new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        Flowable.never().window(just1, _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void withLatestFromOtherNull() {
-        just1.withLatestFrom(null, new BiFunction<Integer, Object, Object>() {
-            @Override
-            public Object apply(Integer a, Object b) {
-                return 1;
-            }
-        });
+        just1.withLatestFrom(null, (BiFunction<Integer, Object, Object>) (_, _) -> 1);
     }
 
     @Test(expected = NullPointerException.class)
     public void withLatestFromCombinerReturnsNull() {
-        just1.withLatestFrom(just1, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.withLatestFrom(just1, (BiFunction<Integer, Integer, Object>) (_, _) -> null)
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipWithIterableNull() {
-        just1.zipWith((Iterable<Integer>)null, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return 1;
-            }
-        });
+        just1.zipWith((Iterable<Integer>)null, (BiFunction<Integer, Integer, Object>) (_, _) -> 1);
     }
 
     @Test(expected = NullPointerException.class)
     public void zipWithIterableCombinerReturnsNull() {
-        just1.zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.zipWith(Arrays.asList(1), (BiFunction<Integer, Integer, Object>) (_, _) -> null)
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipWithIterableIteratorNull() {
-        just1.zipWith(new Iterable<Object>() {
-            @Override
-            public Iterator<Object> iterator() {
-                return null;
-            }
-        }, new BiFunction<Integer, Object, Object>() {
-            @Override
-            public Object apply(Integer a, Object b) {
-                return 1;
-            }
-        }).blockingSubscribe();
+        just1.zipWith(() -> null, (BiFunction<Integer, Object, Object>) (_, _) -> 1)
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipWithIterableOneIsNull() {
-        Flowable.just(1, 2).zipWith(Arrays.asList(1, null), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return 1;
-            }
-        }).blockingSubscribe();
+        Flowable.just(1, 2).zipWith(Arrays.asList(1, null), (BiFunction<Integer, Integer, Object>) (_, _) -> 1)
+        .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipWithPublisherNull() {
-        just1.zipWith((Publisher<Integer>)null, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return 1;
-            }
-        });
+        just1.zipWith((Publisher<Integer>)null, (BiFunction<Integer, Integer, Object>) (_, _) -> 1);
     }
 
     @Test(expected = NullPointerException.class)
     public void zipWithCombinerReturnsNull() {
-        just1.zipWith(just1, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.zipWith(just1, (BiFunction<Integer, Integer, Object>) (_, _) -> null).blockingSubscribe();
     }
 
     //*********************************************
@@ -1315,26 +746,11 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableIteratorNull() {
-        Flowable.combineLatestDelayError(new Iterable<Flowable<Object>>() {
-            @Override
-            public Iterator<Flowable<Object>> iterator() {
-                return null;
-            }
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, 128).blockingLast();
+        Flowable.combineLatestDelayError((Iterable<Flowable<Object>>) () -> null, _ -> 1, 128).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableOneIsNull() {
-        Flowable.combineLatestDelayError(Arrays.asList(Flowable.never(), null), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, 128).blockingLast();
+        Flowable.combineLatestDelayError(Arrays.asList(Flowable.never(), null), _ -> 1, 128).blockingLast();
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableReduceTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableReduceTests.java
@@ -19,19 +19,13 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.flowable.FlowableCovarianceTest.*;
-import io.reactivex.rxjava4.functions.BiFunction;
 
 public class FlowableReduceTests extends RxJavaTest {
 
     @Test
     public void reduceIntsFlowable() {
         Flowable<Integer> f = Flowable.just(1, 2, 3);
-        int value = f.reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        }).toFlowable().blockingSingle();
+        int value = f.reduce((t1, t2) -> t1 + t2).toFlowable().blockingSingle();
 
         assertEquals(6, value);
     }
@@ -41,19 +35,9 @@ public class FlowableReduceTests extends RxJavaTest {
     public void reduceWithObjectsFlowable() {
         Flowable<Movie> horrorMovies = Flowable.<Movie> just(new HorrorMovie());
 
-        Flowable<Movie> reduceResult = horrorMovies.scan(new BiFunction<Movie, Movie, Movie>() {
-            @Override
-            public Movie apply(Movie t1, Movie t2) {
-                return t2;
-            }
-        }).takeLast(1);
+        Flowable<Movie> reduceResult = horrorMovies.scan((t1, t2) -> t2).takeLast(1);
 
-        Flowable<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
-            @Override
-            public Movie apply(Movie t1, Movie t2) {
-                return t2;
-            }
-        }).toFlowable();
+        Flowable<Movie> reduceResult2 = horrorMovies.reduce((t1, t2) -> t2).toFlowable();
 
         assertNotNull(reduceResult2);
     }
@@ -67,12 +51,7 @@ public class FlowableReduceTests extends RxJavaTest {
     public void reduceWithCovariantObjectsFlowable() {
         Flowable<Movie> horrorMovies = Flowable.<Movie> just(new HorrorMovie());
 
-        Flowable<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
-            @Override
-            public Movie apply(Movie t1, Movie t2) {
-                return t2;
-            }
-        }).toFlowable();
+        Flowable<Movie> reduceResult2 = horrorMovies.reduce((_, t2) -> t2).toFlowable();
 
         assertNotNull(reduceResult2);
     }
@@ -80,12 +59,7 @@ public class FlowableReduceTests extends RxJavaTest {
     @Test
     public void reduceInts() {
         Flowable<Integer> f = Flowable.just(1, 2, 3);
-        int value = f.reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        }).toFlowable().blockingSingle();
+        int value = f.reduce((t1, t2) -> t1 + t2).toFlowable().blockingSingle();
 
         assertEquals(6, value);
     }
@@ -95,19 +69,9 @@ public class FlowableReduceTests extends RxJavaTest {
     public void reduceWithObjects() {
         Flowable<Movie> horrorMovies = Flowable.<Movie> just(new HorrorMovie());
 
-        Flowable<Movie> reduceResult = horrorMovies.scan(new BiFunction<Movie, Movie, Movie>() {
-            @Override
-            public Movie apply(Movie t1, Movie t2) {
-                return t2;
-            }
-        }).takeLast(1);
+        Flowable<Movie> reduceResult = horrorMovies.scan((t1, t2) -> t2).takeLast(1);
 
-        Maybe<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
-            @Override
-            public Movie apply(Movie t1, Movie t2) {
-                return t2;
-            }
-        });
+        Maybe<Movie> reduceResult2 = horrorMovies.reduce((t1, t2) -> t2);
 
         assertNotNull(reduceResult2);
     }
@@ -121,12 +85,7 @@ public class FlowableReduceTests extends RxJavaTest {
     public void reduceWithCovariantObjects() {
         Flowable<Movie> horrorMovies = Flowable.<Movie> just(new HorrorMovie());
 
-        Maybe<Movie> reduceResult2 = horrorMovies.reduce(new BiFunction<Movie, Movie, Movie>() {
-            @Override
-            public Movie apply(Movie t1, Movie t2) {
-                return t2;
-            }
-        });
+        Maybe<Movie> reduceResult2 = horrorMovies.reduce((_, t2) -> t2);
 
         assertNotNull(reduceResult2);
     }
@@ -148,12 +107,7 @@ public class FlowableReduceTests extends RxJavaTest {
      */
     public void libraryFunctionActingOnMovieObservables(Flowable<Movie> obs) {
 
-        obs.reduce(new BiFunction<Movie, Movie, Movie>() {
-            @Override
-            public Movie apply(Movie t1, Movie t2) {
-                return t2;
-            }
-        });
+        obs.reduce((_, t2) -> t2);
     }
 
 }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
@@ -85,33 +85,28 @@ public class FlowableSubscriberTest {
     @Test
     public void requestFromChainedOperator() throws Throwable {
         TestSubscriber<String> s = new TestSubscriber<>(10L);
-        FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
+        FlowableOperator<String, String> o = s1 -> new FlowableSubscriber<String>() /* NFI */ {
+
             @Override
-            public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
-                return new FlowableSubscriber<String>() /* NFI */ {
-
-                    @Override
-                    public void onSubscribe(Subscription a) {
-                        s1.onSubscribe(a);
-                    }
-
-                    @Override
-                    public void onComplete() {
-
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-
-                    }
-
-                    @Override
-                    public void onNext(String t) {
-
-                    }
-
-                };
+            public void onSubscribe(Subscription a) {
+                s1.onSubscribe(a);
             }
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(String t) {
+
+            }
+
         };
         Subscriber<? super String> ns = o.apply(s);
 
@@ -137,33 +132,28 @@ public class FlowableSubscriberTest {
     @Test
     public void requestFromDecoupledOperator() throws Throwable {
         TestSubscriber<String> s = new TestSubscriber<>(0L);
-        FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
+        FlowableOperator<String, String> o = s1 -> new FlowableSubscriber<String>() /* NFI */ {
+
             @Override
-            public Subscriber<? super String> apply(final Subscriber<? super String> s1) {
-                return new FlowableSubscriber<String>() {
-
-                    @Override
-                    public void onSubscribe(Subscription a) {
-                        s1.onSubscribe(a);
-                    }
-
-                    @Override
-                    public void onComplete() {
-
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-
-                    }
-
-                    @Override
-                    public void onNext(String t) {
-
-                    }
-
-                };
+            public void onSubscribe(Subscription a) {
+                s1.onSubscribe(a);
             }
+
+            @Override
+            public void onComplete() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(String t) {
+
+            }
+
         };
         s.request(10);
         Subscriber<? super String> ns = o.apply(s);
@@ -191,50 +181,47 @@ public class FlowableSubscriberTest {
     public void requestFromDecoupledOperatorThatRequestsN() throws Throwable {
         TestSubscriber<String> s = new TestSubscriber<>(10L);
         final AtomicLong innerR = new AtomicLong();
-        FlowableOperator<String, String> o = new FlowableOperator<String, String>() {
-            @Override
-            public Subscriber<? super String> apply(Subscriber<? super String> child) {
-                // we want to decouple the chain so set our own Producer on the child instead of it coming from the parent
-                child.onSubscribe(new Subscription() /* NFI */ {
+        FlowableOperator<String, String> o = child -> {
+            // we want to decouple the chain so set our own Producer on the child instead of it coming from the parent
+            child.onSubscribe(new Subscription() /* NFI */ {
 
-                    @Override
-                    public void request(long n) {
-                        innerR.set(n);
-                    }
+                @Override
+                public void request(long n) {
+                    innerR.set(n);
+                }
 
-                    @Override
-                    public void cancel() {
+                @Override
+                public void cancel() {
 
-                    }
+                }
 
-                });
+            });
 
-                ResourceSubscriber<String> as = new ResourceSubscriber<String>() {
+            ResourceSubscriber<String> as = new ResourceSubscriber<String>() /* NFI */ {
 
-                    @Override
-                    protected void onStart() {
-                        // we request 99 up to the parent
-                        request(99);
-                    }
+                @Override
+                protected void onStart() {
+                    // we request 99 up to the parent
+                    request(99);
+                }
 
-                    @Override
-                    public void onComplete() {
+                @Override
+                public void onComplete() {
 
-                    }
+                }
 
-                    @Override
-                    public void onError(Throwable e) {
+                @Override
+                public void onError(Throwable e) {
 
-                    }
+                }
 
-                    @Override
-                    public void onNext(String t) {
+                @Override
+                public void onNext(String t) {
 
-                    }
-                };
+                }
+            };
 
-                return as;
-            }
+            return as;
         };
         Subscriber<? super String> ns = o.apply(s);
 
@@ -262,23 +249,18 @@ public class FlowableSubscriberTest {
     public void requestToFlowable() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(3L);
         final AtomicLong requested = new AtomicLong();
-        Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
+
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() /* NFI */ {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
+            public void request(long n) {
+                requested.set(n);
             }
-        }).subscribe(ts);
+
+            @Override
+            public void cancel() {
+
+            }
+        })).subscribe(ts);
         assertEquals(3, requested.get());
     }
 
@@ -287,23 +269,18 @@ public class FlowableSubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
+
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() /* NFI */ {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
+            public void request(long n) {
+                requested.set(n);
             }
-        }).map(Functions.<Integer>identity()).subscribe(ts);
+
+            @Override
+            public void cancel() {
+
+            }
+        })).map(Functions.<Integer>identity()).subscribe(ts);
         assertEquals(3, requested.get());
     }
 
@@ -312,24 +289,19 @@ public class FlowableSubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
+
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() /* NFI */ {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
             }
-        }).take(2).subscribe(ts);
+
+            @Override
+            public void cancel() {
+
+            }
+
+        })).take(2).subscribe(ts);
 
         assertEquals(2, requested.get());
     }
@@ -339,31 +311,26 @@ public class FlowableSubscriberTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
         ts.request(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.<Integer>unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
+
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() /* NFI */ {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
             }
-        }).take(10).subscribe(ts);
+
+            @Override
+            public void cancel() {
+
+            }
+
+        })).take(10).subscribe(ts);
         assertEquals(3, requested.get());
     }
 
     @Test
     public void onStartCalledOnceViaSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -394,7 +361,7 @@ public class FlowableSubscriberTest {
     @Test
     public void onStartCalledOnceViaUnsafeSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -425,35 +392,28 @@ public class FlowableSubscriberTest {
     @Test
     public void onStartCalledOnceViaLift() {
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1, 2, 3, 4).lift(new FlowableOperator<Integer, Integer>() {
+        Flowable.just(1, 2, 3, 4).lift(child -> new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
-            public Subscriber<? super Integer> apply(final Subscriber<? super Integer> child) {
-                return new DefaultSubscriber<Integer>() {
+            public void onStart() {
+                c.incrementAndGet();
+                request(1);
+            }
 
-                    @Override
-                    public void onStart() {
-                        c.incrementAndGet();
-                        request(1);
-                    }
+            @Override
+            public void onComplete() {
+                child.onComplete();
+            }
 
-                    @Override
-                    public void onComplete() {
-                        child.onComplete();
-                    }
+            @Override
+            public void onError(Throwable e) {
+                child.onError(e);
+            }
 
-                    @Override
-                    public void onError(Throwable e) {
-                        child.onError(e);
-                    }
-
-                    @Override
-                    public void onNext(Integer t) {
-                        child.onNext(t);
-                        request(1);
-                    }
-
-                };
+            @Override
+            public void onNext(Integer t) {
+                child.onNext(t);
+                request(1);
             }
 
         }).subscribe();
@@ -465,7 +425,7 @@ public class FlowableSubscriberTest {
     public void onStartRequestsAreAdditive() {
         final List<Integer> list = new ArrayList<>();
         Flowable.just(1, 2, 3, 4, 5)
-        .subscribe(new DefaultSubscriber<Integer>() {
+        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
             @Override
             public void onStart() {
                 request(3);
@@ -492,7 +452,7 @@ public class FlowableSubscriberTest {
     @Test
     public void onStartRequestsAreAdditiveAndOverflowBecomesMaxValue() {
         final List<Integer> list = new ArrayList<>();
-        Flowable.just(1, 2, 3, 4, 5).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.just(1, 2, 3, 4, 5).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
             @Override
             public void onStart() {
                 request(2);
@@ -522,12 +482,9 @@ public class FlowableSubscriberTest {
 
         final List<Integer> list = new ArrayList<>();
 
-        Disposable d = pp.forEachWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                list.add(v);
-                return v < 3;
-            }
+        Disposable d = pp.forEachWhile(v -> {
+            list.add(v);
+            return v < 3;
         });
 
         assertFalse(d.isDisposed());
@@ -544,12 +501,8 @@ public class FlowableSubscriberTest {
     @Test
     public void doubleSubscribe() {
         @SuppressWarnings("resource")
-        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        }, Functions.<Throwable>emptyConsumer(), Functions.EMPTY_ACTION);
+        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(_ -> true,
+                Functions.<Throwable>emptyConsumer(), Functions.EMPTY_ACTION);
 
         List<Throwable> list = TestHelper.trackPluginErrors();
 
@@ -641,16 +594,8 @@ public class FlowableSubscriberTest {
     @Test
     public void onCompleteThrows() {
         @SuppressWarnings("resource")
-        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-            }
-        }, () -> {
+        ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(_ -> true,
+                _ -> { }, () -> {
             throw new TestException("Inner");
         });
 
@@ -671,17 +616,7 @@ public class FlowableSubscriberTest {
     public void subscribeConsumerConsumerWithError() {
         final List<Integer> list = new ArrayList<>();
 
-        Flowable.<Integer>error(new TestException()).subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                list.add(100);
-            }
-        });
+        Flowable.<Integer>error(new TestException()).subscribe(v -> list.add(v), e -> list.add(100));
 
         assertEquals(Arrays.asList(100), list);
     }
@@ -716,30 +651,14 @@ public class FlowableSubscriberTest {
     public void subscribeConsumerConsumer() {
         final List<Integer> list = new ArrayList<>();
 
-        Flowable.just(1).subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                list.add(100);
-            }
-        });
+        Flowable.just(1).subscribe(v -> list.add(v), _ -> list.add(100));
 
         assertEquals(Arrays.asList(1), list);
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void pluginNull() {
-        RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
-            @Override
-            public Subscriber apply(Flowable a, Subscriber b) throws Exception {
-                return null;
-            }
-        });
+        RxJavaPlugins.setOnFlowableSubscribe((_, _) -> null);
 
         try {
             try {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
@@ -47,12 +47,7 @@ public class FlowableTests extends RxJavaTest {
 
     MaybeObserver<Number> wm;
 
-    private static final Predicate<Integer> IS_EVEN = new Predicate<Integer>() {
-        @Override
-        public boolean test(Integer v) {
-            return v % 2 == 0;
-        }
-    };
+    private static final Predicate<Integer> IS_EVEN = v -> v % 2 == 0;
 
     @Before
     public void before() {
@@ -138,12 +133,7 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void countErrorFlowable() {
-        Flowable<String> f = Flowable.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new RuntimeException();
-            }
-        });
+        Flowable<String> f = Flowable.error(() -> new RuntimeException());
 
         f.count().toFlowable().subscribe(w);
         verify(w, never()).onNext(anyInt());
@@ -173,12 +163,7 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void countError() {
-        Flowable<String> f = Flowable.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new RuntimeException();
-            }
-        });
+        Flowable<String> f = Flowable.error(() -> new RuntimeException());
 
         f.count().subscribe(wo);
         verify(wo, never()).onSuccess(anyInt());
@@ -262,12 +247,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void reduce() {
         Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4);
-        flowable.reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        })
+        flowable.reduce((t1, t2) -> t1 + t2)
         .toFlowable()
         .subscribe(w);
         // we should be called only once
@@ -278,12 +258,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void reduceWithEmptyObservable() {
         Flowable<Integer> flowable = Flowable.range(1, 0);
-        flowable.reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        })
+        flowable.reduce((t1, t2) -> t1 + t2)
         .toFlowable()
         .test()
         .assertResult();
@@ -297,12 +272,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void reduceWithEmptyObservableAndSeed() {
         Flowable<Integer> flowable = Flowable.range(1, 0);
-        int value = flowable.reduce(1, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        })
+        int value = flowable.reduce(1, (t1, t2) -> t1 + t2)
         .blockingGet();
 
         assertEquals(1, value);
@@ -311,12 +281,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void reduceWithInitialValue() {
         Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4);
-        flowable.reduce(50, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        })
+        flowable.reduce(50, (t1, t2) -> t1 + t2)
         .subscribe(wo);
         // we should be called only once
         verify(wo, times(1)).onSuccess(anyInt());
@@ -355,7 +320,7 @@ public class FlowableTests extends RxJavaTest {
         // FIXME custom built???
         Flowable.just("1", "2", "three", "4")
         .subscribeOn(Schedulers.newThread())
-        .safeSubscribe(new DefaultSubscriber<String>() {
+        .safeSubscribe(new DefaultSubscriber<String>() /* NFI */ {
             @Override
             public void onComplete() {
                 System.out.println("completed");
@@ -402,7 +367,7 @@ public class FlowableTests extends RxJavaTest {
 
         // FIXME custom built???
         Flowable.just("1", "2", "three", "4")
-        .safeSubscribe(new DefaultSubscriber<String>() {
+        .safeSubscribe(new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -442,13 +407,8 @@ public class FlowableTests extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<>();
         // FIXME custom built???
-        Flowable.just("1", "2").concatWith(Flowable.<String>error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() {
-                return new NumberFormatException();
-            }
-        }))
-        .subscribe(new DefaultSubscriber<String>() {
+        Flowable.just("1", "2").concatWith(Flowable.<String>error(() -> new NumberFormatException()))
+        .subscribe(new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -479,27 +439,21 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void publishLast() throws InterruptedException {
         final AtomicInteger count = new AtomicInteger();
-        ConnectableFlowable<String> connectable = Flowable.<String>unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                count.incrementAndGet();
-                new Thread(() -> {
-                    subscriber.onNext("first");
-                    subscriber.onNext("last");
-                    subscriber.onComplete();
-                }).start();
-            }
+        ConnectableFlowable<String> connectable = Flowable.<String>unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            count.incrementAndGet();
+            new Thread(() -> {
+                subscriber.onNext("first");
+                subscriber.onNext("last");
+                subscriber.onComplete();
+            }).start();
         }).takeLast(1).publish();
 
         // subscribe once
         final CountDownLatch latch = new CountDownLatch(1);
-        connectable.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String value) {
-                assertEquals("last", value);
-                latch.countDown();
-            }
+        connectable.subscribe(value -> {
+            assertEquals("last", value);
+            latch.countDown();
         });
 
         // subscribe twice
@@ -514,16 +468,13 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void replay() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableFlowable<String> f = Flowable.<String>unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                    subscriber.onSubscribe(new BooleanSubscription());
-                    new Thread(() -> {
-                        counter.incrementAndGet();
-                        subscriber.onNext("one");
-                        subscriber.onComplete();
-                    }).start();
-            }
+        ConnectableFlowable<String> f = Flowable.<String>unsafeCreate(subscriber -> {
+                subscriber.onSubscribe(new BooleanSubscription());
+                new Thread(() -> {
+                    counter.incrementAndGet();
+                    subscriber.onNext("one");
+                    subscriber.onComplete();
+                }).start();
         }).replay();
 
         // we connect immediately and it will emit the value
@@ -534,21 +485,15 @@ public class FlowableTests extends RxJavaTest {
             final CountDownLatch latch = new CountDownLatch(2);
 
             // subscribe once
-            f.subscribe(new Consumer<String>() {
-                @Override
-                public void accept(String v) {
-                    assertEquals("one", v);
-                    latch.countDown();
-                }
+            f.subscribe(v -> {
+                assertEquals("one", v);
+                latch.countDown();
             });
 
             // subscribe again
-            f.subscribe(new Consumer<String>() {
-                @Override
-                public void accept(String v) {
-                    assertEquals("one", v);
-                    latch.countDown();
-                }
+            f.subscribe(v -> {
+                assertEquals("one", v);
+                latch.countDown();
             });
 
             if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
@@ -563,37 +508,28 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void cache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> f = Flowable.<String>unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                    subscriber.onSubscribe(new BooleanSubscription());
-                    new Thread(() -> {
-                        counter.incrementAndGet();
-                        subscriber.onNext("one");
-                        subscriber.onComplete();
-                    }).start();
-            }
+        Flowable<String> f = Flowable.<String>unsafeCreate(subscriber -> {
+                subscriber.onSubscribe(new BooleanSubscription());
+                new Thread(() -> {
+                    counter.incrementAndGet();
+                    subscriber.onNext("one");
+                    subscriber.onComplete();
+                }).start();
         }).cache();
 
         // we then expect the following 2 subscriptions to get that same value
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        f.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            assertEquals("one", v);
+            latch.countDown();
         });
 
         // subscribe again
-        f.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            assertEquals("one", v);
+            latch.countDown();
         });
 
         if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
@@ -605,16 +541,13 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void cacheWithCapacity() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> f = Flowable.<String>unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                new Thread(() -> {
-                    counter.incrementAndGet();
-                    subscriber.onNext("one");
-                    subscriber.onComplete();
-                }).start();
-            }
+        Flowable<String> f = Flowable.<String>unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            new Thread(() -> {
+                counter.incrementAndGet();
+                subscriber.onNext("one");
+                subscriber.onComplete();
+            }).start();
         }).cacheWithInitialCapacity(1);
 
         // we then expect the following 2 subscriptions to get that same value
@@ -643,7 +576,7 @@ public class FlowableTests extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<>();
         Flowable.just("1", "2", "three", "4").take(3)
-        .safeSubscribe(new DefaultSubscriber<String>() {
+        .safeSubscribe(new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -905,19 +838,9 @@ public class FlowableTests extends RxJavaTest {
         for (int i = 0; i < expectedCount; i++) {
             Flowable
                     .just(Boolean.TRUE, Boolean.FALSE)
-                    .takeWhile(new Predicate<Boolean>() {
-                        @Override
-                        public boolean test(Boolean v) {
-                            return v;
-                        }
-                    })
+                    .takeWhile(v -> v)
                     .toList()
-                    .doOnSuccess(new Consumer<List<Boolean>>() {
-                        @Override
-                        public void accept(List<Boolean> booleans) {
-                            count.incrementAndGet();
-                        }
-                    })
+                    .doOnSuccess(_ -> count.incrementAndGet())
                     .subscribe();
         }
         assertEquals(expectedCount, count.get());
@@ -926,17 +849,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void compose() {
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
-        Flowable.just(1, 2, 3).compose(new FlowableTransformer<Integer, String>() {
-            @Override
-            public Publisher<String> apply(Flowable<Integer> t1) {
-                return t1.map(new Function<Integer, String>() {
-                    @Override
-                    public String apply(Integer v) {
-                        return String.valueOf(v);
-                    }
-                });
-            }
-        })
+        Flowable.just(1, 2, 3).compose(t1 -> t1.map((Function<Integer, String>) String::valueOf))
         .subscribe(ts);
         ts.assertTerminated();
         ts.assertNoErrors();
@@ -984,16 +897,13 @@ public class FlowableTests extends RxJavaTest {
     public void extend() {
         final TestSubscriber<Object> subscriber = new TestSubscriber<>();
         final Object value = new Object();
-        Object returned = Flowable.just(value).to(new FlowableConverter<Object, Object>() {
-            @Override
-            public Object apply(Flowable<Object> onSubscribe) {
-                    onSubscribe.subscribe(subscriber);
-                    subscriber.assertNoErrors();
-                    subscriber.assertComplete();
-                    subscriber.assertValue(value);
-                    return subscriber.values().get(0);
-                }
-        });
+        Object returned = Flowable.just(value).to(onSubscribe -> {
+                onSubscribe.subscribe(subscriber);
+                subscriber.assertNoErrors();
+                subscriber.assertComplete();
+                subscriber.assertValue(value);
+                return subscriber.values().get(0);
+            });
         assertSame(returned, value);
     }
 
@@ -1001,27 +911,19 @@ public class FlowableTests extends RxJavaTest {
     public void asExtend() {
         final TestSubscriber<Object> subscriber = new TestSubscriber<>();
         final Object value = new Object();
-        Object returned = Flowable.just(value).to(new FlowableConverter<Object, Object>() {
-            @Override
-            public Object apply(Flowable<Object> onSubscribe) {
-                    onSubscribe.subscribe(subscriber);
-                    subscriber.assertNoErrors();
-                    subscriber.assertComplete();
-                    subscriber.assertValue(value);
-                    return subscriber.values().get(0);
-                }
-        });
+        Object returned = Flowable.just(value).to(onSubscribe -> {
+                onSubscribe.subscribe(subscriber);
+                subscriber.assertNoErrors();
+                subscriber.assertComplete();
+                subscriber.assertValue(value);
+                return subscriber.values().get(0);
+            });
         assertSame(returned, value);
     }
 
     @Test
     public void as() {
-        Flowable.just(1).to(new FlowableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Flowable<Integer> v) {
-                return v.toObservable();
-            }
-        })
+        Flowable.just(1).to((FlowableConverter<Integer, Observable<Integer>>) Flowable::toObservable)
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableWindowTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableWindowTests.java
@@ -35,19 +35,9 @@ public class FlowableWindowTests extends RxJavaTest {
         Flowable.concat(
             Flowable.just(1, 2, 3, 4, 5, 6)
             .window(3)
-            .map(new Function<Flowable<Integer>, Flowable<List<Integer>>>() {
-                @Override
-                public Flowable<List<Integer>> apply(Flowable<Integer> xs) {
-                    return xs.toList().toFlowable();
-                }
-            })
+            .map(xs -> xs.toList().toFlowable())
         )
-        .blockingForEach(new Consumer<List<Integer>>() {
-            @Override
-            public void accept(List<Integer> xs) {
-                lists.add(xs);
-            }
-        });
+        .blockingForEach(xs -> lists.add(xs));
 
         assertArrayEquals(lists.get(0).toArray(new Integer[3]), new Integer[] { 1, 2, 3 });
         assertArrayEquals(lists.get(1).toArray(new Integer[3]), new Integer[] { 4, 5, 6 });
@@ -61,12 +51,7 @@ public class FlowableWindowTests extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<List<Integer>> ts = pp.window(5, TimeUnit.SECONDS, scheduler, 2)
-        .flatMapSingle(new Function<Flowable<Integer>, SingleSource<List<Integer>>>() {
-            @Override
-            public SingleSource<List<Integer>> apply(Flowable<Integer> v) throws Throwable {
-                return v.toList();
-            }
-        })
+        .flatMapSingle((Function<Flowable<Integer>, SingleSource<List<Integer>>>) Flowable::toList)
         .test();
 
         pp.onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableZipTests.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava4.flowable;
 import static org.junit.Assert.*;
 
 import java.util.*;
+import java.util.concurrent.Flow.Publisher;
 
 import org.junit.Test;
 import static java.util.concurrent.Flow.*;
@@ -31,35 +32,18 @@ public class FlowableZipTests extends RxJavaTest {
     @Test
     public void zipObservableOfObservables() {
         FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
-                .groupBy(new Function<Event, String>() {
-                    @Override
-                    public String apply(Event e) {
-                        return e.instanceId;
-                    }
-                })
+                .groupBy(e -> e.instanceId)
                 // now we have streams of cluster+instanceId
-                .flatMap(new Function<GroupedFlowable<String, Event>, Publisher<HashMap<String, String>>>() {
-                    @Override
-                    public Publisher<HashMap<String, String>> apply(final GroupedFlowable<String, Event> ge) {
-                            return ge.scan(new HashMap<>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
-                                @Override
-                                public HashMap<String, String> apply(HashMap<String, String> accum,
-                                        Event perInstanceEvent) {
-                                    synchronized (accum) {
-                                            accum.put("instance", ge.getKey());
-                                    }
-                                    return accum;
-                                }
-                            });
-                    }
-                })
+                .flatMap((Function<GroupedFlowable<String, Event>, Publisher<HashMap<String, String>>>) ge -> ge.scan(new HashMap<>(), (accum, _) -> {
+                     synchronized (accum) {
+                         accum.put("instance", ge.getKey());
+                     }
+                     return accum;
+                  }))
                 .take(10)
-                .blockingForEach(new Consumer<HashMap<String, String>>() {
-                    @Override
-                    public void accept(HashMap<String, String> v) {
-                        synchronized (v) {
-                            System.out.println(v);
-                        }
+                .blockingForEach(v -> {
+                    synchronized (v) {
+                        System.out.println(v);
                     }
                 });
 
@@ -108,36 +92,16 @@ public class FlowableZipTests extends RxJavaTest {
         assertSame(invoked, result.blockingLast());
     }
 
-    BiFunction<Media, Rating, ExtendedResult> combine = new BiFunction<Media, Rating, ExtendedResult>() {
-        @Override
-        public ExtendedResult apply(Media m, Rating r) {
-                return new ExtendedResult();
-        }
-    };
+    BiFunction<Media, Rating, ExtendedResult> combine = (_, _) -> new ExtendedResult();
 
-    Consumer<Result> action = new Consumer<Result>() {
-        @Override
-        public void accept(Result t1) {
-            System.out.println("Result: " + t1);
-        }
-    };
+    Consumer<Result> action = t1 -> System.out.println("Result: " + t1);
 
-    Consumer<ExtendedResult> extendedAction = new Consumer<ExtendedResult>() {
-        @Override
-        public void accept(ExtendedResult t1) {
-            System.out.println("Result: " + t1);
-        }
-    };
+    Consumer<ExtendedResult> extendedAction = t1 -> System.out.println("Result: " + t1);
 
     @Test
     public void zipWithDelayError() {
         Flowable.just(1)
-        .zipWith(Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true)
+        .zipWith(Flowable.just(2), (a, b) -> a + b, true)
         .test()
         .assertResult(3);
     }
@@ -145,12 +109,7 @@ public class FlowableZipTests extends RxJavaTest {
     @Test
     public void zipWithDelayErrorBufferSize() {
         Flowable.just(1)
-        .zipWith(Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true, 16)
+        .zipWith(Flowable.just(2), (a, b) -> a + b, true, 16)
         .test()
         .assertResult(3);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java
@@ -85,82 +85,47 @@ public class FunctionsTest extends RxJavaTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void toFunction2() throws Throwable {
-        Functions.toFunction(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) throws Exception {
-                return null;
-            }
-        }).apply(new Object[20]);
+        Functions.toFunction((BiFunction<Integer, Integer, Integer>) (_, _) -> null).apply(new Object[20]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void toFunction3() throws Throwable {
-        Functions.toFunction(new Function3<Integer, Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2, Integer t3) throws Exception {
-                return null;
-            }
-        }).apply(new Object[20]);
+        Functions.toFunction((Function3<Integer, Integer, Integer, Integer>) (_, _, _) -> null).apply(new Object[20]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void toFunction4() throws Throwable {
-        Functions.toFunction(new Function4<Integer, Integer, Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4) throws Exception {
-                return null;
-            }
-        }).apply(new Object[20]);
+        Functions.toFunction((Function4<Integer, Integer, Integer, Integer, Integer>) (_, _, _, _) -> null).apply(new Object[20]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void toFunction5() throws Throwable {
-        Functions.toFunction(new Function5<Integer, Integer, Integer, Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5) throws Exception {
-                return null;
-            }
-        }).apply(new Object[20]);
+        Functions.toFunction((Function5<Integer, Integer, Integer, Integer, Integer, Integer>) (_, _, _, _,
+                _) -> null).apply(new Object[20]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void toFunction6() throws Throwable {
-        Functions.toFunction(new Function6<Integer, Integer, Integer, Integer, Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6) throws Exception {
-                return null;
-            }
-        }).apply(new Object[20]);
+        Functions.toFunction((Function6<Integer, Integer, Integer, Integer, Integer, Integer, Integer>) (_, _, _, _,
+                _, _) -> null).apply(new Object[20]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void toFunction7() throws Throwable {
-        Functions.toFunction(new Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7) throws Exception {
-                return null;
-            }
-        }).apply(new Object[20]);
+        Functions.toFunction((Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>) (_, _, _,
+                _, _, _, _) -> null).apply(new Object[20]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void toFunction8() throws Throwable {
-        Functions.toFunction(new Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7, Integer t8) throws Exception {
-                return null;
-            }
-        }).apply(new Object[20]);
+        Functions.toFunction((Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>) (_, _,
+                _, _, _, _, _, _) -> null).apply(new Object[20]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void toFunction9() throws Throwable {
-        Functions.toFunction(new Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7, Integer t8, Integer t9) throws Exception {
-                return null;
-            }
-        }).apply(new Object[20]);
+        Functions.toFunction((Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>) (_,
+                _, _, _, _, _, _, _, _) -> null).apply(new Object[20]);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/fuseable/CancellableQueueFuseableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/fuseable/CancellableQueueFuseableTest.java
@@ -71,7 +71,7 @@ public class CancellableQueueFuseableTest {
     @Test
     public void cancel2() {
         @SuppressWarnings("resource")
-        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() { };
+        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() /* NFI */ { };
 
         assertFalse(qs.isDisposed());
 
@@ -81,7 +81,7 @@ public class CancellableQueueFuseableTest {
     @Test
     public void dispose2() {
         @SuppressWarnings("resource")
-        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() { };
+        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() /* NFI */ { };
 
         assertFalse(qs.isDisposed());
 


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>,.?]|\s*<[\s\w<>,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080