### PR TITLE
4.x: Unit test lambdaification 8 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
@@ -735,12 +735,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableFunctionReturnsNull() {
-        Flowable.combineLatestDelayError(Arrays.asList(just1), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return null;
-            }
-        }, 128).blockingLast();
+        Flowable.combineLatestDelayError(Arrays.asList(just1), _ -> null, 128).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
@@ -951,30 +951,24 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void zipIterableObject() {
         final List<Flowable<Integer>> flowables = Arrays.asList(Flowable.just(1, 2, 3), Flowable.just(1, 2, 3));
-        Flowable.zip(flowables, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] o) throws Exception {
-                int sum = 0;
-                for (Object i : o) {
-                    sum += (Integer) i;
-                }
-                return sum;
+        Flowable.zip(flowables, o -> {
+            int sum = 0;
+            for (Object i : o) {
+                sum += (Integer) i;
             }
+            return sum;
         }).test().assertResult(2, 4, 6);
     }
 
     @Test
     public void combineLatestObject() {
         final List<Flowable<Integer>> flowables = Arrays.asList(Flowable.just(1, 2, 3), Flowable.just(1, 2, 3));
-        Flowable.combineLatest(flowables, new Function<Object[], Object>() {
-            @Override
-            public Object apply(final Object[] o) throws Exception {
-                int sum = 1;
-                for (Object i : o) {
-                    sum *= (Integer) i;
-                }
-                return sum;
+        Flowable.combineLatest(flowables, o -> {
+            int sum = 1;
+            for (Object i : o) {
+                sum *= (Integer) i;
             }
+            return sum;
         }).test().assertResult(3, 6, 9);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableZipTests.java
@@ -79,13 +79,10 @@ public class FlowableZipTests extends RxJavaTest {
 
         Collection<Flowable<Object>> observables = Collections.emptyList();
 
-        Flowable<Object> result = Flowable.zip(observables, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] args) {
-                System.out.println("received: " + args);
-                assertEquals("No argument should have been passed", 0, args.length);
-                return invoked;
-            }
+        Flowable<Object> result = Flowable.zip(observables, args -> {
+            System.out.println("received: " + args);
+            assertEquals("No argument should have been passed", 0, args.length);
+            return invoked;
         });
 
         assertSame(invoked, result.blockingLast());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.SerialDisposable;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
@@ -51,39 +51,35 @@ public class FlowableAmbTest extends RxJavaTest {
 
     private Flowable<String> createFlowable(final String[] values,
             final long interval, final Throwable e) {
-        return Flowable.unsafeCreate(new Publisher<String>() {
+        return Flowable.unsafeCreate(subscriber -> {
+            @SuppressWarnings("resource")
+            final CompositeDisposable parentSubscription = new CompositeDisposable();
 
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                @SuppressWarnings("resource")
-                final CompositeDisposable parentSubscription = new CompositeDisposable();
+            subscriber.onSubscribe(new Subscription() /* NFI */ {
+                @Override
+                public void request(long n) {
 
-                subscriber.onSubscribe(new Subscription() /* NFI */ {
-                    @Override
-                    public void request(long n) {
-
-                    }
-
-                    @Override
-                    public void cancel() {
-                        parentSubscription.dispose();
-                    }
-                });
-
-                long delay = interval;
-                for (final String value : values) {
-                    parentSubscription.add(innerScheduler.schedule(() -> subscriber.onNext(value)
-                        , delay, TimeUnit.MILLISECONDS));
-                    delay += interval;
                 }
-                parentSubscription.add(innerScheduler.schedule(() -> {
-                        if (e == null) {
-                            subscriber.onComplete();
-                        } else {
-                            subscriber.onError(e);
-                        }
-                }, delay, TimeUnit.MILLISECONDS));
+
+                @Override
+                public void cancel() {
+                    parentSubscription.dispose();
+                }
+            });
+
+            long delay = interval;
+            for (final String value : values) {
+                parentSubscription.add(innerScheduler.schedule(() -> subscriber.onNext(value)
+                    , delay, TimeUnit.MILLISECONDS));
+                delay += interval;
             }
+            parentSubscription.add(innerScheduler.schedule(() -> {
+                    if (e == null) {
+                        subscriber.onComplete();
+                    } else {
+                        subscriber.onError(e);
+                    }
+            }, delay, TimeUnit.MILLISECONDS));
         });
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAnyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAnyTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -38,12 +39,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithTwoItems() {
         Flowable<Integer> w = Flowable.just(1, 2);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        });
+        Single<Boolean> single = w.any(_ -> true);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -71,12 +67,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithOneItem() {
         Flowable<Integer> w = Flowable.just(1);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        });
+        Single<Boolean> single = w.any(_ -> true);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -104,12 +95,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithEmpty() {
         Flowable<Integer> w = Flowable.empty();
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        });
+        Single<Boolean> single = w.any(_ -> true);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -137,12 +123,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithPredicate1() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        });
+        Single<Boolean> single = w.any(t1 -> t1 < 2);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -156,12 +137,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void exists1() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        });
+        Single<Boolean> single = w.any(t1 -> t1 < 2);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -175,12 +151,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithPredicate2() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 1;
-            }
-        });
+        Single<Boolean> single = w.any(t1 -> t1 < 1);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -195,12 +166,7 @@ public class FlowableAnyTest extends RxJavaTest {
     public void anyWithEmptyAndPredicate() {
         // If the source is empty, always output false.
         Flowable<Integer> w = Flowable.empty();
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t) {
-                return true;
-            }
-        });
+        Single<Boolean> single = w.any(_ -> true);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -214,12 +180,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void withFollowingFirst() {
         Flowable<Integer> f = Flowable.fromArray(1, 3, 5, 6);
-        Single<Boolean> anyEven = f.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 0;
-            }
-        });
+        Single<Boolean> anyEven = f.any(i -> i % 2 == 0);
 
         assertTrue(anyEven.blockingGet());
     }
@@ -227,12 +188,8 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void issue1935NoUnsubscribeDownstream() {
         Flowable<Integer> source = Flowable.just(1).isEmpty()
-            .flatMapPublisher(new Function<Boolean, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Boolean t1) {
-                    return Flowable.just(2).delay(500, TimeUnit.MILLISECONDS);
-                }
-            });
+            .flatMapPublisher((Function<Boolean, Publisher<Integer>>) _ -> Flowable.just(2)
+                    .delay(500, TimeUnit.MILLISECONDS));
 
         assertEquals((Object)2, source.blockingFirst());
     }
@@ -240,12 +197,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void backpressureIfOneRequestedOneShouldBeDelivered() {
         TestObserverEx<Boolean> to = new TestObserverEx<>();
-        Flowable.just(1).any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        }).subscribe(to);
+        Flowable.just(1).any(_ -> true).subscribe(to);
 
         to.assertTerminated();
         to.assertNoErrors();
@@ -258,11 +210,8 @@ public class FlowableAnyTest extends RxJavaTest {
         TestObserverEx<Boolean> to = new TestObserverEx<>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
-        Flowable.just("Boo!").any(new Predicate<String>() {
-            @Override
-            public boolean test(String v) {
-                throw ex;
-            }
+        Flowable.just("Boo!").any(_ -> {
+            throw ex;
         }).subscribe(to);
 
         to.assertTerminated();
@@ -276,12 +225,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithTwoItemsFlowable() {
         Flowable<Integer> w = Flowable.just(1, 2);
-        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        })
+        Flowable<Boolean> flowable = w.any(_ -> true)
         .toFlowable()
         ;
 
@@ -313,12 +257,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithOneItemFlowable() {
         Flowable<Integer> w = Flowable.just(1);
-        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        }).toFlowable();
+        Flowable<Boolean> flowable = w.any(_ -> true).toFlowable();
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
@@ -347,12 +286,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithEmptyFlowable() {
         Flowable<Integer> w = Flowable.empty();
-        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        }).toFlowable();
+        Flowable<Boolean> flowable = w.any(_ -> true).toFlowable();
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
@@ -382,12 +316,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithPredicate1Flowable() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        }).toFlowable();
+        Flowable<Boolean> flowable = w.any(t1 -> t1 < 2).toFlowable();
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
@@ -402,12 +331,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void exists1Flowable() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        }).toFlowable();
+        Flowable<Boolean> flowable = w.any(t1 -> t1 < 2).toFlowable();
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
@@ -422,12 +346,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void anyWithPredicate2Flowable() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 1;
-            }
-        }).toFlowable();
+        Flowable<Boolean> flowable = w.any(t1 -> t1 < 1).toFlowable();
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
@@ -443,12 +362,7 @@ public class FlowableAnyTest extends RxJavaTest {
     public void anyWithEmptyAndPredicateFlowable() {
         // If the source is empty, always output false.
         Flowable<Integer> w = Flowable.empty();
-        Flowable<Boolean> flowable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t) {
-                return true;
-            }
-        }).toFlowable();
+        Flowable<Boolean> flowable = w.any(_ -> true).toFlowable();
 
         Subscriber<Boolean> subscriber = TestHelper.mockSubscriber();
 
@@ -463,12 +377,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void withFollowingFirstFlowable() {
         Flowable<Integer> f = Flowable.fromArray(1, 3, 5, 6);
-        Flowable<Boolean> anyEven = f.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 0;
-            }
-        }).toFlowable();
+        Flowable<Boolean> anyEven = f.any(i -> i % 2 == 0).toFlowable();
 
         assertTrue(anyEven.blockingFirst());
     }
@@ -476,12 +385,8 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void issue1935NoUnsubscribeDownstreamFlowable() {
         Flowable<Integer> source = Flowable.just(1).isEmpty()
-            .flatMapPublisher(new Function<Boolean, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Boolean t1) {
-                    return Flowable.just(2).delay(500, TimeUnit.MILLISECONDS);
-                }
-            });
+            .flatMapPublisher((Function<Boolean, Publisher<Integer>>) _ -> Flowable.just(2)
+                    .delay(500, TimeUnit.MILLISECONDS));
 
         assertEquals((Object)2, source.blockingFirst());
     }
@@ -490,12 +395,7 @@ public class FlowableAnyTest extends RxJavaTest {
     public void backpressureIfNoneRequestedNoneShouldBeDeliveredFlowable() {
         TestSubscriber<Boolean> ts = new TestSubscriber<>(0L);
 
-        Flowable.just(1).any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t) {
-                return true;
-            }
-        }).toFlowable()
+        Flowable.just(1).any(_ -> true).toFlowable()
         .subscribe(ts);
 
         ts.assertNoValues();
@@ -506,12 +406,7 @@ public class FlowableAnyTest extends RxJavaTest {
     @Test
     public void backpressureIfOneRequestedOneShouldBeDeliveredFlowable() {
         TestSubscriberEx<Boolean> ts = new TestSubscriberEx<>(1L);
-        Flowable.just(1).any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        }).toFlowable().subscribe(ts);
+        Flowable.just(1).any(_ -> true).toFlowable().subscribe(ts);
 
         ts.assertTerminated();
         ts.assertNoErrors();
@@ -524,11 +419,8 @@ public class FlowableAnyTest extends RxJavaTest {
         TestSubscriberEx<Boolean> ts = new TestSubscriberEx<>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
-        Flowable.just("Boo!").any(new Predicate<String>() {
-            @Override
-            public boolean test(String v) {
-                throw ex;
-            }
+        Flowable.just("Boo!").any(_ -> {
+            throw ex;
         }).toFlowable().subscribe(ts);
 
         ts.assertTerminated();
@@ -548,26 +440,17 @@ public class FlowableAnyTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Boolean>>() {
-            @Override
-            public Publisher<Boolean> apply(Flowable<Object> f) throws Exception {
-                return f.any(Functions.alwaysTrue()).toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.any(Functions.alwaysTrue()).toFlowable());
 
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<Boolean>>() {
-            @Override
-            public Single<Boolean> apply(Flowable<Object> f) throws Exception {
-                return f.any(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(
+                (Function<Flowable<Object>, Single<Boolean>>) f -> f.any(Functions.alwaysTrue()));
     }
 
     @Test
     public void predicateThrowsSuppressOthers() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -578,11 +461,8 @@ public class FlowableAnyTest extends RxJavaTest {
                     subscriber.onComplete();
                 }
             }
-            .any(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .any(_ -> {
+                throw new TestException();
             })
             .toFlowable()
             .test()
@@ -598,7 +478,7 @@ public class FlowableAnyTest extends RxJavaTest {
     public void badSourceSingle() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBlockingTest.java
@@ -16,11 +16,11 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import static org.junit.Assert.assertEquals;
 
 import java.util.*;
+import java.util.concurrent.Flow.*;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
@@ -53,12 +53,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        });
+        .blockingSubscribe(v -> list.add(v));
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -69,12 +64,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
-                .blockingSubscribe(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer v) throws Exception {
-                        list.add(v);
-                    }
-                }, 128);
+                .blockingSubscribe((Consumer<Integer>) v -> list.add(v), 128);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -85,12 +75,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
-                .blockingSubscribe(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer v) throws Exception {
-                        list.add(v);
-                    }
-                }, 3);
+                .blockingSubscribe((Consumer<Integer>) v -> list.add(v), 3);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -101,12 +86,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        }, Functions.emptyConsumer());
+        .blockingSubscribe((Consumer<Integer>) v -> list.add(v), Functions.emptyConsumer());
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -117,12 +97,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
-                .blockingSubscribe(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer v) throws Exception {
-                        list.add(v);
-                    }
-                }, Functions.emptyConsumer(), 128);
+                .blockingSubscribe((Consumer<Integer>) v -> list.add(v), Functions.emptyConsumer(), 128);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -133,12 +108,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
-                .blockingSubscribe(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer v) throws Exception {
-                        list.add(v);
-                    }
-                }, Functions.emptyConsumer(), 3);
+                .blockingSubscribe((Consumer<Integer>) v -> list.add(v), Functions.emptyConsumer(), 3);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -149,12 +119,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         TestException ex = new TestException();
 
-        Consumer<Object> cons = new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                list.add(v);
-            }
-        };
+        Consumer<Object> cons = v -> list.add(v);
 
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(ex))
         .subscribeOn(Schedulers.computation())
@@ -169,12 +134,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         TestException ex = new TestException();
 
-        Consumer<Object> cons = new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                list.add(v);
-            }
-        };
+        Consumer<Object> cons = v -> list.add(v);
 
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(ex))
                 .subscribeOn(Schedulers.computation())
@@ -187,21 +147,11 @@ public class FlowableBlockingTest extends RxJavaTest {
     public void blockingSubscribeConsumerConsumerAction() {
         final List<Object> list = new ArrayList<>();
 
-        Consumer<Object> cons = new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                list.add(v);
-            }
-        };
+        Consumer<Object> cons = v -> list.add(v);
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(cons, cons, new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add(100);
-            }
-        });
+        .blockingSubscribe(cons, cons, () -> list.add(100));
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
     }
@@ -210,19 +160,9 @@ public class FlowableBlockingTest extends RxJavaTest {
     public void boundedBlockingSubscribeConsumerConsumerAction() {
         final List<Object> list = new ArrayList<>();
 
-        Consumer<Object> cons = new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                list.add(v);
-            }
-        };
+        Consumer<Object> cons = v -> list.add(v);
 
-        Action action = new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add(100);
-            }
-        };
+        Action action = () -> list.add(100);
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
@@ -235,19 +175,9 @@ public class FlowableBlockingTest extends RxJavaTest {
     public void boundedBlockingSubscribeConsumerConsumerActionBufferExceed() {
         final List<Object> list = new ArrayList<>();
 
-        Consumer<Object> cons = new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                list.add(v);
-            }
-        };
+        Consumer<Object> cons = v -> list.add(v);
 
-        Action action = new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add(100);
-            }
-        };
+        Action action = () -> list.add(100);
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
@@ -260,19 +190,9 @@ public class FlowableBlockingTest extends RxJavaTest {
     public void boundedBlockingSubscribeConsumerConsumerActionBufferExceedMillionItem() {
         final List<Object> list = new ArrayList<>();
 
-        Consumer<Object> cons = new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                list.add(v);
-            }
-        };
+        Consumer<Object> cons = v -> list.add(v);
 
-        Action action = new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add(1000001);
-            }
-        };
+        Action action = () -> list.add(1000001);
 
         Flowable.range(1, 1000000)
                 .subscribeOn(Schedulers.computation())
@@ -287,7 +207,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new FlowableSubscriber<Object>() {
+        .blockingSubscribe(new FlowableSubscriber<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -322,7 +242,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(ex))
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new FlowableSubscriber<Object>() {
+        .blockingSubscribe(new FlowableSubscriber<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -352,11 +272,8 @@ public class FlowableBlockingTest extends RxJavaTest {
     @Test(expected = TestException.class)
     public void blockingForEachThrows() {
         Flowable.just(1)
-        .blockingForEach(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                throw new TestException();
-            }
+        .blockingForEach(_ -> {
+            throw new TestException();
         });
     }
 
@@ -382,13 +299,10 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test
     public void firstFgnoredCancelAndOnNext() {
-        Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new BooleanSubscription());
-                s.onNext(1);
-                s.onNext(2);
-            }
+        Flowable<Integer> source = Flowable.fromPublisher(s -> {
+            s.onSubscribe(new BooleanSubscription());
+            s.onNext(1);
+            s.onNext(2);
         });
 
         assertEquals(1, source.blockingFirst().intValue());
@@ -398,13 +312,10 @@ public class FlowableBlockingTest extends RxJavaTest {
     public void firstIgnoredCancelAndOnError() {
         List<Throwable> list = TestHelper.trackPluginErrors();
         try {
-            Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onError(new TestException());
-                }
+            Flowable<Integer> source = Flowable.fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onError(new TestException());
             });
 
             assertEquals(1, source.blockingFirst().intValue());
@@ -417,12 +328,9 @@ public class FlowableBlockingTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void firstOnError() {
-        Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new BooleanSubscription());
-                s.onError(new TestException());
-            }
+        Flowable<Integer> source = Flowable.fromPublisher(s -> {
+            s.onSubscribe(new BooleanSubscription());
+            s.onError(new TestException());
         });
 
         source.blockingFirst();
@@ -473,26 +381,21 @@ public class FlowableBlockingTest extends RxJavaTest {
         ts.assertEmpty();
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void delayed() throws Exception {
         final TestSubscriber<Object> ts = new TestSubscriber<>();
-        final Subscriber[] s = { null };
+        var s = new AtomicReference<Subscriber<? super Integer>>();
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @SuppressWarnings("unchecked")
-            @Override
-            public void run() {
-                ts.cancel();
-                s[0].onNext(1);
-            }
+        Schedulers.single().scheduleDirect(() -> {
+            ts.cancel();
+            s.get().onNext(1);
         }, 200, TimeUnit.MILLISECONDS);
 
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
-                s[0] = subscriber;
+                s.set(subscriber);
             }
         }.blockingSubscribe(ts);
 
@@ -510,30 +413,17 @@ public class FlowableBlockingTest extends RxJavaTest {
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            final Runnable r1 = () -> ts.cancel();
 
-            final Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            final Runnable r2 = () -> pp.onNext(1);
 
             final AtomicInteger c = new AtomicInteger(2);
 
-            Schedulers.computation().scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    c.decrementAndGet();
-                    while (c.get() != 0 && !pp.hasSubscribers()) { }
+            Schedulers.computation().scheduleDirect(() -> {
+                c.decrementAndGet();
+                while (c.get() != 0 && !pp.hasSubscribers()) { }
 
-                    TestHelper.race(r1, r2);
-                }
+                TestHelper.race(r1, r2);
             });
 
             c.decrementAndGet();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -66,16 +67,13 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void skipAndCountOverlappingBuffers() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                subscriber.onNext("one");
-                subscriber.onNext("two");
-                subscriber.onNext("three");
-                subscriber.onNext("four");
-                subscriber.onNext("five");
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onNext("one");
+            subscriber.onNext("two");
+            subscriber.onNext("three");
+            subscriber.onNext("four");
+            subscriber.onNext("five");
         });
 
         Flowable<List<String>> buffered = source.buffer(3, 1);
