### PR TITLE
4.x: Unit test lambdaification 5 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableCollectWithCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableCollectWithCollectorTest.java
@@ -58,7 +58,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorSupplierCrash() {
         Flowable.range(1, 5)
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -94,7 +94,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
         BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
 
         source
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -130,7 +130,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorFinisherCrash() {
         Flowable.range(1, 5)
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -164,7 +164,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorAccumulatorDropSignals() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Flowable<Integer> source = new Flowable<Integer>() {
+            Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -176,7 +176,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
             };
 
             source
-            .collect(new Collector<Integer, Integer, Integer>() {
+            .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
                 @Override
                 public Supplier<Integer> supplier() {
@@ -251,7 +251,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorSupplierCrashToFlowable() {
         Flowable.range(1, 5)
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -288,7 +288,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
         BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
 
         source
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -325,7 +325,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorFinisherCrashToFlowable() {
         Flowable.range(1, 5)
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -360,7 +360,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorAccumulatorDropSignalsToFlowable() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Flowable<Integer> source = new Flowable<Integer>() {
+            Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -372,7 +372,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
             };
 
             source
-            .collect(new Collector<Integer, Integer, Integer>() {
+            .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
                 @Override
                 public Supplier<Integer> supplier() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFlatMapStreamTest.java
@@ -262,7 +262,7 @@ public class FlowableFlatMapStreamTest extends RxJavaTest {
     @Test
     public void queueOverflow() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -370,7 +370,7 @@ public class FlowableFlatMapStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStreamTest.java
@@ -149,7 +149,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
 
         Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Subscription s) {
                 queue.set((SimpleQueue<?>)s);
@@ -192,7 +192,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
         AtomicInteger calls = new AtomicInteger();
 
         Flowable.fromStream(Stream.of(1).onClose(() -> calls.getAndIncrement()))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Subscription s) {
                 queue.set((SimpleQueue<?>)s);
@@ -340,7 +340,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
             source = source.filter(_ -> true);
         }
 
-        source.subscribe(new FlowableSubscriber<Integer>() {
+        source.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @NonNull Subscription upstream;
 
@@ -397,7 +397,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
                 CountDownLatch cdl = new CountDownLatch(1);
 
                 source
-                .subscribe(new FlowableSubscriber<Integer>() {
+                .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
                     @NonNull Subscription upstream;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableMapOptionalTest.java
@@ -83,7 +83,7 @@ public class FlowableMapOptionalTest extends RxJavaTest {
 
     @Test
     public void crashDropsOnNexts() {
-        Flowable<Integer> source = new Flowable<Integer>() {
+        Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -297,7 +297,7 @@ public class FlowableMapOptionalTest extends RxJavaTest {
 
     @Test
     public void crashDropsOnNextsConditional() {
-        Flowable<Integer> source = new Flowable<Integer>() {
+        Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java
@@ -137,7 +137,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void firstSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -159,7 +159,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void firstDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -285,7 +285,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void singleSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -308,7 +308,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void singleDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -432,7 +432,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void lastSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -455,7 +455,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void lastDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java
@@ -136,7 +136,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void firstSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -158,7 +158,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void firstDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -282,7 +282,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void singleSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -305,7 +305,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void singleDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -426,7 +426,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void lastSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -449,7 +449,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void lastDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Flowable<Integer>() {
+            Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsFlowableTest.java
@@ -233,7 +233,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
         ms
         .flattenStreamAsFlowable(Stream::of)
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -281,7 +281,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
         Maybe.just(1)
         .flattenStreamAsFlowable(_ -> Stream.of(1, 2, 3, 4, 5))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             Subscription upstream;
 
@@ -328,7 +328,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
     public void hasNextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int count;
 
@@ -356,7 +356,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
     public void nextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -382,7 +382,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int count;
 
@@ -413,7 +413,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsObservableTest.java
@@ -197,7 +197,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
         ms
         .flattenStreamAsObservable(Stream::of)
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -247,7 +247,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
         ms
         .flattenStreamAsObservable(v -> Stream.of(v, v + 1))
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -308,7 +308,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
     public void hasNextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int count;
 
@@ -336,7 +336,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
     public void nextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -362,7 +362,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int count;
 
@@ -393,7 +393,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeToCompletionStageTest.java
@@ -132,7 +132,7 @@ public class MaybeToCompletionStageTest extends RxJavaTest {
     @Test
     public void sourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Maybe<Integer>() {
+            Integer v = new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -154,7 +154,7 @@ public class MaybeToCompletionStageTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Maybe<Integer>() {
+            Integer v = new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableCollectWithCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableCollectWithCollectorTest.java
@@ -61,7 +61,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorSupplierCrash() {
         Observable.range(1, 5)
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -97,7 +97,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
         BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
 
         source
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -133,7 +133,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorFinisherCrash() {
         Observable.range(1, 5)
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -167,7 +167,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorAccumulatorDropSignals() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Observable<Integer> source = new Observable<Integer>() {
+            Observable<Integer> source = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -179,7 +179,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
             };
 
             source
-            .collect(new Collector<Integer, Integer, Integer>() {
+            .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
                 @Override
                 public Supplier<Integer> supplier() {
@@ -254,7 +254,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorSupplierCrashToObservable() {
         Observable.range(1, 5)
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -291,7 +291,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
         BehaviorProcessor<Integer> source = BehaviorProcessor.createDefault(1);
 
         source
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -328,7 +328,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorFinisherCrashToObservable() {
         Observable.range(1, 5)
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -363,7 +363,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorAccumulatorDropSignalsToObservable() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Observable<Integer> source = new Observable<Integer>() {
+            Observable<Integer> source = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -375,7 +375,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
             };
 
             source
-            .collect(new Collector<Integer, Integer, Integer>() {
+            .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
                 @Override
                 public Supplier<Integer> supplier() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFlatMapStreamTest.java
@@ -304,7 +304,7 @@ public class ObservableFlatMapStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -332,7 +332,7 @@ public class ObservableFlatMapStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -420,7 +420,7 @@ public class ObservableFlatMapStreamTest extends RxJavaTest {
     public void eventsIgnoredAfterCrash() {
         AtomicInteger calls = new AtomicInteger();
 
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -444,7 +444,7 @@ public class ObservableFlatMapStreamTest extends RxJavaTest {
     public void eventsIgnoredAfterDispose() {
         AtomicInteger calls = new AtomicInteger();
 
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromStreamTest.java
@@ -122,7 +122,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
 
         Observable.fromStream(IntStream.rangeClosed(1, 10).boxed())
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Disposable d) {
                 queue.set((SimpleQueue<?>)d);
@@ -166,7 +166,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
         AtomicInteger calls = new AtomicInteger();
 
         Observable.fromStream(Stream.of(1).onClose(() -> calls.getAndIncrement()))
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Disposable d) {
                 queue.set((SimpleQueue<?>)d);
@@ -203,7 +203,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
         AtomicInteger calls = new AtomicInteger();
 
         Observable.fromStream(Stream.of(1, 2).onClose(() -> calls.getAndIncrement()))
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Disposable d) {
                 queue.set((SimpleQueue<?>)d);
@@ -438,7 +438,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -464,7 +464,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int calls;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableMapOptionalTest.java
@@ -81,7 +81,7 @@ public class ObservableMapOptionalTest extends RxJavaTest {
 
     @Test
     public void crashDropsOnNexts() {
-        Observable<Integer> source = new Observable<Integer>() {
+        Observable<Integer> source = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -259,7 +259,7 @@ public class ObservableMapOptionalTest extends RxJavaTest {
 
     @Test
     public void crashDropsOnNextsConditional() {
-        Observable<Integer> source = new Observable<Integer>() {
+        Observable<Integer> source = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java
@@ -136,7 +136,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void firstSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -158,7 +158,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void firstDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -284,7 +284,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void singleSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -307,7 +307,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void singleDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -431,7 +431,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void lastSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -454,7 +454,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
     @Test
     public void lastDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java
@@ -135,7 +135,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void firstSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -157,7 +157,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void firstDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -281,7 +281,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void singleSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -304,7 +304,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void singleDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -425,7 +425,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void lastSourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -448,7 +448,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
     @Test
     public void lastDoubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Observable<Integer>() {
+            Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ParallelCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ParallelCollectorTest.java
@@ -79,7 +79,7 @@ public class ParallelCollectorTest extends RxJavaTest {
     public void collectorSupplierCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -116,7 +116,7 @@ public class ParallelCollectorTest extends RxJavaTest {
 
         source
         .parallel()
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -154,7 +154,7 @@ public class ParallelCollectorTest extends RxJavaTest {
     public void collectorCombinerCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {
@@ -189,7 +189,7 @@ public class ParallelCollectorTest extends RxJavaTest {
     public void collectorFinisherCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .collect(new Collector<Integer, Integer, Integer>() {
+        .collect(new Collector<Integer, Integer, Integer>() /* NFI */ {
 
             @Override
             public Supplier<Integer> supplier() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ParallelMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ParallelMapOptionalTest.java
@@ -36,18 +36,8 @@ public class ParallelMapOptionalTest extends RxJavaTest {
         Flowable.range(1, 10)
         .parallel()
         .mapOptional(Optional::of)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 3 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
+        .filter(v -> v % 3 == 0)
         .sequential()
         .test()
         .assertResult(6);
@@ -59,18 +49,8 @@ public class ParallelMapOptionalTest extends RxJavaTest {
         .parallel()
         .runOn(Schedulers.computation())
         .mapOptional(Optional::of)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 3 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
+        .filter(v -> v % 3 == 0)
         .sequential()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ParallelMapTryOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ParallelMapTryOptionalTest.java
@@ -108,7 +108,7 @@ public class ParallelMapTryOptionalTest extends RxJavaTest implements Consumer<O
     public void mapFailWithRetry() {
         Flowable.range(0, 2)
         .parallel(1)
-        .mapOptional(new Function<Integer, Optional<? extends Integer>>() {
+        .mapOptional(new Function<Integer, Optional<? extends Integer>>() /* NFI */ {
             int count;
             @Override
             public Optional<? extends Integer> apply(Integer v) throws Exception {
@@ -127,12 +127,8 @@ public class ParallelMapTryOptionalTest extends RxJavaTest implements Consumer<O
     public void mapFailWithRetryLimited() {
         Flowable.range(0, 2)
         .parallel(1)
-        .mapOptional(v -> Optional.of(1 / v), new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
-            }
-        })
+        .mapOptional(v -> Optional.of(1 / v),
+                (n, _) -> n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP)
         .sequential()
         .test()
         .assertResult(1);
@@ -152,11 +148,8 @@ public class ParallelMapTryOptionalTest extends RxJavaTest implements Consumer<O
     public void mapFailHandlerThrows() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
         .parallel(1)
-        .mapOptional(v -> Optional.of(1 / v), new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .mapOptional(v -> Optional.of(1 / v), (_, _) -> {
+            throw new TestException();
         })
         .sequential()
         .to(TestHelper.<Integer>testConsumer())
@@ -206,7 +199,7 @@ public class ParallelMapTryOptionalTest extends RxJavaTest implements Consumer<O
     public void mapFailWithRetryConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .mapOptional(new Function<Integer, Optional<? extends Integer>>() {
+        .mapOptional(new Function<Integer, Optional<? extends Integer>>() /* NFI */ {
             int count;
             @Override
             public Optional<? extends Integer> apply(Integer v) throws Exception {
@@ -226,12 +219,8 @@ public class ParallelMapTryOptionalTest extends RxJavaTest implements Consumer<O
     public void mapFailWithRetryLimitedConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .mapOptional(v -> Optional.of(1 / v), new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
-            }
-        })
+        .mapOptional(v -> Optional.of(1 / v),
+                (n, _) -> n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -253,11 +242,8 @@ public class ParallelMapTryOptionalTest extends RxJavaTest implements Consumer<O
     public void mapFailHandlerThrowsConditional() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
         .parallel(1)
-        .mapOptional(v -> Optional.of(1 / v), new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .mapOptional(v -> Optional.of(1 / v), (_, _) -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .sequential()

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsFlowableTest.java
@@ -220,7 +220,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
         ss
         .flattenStreamAsFlowable(Stream::of)
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -268,7 +268,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
         Single.just(1)
         .flattenStreamAsFlowable(_ -> Stream.of(1, 2, 3, 4, 5))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             Subscription upstream;
 
@@ -315,7 +315,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
     public void hasNextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int count;
 
@@ -343,7 +343,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
     public void nextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -369,7 +369,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int count;
 
@@ -400,7 +400,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsObservableTest.java
@@ -184,7 +184,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
         ss
         .flattenStreamAsObservable(Stream::of)
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -234,7 +234,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
         ss
         .flattenStreamAsObservable(v -> Stream.of(v, v + 1))
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -295,7 +295,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
     public void hasNextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int count;
 
@@ -323,7 +323,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
     public void nextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -349,7 +349,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             int count;
 
@@ -380,7 +380,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() {
+        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleToCompletionStageTest.java
@@ -112,7 +112,7 @@ public class SingleToCompletionStageTest extends RxJavaTest {
     @Test
     public void sourceIgnoresCancel() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Single<Integer>() {
+            Integer v = new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -133,7 +133,7 @@ public class SingleToCompletionStageTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Integer v = new Single<Integer>() {
+            Integer v = new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/BasicFuseableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/BasicFuseableObserverTest.java
@@ -26,7 +26,7 @@ public class BasicFuseableObserverTest extends RxJavaTest {
     @Test(expected = UnsupportedOperationException.class)
     public void offer() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
-        BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(to) {
+        try (var o = new BasicFuseableObserver<Integer, Integer>(to) /* NFI */ {
             @Nullable
             @Override
             public Integer poll() throws Exception {
@@ -46,13 +46,14 @@ public class BasicFuseableObserverTest extends RxJavaTest {
             protected boolean beforeDownstream() {
                 return false;
             }
-        };
+        }) {
 
-        o.onSubscribe(Disposable.disposed());
+            o.onSubscribe(Disposable.disposed());
 
-        to.assertNotSubscribed();
+            to.assertNotSubscribed();
 
-        o.offer(1);
+            o.offer(1);
+        }
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/BasicQueueDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/BasicQueueDisposableTest.java
@@ -20,7 +20,7 @@ import io.reactivex.rxjava4.core.RxJavaTest;
 
 public class BasicQueueDisposableTest extends RxJavaTest {
 
-    BasicQueueDisposable<Integer> q = new BasicQueueDisposable<Integer>() {
+    BasicQueueDisposable<Integer> q = new BasicQueueDisposable<Integer>() /* NFI */ {
 
         @Override
         public boolean isDisposed() {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
@@ -134,7 +134,7 @@ public class LambdaObserverTest extends RxJavaTest {
     public void badSourceOnSubscribe() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable<Integer> source = new Observable<Integer>() {
+            Observable<Integer> source = new Observable<Integer>() /* NFI */ {
                 @Override
                 public void subscribeActual(Observer<? super Integer> observer) {
                     Disposable d1 = Disposable.empty();
@@ -172,7 +172,7 @@ public class LambdaObserverTest extends RxJavaTest {
     public void badSourceEmitAfterDone() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable<Integer> source = new Observable<Integer>() {
+            Observable<Integer> source = new Observable<Integer>() /* NFI */ {
                 @Override
                 public void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -187,27 +187,8 @@ public class LambdaObserverTest extends RxJavaTest {
 
             final List<Object> received = new ArrayList<>();
 
-            LambdaObserver<Object> o = new LambdaObserver<>(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    received.add(v);
-                }
-            },
-                    new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable e) throws Exception {
-                            received.add(e);
-                        }
-                    }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    received.add(100);
-                }
-            }, new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                }
-            });
+            LambdaObserver<Object> o = new LambdaObserver<>(v -> received.add(v),
+                    e -> received.add(e), () -> received.add(100), _ -> { });
 
             source.subscribe(o);
 
@@ -225,17 +206,9 @@ public class LambdaObserverTest extends RxJavaTest {
 
         final List<Throwable> errors = new ArrayList<>();
 
-        ps.subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                errors.add(e);
-            }
-        });
+        ps.subscribe(_ -> {
+            throw new TestException();
+        }, e -> errors.add(e));
 
         assertTrue("No observers?!", ps.hasObservers());
         assertTrue("Has errors already?!", errors.isEmpty());
@@ -254,24 +227,10 @@ public class LambdaObserverTest extends RxJavaTest {
 
         final List<Throwable> errors = new ArrayList<>();
 
-        ps.subscribe(new LambdaObserver<>(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                errors.add(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-            }
-        }, new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) throws Exception {
-                throw new TestException();
-            }
+        ps.subscribe(new LambdaObserver<>(_ -> {
+        }, e -> errors.add(e), () -> {
+        }, _ -> {
+            throw new TestException();
         }));
 
         assertFalse("Has observers?!", ps.hasObservers());
@@ -310,12 +269,7 @@ public class LambdaObserverTest extends RxJavaTest {
 
             @SuppressWarnings("resource")
             LambdaObserver<Integer> o = new LambdaObserver<>(Functions.<Integer>emptyConsumer(),
-                    new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable t) {
-                            observerErrors.add(t);
-                        }
-                    },
+                    t -> observerErrors.add(t),
                     Functions.EMPTY_ACTION,
                     Functions.<Disposable>emptyConsumer());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/MaybeConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/MaybeConsumersTest.java
@@ -181,11 +181,8 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
     public void onSuccessCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            subscribeAutoDispose(processor, composite, new Consumer<Object>() {
-                @Override
-                public void accept(Object t) throws Exception {
-                    throw new IOException();
-                }
+            subscribeAutoDispose(processor, composite, _ -> {
+                throw new IOException();
             }, this, this);
 
             processor.onSuccess(1);
@@ -202,11 +199,8 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
     public void onErrorCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            subscribeAutoDispose(processor, composite, this, new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) throws Exception {
-                    throw new IOException(t);
-                }
+            subscribeAutoDispose(processor, composite, this, t -> {
+                throw new IOException(t);
             }, this);
 
             processor.onError(new IllegalArgumentException());
@@ -226,11 +220,8 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
     public void onCompleteCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            subscribeAutoDispose(processor, composite, this, this, new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            subscribeAutoDispose(processor, composite, this, this, () -> {
+                throw new IOException();
             });
 
             processor.onComplete();
@@ -248,7 +239,7 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             subscribeAutoDispose(
-                    new Maybe<Integer>() {
+                    new Maybe<Integer>() /* NFI */ {
                         @Override
                         protected void subscribeActual(
                                 MaybeObserver<? super Integer> observer) {


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>,.?]|\s*<[\s\w<>,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080