### PR TITLE
4.x: Unit test lambdaification 7 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatTest.java
@@ -20,11 +20,9 @@ import java.util.concurrent.CountDownLatch;
 
 import io.reactivex.rxjava4.disposables.Disposable;
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDelayTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDoOnTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.*;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromActionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromActionTest.java
@@ -31,12 +31,7 @@ public class CompletableFromActionTest extends RxJavaTest {
     public void fromAction() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        })
+        Completable.fromAction(() -> atomicInteger.incrementAndGet())
             .test()
             .assertResult();
 
@@ -47,12 +42,7 @@ public class CompletableFromActionTest extends RxJavaTest {
     public void fromActionTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Action run = new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Action run = () -> atomicInteger.incrementAndGet();
 
         Completable.fromAction(run)
             .test()
@@ -71,12 +61,7 @@ public class CompletableFromActionTest extends RxJavaTest {
     public void fromActionInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Completable completable = Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        });
+        Completable completable = Completable.fromAction(() -> atomicInteger.incrementAndGet());
 
         assertEquals(0, atomicInteger.get());
 
@@ -89,11 +74,8 @@ public class CompletableFromActionTest extends RxJavaTest {
 
     @Test
     public void fromActionThrows() {
-        Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Completable.fromAction(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -102,12 +84,7 @@ public class CompletableFromActionTest extends RxJavaTest {
     @Test
     public void fromActionDisposed() {
         final AtomicInteger calls = new AtomicInteger();
-        Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                calls.incrementAndGet();
-            }
-        })
+        Completable.fromAction(() -> calls.incrementAndGet())
         .test(true)
         .assertEmpty();
 
@@ -117,12 +94,9 @@ public class CompletableFromActionTest extends RxJavaTest {
     @Test
     public void fromActionErrorsDisposed() {
         final AtomicInteger calls = new AtomicInteger();
-        Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                calls.incrementAndGet();
-                throw new TestException();
-            }
+        Completable.fromAction(() -> {
+            calls.incrementAndGet();
+            throw new TestException();
         })
         .test(true)
         .assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromCallableTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.rxjava4.core.*;
@@ -37,12 +36,9 @@ public class CompletableFromCallableTest extends RxJavaTest {
     public void fromCallable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Completable.fromCallable(() -> {
+            atomicInteger.incrementAndGet();
+            return null;
         })
             .test()
             .assertResult();
@@ -54,12 +50,9 @@ public class CompletableFromCallableTest extends RxJavaTest {
     public void fromCallableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Callable<Object> callable = new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Callable<Object> callable = () -> {
+            atomicInteger.incrementAndGet();
+            return null;
         };
 
         Completable.fromCallable(callable)
@@ -79,12 +72,9 @@ public class CompletableFromCallableTest extends RxJavaTest {
     public void fromCallableInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Completable completable = Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Completable completable = Completable.fromCallable(() -> {
+            atomicInteger.incrementAndGet();
+            return null;
         });
 
         assertEquals(0, atomicInteger.get());
@@ -98,11 +88,8 @@ public class CompletableFromCallableTest extends RxJavaTest {
 
     @Test
     public void fromCallableThrows() {
-        Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Completable.fromCallable(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -116,22 +103,19 @@ public class CompletableFromCallableTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.call()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.call()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Completable fromCallableObservable = Completable.fromCallable(func);
@@ -165,12 +149,9 @@ public class CompletableFromCallableTest extends RxJavaTest {
     @SuppressUndeliverable
     public void fromActionErrorsDisposed() {
         final AtomicInteger calls = new AtomicInteger();
-        Completable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                calls.incrementAndGet();
-                throw new TestException();
-            }
+        Completable.fromCallable(() -> {
+            calls.incrementAndGet();
+            throw new TestException();
         })
         .test(true)
         .assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromPublisherTest.java
@@ -48,11 +48,7 @@ public class CompletableFromPublisherTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowableToCompletable(new Function<Flowable<Object>, Completable>() {
-            @Override
-            public Completable apply(Flowable<Object> f) throws Exception {
-                return Completable.fromPublisher(f);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToCompletable(
+        (Function<Flowable<Object>, Completable>) Completable::fromPublisher);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromRunnableTest.java
@@ -30,12 +30,7 @@ public class CompletableFromRunnableTest extends RxJavaTest {
     public void fromRunnable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Completable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        })
+        Completable.fromRunnable(() -> atomicInteger.incrementAndGet())
             .test()
             .assertResult();
 
@@ -46,12 +41,7 @@ public class CompletableFromRunnableTest extends RxJavaTest {
     public void fromRunnableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Runnable run = new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Runnable run = () -> atomicInteger.incrementAndGet();
 
         Completable.fromRunnable(run)
             .test()
@@ -70,12 +60,7 @@ public class CompletableFromRunnableTest extends RxJavaTest {
     public void fromRunnableInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Completable completable = Completable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        });
+        Completable completable = Completable.fromRunnable(() -> atomicInteger.incrementAndGet());
 
         assertEquals(0, atomicInteger.get());
 
@@ -88,11 +73,8 @@ public class CompletableFromRunnableTest extends RxJavaTest {
 
     @Test
     public void fromRunnableThrows() {
-        Completable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                throw new UnsupportedOperationException();
-            }
+        Completable.fromRunnable(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -101,12 +83,7 @@ public class CompletableFromRunnableTest extends RxJavaTest {
     @Test
     public void fromRunnableDisposed() {
         final AtomicInteger calls = new AtomicInteger();
-        Completable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                calls.incrementAndGet();
-            }
-        })
+        Completable.fromRunnable(() -> calls.incrementAndGet())
         .test(true)
         .assertEmpty();
 
@@ -116,12 +93,9 @@ public class CompletableFromRunnableTest extends RxJavaTest {
     @Test
     public void fromRunnableErrorsDisposed() {
         final AtomicInteger calls = new AtomicInteger();
-        Completable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                calls.incrementAndGet();
-                throw new TestException();
-            }
+        Completable.fromRunnable(() -> {
+            calls.incrementAndGet();
+            throw new TestException();
         })
         .test(true)
         .assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromSupplierTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.rxjava4.core.*;
@@ -38,12 +37,9 @@ public class CompletableFromSupplierTest extends RxJavaTest {
     public void fromSupplier() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Completable.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Completable.fromSupplier(() -> {
+            atomicInteger.incrementAndGet();
+            return null;
         })
             .test()
             .assertResult();
@@ -55,12 +51,9 @@ public class CompletableFromSupplierTest extends RxJavaTest {
     public void fromSupplierTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Supplier<Object> supplier = new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Supplier<Object> supplier = () -> {
+            atomicInteger.incrementAndGet();
+            return null;
         };
 
         Completable.fromSupplier(supplier)
@@ -80,12 +73,9 @@ public class CompletableFromSupplierTest extends RxJavaTest {
     public void fromSupplierInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Completable completable = Completable.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Completable completable = Completable.fromSupplier(() -> {
+            atomicInteger.incrementAndGet();
+            return null;
         });
 
         assertEquals(0, atomicInteger.get());
@@ -99,11 +89,8 @@ public class CompletableFromSupplierTest extends RxJavaTest {
 
     @Test
     public void fromSupplierThrows() {
-        Completable.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Completable.fromSupplier(() -> {
+            throw new UnsupportedOperationException();
         })
         .test()
         .assertFailure(UnsupportedOperationException.class);
@@ -117,22 +104,19 @@ public class CompletableFromSupplierTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.get()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.get()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Completable fromSupplierObservable = Completable.fromSupplier(func);
@@ -166,12 +150,9 @@ public class CompletableFromSupplierTest extends RxJavaTest {
     @SuppressUndeliverable
     public void fromActionErrorsDisposed() {
         final AtomicInteger calls = new AtomicInteger();
-        Completable.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                calls.incrementAndGet();
-                throw new TestException();
-            }
+        Completable.fromSupplier(() -> {
+            calls.incrementAndGet();
+            throw new TestException();
         })
         .test(true)
         .assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableHideTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableHideTest.java
@@ -58,12 +58,7 @@ public class CompletableHideTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposedCompletable(new Function<Completable, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Completable m) throws Exception {
-                return m.hide();
-            }
-        });
+        TestHelper.checkDisposedCompletable(Completable::hide);
     }
 
     @Test
@@ -75,11 +70,6 @@ public class CompletableHideTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletable(new Function<Completable, Completable>() {
-            @Override
-            public Completable apply(Completable f) throws Exception {
-                return f.hide();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletable((Function<Completable, Completable>) Completable::hide);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableLiftTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableLiftTest.java
@@ -29,11 +29,8 @@ public class CompletableLiftTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Completable.complete()
-            .lift(new CompletableOperator() {
-                @Override
-                public CompletableObserver apply(CompletableObserver o) throws Exception {
-                    throw new TestException();
-                }
+            .lift(_ -> {
+                throw new TestException();
             })
             .test();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMaterializeTest.java
@@ -42,12 +42,8 @@ public class CompletableMaterializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletableToSingle(new Function<Completable, SingleSource<Notification<Object>>>() {
-            @Override
-            public SingleSource<Notification<Object>> apply(Completable v) throws Exception {
-                return v.materialize();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletableToSingle(
+                (Function<Completable, SingleSource<Notification<Object>>>) Completable::materialize);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeIterableTest.java
@@ -42,18 +42,8 @@ public class CompletableMergeIterableTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps1.onError(ex);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps2.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> ps1.onError(ex);
+                Runnable r2 = () -> ps2.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -72,26 +62,21 @@ public class CompletableMergeIterableTest extends RxJavaTest {
     public void cancelAfterHasNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.merge(new Iterable<Completable>() {
+        Completable.merge((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
             @Override
-            public Iterator<Completable> iterator() {
-                return new Iterator<Completable>() {
-                    @Override
-                    public boolean hasNext() {
-                        to.dispose();
-                        return true;
-                    }
+            public boolean hasNext() {
+                to.dispose();
+                return true;
+            }
 
-                    @Override
-                    public Completable next() {
-                        return Completable.complete();
-                    }
+            @Override
+            public Completable next() {
+                return Completable.complete();
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         }).subscribe(to);
 
@@ -102,26 +87,21 @@ public class CompletableMergeIterableTest extends RxJavaTest {
     public void cancelAfterNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.merge(new Iterable<Completable>() {
+        Completable.merge((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
             @Override
-            public Iterator<Completable> iterator() {
-                return new Iterator<Completable>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Completable next() {
-                        to.dispose();
-                        return Completable.complete();
-                    }
+            @Override
+            public Completable next() {
+                to.dispose();
+                return Completable.complete();
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         }).subscribe(to);
 
@@ -130,6 +110,7 @@ public class CompletableMergeIterableTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(new MergeCompletableObserver(new TestObserver<Void>(), new CompositeDisposable(), new AtomicInteger()));
+        TestHelper.checkDisposed(new MergeCompletableObserver(
+                new TestObserver<Void>(), new CompositeDisposable(), new AtomicInteger()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.internal.util.AtomicThrowable;
 import io.reactivex.rxjava4.observers.TestObserver;
@@ -48,7 +47,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void cancelAfterFirst() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeArray(new Completable() {
+        Completable.mergeArray(new Completable() /* NFI */ {
             @Override
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -65,7 +64,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void cancelAfterFirstDelayError() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeArrayDelayError(new Completable() {
+        Completable.mergeArrayDelayError(new Completable() /* NFI */ {
             @Override
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -84,7 +83,7 @@ public class CompletableMergeTest extends RxJavaTest {
         try {
             final CompletableObserver[] co = { null };
 
-            Completable.mergeArrayDelayError(Completable.complete(), new Completable() {
+            Completable.mergeArrayDelayError(Completable.complete(), new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -201,30 +200,16 @@ public class CompletableMergeTest extends RxJavaTest {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
                 final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                TestObserverEx<Void> to = Completable.merge(pp1.map(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Exception {
-                        return pp2.ignoreElements();
-                    }
-                })).to(TestHelper.<Void>testConsumer());
+                TestObserverEx<Void> to = Completable.merge(pp1.map(_ -> pp2.ignoreElements()))
+                        .to(TestHelper.<Void>testConsumer());
 
                 pp1.onNext(1);
 
                 final Throwable ex1 = new TestException();
                 final Throwable ex2 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -254,31 +239,17 @@ public class CompletableMergeTest extends RxJavaTest {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-            TestObserverEx<Void> to = Completable.mergeDelayError(pp1.map(new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer v) throws Exception {
-                    return pp2.ignoreElements();
-                }
-            })).to(TestHelper.<Void>testConsumer());
+            TestObserverEx<Void> to = Completable.mergeDelayError(pp1.map(_ -> pp2.ignoreElements()))
+                    .to(TestHelper.<Void>testConsumer());
 
             pp1.onNext(1);
 
             final Throwable ex1 = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onError(ex1);
-                }
-            };
+            Runnable r1 = () -> pp1.onError(ex1);
 
             final Throwable ex2 = new TestException();
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onError(ex2);
-                }
-            };
+            Runnable r2 = () -> pp2.onError(ex2);
 
             TestHelper.race(r1, r2);
 
@@ -358,12 +329,7 @@ public class CompletableMergeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
         TestObserver<Void> to = Completable.mergeDelayError(
-        pp0.map(new Function<PublishProcessor<Integer>, Completable>() {
-            @Override
-            public Completable apply(PublishProcessor<Integer> v) throws Exception {
-                return v.ignoreElements();
-            }
-        }), 1)
+        pp0.map(PublishProcessor::ignoreElements), 1)
         .test();
 
         pp0.onNext(pp1);
@@ -387,7 +353,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void mainDoubleOnError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Completable.mergeDelayError(new Flowable<Completable>() {
+            Completable.mergeDelayError(new Flowable<Completable>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Completable> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -410,7 +376,7 @@ public class CompletableMergeTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final CompletableObserver[] o = { null };
-            Completable.mergeDelayError(Flowable.just(new Completable() {
+            Completable.mergeDelayError(Flowable.just(new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -433,7 +399,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void innerIsDisposed() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeDelayError(Flowable.just(new Completable() {
+        Completable.mergeDelayError(Flowable.just(new Completable() /* NFI */ {
             @Override
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -462,18 +428,8 @@ public class CompletableMergeTest extends RxJavaTest {
                 final Throwable ex1 = new TestException();
                 final Throwable ex2 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -499,26 +455,21 @@ public class CompletableMergeTest extends RxJavaTest {
     public void delayErrorIterableCancelAfterHasNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeDelayError(new Iterable<Completable>() {
+        Completable.mergeDelayError((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
             @Override
-            public Iterator<Completable> iterator() {
-                return new Iterator<Completable>() {
-                    @Override
-                    public boolean hasNext() {
-                        to.dispose();
-                        return true;
-                    }
+            public boolean hasNext() {
+                to.dispose();
+                return true;
+            }
 
-                    @Override
-                    public Completable next() {
-                        return Completable.complete();
-                    }
+            @Override
+            public Completable next() {
+                return Completable.complete();
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(to);
@@ -530,26 +481,21 @@ public class CompletableMergeTest extends RxJavaTest {
     public void delayErrorIterableCancelAfterNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeDelayError(new Iterable<Completable>() {
+        Completable.mergeDelayError((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
             @Override
-            public Iterator<Completable> iterator() {
-                return new Iterator<Completable>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Completable next() {
-                        to.dispose();
-                        return Completable.complete();
-                    }
+            @Override
+            public Completable next() {
+                to.dispose();
+                return Completable.complete();
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(to);
@@ -559,42 +505,26 @@ public class CompletableMergeTest extends RxJavaTest {
 
     @Test
     public void arrayUndeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return Completable.mergeArray(upstream.ignoreElements(), Completable.complete().hide());
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            Completable.mergeArray(upstream.ignoreElements(), Completable.complete().hide()));
     }
 
     @Test
     public void iterableUndeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return Completable.merge(Arrays.asList(upstream.ignoreElements(), Completable.complete().hide()));
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            Completable.merge(Arrays.asList(upstream.ignoreElements(), Completable.complete().hide())));
     }
 
     @Test
     public void arrayUndeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return Completable.mergeArrayDelayError(upstream.ignoreElements(), Completable.complete().hide());
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            Completable.mergeArrayDelayError(upstream.ignoreElements(), Completable.complete().hide()));
     }
 
     @Test
     public void iterableUndeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return Completable.mergeDelayError(Arrays.asList(upstream.ignoreElements(), Completable.complete().hide()));
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            Completable.mergeDelayError(Arrays.asList(upstream.ignoreElements(), Completable.complete().hide())));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableObserveOnTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.completable;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -29,11 +28,6 @@ public class CompletableObserveOnTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletable(new Function<Completable, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Completable c) throws Exception {
-                return c.observeOn(Schedulers.single());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletable(c -> c.observeOn(Schedulers.single()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableOnErrorXTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableOnErrorXTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.subjects.CompletableSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -40,12 +39,9 @@ public class CompletableOnErrorXTest extends RxJavaTest {
     public void normalResumeNext() {
         final int[] call = { 0 };
         Completable.complete()
-        .onErrorResumeNext(new Function<Throwable, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Throwable e) throws Exception {
-                call[0]++;
-                return Completable.complete();
-            }
+        .onErrorResumeNext(_ -> {
+            call[0]++;
+            return Completable.complete();
         })
         .test()
         .assertResult();
@@ -72,11 +68,8 @@ public class CompletableOnErrorXTest extends RxJavaTest {
     @Test
     public void onErrorReturnFunctionThrows() {
         TestHelper.assertCompositeExceptions(Completable.error(new TestException())
-        .onErrorReturn(new Function<Throwable, Object>() {
-            @Override
-            public Object apply(Throwable v) throws Exception {
-                throw new IOException();
-            }
+        .onErrorReturn(_ -> {
+            throw new IOException();
         })
         .to(TestHelper.testConsumer()), TestException.class, IOException.class);
     }
@@ -96,11 +89,6 @@ public class CompletableOnErrorXTest extends RxJavaTest {
 
     @Test
     public void onErrorReturnDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletableToMaybe(new Function<Completable, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Completable v) throws Exception {
-                return v.onErrorReturnItem(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletableToMaybe(v -> v.onErrorReturnItem(1));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletablePeekTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletablePeekTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.subjects.CompletableSubject;
@@ -32,11 +31,8 @@ public class CompletablePeekTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Completable.complete()
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doAfterTerminate(() -> {
+                throw new TestException();
             })
             .test()
             .assertResult();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableRepeatWhenTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableRepeatWhenTest.java
@@ -15,8 +15,9 @@ package io.reactivex.rxjava4.internal.operators.completable;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.concurrent.Flow.Publisher;
+
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.*;
@@ -27,23 +28,10 @@ public class CompletableRepeatWhenTest extends RxJavaTest {
 
         final int[] counter = { 0 };
 
-        Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter[0]++;
-            }
-        })
-        .repeatWhen(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                final int[] j = { 3 };
-                return f.takeWhile(new Predicate<Object>() {
-                    @Override
-                    public boolean test(Object v) throws Exception {
-                        return j[0]-- != 0;
-                    }
-                });
-            }
+        Completable.fromAction(() -> counter[0]++)
+        .repeatWhen((Function<Flowable<Object>, Publisher<Object>>) f -> {
+            final int[] j = { 3 };
+            return f.takeWhile(_ -> j[0]-- != 0);
         })
         .subscribe();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableResumeNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableResumeNextTest.java
@@ -34,22 +34,12 @@ public class CompletableResumeNextTest extends RxJavaTest {
 
     @Test
     public void disposeInMain() {
-        TestHelper.checkDisposedCompletable(new Function<Completable, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Completable c) throws Exception {
-                return c.onErrorResumeNext(Functions.justFunction(Completable.complete()));
-            }
-        });
+        TestHelper.checkDisposedCompletable(c -> c.onErrorResumeNext(Functions.justFunction(Completable.complete())));
     }
 
     @Test
     public void disposeInResume() {
-        TestHelper.checkDisposedCompletable(new Function<Completable, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Completable c) throws Exception {
-                return Completable.error(new TestException()).onErrorResumeNext(Functions.justFunction(c));
-            }
-        });
+        TestHelper.checkDisposedCompletable(c -> Completable.error(new TestException()).onErrorResumeNext(Functions.justFunction(c)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSafeSubscribeTest.java
@@ -70,7 +70,7 @@ public class CompletableSafeSubscribeTest {
 
             Disposable d = Disposable.empty();
 
-            new Completable() {
+            new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull CompletableObserver observer) {
                     observer.onSubscribe(d);
@@ -98,7 +98,7 @@ public class CompletableSafeSubscribeTest {
             CompletableObserver consumer = mock(CompletableObserver.class);
             doThrow(new TestException()).when(consumer).onError(any());
 
-            new Completable() {
+            new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -127,7 +127,7 @@ public class CompletableSafeSubscribeTest {
             CompletableObserver consumer = mock(CompletableObserver.class);
             doThrow(new TestException()).when(consumer).onComplete();
 
-            new Completable() {
+            new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSubscribeOnTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.*;
@@ -57,11 +56,6 @@ public class CompletableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletable(new Function<Completable, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Completable c) throws Exception {
-                return c.subscribeOn(Schedulers.single());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletable(c -> c.subscribeOn(Schedulers.single()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTakeUntilTest.java
@@ -142,7 +142,7 @@ public class CompletableTakeUntilTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            new Completable() {
+            new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -164,7 +164,7 @@ public class CompletableTakeUntilTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            new Completable() {
+            new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -189,7 +189,7 @@ public class CompletableTakeUntilTest extends RxJavaTest {
             final AtomicReference<CompletableObserver> ref = new AtomicReference<>();
 
             Completable.complete()
-            .takeUntil(new Completable() {
+            .takeUntil(new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -216,7 +216,7 @@ public class CompletableTakeUntilTest extends RxJavaTest {
             final AtomicReference<CompletableObserver> ref = new AtomicReference<>();
 
             Completable.complete()
-            .takeUntil(new Completable() {
+            .takeUntil(new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimeoutTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.internal.operators.completable.CompletableTimeout.TimeOutObserver;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -50,12 +49,7 @@ public class CompletableTimeoutTest extends RxJavaTest {
 
         final int[] call = { 0 };
 
-        Completable other = Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        });
+        Completable other = Completable.fromAction(() -> call[0]++);
 
         Completable.never()
         .timeout(100, TimeUnit.MILLISECONDS, Schedulers.cached(), other)
@@ -125,19 +119,9 @@ public class CompletableTimeoutTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> ps.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
-                    }
-                };
+                Runnable r2 = () -> scheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimerTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -40,14 +39,11 @@ public class CompletableTimerTest extends RxJavaTest {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Void> to = Completable.timer(1, TimeUnit.MILLISECONDS, s)
-                .doOnComplete(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        try {
-                        Thread.sleep(3000);
-                        } catch (InterruptedException ex) {
-                            interrupted.set(true);
-                        }
+                .doOnComplete(() -> {
+                    try {
+                    Thread.sleep(3000);
+                    } catch (InterruptedException ex) {
+                        interrupted.set(true);
                     }
                 })
                 .test();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableToFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableToFlowableTest.java
@@ -14,21 +14,14 @@
 package io.reactivex.rxjava4.internal.operators.completable;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class CompletableToFlowableTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletableToFlowable(new Function<Completable, Publisher<?>>() {
-            @Override
-            public Publisher<?> apply(Completable c) throws Exception {
-                return c.toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletableToFlowable(Completable::toFlowable);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableToObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableToObservableTest.java
@@ -23,12 +23,8 @@ public class CompletableToObservableTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletableToObservable(new Function<Completable, Observable<?>>() {
-            @Override
-            public Observable<?> apply(Completable c) throws Exception {
-                return c.toObservable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletableToObservable(
+                (Function<Completable, Observable<?>>) Completable::toObservable);
     }
 
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableUnsafeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableUnsafeTest.java
@@ -39,12 +39,9 @@ public class CompletableUnsafeTest extends RxJavaTest {
     @Test
     public void wrapCustomCompletable() {
 
-        Completable.wrap(new CompletableSource() {
-            @Override
-            public void subscribe(CompletableObserver observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onComplete();
-            }
+        Completable.wrap(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onComplete();
         })
         .test()
         .assertResult();
@@ -52,11 +49,8 @@ public class CompletableUnsafeTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void unsafeCreateThrowsNPE() {
-        Completable.unsafeCreate(new CompletableSource() {
-            @Override
-            public void subscribe(CompletableObserver observer) {
-                throw new NullPointerException();
-            }
+        Completable.unsafeCreate(_ -> {
+            throw new NullPointerException();
         }).test();
     }
 
@@ -64,11 +58,8 @@ public class CompletableUnsafeTest extends RxJavaTest {
     public void unsafeCreateThrowsIAE() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Completable.unsafeCreate(new CompletableSource() {
-                @Override
-                public void subscribe(CompletableObserver observer) {
-                    throw new IllegalArgumentException();
-                }
+            Completable.unsafeCreate(_ -> {
+                throw new IllegalArgumentException();
             }).test();
             fail("Should have thrown!");
         } catch (NullPointerException ex) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableUsingTest.java
@@ -34,22 +34,11 @@ public class CompletableUsingTest extends RxJavaTest {
     @Test
     public void resourceSupplierThrows() {
 
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
+        Completable.using(() -> {
                 throw new TestException();
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.complete();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-
-            }
-        })
+            },
+            _ -> Completable.complete(),
+            _ -> { })
         .test()
         .assertFailure(TestException.class);
     }
@@ -57,22 +46,7 @@ public class CompletableUsingTest extends RxJavaTest {
     @Test
     public void errorEager() {
 
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-
-            }
-        }, true)
+        Completable.using(() -> 1, _ -> Completable.error(new TestException()), _ -> { }, true)
         .test()
         .assertFailure(TestException.class);
     }
@@ -80,22 +54,7 @@ public class CompletableUsingTest extends RxJavaTest {
     @Test
     public void emptyEager() {
 
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.complete();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-
-            }
-        }, true)
+        Completable.using(() -> 1, _ -> Completable.complete(), _ -> { }, true)
         .test()
         .assertResult();
     }
@@ -103,22 +62,8 @@ public class CompletableUsingTest extends RxJavaTest {
     @Test
     public void errorNonEager() {
 
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-
-            }
-        }, false)
+        Completable.using(() -> 1, _ -> Completable.error(new TestException()),
+                _ -> { }, false)
         .test()
         .assertFailure(TestException.class);
     }
@@ -126,22 +71,7 @@ public class CompletableUsingTest extends RxJavaTest {
     @Test
     public void emptyNonEager() {
 
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.complete();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-
-            }
-        }, false)
+        Completable.using(() -> 1, _ -> Completable.complete(), _ -> { }, false)
         .test()
         .assertResult();
     }
@@ -149,22 +79,9 @@ public class CompletableUsingTest extends RxJavaTest {
     @Test
     public void supplierCrashEager() {
 
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-
-            }
-        }, true)
+        Completable.using(() -> 1, _ -> {
+            throw new TestException();
+        }, _ -> { }, true)
         .test()
         .assertFailure(TestException.class);
     }
@@ -172,43 +89,19 @@ public class CompletableUsingTest extends RxJavaTest {
     @Test
     public void supplierCrashNonEager() {
 
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-
-            }
-        }, false)
+        Completable.using(() -> 1, _ -> {
+            throw new TestException();
+        }, _ -> { }, false)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void supplierAndDisposerCrashEager() {
-        TestObserverEx<Void> to = Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                throw new TestException("Main");
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                throw new TestException("Disposer");
-            }
+        TestObserverEx<Void> to = Completable.using(() -> 1, _ -> {
+            throw new TestException("Main");
+        }, _ -> {
+            throw new TestException("Disposer");
         }, true)
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
@@ -223,21 +116,10 @@ public class CompletableUsingTest extends RxJavaTest {
     public void supplierAndDisposerCrashNonEager() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Completable.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, CompletableSource>() {
-                @Override
-                public CompletableSource apply(Object v) throws Exception {
-                    throw new TestException("Main");
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                    throw new TestException("Disposer");
-                }
+            Completable.using(() -> 1, _ -> {
+                throw new TestException("Main");
+            }, _ -> {
+                throw new TestException("Disposer");
             }, false)
             .to(TestHelper.<Void>testConsumer())
             .assertFailureAndMessage(TestException.class, "Main");
@@ -252,22 +134,8 @@ public class CompletableUsingTest extends RxJavaTest {
     public void dispose() {
         final int[] call = {0 };
 
-        TestObserverEx<Void> to = Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.never();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                call[0]++;
-            }
-        }, false)
+        TestObserverEx<Void> to = Completable.using(() -> 1, _ -> Completable.never(),
+                _ -> call[0]++, false)
         .to(TestHelper.<Void>testConsumer());
 
         to.dispose();
@@ -279,22 +147,10 @@ public class CompletableUsingTest extends RxJavaTest {
     public void disposeCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Void> to = Completable.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, CompletableSource>() {
-                @Override
-                public CompletableSource apply(Object v) throws Exception {
-                    return Completable.never();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                    throw new TestException();
-                }
-            }, false)
+            TestObserver<Void> to = Completable.using(() -> 1, _ -> Completable.never(),
+                    _ -> {
+                        throw new TestException();
+                    }, false)
             .test();
 
             to.dispose();
@@ -307,86 +163,36 @@ public class CompletableUsingTest extends RxJavaTest {
 
     @Test
     public void isDisposed() {
-        TestHelper.checkDisposed(Completable.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, CompletableSource>() {
-                @Override
-                public CompletableSource apply(Object v) throws Exception {
-                    return Completable.never();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-
-                }
-            }, false));
+        TestHelper.checkDisposed(Completable.using(() -> 1, _ -> Completable.never(),
+                _ -> { }, false));
     }
 
     @Test
     public void justDisposerCrashes() {
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.complete();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                throw new TestException("Disposer");
-            }
-        }, true)
+        Completable.using(() -> 1, _ -> Completable.complete(),
+                _ -> {
+                    throw new TestException("Disposer");
+                }, true)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void emptyDisposerCrashes() {
-        Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.complete();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                throw new TestException("Disposer");
-            }
-        }, true)
+        Completable.using(() -> 1, _ -> Completable.complete(),
+                _ -> {
+                    throw new TestException("Disposer");
+                }, true)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void errorDisposerCrash() {
-        TestObserverEx<Void> to = Completable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Object v) throws Exception {
-                return Completable.error(new TestException("Main"));
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                throw new TestException("Disposer");
-            }
-        }, true)
+        TestObserverEx<Void> to = Completable.using(() -> 1, _ -> Completable.error(new TestException("Main")),
+                _ -> {
+                    throw new TestException("Disposer");
+                }, true)
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -400,37 +206,19 @@ public class CompletableUsingTest extends RxJavaTest {
     public void doubleOnSubscribe() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Completable.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, CompletableSource>() {
-                @Override
-                public CompletableSource apply(Object v) throws Exception {
-                    return Completable.wrap(new CompletableSource() {
-                        @Override
-                        public void subscribe(CompletableObserver observer) {
-                            Disposable d1 = Disposable.empty();
+            Completable.using(() -> 1, _ -> Completable.wrap(observer -> {
+                Disposable d1 = Disposable.empty();
 
-                            observer.onSubscribe(d1);
+                observer.onSubscribe(d1);
 
-                            Disposable d2 = Disposable.empty();
+                Disposable d2 = Disposable.empty();
 
-                            observer.onSubscribe(d2);
+                observer.onSubscribe(d2);
 
-                            assertFalse(d1.isDisposed());
+                assertFalse(d1.isDisposed());
 
-                            assertTrue(d2.isDisposed());
-                        }
-                    });
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-
-                }
-            }, false).test();
+                assertTrue(d2.isDisposed());
+            }), _ -> { }, false).test();
             TestHelper.assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
         } finally {
             RxJavaPlugins.reset();
@@ -443,38 +231,15 @@ public class CompletableUsingTest extends RxJavaTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserverEx<Void> to = Completable.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, CompletableSource>() {
-                @Override
-                public CompletableSource apply(Object v) throws Exception {
-                    return ps.ignoreElements();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                }
-            }, true)
+            final TestObserverEx<Void> to = Completable.using(() -> 1, _ -> ps.ignoreElements(),
+                    _ -> { }, true)
             .to(TestHelper.<Void>testConsumer());
 
             ps.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> to.dispose();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                }
-            };
+            Runnable r2 = () -> ps.onComplete();
 
             TestHelper.race(r1, r2);
         }
@@ -488,38 +253,15 @@ public class CompletableUsingTest extends RxJavaTest {
 
                 final PublishSubject<Integer> ps = PublishSubject.create();
 
-                final TestObserver<Void> to = Completable.using(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return 1;
-                    }
-                }, new Function<Object, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Object v) throws Exception {
-                        return ps.ignoreElements();
-                    }
-                }, new Consumer<Object>() {
-                    @Override
-                    public void accept(Object d) throws Exception {
-                    }
-                }, true)
+                final TestObserver<Void> to = Completable.using(() -> 1, _ -> ps.ignoreElements(),
+                        _ -> { }, true)
                 .test();
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        to.dispose();
-                    }
-                };
+                Runnable r1 = () -> to.dispose();
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> ps.onError(ex);
 
                 TestHelper.race(r1, r2);
             }
@@ -534,37 +276,13 @@ public class CompletableUsingTest extends RxJavaTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Void> to = Completable.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, CompletableSource>() {
-                @Override
-                public CompletableSource apply(Object v) throws Exception {
-                    return ps.ignoreElements();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-
-                }
-            }, true)
+            final TestObserver<Void> to = Completable.using(() -> 1, _ -> ps.ignoreElements(),
+                    _ -> { }, true)
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> to.dispose();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                }
-            };
+            Runnable r2 = () -> ps.onComplete();
 
             TestHelper.race(r1, r2);
         }
@@ -575,24 +293,8 @@ public class CompletableUsingTest extends RxJavaTest {
         final StringBuilder sb = new StringBuilder();
 
         TestObserver<Void> to = Completable.using(Functions.justSupplier(1),
-            new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer t) throws Throwable {
-                    return Completable.never()
-                            .doOnDispose(new Action() {
-                                @Override
-                                public void run() throws Throwable {
-                                    sb.append("Dispose");
-                                }
-                            })
-                            ;
-                }
-            }, new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Throwable {
-                    sb.append("Resource");
-                }
-            }, true)
+            (Function<Integer, Completable>) _ -> Completable.never()
+                    .doOnDispose(() -> sb.append("Dispose")), _ -> sb.append("Resource"), true)
         .test()
         ;
         to.assertEmpty();
@@ -607,24 +309,8 @@ public class CompletableUsingTest extends RxJavaTest {
         final StringBuilder sb = new StringBuilder();
 
         TestObserver<Void> to = Completable.using(Functions.justSupplier(1),
-            new Function<Integer, Completable>() {
-                @Override
-                public Completable apply(Integer t) throws Throwable {
-                    return Completable.never()
-                            .doOnDispose(new Action() {
-                                @Override
-                                public void run() throws Throwable {
-                                    sb.append("Dispose");
-                                }
-                            })
-                            ;
-                }
-            }, new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Throwable {
-                    sb.append("Resource");
-                }
-            }, false)
+            (Function<Integer, Completable>) _ -> Completable.never()
+                    .doOnDispose(() -> sb.append("Dispose")), _ -> sb.append("Resource"), false)
         .test()
         ;
         to.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -35,7 +35,7 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class BlockingFlowableNextTest extends RxJavaTest {
 
     private void fireOnNextInNewThread(final FlowableProcessor<String> o, final String value) {
-        new Thread() {
+        new Thread() /* NFI */ {
             @Override
             public void run() {
                 try {
@@ -49,7 +49,7 @@ public class BlockingFlowableNextTest extends RxJavaTest {
     }
 
     private void fireOnErrorInNewThread(final FlowableProcessor<String> o) {
-        new Thread() {
+        new Thread() /* NFI */ {
             @Override
             public void run() {
                 try {
@@ -240,30 +240,21 @@ public class BlockingFlowableNextTest extends RxJavaTest {
                 final CountDownLatch timeHasPassed = new CountDownLatch(COUNT);
                 final AtomicBoolean running = new AtomicBoolean(true);
                 final AtomicInteger count = new AtomicInteger(0);
-                final Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
-
-                    @Override
-                    public void subscribe(final Subscriber<? super Integer> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        task.replace(Schedulers.single().scheduleDirect(new Runnable() {
-
-                            @Override
-                            public void run() {
-                                try {
-                                    while (running.get() && !task.isDisposed()) {
-                                        subscriber.onNext(count.incrementAndGet());
-                                        timeHasPassed.countDown();
-                                    }
-                                    subscriber.onComplete();
-                                } catch (Throwable e) {
-                                    subscriber.onError(e);
-                                } finally {
-                                    finished.countDown();
-                                }
+                final Flowable<Integer> obs = Flowable.unsafeCreate(subscriber -> {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    task.replace(Schedulers.single().scheduleDirect(() -> {
+                        try {
+                            while (running.get() && !task.isDisposed()) {
+                                subscriber.onNext(count.incrementAndGet());
+                                timeHasPassed.countDown();
                             }
-                        }));
-                    }
-
+                            subscriber.onComplete();
+                        } catch (Throwable e) {
+                            subscriber.onError(e);
+                        } finally {
+                            finished.countDown();
+                        }
+                    }));
                 });
 
                 Iterator<Integer> it = obs.blockingNext().iterator();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToFutureTest.java
@@ -19,7 +19,6 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.Flowable;
 import io.reactivex.rxjava4.exceptions.TestException;
@@ -59,14 +58,10 @@ public class BlockingFlowableToFutureTest {
 
     @Test
     public void toFutureWithException() {
-        Flowable<String> obs = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                subscriber.onNext("one");
-                subscriber.onError(new TestException());
-            }
+        Flowable<String> obs = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onNext("one");
+            subscriber.onError(new TestException());
         });
 
         Future<String> f = obs.toFuture();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToIteratorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToIteratorTest.java
@@ -52,14 +52,10 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void toIteratorWithException() {
-        Flowable<String> obs = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                subscriber.onNext("one");
-                subscriber.onError(new TestException());
-            }
+        Flowable<String> obs = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onNext("one");
+            subscriber.onError(new TestException());
         });
 
         Iterator<String> it = obs.blockingIterable().iterator();
@@ -75,12 +71,7 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
     public void iteratorExertBackpressure() {
         final Counter src = new Counter();
 
-        Flowable<Integer> obs = Flowable.fromIterable(new Iterable<Integer>() {
-            @Override
-            public Iterator<Integer> iterator() {
-                return src;
-            }
-        });
+        Flowable<Integer> obs = Flowable.fromIterable(() -> src);
 
         Iterator<Integer> it = obs.blockingIterable().iterator();
         while (it.hasNext()) {
@@ -158,7 +149,7 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test(expected = QueueOverflowException.class)
     public void overflowQueue() {
-        Iterator<Integer> it = new Flowable<Integer>() {
+        Iterator<Integer> it = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -186,12 +177,7 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
         final Iterator<Integer> it = PublishProcessor.<Integer>create()
                 .blockingIterable().iterator();
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                ((Disposable)it).dispose();
-            }
-        }, 1, TimeUnit.SECONDS);
+        Schedulers.single().scheduleDirect(() -> ((Disposable)it).dispose(), 1, TimeUnit.SECONDS);
 
         assertFalse(it.hasNext());
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BufferUntilSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BufferUntilSubscriberTest.java
@@ -13,12 +13,11 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
-import java.util.List;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.*;
@@ -43,32 +42,21 @@ public class BufferUntilSubscriberTest extends RxJavaTest {
             Flowable.fromArray(numbers)
                     .takeUntil(s)
                     .window(50)
-                    .flatMap(new Function<Flowable<Integer>, Publisher<Object>>() {
-                        @Override
-                        public Publisher<Object> apply(Flowable<Integer> integerObservable) {
-                                return integerObservable
-                                        .subscribeOn(Schedulers.computation())
-                                        .map(new Function<Integer, Object>() {
-                                            @Override
-                                            public Object apply(Integer integer) {
-                                                    if (integer >= 5 && completed.compareAndSet(false, true)) {
-                                                        s.onComplete();
-                                                    }
-                                                    // do some work
-                                                    Math.pow(Math.random(), Math.random());
-                                                    return integer * 2;
-                                            }
-                                        });
-                        }
-                    })
+                    .flatMap((Function<Flowable<Integer>, Publisher<Object>>) integerObservable -> integerObservable
+                            .subscribeOn(Schedulers.computation())
+                            .map(integer -> {
+                                    if (integer >= 5 && completed.compareAndSet(false, true)) {
+                                        s.onComplete();
+                                    }
+                                    // do some work
+                                    Math.pow(Math.random(), Math.random());
+                                    return integer * 2;
+                            }))
                     .toList()
-                    .doOnSuccess(new Consumer<List<Object>>() {
-                        @Override
-                        public void accept(List<Object> integers) {
-                                counter.incrementAndGet();
-                                latch.countDown();
-                                innerLatch.countDown();
-                        }
+                    .doOnSuccess(_ -> {
+                            counter.incrementAndGet();
+                            latch.countDown();
+                            innerLatch.countDown();
                     })
                     .subscribe();
             if (!innerLatch.await(30, TimeUnit.SECONDS)) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAllTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -41,12 +42,7 @@ public class FlowableAllTest extends RxJavaTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
         verify(observer).onSubscribe((Disposable)any());
@@ -60,12 +56,7 @@ public class FlowableAllTest extends RxJavaTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
         verify(observer).onSubscribe((Disposable)any());
@@ -79,12 +70,7 @@ public class FlowableAllTest extends RxJavaTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
         verify(observer).onSubscribe((Disposable)any());
@@ -99,12 +85,7 @@ public class FlowableAllTest extends RxJavaTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
         verify(observer).onSubscribe((Disposable)any());
@@ -115,12 +96,7 @@ public class FlowableAllTest extends RxJavaTest {
     @Test
     public void followingFirst() {
         Flowable<Integer> f = Flowable.fromArray(1, 3, 5, 6);
-        Single<Boolean> allOdd = f.all(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 1;
-            }
-        });
+        Single<Boolean> allOdd = f.all(i -> i % 2 == 1);
 
         assertFalse(allOdd.blockingGet());
     }
@@ -128,18 +104,8 @@ public class FlowableAllTest extends RxJavaTest {
     @Test
     public void issue1935NoUnsubscribeDownstream() {
         Flowable<Integer> source = Flowable.just(1)
-            .all(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer t1) {
-                    return false;
-                }
-            })
-            .flatMapPublisher(new Function<Boolean, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Boolean t1) {
-                    return Flowable.just(2).delay(500, TimeUnit.MILLISECONDS);
-                }
-            });
+            .all(_ -> false)
+            .flatMapPublisher((Function<Boolean, Publisher<Integer>>) _ -> Flowable.just(2).delay(500, TimeUnit.MILLISECONDS));
 
         assertEquals((Object)2, source.blockingFirst());
     }
@@ -148,12 +114,7 @@ public class FlowableAllTest extends RxJavaTest {
     public void backpressureIfOneRequestedOneShouldBeDelivered() {
         TestObserverEx<Boolean> to = new TestObserverEx<>();
 
-        Flowable.empty().all(new Predicate<Object>() {
-            @Override
-            public boolean test(Object t) {
-                return false;
-            }
-        }).subscribe(to);
+        Flowable.empty().all(_ -> false).subscribe(to);
 
         to.assertTerminated();
         to.assertNoErrors();
@@ -168,11 +129,8 @@ public class FlowableAllTest extends RxJavaTest {
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
-        Flowable.just("Boo!").all(new Predicate<String>() {
-            @Override
-            public boolean test(String v) {
-                throw ex;
-            }
+        Flowable.just("Boo!").all(_ -> {
+            throw ex;
         })
         .subscribe(to);
 
@@ -190,12 +148,7 @@ public class FlowableAllTest extends RxJavaTest {
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .toFlowable()
         .subscribe(subscriber);
 
@@ -211,12 +164,7 @@ public class FlowableAllTest extends RxJavaTest {
 
         Subscriber <Boolean> subscriber = TestHelper.mockSubscriber();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .toFlowable()
         .subscribe(subscriber);
 
@@ -232,12 +180,7 @@ public class FlowableAllTest extends RxJavaTest {
 
         Subscriber <Boolean> subscriber = TestHelper.mockSubscriber();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .toFlowable()
         .subscribe(subscriber);
 
@@ -254,12 +197,7 @@ public class FlowableAllTest extends RxJavaTest {
 
         Subscriber <Boolean> subscriber = TestHelper.mockSubscriber();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .toFlowable()
         .subscribe(subscriber);
 
@@ -271,12 +209,7 @@ public class FlowableAllTest extends RxJavaTest {
     @Test
     public void followingFirstFlowable() {
         Flowable<Integer> f = Flowable.fromArray(1, 3, 5, 6);
-        Flowable<Boolean> allOdd = f.all(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 1;
-            }
-        })
+        Flowable<Boolean> allOdd = f.all(i -> i % 2 == 1)
         .toFlowable()
         ;
 
@@ -286,19 +219,9 @@ public class FlowableAllTest extends RxJavaTest {
     @Test
     public void issue1935NoUnsubscribeDownstreamFlowable() {
         Flowable<Integer> source = Flowable.just(1)
-            .all(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer t1) {
-                    return false;
-                }
-            })
+            .all(_ -> false)
             .toFlowable()
-            .flatMap(new Function<Boolean, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Boolean t1) {
-                    return Flowable.just(2).delay(500, TimeUnit.MILLISECONDS);
-                }
-            })
+            .flatMap((Function<Boolean, Publisher<Integer>>) _ -> Flowable.just(2).delay(500, TimeUnit.MILLISECONDS))
             ;
 
         assertEquals((Object)2, source.blockingFirst());
@@ -307,12 +230,7 @@ public class FlowableAllTest extends RxJavaTest {
     @Test
     public void backpressureIfNoneRequestedNoneShouldBeDeliveredFlowable() {
         TestSubscriber<Boolean> ts = new TestSubscriber<>(0L);
-        Flowable.empty().all(new Predicate<Object>() {
-            @Override
-            public boolean test(Object t1) {
-                return false;
-            }
-        })
+        Flowable.empty().all(_ -> false)
         .toFlowable()
         .subscribe(ts);
 
@@ -325,12 +243,7 @@ public class FlowableAllTest extends RxJavaTest {
     public void backpressureIfOneRequestedOneShouldBeDeliveredFlowable() {
         TestSubscriberEx<Boolean> ts = new TestSubscriberEx<>(1L);
 
-        Flowable.empty().all(new Predicate<Object>() {
-            @Override
-            public boolean test(Object t) {
-                return false;
-            }
-        })
+        Flowable.empty().all(_ -> false)
         .toFlowable()
         .subscribe(ts);
 
@@ -347,11 +260,8 @@ public class FlowableAllTest extends RxJavaTest {
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
-        Flowable.just("Boo!").all(new Predicate<String>() {
-            @Override
-            public boolean test(String v) {
-                throw ex;
-            }
+        Flowable.just("Boo!").all(_ -> {
+            throw ex;
         })
         .toFlowable()
         .subscribe(ts);
@@ -375,7 +285,7 @@ public class FlowableAllTest extends RxJavaTest {
     public void predicateThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -386,11 +296,8 @@ public class FlowableAllTest extends RxJavaTest {
                     subscriber.onComplete();
                 }
             }
-            .all(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .all(_ -> {
+                throw new TestException();
             })
             .toFlowable()
             .test()
@@ -406,7 +313,7 @@ public class FlowableAllTest extends RxJavaTest {
     public void predicateThrowsObservable() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -417,11 +324,8 @@ public class FlowableAllTest extends RxJavaTest {
                     subscriber.onComplete();
                 }
             }
-            .all(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .all(_ -> {
+                throw new TestException();
             })
             .toFlowable()
             .test()
@@ -435,34 +339,14 @@ public class FlowableAllTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.all(Functions.alwaysTrue());
-            }
-        }, false, 1, 1, true);
+        TestHelper.checkBadSourceFlowable(f -> f.all(Functions.alwaysTrue()), false, 1, 1, true);
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.all(Functions.alwaysTrue()).toFlowable();
-            }
-        }, false, 1, 1, true);
+        TestHelper.checkBadSourceFlowable(f -> f.all(Functions.alwaysTrue()).toFlowable(), false, 1, 1, true);
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Boolean>>() {
-            @Override
-            public Publisher<Boolean> apply(Flowable<Object> f) throws Exception {
-                return f.all(Functions.alwaysTrue()).toFlowable();
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<Boolean>>() {
-            @Override
-            public Single<Boolean> apply(Flowable<Object> f) throws Exception {
-                return f.all(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.all(Functions.alwaysTrue()).toFlowable());
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle((Function<Flowable<Object>, Single<Boolean>>) f -> f.all(Functions.alwaysTrue()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
@@ -58,7 +58,7 @@ public class FlowableAmbTest extends RxJavaTest {
                 @SuppressWarnings("resource")
                 final CompositeDisposable parentSubscription = new CompositeDisposable();
 
-                subscriber.onSubscribe(new Subscription() {
+                subscriber.onSubscribe(new Subscription() /* NFI */ {
                     @Override
                     public void request(long n) {
 
@@ -72,24 +72,16 @@ public class FlowableAmbTest extends RxJavaTest {
 
                 long delay = interval;
                 for (final String value : values) {
-                    parentSubscription.add(innerScheduler.schedule(new Runnable() {
-                            @Override
-                            public void run() {
-                                subscriber.onNext(value);
-                            }
-                        }
+                    parentSubscription.add(innerScheduler.schedule(() -> subscriber.onNext(value)
                         , delay, TimeUnit.MILLISECONDS));
                     delay += interval;
                 }
-                parentSubscription.add(innerScheduler.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                            if (e == null) {
-                                subscriber.onComplete();
-                            } else {
-                                subscriber.onError(e);
-                            }
-                    }
+                parentSubscription.add(innerScheduler.schedule(() -> {
+                        if (e == null) {
+                            subscriber.onComplete();
+                        } else {
+                            subscriber.onError(e);
+                        }
                 }, delay, TimeUnit.MILLISECONDS));
             }
         });
@@ -176,46 +168,32 @@ public class FlowableAmbTest extends RxJavaTest {
         ts.request(3);
         final AtomicLong requested1 = new AtomicLong();
         final AtomicLong requested2 = new AtomicLong();
-        Flowable<Integer> f1 = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> f1 = Flowable.unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        System.out.println("1-requested: " + n);
-                        requested1.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
+            public void request(long n) {
+                System.out.println("1-requested: " + n);
+                requested1.set(n);
             }
-
-        });
-        Flowable<Integer> f2 = Flowable.unsafeCreate(new Publisher<Integer>() {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
+            public void cancel() {
 
-                    @Override
-                    public void request(long n) {
-                        System.out.println("2-requested: " + n);
-                        requested2.set(n);
-                    }
+            }
+        }));
+        Flowable<Integer> f2 = Flowable.unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
 
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
+            @Override
+            public void request(long n) {
+                System.out.println("2-requested: " + n);
+                requested2.set(n);
             }
 
-        });
+            @Override
+            public void cancel() {
+
+            }
+        }));
         Flowable.ambArray(f1, f2).subscribe(ts);
         assertEquals(3, requested1.get());
         assertEquals(3, requested2.get());
@@ -238,12 +216,7 @@ public class FlowableAmbTest extends RxJavaTest {
     @Test
     public void subscriptionOnlyHappensOnce() throws InterruptedException {
         final AtomicLong count = new AtomicLong();
-        Consumer<Subscription> incrementer = new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                count.incrementAndGet();
-            }
-        };
+        Consumer<Subscription> incrementer = _ -> count.incrementAndGet();
 
         //this aync stream should emit first
         Flowable<Integer> f1 = Flowable.just(1).doOnSubscribe(incrementer)
@@ -285,15 +258,12 @@ public class FlowableAmbTest extends RxJavaTest {
         // then second Flowable does not get subscribed to before first
         // subscription completes hence first Flowable emits result through
         // amb
-        int result = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {
-                        //
-                    }
-            }
+        int result = Flowable.just(1).doOnNext(_ -> {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    //
+                }
         }).ambWith(Flowable.just(2)).blockingSingle();
         assertEquals(1, result);
     }
@@ -435,18 +405,8 @@ public class FlowableAmbTest extends RxJavaTest {
 
             TestSubscriberEx<Integer> ts = Flowable.ambArray(pp1, pp2).to(TestHelper.<Integer>testConsumer());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onNext(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp1.onNext(1);
+            Runnable r2 = () -> pp2.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -463,18 +423,8 @@ public class FlowableAmbTest extends RxJavaTest {
 
             TestSubscriber<Integer> ts = Flowable.ambArray(pp1, pp2).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onComplete();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp1.onComplete();
+            Runnable r2 = () -> pp2.onComplete();
 
             TestHelper.race(r1, r2);
 
@@ -492,18 +442,8 @@ public class FlowableAmbTest extends RxJavaTest {
 
             final Throwable ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onError(ex);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onError(ex);
-                }
-            };
+            Runnable r1 = () -> pp1.onError(ex);
+            Runnable r2 = () -> pp2.onError(ex);
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
@@ -528,30 +468,15 @@ public class FlowableAmbTest extends RxJavaTest {
 
     @Test
     public void iteratorThrows() {
-        Flowable.amb(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.never();
-            }
-        }))
+        Flowable.amb(new CrashingMappedIterable<>(1, 100, 100, _ -> Flowable.<Integer>never()))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
 
-        Flowable.amb(new CrashingMappedIterable<>(100, 1, 100, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.never();
-            }
-        }))
+        Flowable.amb(new CrashingMappedIterable<>(100, 1, 100, _ -> Flowable.<Integer>never()))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
 
-        Flowable.amb(new CrashingMappedIterable<>(100, 100, 1, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.never();
-            }
-        }))
+        Flowable.amb(new CrashingMappedIterable<>(100, 100, 1, _ -> Flowable.<Integer>never()))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -586,12 +511,9 @@ public class FlowableAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Flowable.never()
             )
-            .subscribe(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe(_ -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -612,12 +534,9 @@ public class FlowableAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Flowable.never()
             )
-            .subscribe(Functions.emptyConsumer(), new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe(Functions.emptyConsumer(), _ -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -637,12 +556,9 @@ public class FlowableAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Flowable.never()
             )
-            .subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), new Action() {
-                @Override
-                public void run() throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), () -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -652,12 +568,7 @@ public class FlowableAmbTest extends RxJavaTest {
 
     @Test
     public void publishersInIterable() {
-        Publisher<Integer> source = new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> subscriber) {
-                Flowable.just(1).subscribe(subscriber);
-            }
-        };
+        Publisher<Integer> source = subscriber -> Flowable.just(1).subscribe(subscriber);
 
         Flowable.amb(Arrays.asList(source, source))
         .test()
@@ -672,7 +583,7 @@ public class FlowableAmbTest extends RxJavaTest {
     @Test
     public void requestAfterCancel() {
         Flowable.amb(Arrays.asList(Flowable.never(), Flowable.never()))
-        .subscribe(new FlowableSubscriber<Object>() {
+        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
 
             @Override
             public void onNext(@NonNull Object t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1163,13 +1163,13 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         .assertFailure(TestException.class, "[1, 2]");
     }
 
-    @SuppressWarnings("unchecked")
+    // @SuppressWarnings("unchecked")
     @Test
     public void combineLatestArrayEmpty() {
         assertSame(Flowable.empty(), Flowable.combineLatestArray(new Flowable[0], Functions.<Object[]>identity(), 16));
     }
 
-    @SuppressWarnings("unchecked")
+    // @SuppressWarnings("unchecked")
     @Test
     public void combineLatestDelayErrorEmpty() {
         assertSame(Flowable.empty(), Flowable.combineLatestArrayDelayError(new Flowable[0], Functions.<Object[]>identity(), 16));

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -848,13 +848,13 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         .assertFailure(TestException.class, "[1, 2]");
     }
 
-    @SuppressWarnings("unchecked")
+    // @SuppressWarnings("unchecked")
     @Test
     public void combineLatestArrayEmpty() {
         assertSame(Observable.empty(), Observable.combineLatestArray(new ObservableSource[0], Functions.<Object[]>identity(), 16));
     }
 
-    @SuppressWarnings("unchecked")
+    // @SuppressWarnings("unchecked")
     @Test
     public void combineLatestDelayErrorEmpty() {
         assertSame(Observable.empty(), Observable.combineLatestArrayDelayError(new ObservableSource[0], Functions.<Object[]>identity(), 16));


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>,.?]|\s*<[\s\w<>,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080