@@ -122,17 +120,14 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void timedAndCount() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                push(subscriber, "one", 10);
-                push(subscriber, "two", 90);
-                push(subscriber, "three", 110);
-                push(subscriber, "four", 190);
-                push(subscriber, "five", 210);
-                complete(subscriber, 250);
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, "one", 10);
+            push(subscriber, "two", 90);
+            push(subscriber, "three", 110);
+            push(subscriber, "four", 190);
+            push(subscriber, "five", 210);
+            complete(subscriber, 250);
         });
 
         Flowable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, scheduler, 2);
@@ -154,22 +149,19 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void timed() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                push(subscriber, "one", 97);
-                push(subscriber, "two", 98);
-                /**
-                 * Changed from 100. Because scheduling the cut to 100ms happens before this
-                 * Flowable even runs due how lift works, pushing at 100ms would execute after the
-                 * buffer cut.
-                 */
-                push(subscriber, "three", 99);
-                push(subscriber, "four", 101);
-                push(subscriber, "five", 102);
-                complete(subscriber, 150);
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, "one", 97);
+            push(subscriber, "two", 98);
+            /**
+             * Changed from 100. Because scheduling the cut to 100ms happens before this
+             * Flowable even runs due how lift works, pushing at 100ms would execute after the
+             * buffer cut.
+             */
+            push(subscriber, "three", 99);
+            push(subscriber, "four", 101);
+            push(subscriber, "five", 102);
+            complete(subscriber, 150);
         });
 
         Flowable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, scheduler);
@@ -188,42 +180,28 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void flowableBasedOpenerAndCloser() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                push(subscriber, "one", 10);
-                push(subscriber, "two", 60);
-                push(subscriber, "three", 110);
-                push(subscriber, "four", 160);
-                push(subscriber, "five", 210);
-                complete(subscriber, 500);
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, "one", 10);
+            push(subscriber, "two", 60);
+            push(subscriber, "three", 110);
+            push(subscriber, "four", 160);
+            push(subscriber, "five", 210);
+            complete(subscriber, 500);
         });
 
-        Flowable<Object> openings = Flowable.unsafeCreate(new Publisher<Object>() {
-            @Override
-            public void subscribe(Subscriber<Object> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                push(subscriber, new Object(), 50);
-                push(subscriber, new Object(), 200);
-                complete(subscriber, 250);
-            }
+        Flowable<Object> openings = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, new Object(), 50);
+            push(subscriber, new Object(), 200);
+            complete(subscriber, 250);
         });
 
-        Function<Object, Flowable<Object>> closer = new Function<Object, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Object opening) {
-                return Flowable.unsafeCreate(new Publisher<Object>() {
-                    @Override
-                    public void subscribe(Subscriber<? super Object> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        push(subscriber, new Object(), 100);
-                        complete(subscriber, 101);
-                    }
-                });
-            }
-        };
+        Function<Object, Flowable<Object>> closer = _ -> Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, new Object(), 100);
+            complete(subscriber, 101);
+        });
 
         Flowable<List<String>> buffered = source.buffer(openings, closer);
         buffered.subscribe(subscriber);
@@ -280,21 +258,11 @@ public class FlowableBufferTest extends RxJavaTest {
     }
 
     private <T> void push(final Subscriber<T> subscriber, final T value, int delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onNext(value);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onNext(value), delay, TimeUnit.MILLISECONDS);
     }
 
     private void complete(final Subscriber<?> subscriber, int delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onComplete();
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onComplete(), delay, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -305,12 +273,7 @@ public class FlowableBufferTest extends RxJavaTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>(subscriber, 0L);
 
         source.buffer(100, 200, TimeUnit.MILLISECONDS, scheduler)
-        .doOnNext(new Consumer<List<Integer>>() {
-            @Override
-            public void accept(List<Integer> pv) {
-                System.out.println(pv);
-            }
-        })
+        .doOnNext(System.out::println)
         .subscribe(ts);
 
         InOrder inOrder = Mockito.inOrder(subscriber);
@@ -542,12 +505,7 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void bufferWithStartEndBoundaryTake2() {
         Flowable<Long> start = Flowable.interval(61, 61, TimeUnit.MILLISECONDS, scheduler);
-        Function<Long, Flowable<Long>> end = new Function<Long, Flowable<Long>>() {
-            @Override
-            public Flowable<Long> apply(Long t1) {
-                return Flowable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler);
-            }
-        };
+        Function<Long, Flowable<Long>> end = _ -> Flowable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler);
 
         Flowable<Long> source = Flowable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
 
@@ -557,12 +515,7 @@ public class FlowableBufferTest extends RxJavaTest {
         InOrder inOrder = inOrder(subscriber);
 
         result
-        .doOnNext(new Consumer<List<Long>>() {
-            @Override
-            public void accept(List<Long> pv) {
-                System.out.println(pv);
-            }
-        })
+        .doOnNext(System.out::println)
         .subscribe(subscriber);
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
@@ -647,12 +600,7 @@ public class FlowableBufferTest extends RxJavaTest {
     public void bufferWithStartEndStartThrows() {
         PublishProcessor<Integer> start = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> end = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return Flowable.never();
-            }
-        };
+        Function<Integer, Flowable<Integer>> end = _ -> Flowable.never();
 
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -676,11 +624,8 @@ public class FlowableBufferTest extends RxJavaTest {
     public void bufferWithStartEndEndFunctionThrows() {
         PublishProcessor<Integer> start = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> end = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Flowable<Integer>> end = _ -> {
+            throw new TestException();
         };
 
         PublishProcessor<Integer> source = PublishProcessor.create();
@@ -704,12 +649,7 @@ public class FlowableBufferTest extends RxJavaTest {
     public void bufferWithStartEndEndThrows() {
         PublishProcessor<Integer> start = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> end = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return Flowable.error(new TestException());
-            }
-        };
+        Function<Integer, Flowable<Integer>> end = _ -> Flowable.error(new TestException());
 
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -733,26 +673,19 @@ public class FlowableBufferTest extends RxJavaTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>(3L);
 
         final AtomicLong requested = new AtomicLong();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
             }
 
-        }).buffer(5, 5).subscribe(ts);
+            @Override
+            public void cancel() {
+
+            }
+
+        })).buffer(5, 5).subscribe(ts);
         assertEquals(15, requested.get());
 
         ts.request(4);
@@ -764,26 +697,19 @@ public class FlowableBufferTest extends RxJavaTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
         final AtomicLong requested = new AtomicLong();
 
-        Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
             }
 
-        }).buffer(5, 5).subscribe(ts);
+            @Override
+            public void cancel() {
+
+            }
+
+        })).buffer(5, 5).subscribe(ts);
         assertEquals(Long.MAX_VALUE, requested.get());
     }
 
@@ -791,26 +717,19 @@ public class FlowableBufferTest extends RxJavaTest {
     public void producerRequestThroughBufferWithSize3() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>(3L);
         final AtomicLong requested = new AtomicLong();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
             }
 
-        }).buffer(5, 2).subscribe(ts);
+            @Override
+            public void cancel() {
+
+            }
+
+        })).buffer(5, 2).subscribe(ts);
         assertEquals(9, requested.get());
         ts.request(3);
         assertEquals(6, requested.get());
@@ -820,26 +739,19 @@ public class FlowableBufferTest extends RxJavaTest {
     public void producerRequestThroughBufferWithSize4() {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
         final AtomicLong requested = new AtomicLong();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
             }
 
-        }).buffer(5, 2).subscribe(ts);
+            @Override
+            public void cancel() {
+
+            }
+
+        })).buffer(5, 2).subscribe(ts);
         assertEquals(Long.MAX_VALUE, requested.get());
     }
 
@@ -849,26 +761,19 @@ public class FlowableBufferTest extends RxJavaTest {
 
         final AtomicLong requested = new AtomicLong();
 
-        Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
             }
 
-        }).buffer(3, 3).subscribe(ts);
+            @Override
+            public void cancel() {
+
+            }
+
+        })).buffer(3, 3).subscribe(ts);
         assertEquals(Long.MAX_VALUE, requested.get());
     }
 
@@ -878,57 +783,43 @@ public class FlowableBufferTest extends RxJavaTest {
 
         final AtomicLong requested = new AtomicLong();
 
-        Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
             }
 
-        }).buffer(3, 2).subscribe(ts);
+            @Override
+            public void cancel() {
+
+            }
+
+        })).buffer(3, 2).subscribe(ts);
         assertEquals(Long.MAX_VALUE, requested.get());
     }
 
     @Test
     public void producerRequestOverflowThroughBufferWithSize3() {
         final AtomicLong requested = new AtomicLong();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-
+        Flowable.<Integer>unsafeCreate(s -> s.onSubscribe(new Subscription() /* NFI */ {
+            AtomicBoolean once = new AtomicBoolean();
             @Override
-            public void subscribe(final Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-                    AtomicBoolean once = new AtomicBoolean();
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                        if (once.compareAndSet(false, true)) {
-                            s.onNext(1);
-                            s.onNext(2);
-                            s.onNext(3);
-                        }
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-
-                });
+            public void request(long n) {
+                requested.set(n);
+                if (once.compareAndSet(false, true)) {
+                    s.onNext(1);
+                    s.onNext(2);
+                    s.onNext(3);
+                }
             }
 
-        }).buffer(3, 2).subscribe(new DefaultSubscriber<List<Integer>>() {
+            @Override
+            public void cancel() {
+
+            }
+
+        })).buffer(3, 2).subscribe(new DefaultSubscriber<List<Integer>>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -958,7 +849,7 @@ public class FlowableBufferTest extends RxJavaTest {
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final CountDownLatch cdl = new CountDownLatch(1);
-        ResourceSubscriber<Object> s = new ResourceSubscriber<Object>() {
+        ResourceSubscriber<Object> s = new ResourceSubscriber<Object>() /* NFI */ {
             @Override
             public void onNext(Object t) {
                 subscriber.onNext(t);
@@ -1141,12 +1032,7 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void timeAndSkipOverlapScheduler() {
 
-        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler t) {
-                return scheduler;
-            }
-        });
+        RxJavaPlugins.setComputationSchedulerHandler(_ -> scheduler);
 
         try {
             PublishProcessor<Integer> pp = PublishProcessor.create();
@@ -1190,12 +1076,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void timeAndSkipSkipDefaultScheduler() {
-        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler t) {
-                return scheduler;
-            }
-        });
+        RxJavaPlugins.setComputationSchedulerHandler(_ -> scheduler);
 
         try {
 
@@ -1249,12 +1130,7 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void bufferIntoCustomCollection() {
         Flowable.just(1, 1, 2, 2, 3, 3, 4, 4)
-        .buffer(3, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                return new HashSet<>();
-            }
-        })
+        .buffer(3, (Supplier<Collection<Integer>>) () -> new HashSet<>())
         .test()
         .assertResult(set(1, 2), set(2, 3), set(4));
     }
@@ -1262,12 +1138,7 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void bufferSkipIntoCustomCollection() {
         Flowable.just(1, 1, 2, 2, 3, 3, 4, 4)
-        .buffer(3, 3, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                return new HashSet<>();
-            }
-        })
+        .buffer(3, 3, (Supplier<Collection<Integer>>) () -> new HashSet<>())
         .test()
         .assertResult(set(1, 2), set(2, 3), set(4));
     }
@@ -1300,7 +1171,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierReturnsNull() {
         Flowable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE,
+        new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -1319,7 +1191,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierReturnsNull2() {
         Flowable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10,
+        new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -1338,7 +1211,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierReturnsNull3() {
         Flowable.<Integer>never()
-        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(),
+        new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -1357,11 +1231,9 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows() {
         Flowable.just(1)
-        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE,
+        () -> {
+            throw new TestException();
         }, false)
         .test()
         .assertFailure(TestException.class);
@@ -1370,11 +1242,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows2() {
         Flowable.just(1)
-        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, () -> {
+            throw new TestException();
         }, false)
         .test()
         .assertFailure(TestException.class);
@@ -1383,11 +1252,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows3() {
         Flowable.just(1)
-        .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), () -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -1396,7 +1262,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows4() {
         Flowable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE,
+        new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -1415,7 +1282,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows5() {
         Flowable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10,
+        new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -1434,7 +1302,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows6() {
         Flowable.<Integer>never()
-        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(),
+        new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -1469,7 +1338,7 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void bufferSupplierCrash2() {
         Flowable.range(1, 2)
-        .buffer(1, new Supplier<List<Integer>>() {
+        .buffer(1, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -1486,7 +1355,7 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void bufferSkipSupplierCrash2() {
         Flowable.range(1, 2)
-        .buffer(1, 2, new Supplier<List<Integer>>() {
+        .buffer(1, 2, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -1503,7 +1372,7 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void bufferOverlapSupplierCrash2() {
         Flowable.range(1, 2)
-        .buffer(2, 1, new Supplier<List<Integer>>() {
+        .buffer(2, 1, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -1586,7 +1455,8 @@ public class FlowableBufferTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<List<Integer>> ts = pp
-        .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, new Supplier<List<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1,
+        new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -1626,50 +1496,20 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.buffer(1);
-            }
-        }, false, 1, 1, Arrays.asList(1));
+        TestHelper.checkBadSourceFlowable(f -> f.buffer(1), false, 1, 1, Arrays.asList(1));
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.buffer(1, 2);
-            }
-        }, false, 1, 1, Arrays.asList(1));
+        TestHelper.checkBadSourceFlowable(f -> f.buffer(1, 2), false, 1, 1, Arrays.asList(1));
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.buffer(2, 1);
-            }
-        }, false, 1, 1, Arrays.asList(1));
+        TestHelper.checkBadSourceFlowable(f -> f.buffer(2, 1), false, 1, 1, Arrays.asList(1));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<List<Object>>>() {
-            @Override
-            public Publisher<List<Object>> apply(Flowable<Object> f) throws Exception {
-                return f.buffer(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.buffer(1));
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<List<Object>>>() {
-            @Override
-            public Publisher<List<Object>> apply(Flowable<Object> f) throws Exception {
-                return f.buffer(1, 2);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.buffer(1, 2));
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<List<Object>>>() {
-            @Override
-            public Publisher<List<Object>> apply(Flowable<Object> f) throws Exception {
-                return f.buffer(2, 1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.buffer(2, 1));
     }
 
     @Test
@@ -1720,19 +1560,9 @@ public class FlowableBufferTest extends RxJavaTest {
             pp.onNext(3);
             pp.onNext(4);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(5);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(5);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-                }
-            };
+            Runnable r2 = () -> scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
             TestHelper.race(r1, r2);
 
@@ -1752,12 +1582,7 @@ public class FlowableBufferTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Flowable.<Integer>empty()
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        })
+        .doOnCancel(() -> counter.getAndIncrement())
         .buffer(5, TimeUnit.SECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1771,12 +1596,7 @@ public class FlowableBufferTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Flowable.<Integer>empty()
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        })
+        .doOnCancel(() -> counter.getAndIncrement())
         .buffer(5, 10, TimeUnit.SECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1790,12 +1610,7 @@ public class FlowableBufferTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Flowable.<Integer>empty()
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        })
+        .doOnCancel(() -> counter.getAndIncrement())
         .buffer(10, 5, TimeUnit.SECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1837,19 +1652,9 @@ public class FlowableBufferTest extends RxJavaTest {
     public void bufferedCanCompleteIfOpenNeverCompletesDropping() {
         Flowable.range(1, 50)
                 .zipWith(Flowable.interval(5, TimeUnit.MILLISECONDS),
-                        new BiFunction<Integer, Long, Integer>() {
-                            @Override
-                            public Integer apply(Integer integer, Long aLong) {
-                                return integer;
-                            }
-                        })
+                        (BiFunction<Integer, Long, Integer>) (integer, _) -> integer)
                 .buffer(Flowable.interval(0, 200, TimeUnit.MILLISECONDS),
-                        new Function<Long, Publisher<?>>() {
-                            @Override
-                            public Publisher<?> apply(Long a) {
-                                return Flowable.just(a).delay(100, TimeUnit.MILLISECONDS);
-                            }
-                        })
+                        (Function<Long, Publisher<?>>) a -> Flowable.just(a).delay(100, TimeUnit.MILLISECONDS))
                 .to(TestHelper.<List<Integer>>testConsumer())
                 .assertSubscribed()
                 .awaitDone(3, TimeUnit.SECONDS)
@@ -1860,19 +1665,9 @@ public class FlowableBufferTest extends RxJavaTest {
     public void bufferedCanCompleteIfOpenNeverCompletesOverlapping() {
         Flowable.range(1, 50)
                 .zipWith(Flowable.interval(5, TimeUnit.MILLISECONDS),
-                        new BiFunction<Integer, Long, Integer>() {
-                            @Override
-                            public Integer apply(Integer integer, Long aLong) {
-                                return integer;
-                            }
-                        })
+                        (BiFunction<Integer, Long, Integer>) (integer, _) -> integer)
                 .buffer(Flowable.interval(0, 100, TimeUnit.MILLISECONDS),
-                        new Function<Long, Publisher<?>>() {
-                            @Override
-                            public Publisher<?> apply(Long a) {
-                                return Flowable.just(a).delay(200, TimeUnit.MILLISECONDS);
-                            }
-                        })
+                        (Function<Long, Publisher<?>>) a -> Flowable.just(a).delay(200, TimeUnit.MILLISECONDS))
                 .to(TestHelper.<List<Integer>>testConsumer())
                 .assertSubscribed()
                 .awaitDone(3, TimeUnit.SECONDS)
@@ -1891,7 +1686,7 @@ public class FlowableBufferTest extends RxJavaTest {
     public void openClosebadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Object>() {
+            new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> s) {
                     BooleanSubscription bs1 = new BooleanSubscription();
@@ -2048,7 +1843,7 @@ public class FlowableBufferTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.never()
-            .buffer(new Flowable<Object>() {
+            .buffer(new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> s) {
 
@@ -2092,7 +1887,7 @@ public class FlowableBufferTest extends RxJavaTest {
         try {
             Flowable.never()
             .buffer(Flowable.just(1).concatWith(Flowable.<Integer>never()),
-                    Functions.justFunction(new Flowable<Object>() {
+                    Functions.justFunction(new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> s) {
 
@@ -2133,13 +1928,7 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void bufferExactBoundaryDoubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(
-                new Function<Flowable<Object>, Flowable<List<Object>>>() {
-                    @Override
-                    public Flowable<List<Object>> apply(Flowable<Object> f)
-                            throws Exception {
-                        return f.buffer(Flowable.never());
-                    }
-                }
+                (Function<Flowable<Object>, Flowable<List<Object>>>) f -> f.buffer(Flowable.never())
         );
     }
 
@@ -2148,7 +1937,8 @@ public class FlowableBufferTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         PublishProcessor<Integer> b = PublishProcessor.create();
 
-        TestSubscriber<List<Integer>> ts = pp.buffer(b, new Supplier<List<Integer>>() {
+        TestSubscriber<List<Integer>> ts = pp.buffer(b,
+        new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -2166,7 +1956,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferExactBoundaryBadSource() {
-        Flowable<Integer> pp = new Flowable<Integer>() {
+        Flowable<Integer> pp = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -2177,7 +1967,7 @@ public class FlowableBufferTest extends RxJavaTest {
         };
 
         final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<>();
-        Flowable<Integer> b = new Flowable<Integer>() {
+        Flowable<Integer> b = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -2206,7 +1996,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferExactBoundaryDisposed() {
-        Flowable<Integer> pp = new Flowable<Integer>() {
+        Flowable<Integer> pp = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -2227,13 +2017,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void timedDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<List<Object>>>() {
-            @Override
-            public Publisher<List<Object>> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.buffer(1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.buffer(1, TimeUnit.SECONDS));
     }
 
     @Test
@@ -2280,24 +2064,12 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void timedSkipDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<List<Object>>>() {
-            @Override
-            public Publisher<List<Object>> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.buffer(2, 1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.buffer(2, 1, TimeUnit.SECONDS));
     }
 
     @Test
     public void timedSizedDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<List<Object>>>() {
-            @Override
-            public Publisher<List<Object>> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.buffer(2, TimeUnit.SECONDS, 10);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.buffer(2, TimeUnit.SECONDS, 10));
     }
 
     @Test
@@ -2326,7 +2098,7 @@ public class FlowableBufferTest extends RxJavaTest {
         final TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<>(
-                ts, new Supplier<List<Integer>>() {
+                ts, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
 
             @Override
@@ -2379,11 +2151,8 @@ public class FlowableBufferTest extends RxJavaTest {
     @Test
     public void bufferExactFailingSupplier() {
         Flowable.empty()
-                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Supplier<List<Object>>() {
-                    @Override
-                    public List<Object> get() throws Exception {
-                        throw new TestException();
-                    }
+                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, () -> {
+                    throw new TestException();
                 }, false)
                 .test()
                 .awaitDone(1, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCacheTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
@@ -86,45 +85,31 @@ public class FlowableCacheTest extends RxJavaTest {
     @Test
     public void cache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        counter.incrementAndGet();
-                        System.out.println("published observable being executed");
-                        subscriber.onNext("one");
-                        subscriber.onComplete();
-                    }
-                }).start();
-            }
+        Flowable<String> f = Flowable.<String>unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            new Thread(() -> {
+                counter.incrementAndGet();
+                System.out.println("published observable being executed");
+                subscriber.onNext("one");
+                subscriber.onComplete();
+            }).start();
         }).cache();
 
         // we then expect the following 2 subscriptions to get that same value
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        f.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                    assertEquals("one", v);
-                    System.out.println("v: " + v);
-                    latch.countDown();
-            }
+        f.subscribe(v -> {
+                assertEquals("one", v);
+                System.out.println("v: " + v);
+                latch.countDown();
         });
 
         // subscribe again
-        f.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                    assertEquals("one", v);
-                    System.out.println("v: " + v);
-                    latch.countDown();
-            }
+        f.subscribe(v -> {
+                assertEquals("one", v);
+                System.out.println("v: " + v);
+                latch.countDown();
         });
 
         if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
@@ -220,15 +205,12 @@ public class FlowableCacheTest extends RxJavaTest {
     @Test
     public void noMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Flowable<Integer> firehose = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> t) {
-                t.onSubscribe(new BooleanSubscription());
-                for (int i = 0; i < m; i++) {
-                    t.onNext(i);
-                }
-                t.onComplete();
+        Flowable<Integer> firehose = Flowable.unsafeCreate(t -> {
+            t.onSubscribe(new BooleanSubscription());
+            for (int i = 0; i < m; i++) {
+                t.onNext(i);
             }
+            t.onComplete();
         });
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
@@ -296,21 +278,13 @@ public class FlowableCacheTest extends RxJavaTest {
 
             final TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cache.subscribe(ts);
-                }
-            };
+            Runnable r1 = () -> cache.subscribe(ts);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 500; j++) {
-                        pp.onNext(j);
-                    }
-                    pp.onComplete();
+            Runnable r2 = () -> {
+                for (int j = 0; j < 500; j++) {
+                    pp.onNext(j);
                 }
+                pp.onComplete();
             };
 
             TestHelper.race(r1, r2);
@@ -350,12 +324,7 @@ public class FlowableCacheTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> f) throws Exception {
-                return f.cache();
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable((Function<Flowable<Object>, Object>) Flowable::cache, false, 1, 1, 1);
     }
 
     @Test
@@ -395,12 +364,7 @@ public class FlowableCacheTest extends RxJavaTest {
     @Test
     public void cancelledUpFrontConnectAnyway() {
         final AtomicInteger call = new AtomicInteger();
-        Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return call.incrementAndGet();
-            }
-        })
+        Flowable.fromCallable(() -> call.incrementAndGet())
         .cache()
         .test(1L, true)
         .assertNoValues();
@@ -411,12 +375,8 @@ public class FlowableCacheTest extends RxJavaTest {
     @Test
     public void cancelledUpFront() {
         final AtomicInteger call = new AtomicInteger();
-        Flowable<Object> f = Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return call.incrementAndGet();
-            }
-        }).concatWith(Flowable.never())
+        Flowable<Integer> f = Flowable.<Integer>fromCallable(() -> call.incrementAndGet())
+                .concatWith(Flowable.<Integer>never())
         .cache();
 
         f.test().assertValuesOnly(1);
@@ -435,19 +395,9 @@ public class FlowableCacheTest extends RxJavaTest {
             final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
             final TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cache.subscribe(ts1);
-                }
-            };
+            Runnable r1 = () -> cache.subscribe(ts1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cache.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> cache.subscribe(ts2);
 
             TestHelper.race(r1, r2);
 
@@ -478,19 +428,9 @@ public class FlowableCacheTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cache.subscribe(ts);
-                }
-            };
+            Runnable r1 = () -> cache.subscribe(ts);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r2 = () -> pp.onComplete();
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
@@ -48,11 +49,8 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         PublishProcessor<String> w1 = PublishProcessor.create();
         PublishProcessor<String> w2 = PublishProcessor.create();
 
-        Flowable<String> combined = Flowable.combineLatest(w1, w2, new BiFunction<String, String, String>() {
-            @Override
-            public String apply(String v1, String v2) {
-                throw new RuntimeException("I don't work.");
-            }
+        Flowable<String> combined = Flowable.combineLatest(w1, w2, (_, _) -> {
+            throw new RuntimeException("I don't work.");
         });
         combined.subscribe(w);
 
@@ -224,41 +222,28 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     }
 
     private Function3<String, String, String, String> getConcat3StringsCombineLatestFunction() {
-        Function3<String, String, String, String> combineLatestFunction = new Function3<String, String, String, String>() {
-            @Override
-            public String apply(String a1, String a2, String a3) {
-                if (a1 == null) {
-                    a1 = "";
-                }
-                if (a2 == null) {
-                    a2 = "";
-                }
-                if (a3 == null) {
-                    a3 = "";
-                }
-                return a1 + a2 + a3;
+        Function3<String, String, String, String> combineLatestFunction = (a1, a2, a3) -> {
+            if (a1 == null) {
+                a1 = "";
             }
+            if (a2 == null) {
+                a2 = "";
+            }
+            if (a3 == null) {
+                a3 = "";
+            }
+            return a1 + a2 + a3;
         };
         return combineLatestFunction;
     }
 
     private BiFunction<String, Integer, String> getConcatStringIntegerCombineLatestFunction() {
-        BiFunction<String, Integer, String> combineLatestFunction = new BiFunction<String, Integer, String>() {
-            @Override
-            public String apply(String s, Integer i) {
-                return getStringValue(s) + getStringValue(i);
-            }
-        };
+        BiFunction<String, Integer, String> combineLatestFunction = (s, i) -> getStringValue(s) + getStringValue(i);
         return combineLatestFunction;
     }
 
     private Function3<String, Integer, int[], String> getConcatStringIntegerIntArrayCombineLatestFunction() {
-        return new Function3<String, Integer, int[], String>() {
-            @Override
-            public String apply(String s, Integer i, int[] iArray) {
-                return getStringValue(s) + getStringValue(i) + getStringValue(iArray);
-            }
-        };
+        return (s, i, iArray) -> getStringValue(s) + getStringValue(i) + getStringValue(iArray);
     }
 
     private static String getStringValue(Object o) {
@@ -273,12 +258,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         }
     }
 
-    BiFunction<Integer, Integer, Integer> or = new BiFunction<Integer, Integer, Integer>() {
-        @Override
-        public Integer apply(Integer t1, Integer t2) {
-            return t1 | t2;
-        }
-    };
+    BiFunction<Integer, Integer, Integer> or = (t1, t2) -> t1 | t2;
 
     @Test
     public void combineSimple() {
@@ -429,13 +409,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @Test
     public void oneToNSources() {
         int n = 30;
-        Function<Object[], List<Object>> func = new Function<Object[], List<Object>>() {
-
-            @Override
-            public List<Object> apply(Object[] args) {
-                return Arrays.asList(args);
-            }
-        };
+        Function<Object[], List<Object>> func = Arrays::asList;
         for (int i = 1; i <= n; i++) {
             System.out.println("test1ToNSources: " + i + " sources");
             List<Flowable<Integer>> sources = new ArrayList<>();
@@ -460,13 +434,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @Test
     public void oneToNSourcesScheduled() throws InterruptedException {
         int n = 10;
-        Function<Object[], List<Object>> func = new Function<Object[], List<Object>>() {
-
-            @Override
-            public List<Object> apply(Object[] args) {
-                return Arrays.asList(args);
-            }
-        };
+        Function<Object[], List<Object>> func = Arrays::asList;
         for (int i = 1; i <= n; i++) {
             System.out.println("test1ToNSourcesScheduled: " + i + " sources");
             List<Flowable<Integer>> sources = new ArrayList<>();
@@ -482,7 +450,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Subscriber<List<Object>> s = new DefaultSubscriber<List<Object>>() {
+            Subscriber<List<Object>> s = new DefaultSubscriber<List<Object>>() /* NFI */ {
 
                 @Override
                 public void onNext(List<Object> t) {
@@ -518,12 +486,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s2 = Flowable.just(2);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2,
-                new BiFunction<Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2) {
-                        return Arrays.asList(t1, t2);
-                    }
-                });
+                (BiFunction<Integer, Integer, List<Integer>>) Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -541,12 +504,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s3 = Flowable.just(3);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3,
-                new Function3<Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3) {
-                        return Arrays.asList(t1, t2, t3);
-                    }
-                });
+                (Function3<Integer, Integer, Integer, List<Integer>>) Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -565,12 +523,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s4 = Flowable.just(4);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4,
-                new Function4<Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4) {
-                        return Arrays.asList(t1, t2, t3, t4);
-                    }
-                });
+                (Function4<Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -590,12 +543,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s5 = Flowable.just(5);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5,
-                new Function5<Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5) {
-                        return Arrays.asList(t1, t2, t3, t4, t5);
-                    }
-                });
+                (Function5<Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -616,12 +564,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s6 = Flowable.just(6);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5, s6,
-                new Function6<Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6) {
-                        return Arrays.asList(t1, t2, t3, t4, t5, t6);
-                    }
-                });
+                (Function6<Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -643,12 +586,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s7 = Flowable.just(7);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5, s6, s7,
-                new Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7) {
-                        return Arrays.asList(t1, t2, t3, t4, t5, t6, t7);
-                    }
-                });
+                (Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -671,12 +609,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s8 = Flowable.just(8);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5, s6, s7, s8,
-                new Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7, Integer t8) {
-                        return Arrays.asList(t1, t2, t3, t4, t5, t6, t7, t8);
-                    }
-                });
+                (Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -700,12 +633,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s9 = Flowable.just(9);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5, s6, s7, s8, s9,
-                new Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7, Integer t8, Integer t9) {
-                        return Arrays.asList(t1, t2, t3, t4, t5, t6, t7, t8, t9);
-                    }
-                });
+                (Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -719,14 +647,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     @Test
     public void zeroSources() {
         Flowable<Object> result = Flowable.combineLatest(
-                Collections.<Flowable<Object>> emptyList(), new Function<Object[], Object>() {
-
-            @Override
-            public Object apply(Object[] args) {
-                return args;
-            }
-
-        });
+                Collections.<Flowable<Object>> emptyList(), args -> args);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -775,24 +696,16 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         final int SIZE = 2000;
         Flowable<Long> timer = Flowable.interval(0, 1, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.newThread())
-                .doOnEach(new Consumer<Notification<Long>>() {
-                    @Override
-                    public void accept(Notification<Long> n) {
-                            //                        System.out.println(n);
-                            if (count.incrementAndGet() >= SIZE) {
-                                latch.countDown();
-                            }
-                    }
+                .doOnEach(_ -> {
+                        //                        System.out.println(n);
+                        if (count.incrementAndGet() >= SIZE) {
+                            latch.countDown();
+                        }
                 }).take(SIZE);
 
         TestSubscriber<Long> ts = new TestSubscriber<>();
 
-        Flowable.combineLatest(timer, Flowable.<Integer> never(), new BiFunction<Long, Integer, Long>() {
-            @Override
-            public Long apply(Long t1, Integer t2) {
-                return t1;
-            }
-        }).subscribe(ts);
+        Flowable.combineLatest(timer, Flowable.<Integer> never(), (t1, _) -> t1).subscribe(ts);
 
         if (!latch.await(SIZE + 2000, TimeUnit.MILLISECONDS)) {
             fail("timed out");
@@ -805,14 +718,10 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     public void combineLatestRequestOverflow() throws InterruptedException {
         List<Flowable<Integer>> sources = Arrays.asList(Flowable.fromArray(1, 2, 3, 4),
                 Flowable.fromArray(5, 6, 7, 8));
-        Flowable<Integer> f = Flowable.combineLatest(sources, new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] args) {
-                return (Integer) args[0];
-            }});
+        Flowable<Integer> f = Flowable.combineLatest(sources, args -> (Integer) args[0]);
         //should get at least 4
         final CountDownLatch latch = new CountDownLatch(4);
-        f.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() {
+        f.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -837,12 +746,8 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
-    private static final Function<Object[], Integer> THROW_NON_FATAL = new Function<Object[], Integer>() {
-        @Override
-        public Integer apply(Object[] args) {
-            throw new RuntimeException();
-        }
-
+    private static final Function<Object[], Integer> THROW_NON_FATAL = _ -> {
+        throw new RuntimeException();
     };
 
     @Test
@@ -852,12 +757,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> source = Flowable.just(1)
             // if haven't caught exception in combineLatest operator then would incorrectly
             // be picked up by this call to doOnError
-            .doOnError(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) {
-                    errorOccurred.set(true);
-                }
-            });
+            .doOnError(_ -> errorOccurred.set(true));
         Flowable
             .combineLatest(Collections.singletonList(source), THROW_NON_FATAL)
             .subscribe(ts);
@@ -871,12 +771,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.combineLatest(Arrays.asList(source, source),
-        new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] args) {
-                return (Integer)args[0] + (Integer)args[1];
-            }
-        })
+        args -> (Integer)args[0] + (Integer)args[1])
         .subscribe(ts);
 
         ts.assertValue(2);
@@ -899,15 +794,12 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         TestSubscriber<String> ts = TestSubscriber.create();
 
-        Flowable.combineLatest(sources, new Function<Object[], String>() {
-            @Override
-            public String apply(Object[] args) {
-                StringBuilder b = new StringBuilder();
-                for (Object o : args) {
-                    b.append(o);
-                }
-                return b.toString();
+        Flowable.combineLatest(sources, args -> {
+            StringBuilder b = new StringBuilder();
+            for (Object o : args) {
+                b.append(o);
             }
+            return b.toString();
         }).subscribe(ts);
 
         ts.assertNoErrors();
@@ -921,12 +813,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestDelayError(
                 Arrays.asList(Flowable.just(1), Flowable.<Integer>error(new TestException())),
-                new Function<Object[], Integer>() {
-                    @Override
-                    public Integer apply(Object[] args) {
-                        return ((Integer)args[0]) + ((Integer)args[1]);
-                    }
-                }
+                args -> ((Integer)args[0]) + ((Integer)args[1])
         ).subscribe(ts);
 
         ts.assertNoValues();
@@ -940,12 +827,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestDelayError(
                 Arrays.asList(Flowable.<Integer>error(new TestException()), Flowable.just(1)),
-                new Function<Object[], Integer>() {
-                    @Override
-                    public Integer apply(Object[] args) {
-                        return ((Integer)args[0]) + ((Integer)args[1]);
-                    }
-                }
+                args -> ((Integer)args[0]) + ((Integer)args[1])
         ).subscribe(ts);
 
         ts.assertNoValues();
@@ -959,12 +841,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestDelayError(
                 Arrays.asList(Flowable.just(10).concatWith(Flowable.<Integer>error(new TestException())), Flowable.just(1)),
-                new Function<Object[], Integer>() {
-                    @Override
-                    public Integer apply(Object[] args) {
-                        return ((Integer)args[0]) + ((Integer)args[1]);
-                    }
-                }
+                args -> ((Integer)args[0]) + ((Integer)args[1])
         ).subscribe(ts);
 
         ts.assertValues(11);
@@ -978,12 +855,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestDelayError(
                 Arrays.asList(Flowable.just(1), Flowable.just(10).concatWith(Flowable.<Integer>error(new TestException()))),
-                new Function<Object[], Integer>() {
-                    @Override
-                    public Integer apply(Object[] args) {
-                        return ((Integer)args[0]) + ((Integer)args[1]);
-                    }
-                }
+                args -> ((Integer)args[0]) + ((Integer)args[1])
         ).subscribe(ts);
 
         ts.assertValues(11);
@@ -998,12 +870,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable.combineLatestDelayError(
                 Arrays.asList(Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException())),
                         Flowable.just(10).concatWith(Flowable.<Integer>error(new TestException()))),
-                new Function<Object[], Integer>() {
-                    @Override
-                    public Integer apply(Object[] args) {
-                        return ((Integer)args[0]) + ((Integer)args[1]);
-                    }
-                }
+                args -> ((Integer)args[0]) + ((Integer)args[1])
         ).subscribe(ts);
 
         ts.assertValues(11);
@@ -1011,7 +878,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         ts.assertNotComplete();
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void combineLatestNArguments() throws Exception {
         Flowable source = Flowable.just(1);
@@ -1065,21 +932,11 @@ public class FlowableCombineLatestTest extends RxJavaTest {
                 expected.add(1);
             }
 
-            Flowable.combineLatestArray(sources, new Function<Object[], List<Object>>() {
-                @Override
-                public List<Object> apply(Object[] t) throws Exception {
-                    return Arrays.asList(t);
-                }
-            })
+            Flowable.combineLatestArray(sources, (Function<Object[], List<Object>>) Arrays::asList)
             .test()
             .assertResult(expected);
 
-            Flowable.combineLatestArrayDelayError(sources, new Function<Object[], List<Object>>() {
-                @Override
-                public List<Object> apply(Object[] t) throws Exception {
-                    return Arrays.asList(t);
-                }
-            })
+            Flowable.combineLatestArrayDelayError(sources, (Function<Object[], List<Object>>) Arrays::asList)
             .test()
             .assertResult(expected);
         }
@@ -1091,12 +948,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestArray(new Flowable[] {
                 Flowable.just(1), Flowable.just(2)
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        }, (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertResult("[1, 2]");
     }
@@ -1107,12 +959,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestArrayDelayError(new Flowable[] {
                 Flowable.just(1), Flowable.just(2)
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        }, (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertResult("[1, 2]");
     }
@@ -1123,12 +970,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestArrayDelayError(new Flowable[] {
                 Flowable.just(1), Flowable.just(2).concatWith(Flowable.<Integer>error(new TestException()))
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        }, (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertFailure(TestException.class, "[1, 2]");
     }
@@ -1138,12 +980,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestDelayError(Arrays.asList(
                 Flowable.just(1), Flowable.just(2)
-        ), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        ), (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertResult("[1, 2]");
     }
@@ -1153,12 +990,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatestDelayError(Arrays.asList(
                 Flowable.just(1), Flowable.just(2).concatWith(Flowable.<Integer>error(new TestException()))
-        ), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        ), (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertFailure(TestException.class, "[1, 2]");
     }
@@ -1177,24 +1009,14 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void error() {
-        Flowable.combineLatest(Flowable.never(), Flowable.error(new TestException()), new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        })
+        Flowable.combineLatest(Flowable.never(), Flowable.error(new TestException()), (a, _) -> a)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void disposed() {
-        TestHelper.checkDisposed(Flowable.combineLatest(Flowable.never(), Flowable.never(), new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        }));
+        TestHelper.checkDisposed(Flowable.combineLatest(Flowable.never(), Flowable.never(), (a, _) -> a));
     }
 
     @Test
@@ -1203,19 +1025,9 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         Flowable.combineLatest(
                 Flowable.just(1)
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer v) throws Exception {
-                        ts.cancel();
-                    }
-                }),
+                .doOnNext(_ -> ts.cancel()),
                 Flowable.never(),
-                new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        })
+                (a, _) -> a)
         .subscribe(ts);
     }
 
@@ -1227,28 +1039,14 @@ public class FlowableCombineLatestTest extends RxJavaTest {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
                 final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                TestSubscriberEx<Integer> ts = Flowable.combineLatest(pp1, pp2, new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a;
-                    }
-                }).to(TestHelper.<Integer>testConsumer());
+                TestSubscriberEx<Integer> ts = Flowable.combineLatest(pp1, pp2, (a, _) -> a)
+                        .to(TestHelper.<Integer>testConsumer());
 
                 final TestException ex1 = new TestException();
                 final TestException ex2 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -1280,12 +1078,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     public void combineAsync() {
         Flowable<Integer> source = Flowable.range(1, 1000).subscribeOn(Schedulers.computation());
 
-        Flowable.combineLatest(source, source, new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        })
+        Flowable.combineLatest(source, source, (a, _) -> a)
         .take(500)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1298,12 +1091,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     public void errorDelayed() {
         Flowable.combineLatestArrayDelayError(
                 new Publisher[] { Flowable.error(new TestException()), Flowable.just(1) },
-                new Function<Object[], Object>() {
-                    @Override
-                    public Object apply(Object[] a) throws Exception {
-                        return a;
-                    }
-                },
+                a -> a,
                 128
         )
         .test()
@@ -1315,12 +1103,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     public void errorDelayed2() {
         Flowable.combineLatestArrayDelayError(
                 new Publisher[] { Flowable.error(new TestException()).startWithItem(1), Flowable.empty() },
-                new Function<Object[], Object>() {
-                    @Override
-                    public Object apply(Object[] a) throws Exception {
-                        return a;
-                    }
-                },
+                a -> a,
                 128
         )
         .test()
@@ -1335,18 +1118,8 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
             Flowable.combineLatest(Flowable.empty(),
                     Flowable.error(new TestException())
-                    .doOnSubscribe(new Consumer<Subscription>() {
-                        @Override
-                        public void accept(Subscription s) throws Exception {
-                            count[0]++;
-                        }
-                    }),
-                    new BiFunction<Object, Object, Object>() {
-                        @Override
-                        public Object apply(Object a, Object b) throws Exception {
-                            return 0;
-                        }
-                    })
+                    .doOnSubscribe(_ -> count[0]++),
+                    (_, _) -> 0)
             .test()
             .assertResult();
 
@@ -1367,19 +1140,9 @@ public class FlowableCombineLatestTest extends RxJavaTest {
             Flowable.combineLatestDelayError(
                     Arrays.asList(Flowable.empty(),
                         Flowable.error(new TestException())
-                        .doOnSubscribe(new Consumer<Subscription>() {
-                            @Override
-                            public void accept(Subscription s) throws Exception {
-                                count[0]++;
-                            }
-                        })
+                        .doOnSubscribe(_ -> count[0]++)
                     ),
-                    new Function<Object[], Object>() {
-                        @Override
-                        public Object apply(Object[] a) throws Exception {
-                            return 0;
-                        }
-                    })
+                    _ -> 0)
             .test()
             .assertResult();
 
@@ -1400,66 +1163,25 @@ public class FlowableCombineLatestTest extends RxJavaTest {
             TestScheduler testScheduler = new TestScheduler();
 
             Flowable<Integer> emptyFlowable = Flowable.timer(10, TimeUnit.MILLISECONDS, testScheduler)
-                    .flatMap(new Function<Long, Publisher<Integer>>() {
-                        @Override
-                        public Publisher<Integer> apply(Long aLong) throws Exception {
-                            return Flowable.error(new Exception());
-                        }
+                    .flatMap((Function<Long, Publisher<Integer>>) _ -> Flowable.error(new Exception()));
+            Flowable<Object> errorFlowable = Flowable.timer(100, TimeUnit.MILLISECONDS, testScheduler)
+                    .map(_ -> {
+                        throw new Exception();
                     });
-            Flowable<Object> errorFlowable = Flowable.timer(100, TimeUnit.MILLISECONDS, testScheduler).map(new Function<Long, Object>() {
-                @Override
-                public Object apply(Long aLong) throws Exception {
-                    throw new Exception();
-                }
-            });
 
             Flowable.combineLatestDelayError(
                     Arrays.asList(
                             emptyFlowable
-                                    .doOnEach(new Consumer<Notification<Integer>>() {
-                                        @Override
-                                        public void accept(Notification<Integer> integerNotification) throws Exception {
-                                            System.out.println("emptyFlowable: " + integerNotification);
-                                        }
-                                    })
-                                    .doFinally(new Action() {
-                                        @Override
-                                        public void run() throws Exception {
-                                            System.out.println("emptyFlowable: doFinally");
-                                        }
-                                    }),
+                                    .doOnEach(integerNotification -> System.out.println("emptyFlowable: " + integerNotification))
+                                    .doFinally(() -> System.out.println("emptyFlowable: doFinally")),
+
                             errorFlowable
-                                    .doOnEach(new Consumer<Notification<Object>>() {
-                                        @Override
-                                        public void accept(Notification<Object> integerNotification) throws Exception {
-                                            System.out.println("errorFlowable: " + integerNotification);
-                                        }
-                                    })
-                                    .doFinally(new Action() {
-                                        @Override
-                                        public void run() throws Exception {
-                                            System.out.println("errorFlowable: doFinally");
-                                        }
-                                    })),
-                    new Function<Object[], Object>() {
-                        @Override
-                        public Object apply(Object[] objects) throws Exception {
-                            return 0;
-                        }
-                    }
-            )
-                    .doOnEach(new Consumer<Notification<Object>>() {
-                        @Override
-                        public void accept(Notification<Object> integerNotification) throws Exception {
-                            System.out.println("combineLatestDelayError: " + integerNotification);
-                        }
-                    })
-                    .doFinally(new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            System.out.println("combineLatestDelayError: doFinally");
-                        }
-                    })
+                                    .doOnEach(integerNotification -> System.out.println("errorFlowable: " + integerNotification))
+                                    .doFinally(() -> System.out.println("errorFlowable: doFinally"))),
+                        _ -> (Object)0
+                    )
+                    .doOnEach(integerNotification -> System.out.println("combineLatestDelayError: " + integerNotification))
+                    .doFinally(() -> System.out.println("combineLatestDelayError: doFinally"))
                     .subscribe(testSubscriber);
 
             testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
@@ -1477,7 +1199,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1493,12 +1215,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
             }
         };
 
-        Flowable.combineLatest(pp1, pp2, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) throws Exception {
-                return t1 + t2;
-            }
-        })
+        Flowable.combineLatest(pp1, pp2, (t1, t2) -> t1 + t2)
         .subscribe(ts);
 
         pp1.onNext(1);
@@ -1510,12 +1227,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
     public void fusedNullCheck() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ASYNC);
 
-        Flowable.combineLatest(Flowable.just(1), Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) throws Exception {
-                return null;
-            }
-        })
+        Flowable.combineLatest(Flowable.just(1), Flowable.just(2), (_, _) -> (Integer)null)
         .subscribe(ts);
 
         ts
@@ -1529,12 +1241,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
                     Flowable.just(21).concatWith(Flowable.<Integer>error(new TestException())),
                     Flowable.just(21).delay(100, TimeUnit.MILLISECONDS)
                 ),
-                new Function<Object[], Object>() {
-                    @Override
-                    public Object apply(Object[] a) throws Exception {
-                        return (Integer)a[0] + (Integer)a[1];
-                    }
-                }
+                a -> (Integer)a[0] + (Integer)a[1]
                 )
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1543,38 +1250,23 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void publishersInIterable() {
-        Publisher<Integer> source = new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> subscriber) {
-                Flowable.just(1).subscribe(subscriber);
-            }
-        };
+        Publisher<Integer> source = subscriber -> Flowable.just(1).subscribe(subscriber);
 
-        Flowable.combineLatest(Arrays.asList(source, source), new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] t) throws Throwable {
-                return 2;
-            }
-        })
+        Flowable.combineLatest(Arrays.asList(source, source), _ -> 2)
         .test()
         .assertResult(2);
     }
 
     @Test
     public void FlowableSourcesInIterable() {
-        Flowable<Integer> source = new Flowable<Integer>() {
+        Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
             @Override
             public void subscribeActual(Subscriber<? super Integer> s) {
                 Flowable.just(1).subscribe(s);
             }
         };
 
-        Flowable.combineLatest(Arrays.asList(source, source), new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] t) throws Throwable {
-                return 2;
-            }
-        })
+        Flowable.combineLatest(Arrays.asList(source, source), _ -> 2)
         .test()
         .assertResult(2);
     }
@@ -1602,7 +1294,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
                 TestSubscriberEx<Object[]> ts = new TestSubscriberEx<>();
                 AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
-                Flowable<Object> f = new Flowable<Object>() {
+                Flowable<Object> f = new Flowable<Object>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Object> s) {
                         ref.set(s);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -34,12 +34,7 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        source.concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.range(v, 2);
-            }
-        }).subscribe(ts);
+        source.concatMapDelayError((Function<Integer, Flowable<Integer>>) v -> Flowable.range(v, 2)).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -56,12 +51,8 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        source.concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.range(v, 2);
-            }
-        }).subscribe(ts);
+        source.concatMapDelayError((Function<Integer, Flowable<Integer>>) v -> Flowable.range(v, 2))
+        .subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -79,12 +70,7 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        Flowable.range(1, 3).concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return inner;
-            }
-        }).subscribe(ts);
+        Flowable.range(1, 3).concatMapDelayError((Function<Integer, Flowable<Integer>>) _ -> inner).subscribe(ts);
 
         ts.assertValues(1, 2, 1, 2, 1, 2);
         ts.assertError(CompositeException.class);
@@ -99,12 +85,7 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
 
         Flowable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return inner;
-            }
-        }).subscribe(ts);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) _ -> inner).subscribe(ts);
 
         ts.assertValues(1, 2);
         ts.assertError(TestException.class);
@@ -117,12 +98,7 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
 
         Flowable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return null;
-            }
-        }).subscribe(ts);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) _ -> null).subscribe(ts);
 
         ts.assertNoValues();
         ts.assertError(NullPointerException.class);
@@ -135,11 +111,8 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
 
         Flowable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                throw new TestException();
-            }
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) _ -> {
+            throw new TestException();
         }).subscribe(ts);
 
         ts.assertNoValues();
@@ -152,12 +125,8 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(1, 3)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return v == 2 ? Flowable.<Integer>empty() : Flowable.range(1, 2);
-            }
-        }).subscribe(ts);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) v -> v == 2 ? Flowable.<Integer>empty() : Flowable.range(1, 2))
+        .subscribe(ts);
 
         ts.assertValues(1, 2, 1, 2);
         ts.assertNoErrors();
@@ -169,12 +138,8 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(1, 3)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return v == 2 ? Flowable.just(3) : Flowable.range(1, 2);
-            }
-        }).subscribe(ts);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) v -> v == 2 ? Flowable.just(3) : Flowable.range(1, 2))
+        .subscribe(ts);
 
         ts.assertValues(1, 2, 3, 1, 2);
         ts.assertNoErrors();
@@ -185,12 +150,8 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
     public void backpressure() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        Flowable.range(1, 3).concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.range(v, 2);
-            }
-        }).subscribe(ts);
+        Flowable.range(1, 3).concatMapDelayError((Function<Integer, Flowable<Integer>>) v -> Flowable.range(v, 2))
+        .subscribe(ts);
 
         ts.assertNoValues();
         ts.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -38,12 +39,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normal() {
         Flowable.range(1, 5)
-        .concatMapEager(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer t) {
-                return Flowable.range(t, 2);
-            }
-        })
+        .concatMapEager((Function<Integer, Publisher<Integer>>) t -> Flowable.range(t, 2))
         .test()
         .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
@@ -51,12 +47,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalBackpressured() {
         TestSubscriber<Integer> ts = Flowable.range(1, 5)
-        .concatMapEager(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer t) {
-                return Flowable.range(t, 2);
-            }
-        })
+        .concatMapEager((Function<Integer, Publisher<Integer>>) t -> Flowable.range(t, 2))
         .test(3);
 
         ts.assertValues(1, 2, 2);
@@ -77,12 +68,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalDelayBoundary() {
         Flowable.range(1, 5)
-        .concatMapEagerDelayError(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer t) {
-                return Flowable.range(t, 2);
-            }
-        }, false)
+        .concatMapEagerDelayError((Function<Integer, Publisher<Integer>>) t -> Flowable.range(t, 2), false)
         .test()
         .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
@@ -90,12 +76,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalDelayBoundaryBackpressured() {
         TestSubscriber<Integer> ts = Flowable.range(1, 5)
-        .concatMapEagerDelayError(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer t) {
-                return Flowable.range(t, 2);
-            }
-        }, false)
+        .concatMapEagerDelayError((Function<Integer, Publisher<Integer>>) t -> Flowable.range(t, 2), false)
         .test(3);
 
         ts.assertValues(1, 2, 2);
@@ -116,12 +97,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalDelayEnd() {
         Flowable.range(1, 5)
-        .concatMapEagerDelayError(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer t) {
-                return Flowable.range(t, 2);
-            }
-        }, true)
+        .concatMapEagerDelayError((Function<Integer, Publisher<Integer>>) t -> Flowable.range(t, 2), true)
         .test()
         .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
@@ -129,12 +105,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalDelayEndBackpressured() {
         TestSubscriber<Integer> ts = Flowable.range(1, 5)
-        .concatMapEagerDelayError(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer t) {
-                return Flowable.range(t, 2);
-            }
-        }, true)
+        .concatMapEagerDelayError((Function<Integer, Publisher<Integer>>) t -> Flowable.range(t, 2), true)
         .test(3);
 
         ts.assertValues(1, 2, 2);
@@ -158,12 +129,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         final PublishProcessor<Integer> inner = PublishProcessor.create();
 
         TestSubscriberEx<Integer> ts = main.concatMapEagerDelayError(
-                new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer t) {
-                        return inner;
-                    }
-                }, false).to(TestHelper.<Integer>testConsumer());
+                (Function<Integer, Publisher<Integer>>) _ -> inner, false).to(TestHelper.<Integer>testConsumer());
 
         main.onNext(1);
 
@@ -187,12 +153,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         final PublishProcessor<Integer> inner = PublishProcessor.create();
 
         TestSubscriberEx<Integer> ts = main.concatMapEagerDelayError(
-                new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer t) {
-                        return inner;
-                    }
-                }, true).to(TestHelper.<Integer>testConsumer());
+                (Function<Integer, Publisher<Integer>>) _ -> inner, true).to(TestHelper.<Integer>testConsumer());
 
         main.onNext(1);
         main.onNext(2);
@@ -217,12 +178,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         final PublishProcessor<Integer> inner = PublishProcessor.create();
 
         TestSubscriberEx<Integer> ts = main.concatMapEager(
-                new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer t) {
-                        return inner;
-                    }
-                }).to(TestHelper.<Integer>testConsumer());
+                (Function<Integer, Publisher<Integer>>) _ -> inner).to(TestHelper.<Integer>testConsumer());
 
         main.onNext(1);
         main.onNext(2);
@@ -245,12 +201,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     public void longEager() {
 
         Flowable.range(1, 2 * Flowable.bufferSize())
-        .concatMapEager(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.just(1);
-            }
-        })
+        .concatMapEager((Function<Integer, Publisher<Integer>>) _ -> Flowable.just(1))
         .test()
         .assertValueCount(2 * Flowable.bufferSize())
         .assertNoErrors()
@@ -260,19 +211,9 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     TestSubscriber<Object> ts;
     TestSubscriber<Object> tsBp;
 
-    Function<Integer, Flowable<Integer>> toJust = new Function<Integer, Flowable<Integer>>() {
-        @Override
-        public Flowable<Integer> apply(Integer t) {
-            return Flowable.just(t);
-        }
-    };
+    Function<Integer, Flowable<Integer>> toJust = Flowable::just;
 
-    Function<Integer, Flowable<Integer>> toRange = new Function<Integer, Flowable<Integer>>() {
-        @Override
-        public Flowable<Integer> apply(Integer t) {
-            return Flowable.range(t, 2);
-        }
-    };
+    Function<Integer, Flowable<Integer>> toRange = t -> Flowable.range(t, 2);
 
     @Before
     public void before() {
@@ -301,12 +242,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness2() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> source = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Flowable<Integer> source = Flowable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Flowable.concatArrayEager(source, source).subscribe(tsBp);
 
@@ -325,12 +261,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness3() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> source = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Flowable<Integer> source = Flowable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Flowable.concatArrayEager(source, source, source).subscribe(tsBp);
 
@@ -349,12 +280,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness4() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> source = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Flowable<Integer> source = Flowable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Flowable.concatArrayEager(source, source, source, source).subscribe(tsBp);
 
@@ -373,12 +299,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness5() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> source = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Flowable<Integer> source = Flowable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Flowable.concatArrayEager(source, source, source, source, source).subscribe(tsBp);
 
@@ -397,12 +318,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness6() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> source = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Flowable<Integer> source = Flowable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Flowable.concatArrayEager(source, source, source, source, source, source).subscribe(tsBp);
 
@@ -421,12 +337,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness7() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> source = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Flowable<Integer> source = Flowable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Flowable.concatArrayEager(source, source, source, source, source, source, source).subscribe(tsBp);
 
@@ -445,12 +356,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness8() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> source = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Flowable<Integer> source = Flowable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Flowable.concatArrayEager(source, source, source, source, source, source, source, source).subscribe(tsBp);
 
@@ -469,12 +375,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness9() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> source = Flowable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Flowable<Integer> source = Flowable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Flowable.concatArrayEager(source, source, source, source, source, source, source, source, source).subscribe(tsBp);
 
@@ -519,11 +420,8 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void mapperThrows() {
-        Flowable.just(1).concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                throw new TestException();
-            }
+        Flowable.just(1).concatMapEager((Function<Integer, Flowable<Integer>>) _ -> {
+            throw new TestException();
         }).subscribe(ts);
 
         ts.assertNoValues();
@@ -562,12 +460,8 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void asynchronousRun() {
-        Flowable.range(1, 2).concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                return Flowable.range(1, 1000).subscribeOn(Schedulers.computation());
-            }
-        }).observeOn(Schedulers.single())
+        Flowable.range(1, 2).concatMapEager((Function<Integer, Flowable<Integer>>) _ ->
+            Flowable.range(1, 1000).subscribeOn(Schedulers.computation())).observeOn(Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertNoErrors()
@@ -581,18 +475,10 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
         final AtomicBoolean once = new AtomicBoolean();
 
-        processor.concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                return Flowable.just(t);
-            }
-        })
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                if (once.compareAndSet(false, true)) {
-                    processor.onNext(2);
-                }
+        processor.concatMapEager((Function<Integer, Flowable<Integer>>) Flowable::just)
+        .doOnNext(_ -> {
+            if (once.compareAndSet(false, true)) {
+                processor.onNext(2);
             }
         })
         .subscribe(ts);
@@ -610,18 +496,9 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
         TestSubscriber<Object> ts = TestSubscriber.create(0);
 
-        Flowable.just(1).concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                return Flowable.range(1, Flowable.bufferSize() * 2)
-                        .doOnNext(new Consumer<Integer>() {
-                            @Override
-                            public void accept(Integer t) {
-                                count.getAndIncrement();
-                            }
-                        }).hide();
-            }
-        }).subscribe(ts);
+        Flowable.just(1)
+        .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.range(1, Flowable.bufferSize() * 2)
+                .doOnNext(_ -> count.getAndIncrement()).hide()).subscribe(ts);
 
         ts.assertNoErrors();
         ts.assertNoValues();
@@ -632,12 +509,9 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void maxConcurrent5() {
         final List<Long> requests = new ArrayList<>();
-        Flowable.range(1, 100).doOnRequest(new LongConsumer() {
-            @Override
-            public void accept(long reqCount) {
-                requests.add(reqCount);
-            }
-        }).concatMapEager(toJust, 5, Flowable.bufferSize()).subscribe(ts);
+        Flowable.range(1, 100).doOnRequest(reqCount -> requests.add(reqCount))
+        .concatMapEager(toJust, 5, Flowable.bufferSize())
+        .subscribe(ts);
 
         ts.assertNoErrors();
         ts.assertValueCount(100);
@@ -764,34 +638,21 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void empty() {
-        Flowable.<Integer>empty().hide().concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(1, 2);
-            }
-        })
+        Flowable.<Integer>empty().hide().concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.range(1, 2))
         .test()
         .assertResult();
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Flowable.just(1).hide().concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(1, 2);
-            }
-        }));
+        TestHelper.checkDisposed(Flowable.just(1).hide()
+                .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.range(1, 2)));
     }
 
     @Test
     public void innerError2() {
-        Flowable.<Integer>just(1).hide().concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.error(new TestException());
-            }
-        })
+        Flowable.<Integer>just(1).hide()
+        .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
@@ -804,30 +665,16 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
                 final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                TestSubscriberEx<Integer> ts = pp1.concatMapEager(new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) throws Exception {
-                        return pp2;
-                    }
-                }).to(TestHelper.<Integer>testConsumer());
+                TestSubscriberEx<Integer> ts = pp1.concatMapEager((Function<Integer, Flowable<Integer>>) _ -> pp2)
+                        .to(TestHelper.<Integer>testConsumer());
 
                 final TestException ex1 = new TestException();
                 final TestException ex2 = new TestException();
 
                 pp1.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -853,29 +700,18 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void innerErrorMaxConcurrency() {
-        Flowable.<Integer>just(1).hide().concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.error(new TestException());
-            }
-        }, 1, 128)
+        Flowable.<Integer>just(1).hide()
+        .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.error(new TestException()), 1, 128)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void innerCallableThrows() {
-        Flowable.<Integer>just(1).hide().concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.fromCallable(new Callable<Integer>() {
-                    @Override
-                    public Integer call() throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        })
+        Flowable.<Integer>just(1).hide()
+        .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.fromCallable(() -> {
+            throw new TestException();
+        }))
         .test()
         .assertFailure(TestException.class);
     }
@@ -885,7 +721,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         final UnicastProcessor<Integer> up = UnicastProcessor.create();
         up.onNext(1);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -894,12 +730,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         };
 
         Flowable.<Integer>just(1).hide()
-        .concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return up;
-            }
-        }, 1, 128)
+        .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> up, 1, 128)
         .subscribe(ts);
 
         ts
@@ -911,25 +742,12 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
 
-            final TestSubscriber<Integer> ts = pp1.concatMapEager(new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer v) throws Exception {
-                    return Flowable.never();
-                }
-            }).test();
+            final TestSubscriber<Integer> ts = pp1
+                    .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.never())
+                    .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onNext(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> pp1.onNext(1);
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -942,12 +760,9 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1).hide()
-        .concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                ts.cancel();
-                return Flowable.never();
-            }
+        .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> {
+            ts.cancel();
+            return Flowable.never();
         }, 1, 128)
         .subscribe(ts);
 
@@ -956,17 +771,10 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void innerErrorFused() {
-        Flowable.<Integer>just(1).hide().concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(1, 2).map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        })
+        Flowable.<Integer>just(1).hide()
+        .concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.range(1, 2).map(_ -> {
+            throw new TestException();
+        }))
         .test()
         .assertFailure(TestException.class);
     }
@@ -978,12 +786,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         up.onNext(1);
         up.onComplete();
 
-        up.concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(1);
-            }
-        })
+        up.concatMapEager((Function<Integer, Flowable<Integer>>) _ -> Flowable.just(1))
         .take(1)
         .test()
         .assertResult(1);
@@ -991,17 +794,9 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.concatMapEager(new Function<Object, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Object v) throws Exception {
-                        return Flowable.just(v);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(
+        (Function<Flowable<Object>, Flowable<Object>>) f ->
+        f.concatMapEager( (Function<Object, Flowable<Object>>) Flowable::just));
     }
 
     @Test
@@ -1011,7 +806,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
             @SuppressWarnings("rawtypes")
             final Subscriber[] sub = { null };
 
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     sub[0] = s;
@@ -1037,18 +832,13 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .concatMapEager(new Function<Integer, Publisher<Integer>>() {
+            .concatMapEager((Function<Integer, Publisher<Integer>>) _ -> new Flowable<Integer>() /* NFI */ {
                 @Override
-                public Publisher<Integer> apply(Integer v) throws Exception {
-                    return new Flowable<Integer>() {
-                        @Override
-                        protected void subscribeActual(Subscriber<? super Integer> s) {
-                            s.onSubscribe(new BooleanSubscription());
-                            s.onNext(1);
-                            s.onNext(2);
-                            s.onError(new TestException());
-                        }
-                    };
+                protected void subscribeActual(Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onNext(2);
+                    s.onError(new TestException());
                 }
             }, 1, 1)
             .test(0L)
@@ -1064,12 +854,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     public void unboundedIn() {
         int n = Flowable.bufferSize() * 2;
         Flowable.range(1, n)
-        .concatMapEager(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, Integer.MAX_VALUE, 16)
+        .concatMapEager((Function<Integer, Publisher<Integer>>) _ -> Flowable.just(1), Integer.MAX_VALUE, 16)
         .test()
         .assertValueCount(n)
         .assertComplete()
@@ -1087,19 +872,9 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
             .concatMapEager(Functions.justFunction(pp))
             .subscribe(ts);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -1121,14 +896,9 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void oneDelayed() {
         Flowable.just(1, 2, 3, 4, 5)
-        .concatMapEager(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer i) throws Exception {
-                return i == 3 ? Flowable.just(i) : Flowable
-                        .just(i)
-                        .delay(1, TimeUnit.MILLISECONDS, Schedulers.cached());
-            }
-        })
+        .concatMapEager((Function<Integer, Flowable<Integer>>) i -> i == 3 ? Flowable.just(i) : Flowable
+                .just(i)
+                .delay(1, TimeUnit.MILLISECONDS, Schedulers.cached()))
         .observeOn(Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1150,21 +920,9 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
         Flowable.range(1, 1000)
         .buffer(10)
-        .concatMapEager(new Function<List<Integer>, Flowable<List<Integer>>>() {
-            @Override
-            public Flowable<List<Integer>> apply(List<Integer> v)
-                    throws Exception {
-                return Flowable.just(v)
-                        .subscribeOn(Schedulers.cached())
-                        .doOnNext(new Consumer<List<Integer>>() {
-                            @Override
-                            public void accept(List<Integer> v)
-                                    throws Exception {
-                                Thread.sleep(new Random().nextInt(20));
-                            }
-                        });
-            }
-        }
+        .concatMapEager((Function<List<Integer>, Flowable<List<Integer>>>) v -> Flowable.just(v)
+                .subscribeOn(Schedulers.cached())
+                .doOnNext(_ -> Thread.sleep(new Random().nextInt(20)))
                 , 2, 3)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1309,47 +1067,21 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapEager(new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel(
+                (FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+                upstream.concatMapEager((Function<Integer, Flowable<Integer>>) v -> Flowable.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapEagerDelayError(new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                }, false);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+        upstream.concatMapEagerDelayError((Function<Integer, Flowable<Integer>>) v -> Flowable.just(v).hide(), false));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapEagerDelayError(new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                }, true);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+        upstream.concatMapEagerDelayError((Function<Integer, Flowable<Integer>>) v -> Flowable.just(v).hide(), true));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
@@ -42,23 +43,14 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void boundaryFusion() {
         Flowable.range(1, 10000)
         .observeOn(Schedulers.single())
-        .map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer t) throws Exception {
-                String name = Thread.currentThread().getName();
-                if (name.contains("RxSingleScheduler")) {
-                    return "RxSingleScheduler";
-                }
-                return name;
+        .map(_ -> {
+            String name = Thread.currentThread().getName();
+            if (name.contains("RxSingleScheduler")) {
+                return "RxSingleScheduler";
             }
+            return name;
         })
-        .concatMap(new Function<String, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(String v)
-                    throws Exception {
-                return Flowable.just(v);
-            }
-        }, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<String, Publisher<?>>) Flowable::just, 2, ImmediateThinScheduler.INSTANCE)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -120,23 +112,14 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void boundaryFusionDelayError() {
         Flowable.range(1, 10000)
         .observeOn(Schedulers.single())
-        .map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer t) throws Exception {
-                String name = Thread.currentThread().getName();
-                if (name.contains("RxSingleScheduler")) {
-                    return "RxSingleScheduler";
-                }
-                return name;
+        .map(_ -> {
+            String name = Thread.currentThread().getName();
+            if (name.contains("RxSingleScheduler")) {
+                return "RxSingleScheduler";
             }
+            return name;
         })
-        .concatMapDelayError(new Function<String, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(String v)
-                    throws Exception {
-                return Flowable.just(v);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError((Function<String, Publisher<?>>) Flowable::just, true, 2, ImmediateThinScheduler.INSTANCE)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -147,20 +130,11 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void pollThrows() {
         Flowable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .<Integer>map(_ -> {
+            throw new TestException();
         })
         .compose(TestHelper.<Integer>flowableStripBoundary())
-        .concatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v)
-                    throws Exception {
-                return Flowable.just(v);
-            }
-        }, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Integer, Publisher<Integer>>) Flowable::just, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -168,20 +142,11 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void pollThrowsDelayError() {
         Flowable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .<Integer>map(_ -> {
+            throw new TestException();
         })
         .compose(TestHelper.<Integer>flowableStripBoundary())
-        .concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v)
-                    throws Exception {
-                return Flowable.just(v);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError((Function<Integer, Publisher<Integer>>) Flowable::just, true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -191,17 +156,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Flowable.range(1, 5)
-        .concatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(v).doOnCancel(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        counter.getAndIncrement();
-                    }
-                });
-            }
-        }, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Integer, Flowable<Integer>>) v ->
+            Flowable.just(v).doOnCancel(() -> counter.getAndIncrement()), 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1, 2, 3, 4, 5);
 
@@ -211,18 +167,12 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void delayErrorCallableTillTheEnd() {
         Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
-                return Flowable.fromCallable(new Callable<Integer>() {
-                    @Override public Integer call() throws Exception {
-                        if (integer >= 100) {
-                            throw new NullPointerException("test null exp");
-                        }
-                        return integer;
-                    }
-                });
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) integer -> Flowable.fromCallable(() -> {
+            if (integer >= 100) {
+                throw new NullPointerException("test null exp");
             }
-        }, true, 2, ImmediateThinScheduler.INSTANCE)
+            return integer;
+        }), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
     }
@@ -230,18 +180,12 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void delayErrorCallableEager() {
         Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
-                return Flowable.fromCallable(new Callable<Integer>() {
-                    @Override public Integer call() throws Exception {
-                        if (integer >= 100) {
-                            throw new NullPointerException("test null exp");
-                        }
-                        return integer;
-                    }
-                });
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) integer -> Flowable.fromCallable(() -> {
+            if (integer >= 100) {
+                throw new NullPointerException("test null exp");
             }
-        }, false, 2, ImmediateThinScheduler.INSTANCE)
+            return integer;
+        }), false, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);
     }
@@ -249,12 +193,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void mapperScheduled() {
         TestSubscriber<String> ts = Flowable.just(1)
-        .concatMap(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName());
-            }
-        }, 2, Schedulers.single())
+        .concatMap((Function<Integer, Flowable<String>>) _ -> Flowable.just(Thread.currentThread().getName()), 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -267,12 +206,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void mapperScheduledHidden() {
         TestSubscriber<String> ts = Flowable.just(1)
-        .concatMap(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName()).hide();
-            }
-        }, 2, Schedulers.single())
+        .concatMap((Function<Integer, Flowable<String>>) _ -> Flowable.just(Thread.currentThread().getName()).hide(), 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -285,12 +219,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void mapperDelayErrorScheduled() {
         TestSubscriber<String> ts = Flowable.just(1)
-        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName());
-            }
-        }, false, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Flowable<String>>) _ -> Flowable.just(Thread.currentThread().getName()), false, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -303,12 +232,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void mapperDelayErrorScheduledHidden() {
         TestSubscriber<String> ts = Flowable.just(1)
-        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName()).hide();
-            }
-        }, false, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Flowable<String>>) _ ->
+            Flowable.just(Thread.currentThread().getName()).hide(), false, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -321,12 +246,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void mapperDelayError2Scheduled() {
         TestSubscriber<String> ts = Flowable.just(1)
-        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName());
-            }
-        }, true, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Flowable<String>>) _ ->
+            Flowable.just(Thread.currentThread().getName()), true, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -339,12 +260,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void mapperDelayError2ScheduledHidden() {
         TestSubscriber<String> ts = Flowable.just(1)
-        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName()).hide();
-            }
-        }, true, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Flowable<String>>) _ ->
+            Flowable.just(Thread.currentThread().getName()).hide(), true, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -359,22 +276,20 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
 
-        Function<Integer, Flowable<Integer>> func = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                Flowable<Integer> flowable = Flowable.just(t)
-                        .subscribeOn(sch)
-                ;
-                FlowableProcessor<Integer> processor = UnicastProcessor.create();
-                flowable.subscribe(processor);
-                return processor;
-            }
+        Function<Integer, Flowable<Integer>> func = t -> {
+            Flowable<Integer> flowable = Flowable.just(t)
+                    .subscribeOn(sch)
+            ;
+            FlowableProcessor<Integer> processor = UnicastProcessor.create();
+            flowable.subscribe(processor);
+            return processor;
         };
 
         int n = 5000;
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable.range(1, n).concatMap(func, 2, ImmediateThinScheduler.INSTANCE).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(1, n).concatMap(func, 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 // Consume after sleep for 1 ms
@@ -423,12 +338,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             }
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.range(0, 1000)
-            .concatMap(new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer t) {
-                    return Flowable.fromIterable(Arrays.asList(t));
-                }
-            }, 2, ImmediateThinScheduler.INSTANCE)
+            .concatMap(t -> Flowable.fromIterable(Arrays.asList(t)), 2, ImmediateThinScheduler.INSTANCE)
             .observeOn(Schedulers.computation()).subscribe(ts);
 
             ts.awaitDone(2500, TimeUnit.MILLISECONDS);
@@ -542,12 +452,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void concatMapDelayErrorJustSource() {
         Flowable.just(0)
-        .concatMapDelayError(new Function<Object, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Object v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, true, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(_ -> Flowable.just(1), true, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
 
@@ -556,12 +461,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void concatMapJustSource() {
         Flowable.just(0).hide()
-        .concatMap(new Function<Object, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Object v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMap(_ -> Flowable.just(1), 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
     }
@@ -569,12 +469,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void concatMapJustSourceDelayError() {
         Flowable.just(0).hide()
-        .concatMapDelayError(new Function<Object, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Object v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, false, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError(_ -> Flowable.just(1), false, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
     }
@@ -613,7 +508,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
     @Test
     public void ignoreBackpressure() {
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -629,25 +524,17 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Object> f) throws Exception {
-                return f.concatMap(Functions.justFunction(Flowable.just(2)), 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Object> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Flowable.just(2)), true, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f ->
+            f.concatMap(Functions.justFunction(Flowable.just(2)), 2, ImmediateThinScheduler.INSTANCE));
+        TestHelper.checkDoubleOnSubscribeFlowable(f ->
+            f.concatMapDelayError(Functions.justFunction(Flowable.just(2)), true, 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test
     public void immediateInnerNextOuterError() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -671,7 +558,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void immediateInnerNextOuterError2() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -709,19 +596,16 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.concatMap(Functions.justFunction(Flowable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE);
-            }
-        }, true, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f ->
+        f.concatMap(Functions.justFunction(Flowable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE), true, 1, 1, 1);
     }
 
     @Test
     public void badInnerSource() {
         @SuppressWarnings("rawtypes")
         final Subscriber[] ts0 = { null };
-        TestSubscriberEx<Integer> ts = Flowable.just(1).hide().concatMap(Functions.justFunction(new Flowable<Integer>() {
+        TestSubscriberEx<Integer> ts = Flowable.just(1).hide()
+        .concatMap(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 ts0[0] = s;
@@ -747,7 +631,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void badInnerSourceDelayError() {
         @SuppressWarnings("rawtypes")
         final Subscriber[] ts0 = { null };
-        TestSubscriberEx<Integer> ts = Flowable.just(1).hide().concatMapDelayError(Functions.justFunction(new Flowable<Integer>() {
+        TestSubscriberEx<Integer> ts = Flowable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 ts0[0] = s;
@@ -771,21 +656,14 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
     @Test
     public void badSourceDelayError() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Flowable.just(1).hide()), true, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        }, true, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f ->
+            f.concatMapDelayError(Functions.justFunction(Flowable.just(1).hide()), true, 2, ImmediateThinScheduler.INSTANCE), true, 1, 1, 1);
     }
 
     @Test
     public void fusedCrash() {
         Flowable.range(1, 2)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(_ -> { throw new TestException(); })
         .concatMap(Functions.justFunction(Flowable.just(1)), 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -794,10 +672,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void fusedCrashDelayError() {
         Flowable.range(1, 2)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(_ -> { throw new TestException(); })
         .concatMapDelayError(Functions.justFunction(Flowable.just(1)), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -806,11 +681,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void callableCrash() {
         Flowable.just(1).hide()
-        .concatMap(Functions.justFunction(Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        .concatMap(Functions.justFunction(Flowable.fromCallable(() -> {
+            throw new TestException();
         })), 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -819,11 +691,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void callableCrashDelayError() {
         Flowable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        .concatMapDelayError(Functions.justFunction(Flowable.fromCallable(() -> {
+            throw new TestException();
         })), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -857,11 +726,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     @Test
     public void mapperThrows() {
         Flowable.range(1, 2)
-        .concatMap(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMap((Function<Integer, Publisher<Object>>) _ -> {
+            throw new TestException();
         }, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -873,12 +739,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        source.concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.range(v, 2);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        source.concatMapDelayError(v -> Flowable.range(v, 2), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         source.onNext(1);
         source.onNext(2);
@@ -896,12 +757,9 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        Flowable.range(1, 3).concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return inner;
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        Flowable.range(1, 3)
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) _ -> inner, true, 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(ts);
 
         ts.assertValues(1, 2, 1, 2, 1, 2);
         ts.assertError(CompositeException.class);
@@ -916,12 +774,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
         Flowable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return inner;
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) _ -> inner, true, 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(ts);
 
         ts.assertValues(1, 2);
         ts.assertError(TestException.class);
@@ -934,12 +788,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
         Flowable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return null;
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) _ -> null, true, 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(ts);
 
         ts.assertNoValues();
         ts.assertError(NullPointerException.class);
@@ -952,11 +802,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
         Flowable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                throw new TestException();
-            }
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) _ -> {
+            throw new TestException();
         }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertNoValues();
@@ -969,12 +816,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(1, 3)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return v == 2 ? Flowable.<Integer>empty() : Flowable.range(1, 2);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        .concatMapDelayError(v -> v == 2 ? Flowable.<Integer>empty() : Flowable.range(1, 2), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertValues(1, 2, 1, 2);
         ts.assertNoErrors();
@@ -986,12 +828,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(1, 3)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return v == 2 ? Flowable.just(3) : Flowable.range(1, 2);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        .concatMapDelayError(v -> v == 2 ? Flowable.just(3) : Flowable.range(1, 2), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertValues(1, 2, 3, 1, 2);
         ts.assertNoErrors();
@@ -1002,12 +839,8 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void backpressure() {
         TestSubscriber<Integer> ts = TestSubscriber.create(0);
 
-        Flowable.range(1, 3).concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.range(v, 2);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
+        Flowable.range(1, 3)
+        .concatMapDelayError(v -> Flowable.range(v, 2), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(ts);
 
         ts.assertNoValues();
         ts.assertNoErrors();
@@ -1035,14 +868,9 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         TestSubscriber<String> ts = Flowable.range(1, 1000)
         .hide()
         .observeOn(Schedulers.computation())
-        .concatMap(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName())
-                        .repeat(1000)
-                        .observeOn(Schedulers.cached());
-            }
-        }, 2, Schedulers.single())
+        .concatMap(_ -> Flowable.just(Thread.currentThread().getName())
+                .repeat(1000)
+                .observeOn(Schedulers.cached()), 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1058,14 +886,9 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         TestSubscriber<String> ts = Flowable.range(1, 1000)
         .hide()
         .observeOn(Schedulers.computation())
-        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName())
-                        .repeat(1000)
-                        .observeOn(Schedulers.cached());
-            }
-        }, false, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Flowable<String>>) _ -> Flowable.just(Thread.currentThread().getName())
+                .repeat(1000)
+                .observeOn(Schedulers.cached()), false, 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1081,14 +904,9 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         TestSubscriber<String> ts = Flowable.range(1, 1000)
         .hide()
         .observeOn(Schedulers.computation())
-        .concatMapDelayError(new Function<Integer, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Integer t) throws Throwable {
-                return Flowable.just(Thread.currentThread().getName())
-                        .repeat(1000)
-                        .observeOn(Schedulers.cached());
-            }
-        }, true, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Flowable<String>>) _ -> Flowable.just(Thread.currentThread().getName())
+                .repeat(1000)
+                .observeOn(Schedulers.cached()), true, 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1101,47 +919,20 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMap(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                }, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+        upstream.concatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v).hide(), 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                }, false, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+        upstream.concatMapDelayError(v -> Flowable.just(v).hide(), false, 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                }, true, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+        upstream.concatMapDelayError(v -> Flowable.just(v).hide(), true, 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapTest.java
@@ -16,10 +16,10 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
@@ -55,23 +55,14 @@ public class FlowableConcatMapTest extends RxJavaTest {
     public void boundaryFusion() {
         Flowable.range(1, 10000)
         .observeOn(Schedulers.single())
-        .map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer t) throws Exception {
-                String name = Thread.currentThread().getName();
-                if (name.contains("RxSingleScheduler")) {
-                    return "RxSingleScheduler";
-                }
-                return name;
+        .map(_ -> {
+            String name = Thread.currentThread().getName();
+            if (name.contains("RxSingleScheduler")) {
+                return "RxSingleScheduler";
             }
+            return name;
         })
-        .concatMap(new Function<String, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(String v)
-                    throws Exception {
-                return Flowable.just(v);
-            }
-        })
+        .concatMap((Function<String, Publisher<?>>) Flowable::just)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -133,23 +124,14 @@ public class FlowableConcatMapTest extends RxJavaTest {
     public void boundaryFusionDelayError() {
         Flowable.range(1, 10000)
         .observeOn(Schedulers.single())
-        .map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer t) throws Exception {
-                String name = Thread.currentThread().getName();
-                if (name.contains("RxSingleScheduler")) {
-                    return "RxSingleScheduler";
-                }
-                return name;
+        .map(_ -> {
+            String name = Thread.currentThread().getName();
+            if (name.contains("RxSingleScheduler")) {
+                return "RxSingleScheduler";
             }
+            return name;
         })
-        .concatMapDelayError(new Function<String, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(String v)
-                    throws Exception {
-                return Flowable.just(v);
-            }
-        })
+        .concatMapDelayError((Function<String, Publisher<?>>) Flowable::just)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -160,20 +142,11 @@ public class FlowableConcatMapTest extends RxJavaTest {
     @Test
     public void pollThrows() {
         Flowable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .<Integer>map(_ -> {
+            throw new TestException();
         })
         .compose(TestHelper.<Integer>flowableStripBoundary())
-        .concatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v)
-                    throws Exception {
-                return Flowable.just(v);
-            }
-        })
+        .concatMap(Flowable::just)
         .test()
         .assertFailure(TestException.class);
     }
@@ -181,20 +154,11 @@ public class FlowableConcatMapTest extends RxJavaTest {
     @Test
     public void pollThrowsDelayError() {
         Flowable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .<Integer>map(_ -> {
+            throw new TestException();
         })
         .compose(TestHelper.<Integer>flowableStripBoundary())
-        .concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v)
-                    throws Exception {
-                return Flowable.just(v);
-            }
-        })
+        .concatMapDelayError(Flowable::just)
         .test()
         .assertFailure(TestException.class);
     }
@@ -204,17 +168,7 @@ public class FlowableConcatMapTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Flowable.range(1, 5)
-        .concatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(v).doOnCancel(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        counter.getAndIncrement();
-                    }
-                });
-            }
-        })
+        .concatMap(v -> Flowable.just(v).doOnCancel(() -> counter.getAndIncrement()))
         .test()
         .assertResult(1, 2, 3, 4, 5);
 
@@ -224,18 +178,12 @@ public class FlowableConcatMapTest extends RxJavaTest {
     @Test
     public void delayErrorCallableTillTheEnd() {
         Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
-                return Flowable.fromCallable(new Callable<Integer>() {
-                    @Override public Integer call() throws Exception {
-                        if (integer >= 100) {
-                            throw new NullPointerException("test null exp");
-                        }
-                        return integer;
-                    }
-                });
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) integer -> Flowable.fromCallable(() -> {
+            if (integer >= 100) {
+                throw new NullPointerException("test null exp");
             }
-        })
+            return integer;
+        }))
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
     }
@@ -243,65 +191,32 @@ public class FlowableConcatMapTest extends RxJavaTest {
     @Test
     public void delayErrorCallableEager() {
         Flowable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override public Flowable<Integer> apply(final Integer integer) throws Exception {
-                return Flowable.fromCallable(new Callable<Integer>() {
-                    @Override public Integer call() throws Exception {
-                        if (integer >= 100) {
-                            throw new NullPointerException("test null exp");
-                        }
-                        return integer;
-                    }
-                });
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) integer -> Flowable.fromCallable(() -> {
+            if (integer >= 100) {
+                throw new NullPointerException("test null exp");
             }
-        }, false, 2)
+            return integer;
+        }), false, 2)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);
     }
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMap(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMap(v -> Flowable.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                }, false, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMapDelayError(v -> Flowable.just(v).hide(), false, 2));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapDelayError(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMapDelayError(v -> Flowable.just(v).hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
@@ -85,17 +86,12 @@ public class FlowableConcatTest {
         final Flowable<String> odds = Flowable.fromArray(o);
         final Flowable<String> even = Flowable.fromArray(e);
 
-        Flowable<Flowable<String>> flowableOfFlowables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                // simulate what would happen in an observable
-                subscriber.onNext(odds);
-                subscriber.onNext(even);
-                subscriber.onComplete();
-            }
-
+        Flowable<Flowable<String>> flowableOfFlowables = Flowable.unsafeCreate(subscriber1 -> {
+            subscriber1.onSubscribe(new BooleanSubscription());
+            // simulate what would happen in an observable
+            subscriber1.onNext(odds);
+            subscriber1.onNext(even);
+            subscriber1.onComplete();
         });
         Flowable<String> concat = Flowable.concat(flowableOfFlowables);
 
@@ -160,61 +156,53 @@ public class FlowableConcatTest {
         final CountDownLatch parentHasStarted = new CountDownLatch(1);
         final CountDownLatch parentHasFinished = new CountDownLatch(1);
 
-        Flowable<Flowable<String>> observableOfObservables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
+        Flowable<Flowable<String>> observableOfObservables = Flowable.unsafeCreate(subscriber1 -> {
+            final Disposable d = Disposable.empty();
+            subscriber1.onSubscribe(new Subscription() /* NFI */ {
+                @Override
+                public void request(long n) {
 
-            @Override
-            public void subscribe(final Subscriber<? super Flowable<String>> subscriber) {
-                final Disposable d = Disposable.empty();
-                subscriber.onSubscribe(new Subscription() {
-                    @Override
-                    public void request(long n) {
+                }
 
+                @Override
+                public void cancel() {
+                    d.dispose();
+                }
+            });
+            parent.set(new Thread(() -> {
+                try {
+                    // emit first
+                    if (!d.isDisposed()) {
+                        System.out.println("Emit o1");
+                        subscriber1.onNext(Flowable.unsafeCreate(o1));
+                    }
+                    // emit second
+                    if (!d.isDisposed()) {
+                        System.out.println("Emit o2");
+                        subscriber1.onNext(Flowable.unsafeCreate(o2));
                     }
 
-                    @Override
-                    public void cancel() {
-                        d.dispose();
+                    // wait until sometime later and emit third
+                    try {
+                        allowThird.await();
+                    } catch (InterruptedException e) {
+                        subscriber1.onError(e);
                     }
-                });
-                parent.set(new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        try {
-                            // emit first
-                            if (!d.isDisposed()) {
-                                System.out.println("Emit o1");
-                                subscriber.onNext(Flowable.unsafeCreate(o1));
-                            }
-                            // emit second
-                            if (!d.isDisposed()) {
-                                System.out.println("Emit o2");
-                                subscriber.onNext(Flowable.unsafeCreate(o2));
-                            }
-
-                            // wait until sometime later and emit third
-                            try {
-                                allowThird.await();
-                            } catch (InterruptedException e) {
-                                subscriber.onError(e);
-                            }
-                            if (!d.isDisposed()) {
-                                System.out.println("Emit o3");
-                                subscriber.onNext(Flowable.unsafeCreate(o3));
-                            }
-
-                        } catch (Throwable e) {
-                            subscriber.onError(e);
-                        } finally {
-                            System.out.println("Done parent Flowable");
-                            subscriber.onComplete();
-                            parentHasFinished.countDown();
-                        }
+                    if (!d.isDisposed()) {
+                        System.out.println("Emit o3");
+                        subscriber1.onNext(Flowable.unsafeCreate(o3));
                     }
-                }));
-                parent.get().start();
-                parentHasStarted.countDown();
-            }
+
+                } catch (Throwable e) {
+                    subscriber1.onError(e);
+                } finally {
+                    System.out.println("Done parent Flowable");
+                    subscriber1.onComplete();
+                    parentHasFinished.countDown();
+                }
+            }));
+            parent.get().start();
+            parentHasStarted.countDown();
         });
 
         Flowable.concat(observableOfObservables).subscribe(subscriber);
@@ -356,17 +344,12 @@ public class FlowableConcatTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
-        Flowable<Flowable<String>> observableOfObservables = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                // simulate what would happen in an observable
-                subscriber.onNext(Flowable.unsafeCreate(w1));
-                subscriber.onNext(Flowable.unsafeCreate(w2));
-                subscriber.onComplete();
-            }
-
+        Flowable<Flowable<String>> observableOfObservables = Flowable.unsafeCreate(subscriber1 -> {
+            subscriber1.onSubscribe(new BooleanSubscription());
+            // simulate what would happen in an observable
+            subscriber1.onNext(Flowable.unsafeCreate(w1));
+            subscriber1.onNext(Flowable.unsafeCreate(w2));
+            subscriber1.onComplete();
         });
         Flowable<String> concat = Flowable.concat(observableOfObservables);
         concat.subscribe(subscriber);
@@ -483,7 +466,7 @@ public class FlowableConcatTest {
 
     private static class TestObservable<T> implements Publisher<T> {
 
-        private final Subscription s = new Subscription() {
+        private final Subscription s = new Subscription() /* NFI */ {
 
             @Override
             public void request(long n) {
@@ -530,36 +513,31 @@ public class FlowableConcatTest {
         @Override
         public void subscribe(final Subscriber<? super T> subscriber) {
             subscriber.onSubscribe(s);
-            t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        while (count < size && subscribed) {
-                            if (null != values) {
-                                subscriber.onNext(values.get(count));
-                            } else {
-                                subscriber.onNext(seed);
-                            }
-                            count++;
-                            //Unblock the main thread to call unsubscribe.
-                            if (null != once) {
-                                once.countDown();
-                            }
-                            //Block until the main thread has called unsubscribe.
-                            if (null != okToContinue) {
-                                okToContinue.await(5, TimeUnit.SECONDS);
-                            }
+            t = new Thread(() -> {
+                try {
+                    while (count < size && subscribed) {
+                        if (null != values) {
+                            subscriber.onNext(values.get(count));
+                        } else {
+                            subscriber.onNext(seed);
                         }
-                        if (subscribed) {
-                            subscriber.onComplete();
+                        count++;
+                        //Unblock the main thread to call unsubscribe.
+                        if (null != once) {
+                            once.countDown();
                         }
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                        fail(e.getMessage());
+                        //Block until the main thread has called unsubscribe.
+                        if (null != okToContinue) {
+                            okToContinue.await(5, TimeUnit.SECONDS);
+                        }
                     }
+                    if (subscribed) {
+                        subscriber.onComplete();
+                    }
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    fail(e.getMessage());
                 }
-
             });
             t.start();
             threadHasStarted.countDown();
@@ -617,12 +595,7 @@ public class FlowableConcatTest {
     @Test
     public void concatVeryLongObservableOfObservables() {
         final int n = 10000;
-        Flowable<Flowable<Integer>> source = Flowable.range(0, n).map(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        Flowable<Flowable<Integer>> source = Flowable.range(0, n).map(Flowable::just);
 
         Single<List<Integer>> result = Flowable.concat(source).toList();
 
@@ -642,12 +615,7 @@ public class FlowableConcatTest {
     @Test
     public void concatVeryLongObservableOfObservablesTakeHalf() {
         final int n = 10000;
-        Flowable<Flowable<Integer>> source = Flowable.range(0, n).map(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        Flowable<Flowable<Integer>> source = Flowable.range(0, n).map(Flowable::just);
 
         Single<List<Integer>> result = Flowable.concat(source).take(n / 2).toList();
 
@@ -708,16 +676,11 @@ public class FlowableConcatTest {
     // https://github.com/ReactiveX/RxJava/issues/1818
     @Test
     public void concatWithNonCompliantSourceDoubleOnComplete() {
-        Flowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> s) {
-                s.onSubscribe(new BooleanSubscription());
-                s.onNext("hello");
-                s.onComplete();
-                s.onComplete();
-            }
-
+        Flowable<String> f = Flowable.unsafeCreate(s -> {
+            s.onSubscribe(new BooleanSubscription());
+            s.onNext("hello");
+            s.onComplete();
+            s.onComplete();
         });
 
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
@@ -733,22 +696,19 @@ public class FlowableConcatTest {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
 
-        Function<Integer, Flowable<Integer>> func = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                Flowable<Integer> flowable = Flowable.just(t)
-                        .subscribeOn(sch)
-                ;
-                FlowableProcessor<Integer> processor = UnicastProcessor.create();
-                flowable.subscribe(processor);
-                return processor;
-            }
+        Function<Integer, Flowable<Integer>> func = t -> {
+            Flowable<Integer> flowable = Flowable.just(t)
+                    .subscribeOn(sch)
+            ;
+            FlowableProcessor<Integer> processor = UnicastProcessor.create();
+            flowable.subscribe(processor);
+            return processor;
         };
 
         int n = 5000;
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable.range(1, n).concatMap(func).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(1, n).concatMap(func).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 // Consume after sleep for 1 ms
@@ -788,7 +748,7 @@ public class FlowableConcatTest {
         Flowable<Integer> f1 = Flowable.just(1, 2, 3);
         Flowable<Integer> f2 = Flowable.just(4, 5, 6);
         final AtomicBoolean completed = new AtomicBoolean(false);
-        f1.concatWith(f2).subscribe(new DefaultSubscriber<Integer>() {
+        f1.concatWith(f2).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -822,12 +782,7 @@ public class FlowableConcatTest {
             }
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.range(0, 1000)
-            .concatMap(new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer t) {
-                    return Flowable.fromIterable(Arrays.asList(t));
-                }
-            })
+            .concatMap(t -> Flowable.fromIterable(Arrays.asList(t)))
             .observeOn(Schedulers.computation()).subscribe(ts);
 
             ts.awaitDone(2500, TimeUnit.MILLISECONDS);
@@ -1154,12 +1109,7 @@ public class FlowableConcatTest {
     @Test
     public void concatMapIterableBufferSize() {
 
-        Flowable.just(1, 2).concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(1, 2, 3, 4, 5);
-            }
-        }, 1)
+        Flowable.just(1, 2).concatMapIterable(_ -> Arrays.asList(1, 2, 3, 4, 5), 1)
         .test()
         .assertResult(1, 2, 3, 4, 5, 1, 2, 3, 4, 5);
     }
@@ -1177,23 +1127,13 @@ public class FlowableConcatTest {
     @Test
     public void concatMapDelayErrorEmptySource() {
         assertSame(Flowable.empty(), Flowable.<Object>empty()
-                .concatMapDelayError(new Function<Object, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Object v) throws Exception {
-                        return Flowable.just(1);
-                    }
-                }, true, 16));
+                .concatMapDelayError(_ -> Flowable.just(1), true, 16));
     }
 
     @Test
     public void concatMapDelayErrorJustSource() {
         Flowable.just(0)
-        .concatMapDelayError(new Function<Object, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Object v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, true, 16)
+        .concatMapDelayError(_ -> Flowable.just(1), true, 16)
         .test()
         .assertResult(1);
 
@@ -1212,23 +1152,13 @@ public class FlowableConcatTest {
     @Test
     public void concatMapErrorEmptySource() {
         assertSame(Flowable.empty(), Flowable.<Object>empty()
-                .concatMap(new Function<Object, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Object v) throws Exception {
-                        return Flowable.just(1);
-                    }
-                }, 16));
+                .concatMap((Function<Object, Flowable<Integer>>) _ -> Flowable.just(1), 16));
     }
 
     @Test
     public void concatMapJustSource() {
         Flowable.just(0).hide()
-        .concatMap(new Function<Object, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Object v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, 16)
+        .concatMap((Function<Object, Flowable<Integer>>) _ -> Flowable.just(1), 16)
         .test()
         .assertResult(1);
     }
@@ -1236,12 +1166,7 @@ public class FlowableConcatTest {
     @Test
     public void concatMapJustSourceDelayError() {
         Flowable.just(0).hide()
-        .concatMapDelayError(new Function<Object, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Object v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, false, 16)
+        .concatMapDelayError(_ -> Flowable.just(1), false, 16)
         .test()
         .assertResult(1);
     }
@@ -1280,7 +1205,7 @@ public class FlowableConcatTest {
 
     @Test
     public void ignoreBackpressure() {
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -1296,25 +1221,15 @@ public class FlowableConcatTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Object> f) throws Exception {
-                return f.concatMap(Functions.justFunction(Flowable.just(2)));
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Object> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Flowable.just(2)));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.concatMap(Functions.justFunction(Flowable.just(2))));
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.concatMapDelayError(Functions.justFunction(Flowable.just(2))));
     }
 
     @Test
     public void immediateInnerNextOuterError() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1338,7 +1253,7 @@ public class FlowableConcatTest {
     public void immediateInnerNextOuterError2() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1376,19 +1291,15 @@ public class FlowableConcatTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.concatMap(Functions.justFunction(Flowable.just(1).hide()));
-            }
-        }, true, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.concatMap(Functions.justFunction(Flowable.just(1).hide())), true, 1, 1, 1);
     }
 
     @Test
     public void badInnerSource() {
         @SuppressWarnings("rawtypes")
         final Subscriber[] ts0 = { null };
-        TestSubscriberEx<Integer> ts = Flowable.just(1).hide().concatMap(Functions.justFunction(new Flowable<Integer>() {
+        TestSubscriberEx<Integer> ts = Flowable.just(1).hide()
+        .concatMap(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 ts0[0] = s;
@@ -1414,7 +1325,8 @@ public class FlowableConcatTest {
     public void badInnerSourceDelayError() {
         @SuppressWarnings("rawtypes")
         final Subscriber[] ts0 = { null };
-        TestSubscriberEx<Integer> ts = Flowable.just(1).hide().concatMapDelayError(Functions.justFunction(new Flowable<Integer>() {
+        TestSubscriberEx<Integer> ts = Flowable.just(1).hide()
+        .concatMapDelayError(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 ts0[0] = s;
@@ -1438,21 +1350,13 @@ public class FlowableConcatTest {
 
     @Test
     public void badSourceDelayError() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Flowable.just(1).hide()));
-            }
-        }, true, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.concatMapDelayError(Functions.justFunction(Flowable.just(1).hide())), true, 1, 1, 1);
     }
 
     @Test
     public void fusedCrash() {
         Flowable.range(1, 2)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(_ -> { throw new TestException(); })
         .concatMap(Functions.justFunction(Flowable.just(1)))
         .test()
         .assertFailure(TestException.class);
@@ -1461,10 +1365,7 @@ public class FlowableConcatTest {
     @Test
     public void fusedCrashDelayError() {
         Flowable.range(1, 2)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(_ -> { throw new TestException(); })
         .concatMapDelayError(Functions.justFunction(Flowable.just(1)))
         .test()
         .assertFailure(TestException.class);
@@ -1473,11 +1374,8 @@ public class FlowableConcatTest {
     @Test
     public void callableCrash() {
         Flowable.just(1).hide()
-        .concatMap(Functions.justFunction(Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        .concatMap(Functions.justFunction(Flowable.fromCallable(() -> {
+            throw new TestException();
         })))
         .test()
         .assertFailure(TestException.class);
@@ -1486,11 +1384,8 @@ public class FlowableConcatTest {
     @Test
     public void callableCrashDelayError() {
         Flowable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        .concatMapDelayError(Functions.justFunction(Flowable.fromCallable(() -> {
+            throw new TestException();
         })))
         .test()
         .assertFailure(TestException.class);
@@ -1524,11 +1419,8 @@ public class FlowableConcatTest {
     @Test
     public void mapperThrows() {
         Flowable.range(1, 2)
-        .concatMap(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMap((Function<Integer, Publisher<Object>>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -1538,13 +1430,10 @@ public class FlowableConcatTest {
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
 
-        Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onNext(1);
-                s.onComplete();
-            }
+        Flowable<Integer> source = Flowable.create(s -> {
+            calls[0]++;
+            s.onNext(1);
+            s.onComplete();
         }, BackpressureStrategy.MISSING);
 
         Flowable.concatArray(source, source).firstElement()
@@ -1558,13 +1447,10 @@ public class FlowableConcatTest {
     public void noSubsequentSubscriptionDelayError() {
         final int[] calls = { 0 };
 
-        Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onNext(1);
-                s.onComplete();
-            }
+        Flowable<Integer> source = Flowable.create(s -> {
+            calls[0]++;
+            s.onNext(1);
+            s.onComplete();
         }, BackpressureStrategy.MISSING);
 
         Flowable.concatArrayDelayError(source, source).firstElement()
@@ -1578,13 +1464,10 @@ public class FlowableConcatTest {
     public void noSubsequentSubscriptionIterable() {
         final int[] calls = { 0 };
 
-        Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onNext(1);
-                s.onComplete();
-            }
+        Flowable<Integer> source = Flowable.create(s -> {
+            calls[0]++;
+            s.onNext(1);
+            s.onComplete();
         }, BackpressureStrategy.MISSING);
 
         Flowable.concat(Arrays.asList(source, source)).firstElement()
@@ -1598,13 +1481,10 @@ public class FlowableConcatTest {
     public void noSubsequentSubscriptionDelayErrorIterable() {
         final int[] calls = { 0 };
 
-        Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(FlowableEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onNext(1);
-                s.onComplete();
-            }
+        Flowable<Integer> source = Flowable.create(s -> {
+            calls[0]++;
+            s.onNext(1);
+            s.onComplete();
         }, BackpressureStrategy.MISSING);
 
         Flowable.concatDelayError(Arrays.asList(source, source)).firstElement()
@@ -1618,12 +1498,7 @@ public class FlowableConcatTest {
     public void noCancelPreviousArray() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.just(1).doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Flowable<Integer> source = Flowable.just(1).doOnCancel(() -> counter.getAndIncrement());
 
         Flowable.concatArray(source, source, source, source, source)
         .test()
@@ -1636,12 +1511,7 @@ public class FlowableConcatTest {
     public void noCancelPreviousIterable() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.just(1).doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Flowable<Integer> source = Flowable.just(1).doOnCancel(() -> counter.getAndIncrement());
 
         Flowable.concat(Arrays.asList(source, source, source, source, source))
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithCompletableTest.java
@@ -22,7 +22,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.subjects.CompletableSubject;
@@ -36,12 +35,7 @@ public class FlowableConcatWithCompletableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
-        .concatWith(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.onNext(100);
-            }
-        }))
+        .concatWith(Completable.fromAction(() -> ts.onNext(100)))
         .subscribe(ts);
 
         ts.assertResult(1, 2, 3, 4, 5, 100);
@@ -52,12 +46,7 @@ public class FlowableConcatWithCompletableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.<Integer>error(new TestException())
-        .concatWith(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.onNext(100);
-            }
-        }))
+        .concatWith(Completable.fromAction(() -> ts.onNext(100)))
         .subscribe(ts);
 
         ts.assertFailure(TestException.class);
@@ -79,12 +68,7 @@ public class FlowableConcatWithCompletableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
-        .concatWith(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.onNext(100);
-            }
-        }))
+        .concatWith(Completable.fromAction(() -> ts.onNext(100)))
         .take(3)
         .subscribe(ts);
 
@@ -110,7 +94,7 @@ public class FlowableConcatWithCompletableTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     BooleanSubscription bs1 = new BooleanSubscription();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithMaybeTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.subjects.MaybeSubject;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
@@ -30,12 +29,7 @@ public class FlowableConcatWithMaybeTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
-        .concatWith(Maybe.<Integer>fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.onNext(100);
-            }
-        }))
+        .concatWith(Maybe.<Integer>fromAction(() -> ts.onNext(100)))
         .subscribe(ts);
 
         ts.assertResult(1, 2, 3, 4, 5, 100);
@@ -71,12 +65,7 @@ public class FlowableConcatWithMaybeTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.<Integer>error(new TestException())
-        .concatWith(Maybe.<Integer>fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.onNext(100);
-            }
-        }))
+        .concatWith(Maybe.<Integer>fromAction(() -> ts.onNext(100)))
         .subscribe(ts);
 
         ts.assertFailure(TestException.class);
@@ -98,12 +87,7 @@ public class FlowableConcatWithMaybeTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 5)
-        .concatWith(Maybe.<Integer>fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.onNext(100);
-            }
-        }))
+        .concatWith(Maybe.<Integer>fromAction(() -> ts.onNext(100)))
         .take(3)
         .subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCountTest.java
@@ -49,19 +49,9 @@ public class FlowableCountTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Long>>() {
-            @Override
-            public Flowable<Long> apply(Flowable<Object> f) throws Exception {
-                return f.count().toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.count().toFlowable());
 
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Long>>() {
-            @Override
-            public SingleSource<Long> apply(Flowable<Object> f) throws Exception {
-                return f.count();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle((Function<Flowable<Object>, SingleSource<Long>>) Flowable::count);
     }
 
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreateTest.java
@@ -25,7 +25,6 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Cancellable;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -39,20 +38,17 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d);
+            Flowable.<Integer>create(e -> {
+                e.setDisposable(d);
 
-                    e.onNext(1);
-                    e.onNext(2);
-                    e.onNext(3);
-                    e.onComplete();
-                    e.onError(new TestException("first"));
-                    e.onNext(4);
-                    e.onError(new TestException("second"));
-                    e.onComplete();
-                }
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onComplete();
+                e.onError(new TestException("first"));
+                e.onNext(4);
+                e.onError(new TestException("second"));
+                e.onComplete();
             }, BackpressureStrategy.BUFFER)
             .test()
             .assertResult(1, 2, 3);
@@ -73,26 +69,18 @@ public class FlowableCreateTest extends RxJavaTest {
             final Disposable d1 = Disposable.empty();
             final Disposable d2 = Disposable.empty();
 
-            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d1);
-                    e.setCancellable(new Cancellable() {
-                        @Override
-                        public void cancel() throws Exception {
-                            d2.dispose();
-                        }
-                    });
+            Flowable.<Integer>create(e -> {
+                e.setDisposable(d1);
+                e.setCancellable(() -> d2.dispose());
 
-                    e.onNext(1);
-                    e.onNext(2);
-                    e.onNext(3);
-                    e.onComplete();
-                    e.onError(new TestException("first"));
-                    e.onNext(4);
-                    e.onError(new TestException("second"));
-                    e.onComplete();
-                }
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onComplete();
+                e.onError(new TestException("first"));
+                e.onNext(4);
+                e.onError(new TestException("second"));
+                e.onComplete();
             }, BackpressureStrategy.BUFFER)
             .test()
             .assertResult(1, 2, 3);
@@ -113,19 +101,16 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d);
+            Flowable.<Integer>create(e -> {
+                e.setDisposable(d);
 
-                    e.onNext(1);
-                    e.onNext(2);
-                    e.onNext(3);
-                    e.onError(new TestException());
-                    e.onComplete();
-                    e.onNext(4);
-                    e.onError(new TestException("second"));
-                }
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onError(new TestException());
+                e.onComplete();
+                e.onNext(4);
+                e.onError(new TestException("second"));
             }, BackpressureStrategy.BUFFER)
             .test()
             .assertFailure(TestException.class, 1, 2, 3);
@@ -144,22 +129,19 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e = e.serialize();
+            Flowable.<Integer>create(e -> {
+                e = e.serialize();
 
-                    e.setDisposable(d);
+                e.setDisposable(d);
 
-                    e.onNext(1);
-                    e.onNext(2);
-                    e.onNext(3);
-                    e.onComplete();
-                    e.onError(new TestException("first"));
-                    e.onNext(4);
-                    e.onError(new TestException("second"));
-                    e.onComplete();
-                }
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onComplete();
+                e.onError(new TestException("first"));
+                e.onNext(4);
+                e.onError(new TestException("second"));
+                e.onComplete();
             }, BackpressureStrategy.BUFFER)
             .test()
             .assertResult(1, 2, 3);
@@ -179,21 +161,18 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Flowable.<Integer>create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e = e.serialize();
+            Flowable.<Integer>create(e -> {
+                e = e.serialize();
 
-                    e.setDisposable(d);
+                e.setDisposable(d);
 
-                    e.onNext(1);
-                    e.onNext(2);
-                    e.onNext(3);
-                    e.onError(new TestException());
-                    e.onComplete();
-                    e.onNext(4);
-                    e.onError(new TestException("second"));
-                }
+                e.onNext(1);
+                e.onNext(2);
+                e.onNext(3);
+                e.onError(new TestException());
+                e.onComplete();
+                e.onNext(4);
+                e.onError(new TestException("second"));
             }, BackpressureStrategy.BUFFER)
             .test()
             .assertFailure(TestException.class, 1, 2, 3);
@@ -208,17 +187,14 @@ public class FlowableCreateTest extends RxJavaTest {
 
     @Test
     public void wrap() {
-        Flowable.fromPublisher(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                subscriber.onNext(1);
-                subscriber.onNext(2);
-                subscriber.onNext(3);
-                subscriber.onNext(4);
-                subscriber.onNext(5);
-                subscriber.onComplete();
-            }
+        Flowable.fromPublisher(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onNext(1);
+            subscriber.onNext(2);
+            subscriber.onNext(3);
+            subscriber.onNext(4);
+            subscriber.onNext(5);
+            subscriber.onComplete();
         })
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -226,17 +202,14 @@ public class FlowableCreateTest extends RxJavaTest {
 
     @Test
     public void unsafe() {
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                subscriber.onNext(1);
-                subscriber.onNext(2);
-                subscriber.onNext(3);
-                subscriber.onNext(4);
-                subscriber.onNext(5);
-                subscriber.onComplete();
-            }
+        Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onNext(1);
+            subscriber.onNext(2);
+            subscriber.onNext(3);
+            subscriber.onNext(4);
+            subscriber.onNext(5);
+            subscriber.onComplete();
         })
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -254,17 +227,14 @@ public class FlowableCreateTest extends RxJavaTest {
 
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.BUFFER)
             .test()
@@ -284,17 +254,14 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.LATEST)
             .test()
@@ -314,17 +281,14 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.ERROR)
             .test()
@@ -344,17 +308,14 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.DROP)
             .test()
@@ -374,17 +335,14 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.MISSING)
             .test()
@@ -404,18 +362,15 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e = e.serialize();
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.BUFFER)
             .test()
@@ -435,18 +390,15 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e = e.serialize();
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.LATEST)
             .test()
@@ -466,18 +418,15 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e = e.serialize();
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.ERROR)
             .test()
@@ -497,18 +446,15 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e = e.serialize();
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.DROP)
             .test()
@@ -528,18 +474,15 @@ public class FlowableCreateTest extends RxJavaTest {
         try {
             final Throwable[] error = { null };
 
-            Flowable.create(new FlowableOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                    e = e.serialize();
-                    try {
-                        e.onNext(null);
-                        e.onNext(1);
-                        e.onError(new TestException());
-                        e.onComplete();
-                    } catch (Throwable ex) {
-                        error[0] = ex;
-                    }
+            Flowable.create(e -> {
+                e = e.serialize();
+                try {
+                    e.onNext(null);
+                    e.onNext(1);
+                    e.onError(new TestException());
+                    e.onComplete();
+                } catch (Throwable ex) {
+                    error[0] = ex;
                 }
             }, BackpressureStrategy.MISSING)
             .test()
@@ -556,29 +499,16 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void onErrorRace() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable<Object> source = Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    final FlowableEmitter<Object> f = e.serialize();
+            Flowable<Object> source = Flowable.create(e -> {
+                final FlowableEmitter<Object> f = e.serialize();
 
-                    final TestException ex = new TestException();
+                final TestException ex = new TestException();
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            f.onError(null);
-                        }
-                    };
+                Runnable r1 = () -> f.onError(null);
 
-                    Runnable r2 = new Runnable() {
-                        @Override
-                        public void run() {
-                            f.onError(ex);
-                        }
-                    };
+                Runnable r2 = () -> f.onError(ex);
 
-                    TestHelper.race(r1, r2);
-                }
+                TestHelper.race(r1, r2);
             }, m);
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -599,27 +529,14 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void onCompleteRace() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable<Object> source = Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    final FlowableEmitter<Object> f = e.serialize();
+            Flowable<Object> source = Flowable.create(e -> {
+                final FlowableEmitter<Object> f = e.serialize();
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            f.onComplete();
-                        }
-                    };
+                Runnable r1 = () -> f.onComplete();
 
-                    Runnable r2 = new Runnable() {
-                        @Override
-                        public void run() {
-                            f.onComplete();
-                        }
-                    };
+                Runnable r2 = () -> f.onComplete();
 
-                    TestHelper.race(r1, r2);
-                }
+                TestHelper.race(r1, r2);
             }, m);
 
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -633,12 +550,7 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void nullValue() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    e.onNext(null);
-                }
-            }, m)
+            Flowable.create(e -> e.onNext(null), m)
             .test()
             .assertFailure(NullPointerException.class);
         }
@@ -648,12 +560,7 @@ public class FlowableCreateTest extends RxJavaTest {
     public void nullThrowable() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
             System.out.println(m);
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    e.onError(null);
-                }
-            }, m)
+            Flowable.create(e -> e.onError(null), m)
             .test()
             .assertFailure(NullPointerException.class);
         }
@@ -662,32 +569,23 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void serializedConcurrentOnNextOnError() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    final FlowableEmitter<Object> f = e.serialize();
+            Flowable.create(e -> {
+                final FlowableEmitter<Object> f = e.serialize();
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            for (int i = 0; i < 1000; i++) {
-                                f.onNext(1);
-                            }
-                        }
-                    };
+                Runnable r1 = () -> {
+                    for (int i = 0; i < 1000; i++) {
+                        f.onNext(1);
+                    }
+                };
 
-                    Runnable r2 = new Runnable() {
-                        @Override
-                        public void run() {
-                            for (int i = 0; i < 100; i++) {
-                                f.onNext(1);
-                            }
-                            f.onError(new TestException());
-                        }
-                    };
+                Runnable r2 = () -> {
+                    for (int i = 0; i < 100; i++) {
+                        f.onNext(1);
+                    }
+                    f.onError(new TestException());
+                };
 
-                    TestHelper.race(r1, r2);
-                }
+                TestHelper.race(r1, r2);
             }, m)
             .to(TestHelper.<Object>testConsumer())
             .assertSubscribed()
@@ -699,11 +597,8 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void callbackThrows() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    throw new TestException();
-                }
+            Flowable.create(_ -> {
+                throw new TestException();
             }, m)
             .test()
             .assertFailure(TestException.class);
@@ -713,12 +608,7 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void nullValueSync() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    e.serialize().onNext(null);
-                }
-            }, m)
+            Flowable.create(e -> e.serialize().onNext(null), m)
             .test()
             .assertFailure(NullPointerException.class);
         }
@@ -731,17 +621,14 @@ public class FlowableCreateTest extends RxJavaTest {
             try {
                 final Throwable[] error = { null };
 
-                Flowable.create(new FlowableOnSubscribe<Integer>() {
-                    @Override
-                    public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                        try {
-                            e.onNext(null);
-                            e.onNext(1);
-                            e.onError(new TestException());
-                            e.onComplete();
-                        } catch (Throwable ex) {
-                            error[0] = ex;
-                        }
+                Flowable.create(e -> {
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
                     }
                 }, m)
                 .test()
@@ -759,21 +646,18 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void onErrorCrash() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    Disposable d = Disposable.empty();
-                    e.setDisposable(d);
-                    try {
-                        e.onError(new IOException());
-                        fail("Should have thrown");
-                    } catch (TestException ex) {
-                        // expected
-                    }
-                    assertTrue(d.isDisposed());
+            Flowable.create(e -> {
+                Disposable d = Disposable.empty();
+                e.setDisposable(d);
+                try {
+                    e.onError(new IOException());
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
                 }
+                assertTrue(d.isDisposed());
             }, m)
-            .subscribe(new FlowableSubscriber<Object>() {
+            .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
                 @Override
                 public void onSubscribe(Subscription s) {
                 }
@@ -797,21 +681,18 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void onCompleteCrash() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    Disposable d = Disposable.empty();
-                    e.setDisposable(d);
-                    try {
-                        e.onComplete();
-                        fail("Should have thrown");
-                    } catch (TestException ex) {
-                        // expected
-                    }
-                    assertTrue(d.isDisposed());
+            Flowable.create(e -> {
+                Disposable d = Disposable.empty();
+                e.setDisposable(d);
+                try {
+                    e.onComplete();
+                    fail("Should have thrown");
+                } catch (TestException ex) {
+                    // expected
                 }
+                assertTrue(d.isDisposed());
             }, m)
-            .subscribe(new FlowableSubscriber<Object>() {
+            .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
                 @Override
                 public void onSubscribe(Subscription s) {
                 }
@@ -839,18 +720,15 @@ public class FlowableCreateTest extends RxJavaTest {
             try {
                 final Throwable[] error = { null };
 
-                Flowable.create(new FlowableOnSubscribe<Integer>() {
-                    @Override
-                    public void subscribe(FlowableEmitter<Integer> e) throws Exception {
-                        e = e.serialize();
-                        try {
-                            e.onNext(null);
-                            e.onNext(1);
-                            e.onError(new TestException());
-                            e.onComplete();
-                        } catch (Throwable ex) {
-                            error[0] = ex;
-                        }
+                Flowable.create(e -> {
+                    e = e.serialize();
+                    try {
+                        e.onNext(null);
+                        e.onNext(1);
+                        e.onError(new TestException());
+                        e.onComplete();
+                    } catch (Throwable ex) {
+                        error[0] = ex;
                     }
                 }, m)
                 .test()
@@ -868,12 +746,7 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void nullThrowableSync() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    e.serialize().onError(null);
-                }
-            }, m)
+            Flowable.create(e -> e.serialize().onError(null), m)
             .test()
             .assertFailure(NullPointerException.class);
         }
@@ -882,22 +755,16 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void serializedConcurrentOnNext() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    final FlowableEmitter<Object> f = e.serialize();
+            Flowable.create(e -> {
+                final FlowableEmitter<Object> f = e.serialize();
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                                f.onNext(1);
-                            }
-                        }
-                    };
+                Runnable r1 = () -> {
+                    for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+                        f.onNext(1);
+                    }
+                };
 
-                    TestHelper.race(r1, r1);
-                }
+                TestHelper.race(r1, r1);
             }, m)
             .take(TestHelper.RACE_DEFAULT_LOOPS)
             .to(TestHelper.<Object>testConsumer())
@@ -911,32 +778,23 @@ public class FlowableCreateTest extends RxJavaTest {
     @Test
     public void serializedConcurrentOnNextOnComplete() {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
-            TestSubscriberEx<Object> ts = Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                    final FlowableEmitter<Object> f = e.serialize();
+            TestSubscriberEx<Object> ts = Flowable.create(e -> {
+                final FlowableEmitter<Object> f = e.serialize();
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            for (int i = 0; i < 1000; i++) {
-                                f.onNext(1);
-                            }
-                        }
-                    };
+                Runnable r1 = () -> {
+                    for (int i = 0; i < 1000; i++) {
+                        f.onNext(1);
+                    }
+                };
 
-                    Runnable r2 = new Runnable() {
-                        @Override
-                        public void run() {
-                            for (int i = 0; i < 100; i++) {
-                                f.onNext(1);
-                            }
-                            f.onComplete();
-                        }
-                    };
+                Runnable r2 = () -> {
+                    for (int i = 0; i < 100; i++) {
+                        f.onNext(1);
+                    }
+                    f.onComplete();
+                };
 
-                    TestHelper.race(r1, r2);
-                }
+                TestHelper.race(r1, r2);
             }, m)
             .to(TestHelper.<Object>testConsumer())
             .assertSubscribed()
@@ -953,30 +811,22 @@ public class FlowableCreateTest extends RxJavaTest {
         for (BackpressureStrategy m : BackpressureStrategy.values()) {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                Flowable.create(new FlowableOnSubscribe<Object>() {
-                    @Override
-                    public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                        FlowableEmitter<Object> f = e.serialize();
+                Flowable.create(e -> {
+                    FlowableEmitter<Object> f = e.serialize();
 
-                        assertSame(f, f.serialize());
+                    assertSame(f, f.serialize());
 
-                        assertFalse(f.isCancelled());
+                    assertFalse(f.isCancelled());
 
-                        final int[] calls = { 0 };
+                    final int[] calls = { 0 };
 
-                        f.setCancellable(new Cancellable() {
-                            @Override
-                            public void cancel() throws Exception {
-                                calls[0]++;
-                            }
-                        });
+                    f.setCancellable(() -> calls[0]++);
 
-                        e.onComplete();
+                    e.onComplete();
 
-                        assertTrue(f.isCancelled());
+                    assertTrue(f.isCancelled());
 
-                        assertEquals(1, calls[0]);
-                    }
+                    assertEquals(1, calls[0]);
                 }, m)
                 .test()
                 .assertResult();
@@ -994,12 +844,9 @@ public class FlowableCreateTest extends RxJavaTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final Boolean[] response = { null };
-                Flowable.create(new FlowableOnSubscribe<Object>() {
-                    @Override
-                    public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                        e.onNext(1);
-                        response[0] = e.tryOnError(new TestException());
-                    }
+                Flowable.create(e -> {
+                    e.onNext(1);
+                    response[0] = e.tryOnError(new TestException());
                 }, strategy)
                 .take(1)
                 .test()
@@ -1021,13 +868,10 @@ public class FlowableCreateTest extends RxJavaTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
                 final Boolean[] response = { null };
-                Flowable.create(new FlowableOnSubscribe<Object>() {
-                    @Override
-                    public void subscribe(FlowableEmitter<Object> e) throws Exception {
-                        e = e.serialize();
-                        e.onNext(1);
-                        response[0] = e.tryOnError(new TestException());
-                    }
+                Flowable.create(e -> {
+                    e = e.serialize();
+                    e.onNext(1);
+                    response[0] = e.tryOnError(new TestException());
                 }, strategy)
                 .take(1)
                 .test()
@@ -1056,12 +900,9 @@ public class FlowableCreateTest extends RxJavaTest {
         emitterMap.put(BackpressureStrategy.BUFFER, FlowableCreate.BufferAsyncEmitter.class);
 
         for (final Map.Entry<BackpressureStrategy, Class<? extends FlowableEmitter>> entry : emitterMap.entrySet()) {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> emitter) throws Exception {
-                    assertTrue(emitter.toString().contains(entry.getValue().getSimpleName()));
-                    assertTrue(emitter.serialize().toString().contains(entry.getValue().getSimpleName()));
-                }
+            Flowable.create(emitter -> {
+                assertTrue(emitter.toString().contains(entry.getValue().getSimpleName()));
+                assertTrue(emitter.serialize().toString().contains(entry.getValue().getSimpleName()));
             }, entry.getKey()).test().assertEmpty();
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
@@ -225,7 +225,7 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void seedFactoryFlowable() {
         Flowable<List<Integer>> f = Flowable.range(1, 10)
-                .collect(() -> (List<Integer>)new ArrayList<Integer>(), (list, item) -> list.add(item))
+                .<List<Integer>>collect(() -> new ArrayList<>(), (list, item) -> list.add(item))
                 .toFlowable()
                 .takeLast(1);
 

--- a/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
@@ -1140,18 +1140,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
                 }
             };
             BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> completableObserver2completableObserver
-                = new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
-                @Override
-                public CompletableObserver apply(Completable completable, CompletableObserver completableObserver) throws Exception {
-                    return completableObserver;
-                }
-            };
-            Function<? super Completable, ? extends Completable> completable2completable = new Function<Completable, Completable>() {
-                @Override
-                public Completable apply(Completable completable) throws Exception {
-                    return completable;
-                }
-            };
+                = (_, completableObserver) -> completableObserver;
+            Function<? super Completable, ? extends Completable> completable2completable = completable -> completable;
 
             RxJavaPlugins.setInitComputationSchedulerHandler(callable2scheduler);
             RxJavaPlugins.setComputationSchedulerHandler(scheduler2scheduler);

--- a/src/test/java/io/reactivex/rxjava4/schedulers/CachedThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/CachedThreadSchedulerTest.java
@@ -84,11 +84,11 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
     public void workerDisposed() {
         Worker w = Schedulers.cached().createWorker();
 
-        assertFalse(((Disposable)w).isDisposed());
+        assertFalse(w.isDisposed());
 
         w.dispose();
 
-        assertTrue(((Disposable)w).isDisposed());
+        assertTrue(w.isDisposed());
     }
 
     @Test
@@ -96,12 +96,7 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
     public void shutdownRejects() {
         final int[] calls = { 0 };
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                calls[0]++;
-            }
-        };
+        Runnable r = () -> calls[0]++;
 
         CachedScheduler s = new CachedScheduler();
         s.shutdown();

--- a/src/test/java/io/reactivex/rxjava4/schedulers/VirtualThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/VirtualThreadSchedulerTest.java
@@ -84,11 +84,11 @@ public class VirtualThreadSchedulerTest extends AbstractSchedulerConcurrencyTest
     public void workerDisposed() {
         Worker w = Schedulers.virtual().createWorker();
 
-        assertFalse(((Disposable)w).isDisposed());
+        assertFalse(w.isDisposed());
 
         w.dispose();
 
-        assertTrue(((Disposable)w).isDisposed());
+        assertTrue(w.isDisposed());
     }
 
     @Ignore("FIXME DeferredExecutorScheduler doesn't support shutdown yet")


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080