### PR TITLE
4.x: Unit test lambdaification 9 of N

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -9407,13 +9407,12 @@ FlowableDocBasic<T>
      * @see #distinct(Function)
      * @see #distinct(Function, Supplier)
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Flowable<T> distinct() {
-        return distinct((Function)Functions.identity(), Functions.<T>createHashSet());
+        return distinct(Functions.identity(), Functions.<T>createHashSet());
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/BaseTestConsumer.java
@@ -240,10 +240,9 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @param errorClass the error {@code Class} to expect
      * @return this
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @NonNull
     public final U assertError(@NonNull Class<? extends Throwable> errorClass) {
-        return (U)assertError((Predicate)Functions.isInstanceOf(errorClass), true);
+        return assertError(Functions.isInstanceOf(errorClass), true);
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -1761,7 +1761,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void retryBiPredicate5Times() {
-        Completable c = error.completable.retry((BiPredicate<Integer, Throwable>) (n, _) -> n < 5);
+        Completable c = error.completable.retry((n, _) -> n < 5);
 
         c.blockingAwait();
     }
@@ -1795,7 +1795,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void retryPredicateError() {
-        Completable c = error.completable.retry((Predicate<Throwable>) _ -> false);
+        Completable c = error.completable.retry(_ -> false);
 
         c.blockingAwait();
     }
@@ -1808,7 +1808,7 @@ public class CompletableTest extends RxJavaTest {
             if (calls.decrementAndGet() != 0) {
                 throw new TestException();
             }
-        }).retry((Predicate<Throwable>) _ -> true);
+        }).retry(_ -> true);
 
         c.blockingAwait();
     }
@@ -2039,7 +2039,7 @@ public class CompletableTest extends RxJavaTest {
     @Test
     public void toNormal() {
         normal.completable
-                .to((CompletableConverter<Flowable<Object>>) Completable::toFlowable)
+                .to(Completable::toFlowable)
                 .test()
                 .assertComplete()
                 .assertNoValues();
@@ -2048,7 +2048,7 @@ public class CompletableTest extends RxJavaTest {
     @Test
     public void asNormal() {
         normal.completable
-                .to((CompletableConverter<Flowable<Object>>) Completable::toFlowable)
+                .to(Completable::toFlowable)
                 .test()
                 .assertComplete()
                 .assertNoValues();
@@ -2614,7 +2614,7 @@ public class CompletableTest extends RxJavaTest {
     @Test
     public void propagateExceptionSubscribeOneAction() {
         expectUncaughtTestException(() -> error.completable.toSingleDefault(1)
-                .subscribe((Consumer<Integer>) _ -> { }));
+                .subscribe(_ -> { }));
     }
 
     @Test
@@ -3171,7 +3171,7 @@ public class CompletableTest extends RxJavaTest {
     @Test
     public void propagateExceptionSubscribeOneActionThrowFromOnSuccess() {
         expectUncaughtTestException(() -> normal.completable.toSingleDefault(1)
-                .subscribe((Consumer<Integer>) _ -> {
+                .subscribe(_ -> {
                     throw new TestException();
                 }));
     }

--- a/src/test/java/io/reactivex/rxjava4/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/CompositeExceptionTest.java
@@ -183,7 +183,7 @@ public class CompositeExceptionTest extends RxJavaTest {
 
     @Test
     public void nullElement() {
-        CompositeException composite = new CompositeException(Collections.singletonList((Throwable) null));
+        CompositeException composite = new CompositeException(Collections.singletonList(null));
         composite.getCause();
         composite.printStackTrace();
     }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
@@ -34,7 +34,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     public void collectToListFlowable() {
         Flowable<List<Integer>> f = Flowable.just(1, 2, 3)
         .collect((Supplier<List<Integer>>) () -> new ArrayList<>(),
-                (BiConsumer<List<Integer>, Integer>) List::add)
+                List::add)
                 .toFlowable();
 
         List<Integer> list =  f.blockingLast();
@@ -153,7 +153,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     @Test
     public void collectToList() {
         Single<List<Integer>> o = Flowable.just(1, 2, 3)
-        .collect(() -> new ArrayList<>(), (BiConsumer<List<Integer>, Integer>) List::add);
+        .collect(() -> new ArrayList<>(), List::add);
 
         List<Integer> list =  o.blockingGet();
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
@@ -151,25 +151,25 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void generateStateFunctionInitialStateNull() {
-        Flowable.generate(null, (BiFunction<Object, Emitter<Object>, Object>) (s, o) -> {
+        Flowable.generate(null, (s, o) -> {
             o.onNext(1); return s;
         });
     }
 
     @Test(expected = NullPointerException.class)
     public void generateStateConsumerNull() {
-        Flowable.generate((Supplier<Integer>) () -> 1, (BiConsumer<Integer, Emitter<Object>>)null);
+        Flowable.generate(() -> 1, (BiConsumer<Integer, Emitter<Object>>)null);
     }
 
     @Test
     public void generateConsumerStateNullAllowed() {
         BiConsumer<Integer, Emitter<Integer>> generator = (_, o) -> o.onComplete();
-        Flowable.generate((Supplier<Integer>) () -> null, generator).blockingSubscribe();
+        Flowable.generate(() -> null, generator).blockingSubscribe();
     }
 
     @Test
     public void generateFunctionStateNullAllowed() {
-        Flowable.generate((Supplier<Object>) () -> null, (BiFunction<Object, Emitter<Object>, Object>) (s, o) -> {
+        Flowable.generate(() -> null, (s, o) -> {
             o.onComplete(); return s;
         }).blockingSubscribe();
     }
@@ -248,7 +248,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2Null() {
-        Flowable.zip((Iterable<Publisher<Object>>)null, (Function<Object[], Object>) _ -> 1, true, 128);
+        Flowable.zip(null, (Function<Object[], Object>) _ -> 1, true, 128);
     }
 
     @Test(expected = NullPointerException.class)
@@ -259,7 +259,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipIterable2FunctionReturnsNull() {
-        Flowable.zip(Arrays.asList(just1, just1), (Function<Object[], Object>) _ -> null, true, 128)
+        Flowable.zip(Arrays.asList(just1, just1), _ -> null, true, 128)
         .blockingLast();
     }
 
@@ -334,7 +334,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test
     public void distinctUntilChangedFunctionReturnsNull() {
-        Flowable.range(1, 2).distinctUntilChanged((Function<Integer, Object>) _ -> null).test().assertResult(1);
+        Flowable.range(1, 2).distinctUntilChanged(_ -> null).test().assertResult(1);
     }
 
     @Test(expected = NullPointerException.class)
@@ -482,13 +482,13 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void replayBoundedSelectorReturnsNull() {
-        just1.replay((Function<Flowable<Integer>, Publisher<Object>>) _ -> null, 1, 1, TimeUnit.SECONDS)
+        just1.replay(_ -> null, 1, 1, TimeUnit.SECONDS)
         .blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void replayTimeBoundedSelectorReturnsNull() {
-        just1.replay((Function<Flowable<Integer>, Publisher<Object>>) _ -> null, 1, TimeUnit.SECONDS, Schedulers.single())
+        just1.replay(_ -> null, 1, TimeUnit.SECONDS, Schedulers.single())
         .blockingSubscribe();
     }
 
@@ -556,7 +556,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void timeoutFirstItemReturnsNull() {
-        just1.timeout(Flowable.never(), (Function<Integer, Publisher<Object>>) _ -> null).blockingSubscribe();
+        just1.timeout(Flowable.never(), _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
@@ -622,7 +622,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void withLatestFromCombinerReturnsNull() {
-        just1.withLatestFrom(just1, (BiFunction<Integer, Integer, Object>) (_, _) -> null)
+        just1.withLatestFrom(just1, (_, _) -> null)
         .blockingSubscribe();
     }
 
@@ -633,7 +633,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipWithIterableCombinerReturnsNull() {
-        just1.zipWith(Arrays.asList(1), (BiFunction<Integer, Integer, Object>) (_, _) -> null)
+        just1.zipWith(Arrays.asList(1), (_, _) -> null)
         .blockingSubscribe();
     }
 
@@ -656,7 +656,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipWithCombinerReturnsNull() {
-        just1.zipWith(just1, (BiFunction<Integer, Integer, Object>) (_, _) -> null).blockingSubscribe();
+        just1.zipWith(just1, (_, _) -> null).blockingSubscribe();
     }
 
     //*********************************************

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
@@ -26,7 +26,6 @@ import org.mockito.InOrder;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.flowables.ConnectableFlowable;
@@ -849,7 +848,7 @@ public class FlowableTests extends RxJavaTest {
     @Test
     public void compose() {
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
-        Flowable.just(1, 2, 3).compose(t1 -> t1.map((Function<Integer, String>) String::valueOf))
+        Flowable.just(1, 2, 3).compose(t1 -> t1.map(String::valueOf))
         .subscribe(ts);
         ts.assertTerminated();
         ts.assertNoErrors();
@@ -923,7 +922,7 @@ public class FlowableTests extends RxJavaTest {
 
     @Test
     public void as() {
-        Flowable.just(1).to((FlowableConverter<Integer, Observable<Integer>>) Flowable::toObservable)
+        Flowable.just(1).to(Flowable::toObservable)
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromPublisherTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.completable;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class CompletableFromPublisherTest extends RxJavaTest {
@@ -49,6 +48,6 @@ public class CompletableFromPublisherTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowableToCompletable(
-        (Function<Flowable<Object>, Completable>) Completable::fromPublisher);
+                Completable::fromPublisher);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMaterializeTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.subjects.CompletableSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -43,7 +42,7 @@ public class CompletableMaterializeTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeCompletableToSingle(
-                (Function<Completable, SingleSource<Notification<Object>>>) Completable::materialize);
+                Completable::materialize);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAllTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAllTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
@@ -45,7 +44,7 @@ public class FlowableAllTest extends RxJavaTest {
         obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onSuccess(true);
         verifyNoMoreInteractions(observer);
     }
@@ -59,7 +58,7 @@ public class FlowableAllTest extends RxJavaTest {
         obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onSuccess(false);
         verifyNoMoreInteractions(observer);
     }
@@ -73,7 +72,7 @@ public class FlowableAllTest extends RxJavaTest {
         obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onSuccess(true);
         verifyNoMoreInteractions(observer);
     }
@@ -88,7 +87,7 @@ public class FlowableAllTest extends RxJavaTest {
         obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onError(error);
         verifyNoMoreInteractions(observer);
     }
@@ -152,7 +151,7 @@ public class FlowableAllTest extends RxJavaTest {
         .toFlowable()
         .subscribe(subscriber);
 
-        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber).onSubscribe(any());
         verify(subscriber).onNext(true);
         verify(subscriber).onComplete();
         verifyNoMoreInteractions(subscriber);
@@ -168,7 +167,7 @@ public class FlowableAllTest extends RxJavaTest {
         .toFlowable()
         .subscribe(subscriber);
 
-        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber).onSubscribe(any());
         verify(subscriber).onNext(false);
         verify(subscriber).onComplete();
         verifyNoMoreInteractions(subscriber);
@@ -184,7 +183,7 @@ public class FlowableAllTest extends RxJavaTest {
         .toFlowable()
         .subscribe(subscriber);
 
-        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber).onSubscribe(any());
         verify(subscriber).onNext(true);
         verify(subscriber).onComplete();
         verifyNoMoreInteractions(subscriber);
@@ -201,7 +200,7 @@ public class FlowableAllTest extends RxJavaTest {
         .toFlowable()
         .subscribe(subscriber);
 
-        verify(subscriber).onSubscribe((Subscription)any());
+        verify(subscriber).onSubscribe(any());
         verify(subscriber).onError(error);
         verifyNoMoreInteractions(subscriber);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBlockingTest.java
@@ -64,7 +64,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
-                .blockingSubscribe((Consumer<Integer>) v -> list.add(v), 128);
+                .blockingSubscribe(v -> list.add(v), 128);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -75,7 +75,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
-                .blockingSubscribe((Consumer<Integer>) v -> list.add(v), 3);
+                .blockingSubscribe(v -> list.add(v), 3);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -86,7 +86,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe((Consumer<Integer>) v -> list.add(v), Functions.emptyConsumer());
+        .blockingSubscribe(v -> list.add(v), Functions.emptyConsumer());
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -97,7 +97,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
-                .blockingSubscribe((Consumer<Integer>) v -> list.add(v), Functions.emptyConsumer(), 128);
+                .blockingSubscribe(v -> list.add(v), Functions.emptyConsumer(), 128);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -108,7 +108,7 @@ public class FlowableBlockingTest extends RxJavaTest {
 
         Flowable.range(1, 5)
                 .subscribeOn(Schedulers.computation())
-                .blockingSubscribe((Consumer<Integer>) v -> list.add(v), Functions.emptyConsumer(), 3);
+                .blockingSubscribe(v -> list.add(v), Functions.emptyConsumer(), 3);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
@@ -1652,7 +1652,7 @@ public class FlowableBufferTest extends RxJavaTest {
     public void bufferedCanCompleteIfOpenNeverCompletesDropping() {
         Flowable.range(1, 50)
                 .zipWith(Flowable.interval(5, TimeUnit.MILLISECONDS),
-                        (BiFunction<Integer, Long, Integer>) (integer, _) -> integer)
+                        (integer, _) -> integer)
                 .buffer(Flowable.interval(0, 200, TimeUnit.MILLISECONDS),
                         (Function<Long, Publisher<?>>) a -> Flowable.just(a).delay(100, TimeUnit.MILLISECONDS))
                 .to(TestHelper.<List<Integer>>testConsumer())
@@ -1665,7 +1665,7 @@ public class FlowableBufferTest extends RxJavaTest {
     public void bufferedCanCompleteIfOpenNeverCompletesOverlapping() {
         Flowable.range(1, 50)
                 .zipWith(Flowable.interval(5, TimeUnit.MILLISECONDS),
-                        (BiFunction<Integer, Long, Integer>) (integer, _) -> integer)
+                        (integer, _) -> integer)
                 .buffer(Flowable.interval(0, 100, TimeUnit.MILLISECONDS),
                         (Function<Long, Publisher<?>>) a -> Flowable.just(a).delay(200, TimeUnit.MILLISECONDS))
                 .to(TestHelper.<List<Integer>>testConsumer())
@@ -2041,7 +2041,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
         @SuppressWarnings("resource")
         BufferExactUnboundedSubscriber<Integer, List<Integer>> sub = new BufferExactUnboundedSubscriber<>(
-                ts, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
+                ts, Functions.justSupplier(new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2079,7 +2079,7 @@ public class FlowableBufferTest extends RxJavaTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<>(
-                ts, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
+                ts, Functions.justSupplier(new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2126,7 +2126,7 @@ public class FlowableBufferTest extends RxJavaTest {
         @SuppressWarnings("resource")
         BufferExactBoundedSubscriber<Integer, List<Integer>> sub =
                 new BufferExactBoundedSubscriber<>(
-                        ts, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()),
+                        ts, Functions.justSupplier(new ArrayList<Integer>()),
                         1, TimeUnit.SECONDS, 1, false, sch.createWorker())
         ;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -486,7 +486,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s2 = Flowable.just(2);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2,
-                (BiFunction<Integer, Integer, List<Integer>>) Arrays::asList);
+                Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -504,7 +504,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s3 = Flowable.just(3);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3,
-                (Function3<Integer, Integer, Integer, List<Integer>>) Arrays::asList);
+                Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -523,7 +523,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s4 = Flowable.just(4);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4,
-                (Function4<Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
+                Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -543,7 +543,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s5 = Flowable.just(5);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5,
-                (Function5<Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
+                Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -564,7 +564,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s6 = Flowable.just(6);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5, s6,
-                (Function6<Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
+                Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -586,7 +586,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s7 = Flowable.just(7);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5, s6, s7,
-                (Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
+                Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -609,7 +609,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s8 = Flowable.just(8);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5, s6, s7, s8,
-                (Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
+                Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -633,7 +633,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> s9 = Flowable.just(9);
 
         Flowable<List<Integer>> result = Flowable.combineLatest(s1, s2, s3, s4, s5, s6, s7, s8, s9,
-                (Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>) Arrays::asList);
+                Arrays::asList);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -932,11 +932,11 @@ public class FlowableCombineLatestTest extends RxJavaTest {
                 expected.add(1);
             }
 
-            Flowable.combineLatestArray(sources, (Function<Object[], List<Object>>) Arrays::asList)
+            Flowable.combineLatestArray(sources, Arrays::asList)
             .test()
             .assertResult(expected);
 
-            Flowable.combineLatestArrayDelayError(sources, (Function<Object[], List<Object>>) Arrays::asList)
+            Flowable.combineLatestArrayDelayError(sources, Arrays::asList)
             .test()
             .assertResult(expected);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCountTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class FlowableCountTest extends RxJavaTest {
@@ -51,7 +50,7 @@ public class FlowableCountTest extends RxJavaTest {
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(f -> f.count().toFlowable());
 
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle((Function<Flowable<Object>, SingleSource<Long>>) Flowable::count);
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(Flowable::count);
     }
 
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounceTest.java
@@ -54,16 +54,13 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceWithOnDroppedCallbackWithEx() throws Throwable {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
-                publishNext(subscriber, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
-                publishNext(subscriber, 900, "three");   // Should be skipped since "four" will arrive before the timout expires.
-                publishNext(subscriber, 999, "four");   // Should be skipped since onComplete will arrive before the timeout expires.
-                publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
+            publishNext(subscriber, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
+            publishNext(subscriber, 900, "three");   // Should be skipped since "four" will arrive before the timout expires.
+            publishNext(subscriber, 999, "four");   // Should be skipped since onComplete will arrive before the timeout expires.
+            publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Action whenDisposed = mock(Action.class);
@@ -91,16 +88,13 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceWithOnDroppedCallback() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
-                publishNext(subscriber, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
-                publishNext(subscriber, 900, "three");   // Should be skipped since "four" will arrive before the timout expires.
-                publishNext(subscriber, 999, "four");   // Should be skipped since onComplete will arrive before the timeout expires.
-                publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
+            publishNext(subscriber, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
+            publishNext(subscriber, 900, "three");   // Should be skipped since "four" will arrive before the timout expires.
+            publishNext(subscriber, 999, "four");   // Should be skipped since onComplete will arrive before the timeout expires.
+            publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Observer<Object> dropCallbackObserver = TestHelper.mockObserver();
@@ -124,15 +118,12 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceWithCompleted() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
-                publishNext(subscriber, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
-                publishNext(subscriber, 900, "three");   // Should be skipped since onComplete will arrive before the timeout expires.
-                publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
+            publishNext(subscriber, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
+            publishNext(subscriber, 900, "three");   // Should be skipped since onComplete will arrive before the timeout expires.
+            publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Flowable<String> sampled = source.debounce(400, TimeUnit.MILLISECONDS, scheduler);
@@ -150,21 +141,18 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceNeverEmits() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                // all should be skipped since they are happening faster than the 200ms timeout
-                publishNext(subscriber, 100, "a");    // Should be skipped
-                publishNext(subscriber, 200, "b");    // Should be skipped
-                publishNext(subscriber, 300, "c");    // Should be skipped
-                publishNext(subscriber, 400, "d");    // Should be skipped
-                publishNext(subscriber, 500, "e");    // Should be skipped
-                publishNext(subscriber, 600, "f");    // Should be skipped
-                publishNext(subscriber, 700, "g");    // Should be skipped
-                publishNext(subscriber, 800, "h");    // Should be skipped
-                publishCompleted(subscriber, 900);     // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            // all should be skipped since they are happening faster than the 200ms timeout
+            publishNext(subscriber, 100, "a");    // Should be skipped
+            publishNext(subscriber, 200, "b");    // Should be skipped
+            publishNext(subscriber, 300, "c");    // Should be skipped
+            publishNext(subscriber, 400, "d");    // Should be skipped
+            publishNext(subscriber, 500, "e");    // Should be skipped
+            publishNext(subscriber, 600, "f");    // Should be skipped
+            publishNext(subscriber, 700, "g");    // Should be skipped
+            publishNext(subscriber, 800, "h");    // Should be skipped
+            publishCompleted(subscriber, 900);     // Should be published as soon as the timeout expires.
         });
 
         Flowable<String> sampled = source.debounce(200, TimeUnit.MILLISECONDS, scheduler);
@@ -180,15 +168,12 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceWithError() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                Exception error = new TestException();
-                publishNext(subscriber, 100, "one");    // Should be published since "two" will arrive after the timeout expires.
-                publishNext(subscriber, 600, "two");    // Should be skipped since onError will arrive before the timeout expires.
-                publishError(subscriber, 700, error);   // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            Exception error = new TestException();
+            publishNext(subscriber, 100, "one");    // Should be published since "two" will arrive after the timeout expires.
+            publishNext(subscriber, 600, "two");    // Should be skipped since onError will arrive before the timeout expires.
+            publishError(subscriber, 700, error);   // Should be published as soon as the timeout expires.
         });
 
         Flowable<String> sampled = source.debounce(400, TimeUnit.MILLISECONDS, scheduler);
@@ -205,43 +190,22 @@ public class FlowableDebounceTest extends RxJavaTest {
     }
 
     private <T> void publishCompleted(final Subscriber<T> subscriber, long delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onComplete();
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onComplete(), delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishError(final Subscriber<T> subscriber, long delay, final Exception error) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onError(error);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onError(error), delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishNext(final Subscriber<T> subscriber, final long delay, final T value) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onNext(value);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onNext(value), delay, TimeUnit.MILLISECONDS);
     }
 
     @Test
     public void debounceSelectorNormal1() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> debouncer = PublishProcessor.create();
-        Function<Integer, Flowable<Integer>> debounceSel = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return debouncer;
-            }
-        };
+        Function<Integer, Flowable<Integer>> debounceSel = _ -> debouncer;
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -271,12 +235,8 @@ public class FlowableDebounceTest extends RxJavaTest {
     @Test
     public void debounceSelectorFuncThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();
-        Function<Integer, Flowable<Integer>> debounceSel = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Flowable<Integer>> debounceSel = _ -> {
+            throw new TestException();
         };
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -293,13 +253,7 @@ public class FlowableDebounceTest extends RxJavaTest {
     @Test
     public void debounceSelectorFlowableThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();
-        Function<Integer, Flowable<Integer>> debounceSel = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return Flowable.error(new TestException());
-            }
-        };
+        Function<Integer, Flowable<Integer>> debounceSel = _ -> Flowable.error(new TestException());
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -335,13 +289,7 @@ public class FlowableDebounceTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> debouncer = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> debounceSel = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return debouncer;
-            }
-        };
+        Function<Integer, Flowable<Integer>> debounceSel = _ -> debouncer;
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -414,7 +362,7 @@ public class FlowableDebounceTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -436,29 +384,9 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void badSourceSelector() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.debounce(new Function<Integer, Flowable<Long>>() {
-                    @Override
-                    public Flowable<Long> apply(Integer v) throws Exception {
-                        return Flowable.timer(1, TimeUnit.SECONDS);
-                    }
-                });
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.debounce(_ -> Flowable.timer(1, TimeUnit.SECONDS)), false, 1, 1, 1);
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(final Flowable<Integer> f) throws Exception {
-                return Flowable.just(1).debounce(new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) throws Exception {
-                        return f;
-                    }
-                });
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> Flowable.just(1).debounce(_ -> f), false, 1, 1, 1);
     }
 
     @Test
@@ -488,12 +416,7 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.debounce(Functions.justFunction(Flowable.never()));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.debounce(Functions.justFunction(Flowable.never())));
     }
 
     @Test
@@ -501,12 +424,9 @@ public class FlowableDebounceTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         BehaviorProcessor.createDefault(1)
-        .debounce(new Function<Integer, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Integer o) throws Exception {
-                ts.cancel();
-                return Flowable.never();
-            }
+        .debounce(_ -> {
+            ts.cancel();
+            return Flowable.never();
         })
         .subscribeWith(ts)
         .assertEmpty();
@@ -518,7 +438,7 @@ public class FlowableDebounceTest extends RxJavaTest {
     public void disposedInOnComplete() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -536,20 +456,17 @@ public class FlowableDebounceTest extends RxJavaTest {
         final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<>();
 
         TestSubscriber<Integer> ts = Flowable.range(1, 2)
-        .debounce(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer o) throws Exception {
-                if (o != 1) {
-                    return Flowable.never();
-                }
-                return new Flowable<Integer>() {
-                    @Override
-                    protected void subscribeActual(Subscriber<? super Integer> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        ref.set(subscriber);
-                    }
-                };
+        .debounce((Function<Integer, Flowable<Integer>>) o -> {
+            if (o != 1) {
+                return Flowable.never();
             }
+            return new Flowable<Integer>() /* NFI */ {
+                @Override
+                protected void subscribeActual(Subscriber<? super Integer> subscriber) {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    ref.set(subscriber);
+                }
+            };
         })
         .test();
 
@@ -566,20 +483,14 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void timedDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.debounce(1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.debounce(1, TimeUnit.SECONDS));
     }
 
     @Test
     public void timedDisposedIgnoredBySource() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(
                     Subscriber<? super Integer> s) {
@@ -624,11 +535,6 @@ public class FlowableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceOnEmpty() {
-        Flowable.empty().debounce(new Function<Object, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Object o) {
-                return Flowable.just(new Object());
-            }
-        }).subscribe();
+        Flowable.empty().debounce(_ -> Flowable.just(new Object())).subscribe();
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -283,7 +283,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         try {
             for (Scheduler s : new Scheduler[] {
                     Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(),
-                    Schedulers.from(exec), Schedulers.virtual()
+                    Schedulers.from(exec)
                 }) {
                 final TestSubscriber<Boolean> ts = TestSubscriber.create();
                 ts.withTag(s.getClass().getSimpleName());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelaySubscriptionOtherTest.java
@@ -17,11 +17,9 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -37,12 +35,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Flowable.just(1)
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(ts);
 
@@ -70,12 +63,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Flowable.just(1)
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(ts);
 
@@ -104,12 +92,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Flowable.just(1)
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(ts);
 
@@ -137,12 +120,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Flowable.<Integer>error(new TestException())
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(ts);
 
@@ -170,12 +148,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Flowable.<Integer>error(new TestException())
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(ts);
 
@@ -204,12 +177,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Flowable.just(1, 2, 3, 4, 5)
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(ts);
 
@@ -293,12 +261,7 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicBoolean subscribed = new AtomicBoolean(false);
 
         Flowable.just(1)
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                subscribed.set(true);
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.set(true))
         .delaySubscription(delayUntil)
         .takeUntil(interrupt)
         .subscribe();
@@ -311,28 +274,23 @@ public class FlowableDelaySubscriptionOtherTest extends RxJavaTest {
 
     @Test
     public void badSourceOther() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return Flowable.just(1).delaySubscription(f);
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> Flowable.just(1).delaySubscription(f), false, 1, 1, 1);
     }
 
     @Test
     public void afterDelayNoInterrupt() {
         ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
         try {
-            for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec) }) {
+            for (Scheduler s : new Scheduler[] {
+                    Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(),
+                    Schedulers.from(exec), Schedulers.virtual()
+                }) {
                 final TestSubscriber<Boolean> ts = TestSubscriber.create();
                 ts.withTag(s.getClass().getSimpleName());
 
-                Flowable.<Boolean>create(new FlowableOnSubscribe<Boolean>() {
-                    @Override
-                    public void subscribe(FlowableEmitter<Boolean> emitter) throws Exception {
-                      emitter.onNext(Thread.interrupted());
-                      emitter.onComplete();
-                    }
+                Flowable.<Boolean>create(emitter -> {
+                  emitter.onNext(Thread.interrupted());
+                  emitter.onComplete();
                 }, BackpressureStrategy.MISSING)
                 .delaySubscription(100, TimeUnit.MILLISECONDS, s)
                 .subscribe(ts);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
@@ -273,7 +273,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        source.flatMap(just(onNext), funcThrow((Throwable) null, onError), just0(onComplete)).subscribe(subscriber);
+        source.flatMap(just(onNext), funcThrow(null, onError), just0(onComplete)).subscribe(subscriber);
 
         verify(subscriber).onError(any(CompositeException.class));
         verify(subscriber, never()).onNext(any());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapNotificationTest.java
@@ -35,7 +35,7 @@ public class FlowableMapNotificationTest extends RxJavaTest {
                 new Function<Integer, Flowable<Object>>() {
                     @Override
                     public Flowable<Object> apply(Integer item) {
-                        return Flowable.just((Object)(item + 1));
+                        return Flowable.just(item + 1);
                     }
                 },
                 new Function<Throwable, Flowable<Object>>() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
@@ -344,9 +344,8 @@ public class FlowablePublishTest extends RxJavaTest {
         assertFalse(checkPublishDisposed(connection3));
     }
 
-    @SuppressWarnings("unchecked")
     static boolean checkPublishDisposed(Disposable d) {
-        return ((FlowablePublish.PublishConnection<Object>)d).isDisposed();
+        return d.isDisposed();
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -536,8 +536,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         replay.subscribe(spiedSubscriberAfterConnect);
         replay.subscribe(spiedSubscriberAfterConnect);
 
-        verify(spiedSubscriberBeforeConnect, times(2)).onSubscribe((Subscription)any());
-        verify(spiedSubscriberAfterConnect, times(2)).onSubscribe((Subscription)any());
+        verify(spiedSubscriberBeforeConnect, times(2)).onSubscribe(any());
+        verify(spiedSubscriberAfterConnect, times(2)).onSubscribe(any());
 
         // verify interactions
         verify(sourceNext, times(1)).accept(1);
@@ -589,8 +589,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         replay.subscribe(mockObserverAfterConnect);
         replay.subscribe(mockObserverAfterConnect);
 
-        verify(mockObserverBeforeConnect, times(2)).onSubscribe((Subscription)any());
-        verify(mockObserverAfterConnect, times(2)).onSubscribe((Subscription)any());
+        verify(mockObserverBeforeConnect, times(2)).onSubscribe(any());
+        verify(mockObserverAfterConnect, times(2)).onSubscribe(any());
 
         // verify interactions
         verify(sourceNext, times(1)).accept(1);
@@ -598,7 +598,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         verify(sourceNext, times(1)).accept(3);
         verify(sourceCompleted, times(1)).run();
         verify(mockScheduler, times(1)).createWorker();
-        verify(spiedWorker, times(1)).schedule((Runnable)notNull());
+        verify(spiedWorker, times(1)).schedule(notNull());
         verifyObserverMock(mockObserverBeforeConnect, 2, 6);
         verifyObserverMock(mockObserverAfterConnect, 2, 6);
 
@@ -655,12 +655,12 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         replay.subscribe(mockObserverAfterConnect);
         replay.subscribe(mockObserverAfterConnect);
 
-        verify(mockObserverBeforeConnect, times(2)).onSubscribe((Subscription)any());
-        verify(mockObserverAfterConnect, times(2)).onSubscribe((Subscription)any());
+        verify(mockObserverBeforeConnect, times(2)).onSubscribe(any());
+        verify(mockObserverAfterConnect, times(2)).onSubscribe(any());
 
         // verify interactions
         verify(mockScheduler, times(1)).createWorker();
-        verify(spiedWorker, times(1)).schedule((Runnable)notNull());
+        verify(spiedWorker, times(1)).schedule(notNull());
         verify(sourceNext, times(1)).accept(1);
         verify(sourceError, times(1)).accept(illegalArgumentException);
         verifyObserver(mockObserverBeforeConnect, 2, 2, illegalArgumentException);
@@ -682,13 +682,13 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     }
 
     private static void verifyObserverMock(Subscriber<Integer> mock, int numSubscriptions, int numItemsExpected) {
-        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
+        verify(mock, times(numItemsExpected)).onNext(notNull());
         verify(mock, times(numSubscriptions)).onComplete();
         verifyNoMoreInteractions(mock);
     }
 
     private static void verifyObserver(Subscriber<Integer> mock, int numSubscriptions, int numItemsExpected, Throwable error) {
-        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
+        verify(mock, times(numItemsExpected)).onNext(notNull());
         verify(mock, times(numSubscriptions)).onError(error);
         verifyNoMoreInteractions(mock);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -539,8 +539,8 @@ public class FlowableReplayTest extends RxJavaTest {
         replay.subscribe(spiedSubscriberAfterConnect);
         replay.subscribe(spiedSubscriberAfterConnect);
 
-        verify(spiedSubscriberBeforeConnect, times(2)).onSubscribe((Subscription)any());
-        verify(spiedSubscriberAfterConnect, times(2)).onSubscribe((Subscription)any());
+        verify(spiedSubscriberBeforeConnect, times(2)).onSubscribe(any());
+        verify(spiedSubscriberAfterConnect, times(2)).onSubscribe(any());
 
         // verify interactions
         verify(sourceNext, times(1)).accept(1);
@@ -592,8 +592,8 @@ public class FlowableReplayTest extends RxJavaTest {
         replay.subscribe(mockObserverAfterConnect);
         replay.subscribe(mockObserverAfterConnect);
 
-        verify(mockObserverBeforeConnect, times(2)).onSubscribe((Subscription)any());
-        verify(mockObserverAfterConnect, times(2)).onSubscribe((Subscription)any());
+        verify(mockObserverBeforeConnect, times(2)).onSubscribe(any());
+        verify(mockObserverAfterConnect, times(2)).onSubscribe(any());
 
         // verify interactions
         verify(sourceNext, times(1)).accept(1);
@@ -601,7 +601,7 @@ public class FlowableReplayTest extends RxJavaTest {
         verify(sourceNext, times(1)).accept(3);
         verify(sourceCompleted, times(1)).run();
         verify(mockScheduler, times(1)).createWorker();
-        verify(spiedWorker, times(1)).schedule((Runnable)notNull());
+        verify(spiedWorker, times(1)).schedule(notNull());
         verifyObserverMock(mockObserverBeforeConnect, 2, 6);
         verifyObserverMock(mockObserverAfterConnect, 2, 6);
 
@@ -658,12 +658,12 @@ public class FlowableReplayTest extends RxJavaTest {
         replay.subscribe(mockObserverAfterConnect);
         replay.subscribe(mockObserverAfterConnect);
 
-        verify(mockObserverBeforeConnect, times(2)).onSubscribe((Subscription)any());
-        verify(mockObserverAfterConnect, times(2)).onSubscribe((Subscription)any());
+        verify(mockObserverBeforeConnect, times(2)).onSubscribe(any());
+        verify(mockObserverAfterConnect, times(2)).onSubscribe(any());
 
         // verify interactions
         verify(mockScheduler, times(1)).createWorker();
-        verify(spiedWorker, times(1)).schedule((Runnable)notNull());
+        verify(spiedWorker, times(1)).schedule(notNull());
         verify(sourceNext, times(1)).accept(1);
         verify(sourceError, times(1)).accept(illegalArgumentException);
         verifyObserver(mockObserverBeforeConnect, 2, 2, illegalArgumentException);
@@ -685,13 +685,13 @@ public class FlowableReplayTest extends RxJavaTest {
     }
 
     private static void verifyObserverMock(Subscriber<Integer> mock, int numSubscriptions, int numItemsExpected) {
-        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
+        verify(mock, times(numItemsExpected)).onNext(notNull());
         verify(mock, times(numSubscriptions)).onComplete();
         verifyNoMoreInteractions(mock);
     }
 
     private static void verifyObserver(Subscriber<Integer> mock, int numSubscriptions, int numItemsExpected, Throwable error) {
-        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
+        verify(mock, times(numItemsExpected)).onNext(notNull());
         verify(mock, times(numSubscriptions)).onError(error);
         verifyNoMoreInteractions(mock);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
@@ -213,7 +213,7 @@ public class FlowableRetryTest extends RxJavaTest {
         }).subscribe(ts);
 
         InOrder inOrder = inOrder(subscriber);
-        inOrder.verify(subscriber).onSubscribe((Subscription)notNull());
+        inOrder.verify(subscriber).onSubscribe(notNull());
         inOrder.verify(subscriber, never()).onNext("beginningEveryTime");
         inOrder.verify(subscriber, never()).onNext("onSuccessOnly");
         inOrder.verify(subscriber, times(1)).onComplete();
@@ -233,7 +233,7 @@ public class FlowableRetryTest extends RxJavaTest {
         }).subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
-        inOrder.verify(subscriber).onSubscribe((Subscription)notNull());
+        inOrder.verify(subscriber).onSubscribe(notNull());
         inOrder.verify(subscriber, never()).onNext("beginningEveryTime");
         inOrder.verify(subscriber, never()).onNext("onSuccessOnly");
         inOrder.verify(subscriber, never()).onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
@@ -130,7 +130,7 @@ public class FlowableTakeTest extends RxJavaTest {
 
             source.take(1).subscribe(subscriber);
 
-            verify(subscriber).onSubscribe((Subscription)notNull());
+            verify(subscriber).onSubscribe(notNull());
             verify(subscriber, times(1)).onNext("one");
             // even though onError is called we take(1) so shouldn't see it
             verify(subscriber, never()).onError(any(Throwable.class));
@@ -183,7 +183,7 @@ public class FlowableTakeTest extends RxJavaTest {
         }
 
         System.out.println("TestFlowable thread finished");
-        verify(subscriber).onSubscribe((Subscription)notNull());
+        verify(subscriber).onSubscribe(notNull());
         verify(subscriber, times(1)).onNext("one");
         verify(subscriber, never()).onNext("two");
         verify(subscriber, never()).onNext("three");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -366,7 +366,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         assertFalse("CoundDownLatch timeout", latchTimeout.get());
 
         InOrder inOrder = inOrder(subscriber);
-        inOrder.verify(subscriber).onSubscribe((Subscription)notNull());
+        inOrder.verify(subscriber).onSubscribe(notNull());
         inOrder.verify(subscriber).onNext(1);
         inOrder.verify(subscriber).onNext(2);
         inOrder.verify(subscriber, never()).onNext(3);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOfTypeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOfTypeTest.java
@@ -37,7 +37,7 @@ public class MaybeOfTypeTest extends RxJavaTest {
         .ofType(Number.class)
         .test();
         // don't make this fluent, target type required!
-        to.assertResult((Number)1);
+        to.assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
@@ -227,7 +227,7 @@ public class MaybeZipArrayTest extends RxJavaTest {
         AtomicReference<MaybeObserver<? super Integer>> emitter = new AtomicReference<>();
 
         TestObserver<List<Object>> to = Maybe.zipArray(Arrays::asList,
-                (MaybeSource<Integer>)o -> emitter.set(o), Maybe.<Integer>never())
+                        o -> emitter.set(o), Maybe.<Integer>never())
         .test();
 
         emitter.get().onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAllTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAllTest.java
@@ -46,7 +46,7 @@ public class ObservableAllTest extends RxJavaTest {
         }).toObservable()
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onNext(true);
         verify(observer).onComplete();
         verifyNoMoreInteractions(observer);
@@ -66,7 +66,7 @@ public class ObservableAllTest extends RxJavaTest {
         }).toObservable()
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onNext(false);
         verify(observer).onComplete();
         verifyNoMoreInteractions(observer);
@@ -86,7 +86,7 @@ public class ObservableAllTest extends RxJavaTest {
         }).toObservable()
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onNext(true);
         verify(observer).onComplete();
         verifyNoMoreInteractions(observer);
@@ -107,7 +107,7 @@ public class ObservableAllTest extends RxJavaTest {
         }).toObservable()
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onError(error);
         verifyNoMoreInteractions(observer);
     }
@@ -180,7 +180,7 @@ public class ObservableAllTest extends RxJavaTest {
         })
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onSuccess(true);
         verifyNoMoreInteractions(observer);
     }
@@ -199,7 +199,7 @@ public class ObservableAllTest extends RxJavaTest {
         })
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onSuccess(false);
         verifyNoMoreInteractions(observer);
     }
@@ -218,7 +218,7 @@ public class ObservableAllTest extends RxJavaTest {
         })
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onSuccess(true);
         verifyNoMoreInteractions(observer);
     }
@@ -238,7 +238,7 @@ public class ObservableAllTest extends RxJavaTest {
         })
         .subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)any());
+        verify(observer).onSubscribe(any());
         verify(observer).onError(error);
         verifyNoMoreInteractions(observer);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
@@ -1618,7 +1618,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         @SuppressWarnings("resource")
         BufferExactUnboundedObserver<Integer, List<Integer>> sub = new BufferExactUnboundedObserver<>(
-                to, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
+                to, Functions.justSupplier(new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
 
         sub.onSubscribe(Disposable.empty());
 
@@ -1669,7 +1669,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         @SuppressWarnings("resource")
         BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<>(
-                to, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
+                to, Functions.justSupplier(new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(Disposable.empty());
 
@@ -1717,7 +1717,7 @@ public class ObservableBufferTest extends RxJavaTest {
         @SuppressWarnings("resource")
         BufferExactBoundedObserver<Integer, List<Integer>> sub =
                 new BufferExactBoundedObserver<>(
-                        to, Functions.justSupplier((List<Integer>) new ArrayList<Integer>()),
+                        to, Functions.justSupplier(new ArrayList<Integer>()),
                         1, TimeUnit.SECONDS, 1, false, sch.createWorker())
         ;
 
@@ -1760,7 +1760,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         @SuppressWarnings("resource")
         BufferExactObserver<Integer, List<Integer>> sub = new BufferExactObserver<>(
-                to, 1, Functions.justSupplier((List<Integer>) new ArrayList<Integer>())
+                to, 1, Functions.justSupplier(new ArrayList<Integer>())
         );
 
         sub.onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -266,7 +266,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
         Observer<Object> o = TestHelper.mockObserver();
 
-        source.flatMap(just(onNext), funcThrow((Throwable) null, onError), just0(onComplete)).subscribe(o);
+        source.flatMap(just(onNext), funcThrow(null, onError), just0(onComplete)).subscribe(o);
 
         verify(o).onError(any(CompositeException.class));
         verify(o, never()).onNext(any());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMapNotificationTest.java
@@ -33,7 +33,7 @@ public class ObservableMapNotificationTest extends RxJavaTest {
                 new Function<Integer, Observable<Object>>() {
                     @Override
                     public Observable<Object> apply(Integer item) {
-                        return Observable.just((Object)(item + 1));
+                        return Observable.just(item + 1);
                     }
                 },
                 new Function<Throwable, Observable<Object>>() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishTest.java
@@ -343,9 +343,8 @@ public class ObservablePublishTest extends RxJavaTest {
         assertFalse(checkPublishDisposed(connection3));
     }
 
-    @SuppressWarnings("unchecked")
     static boolean checkPublishDisposed(Disposable d) {
-        return ((ObservablePublish.PublishConnection<Object>)d).isDisposed();
+        return d.isDisposed();
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -536,8 +536,8 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         replay.subscribe(spiedSubscriberAfterConnect);
         replay.subscribe(spiedSubscriberAfterConnect);
 
-        verify(spiedSubscriberBeforeConnect, times(2)).onSubscribe((Disposable)any());
-        verify(spiedSubscriberAfterConnect, times(2)).onSubscribe((Disposable)any());
+        verify(spiedSubscriberBeforeConnect, times(2)).onSubscribe(any());
+        verify(spiedSubscriberAfterConnect, times(2)).onSubscribe(any());
 
         // verify interactions
         verify(sourceNext, times(1)).accept(1);
@@ -584,8 +584,8 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         replay.connect();
         replay.subscribe(mockObserverAfterConnect);
 
-        verify(mockObserverBeforeConnect).onSubscribe((Disposable)any());
-        verify(mockObserverAfterConnect).onSubscribe((Disposable)any());
+        verify(mockObserverBeforeConnect).onSubscribe(any());
+        verify(mockObserverAfterConnect).onSubscribe(any());
 
         mockScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
@@ -642,8 +642,8 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         replay.connect();
         replay.subscribe(mockObserverAfterConnect);
 
-        verify(mockObserverBeforeConnect).onSubscribe((Disposable)any());
-        verify(mockObserverAfterConnect).onSubscribe((Disposable)any());
+        verify(mockObserverBeforeConnect).onSubscribe(any());
+        verify(mockObserverAfterConnect).onSubscribe(any());
 
         mockScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
         // verify interactions
@@ -666,13 +666,13 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     }
 
     private static void verifyObserverMock(Observer<Integer> mock, int numSubscriptions, int numItemsExpected) {
-        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
+        verify(mock, times(numItemsExpected)).onNext(notNull());
         verify(mock, times(numSubscriptions)).onComplete();
         verifyNoMoreInteractions(mock);
     }
 
     private static void verifyObserver(Observer<Integer> mock, int numSubscriptions, int numItemsExpected, Throwable error) {
-        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
+        verify(mock, times(numItemsExpected)).onNext(notNull());
         verify(mock, times(numSubscriptions)).onError(error);
         verifyNoMoreInteractions(mock);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
@@ -536,8 +536,8 @@ public class ObservableReplayTest extends RxJavaTest {
         replay.subscribe(spiedSubscriberAfterConnect);
         replay.subscribe(spiedSubscriberAfterConnect);
 
-        verify(spiedSubscriberBeforeConnect, times(2)).onSubscribe((Disposable)any());
-        verify(spiedSubscriberAfterConnect, times(2)).onSubscribe((Disposable)any());
+        verify(spiedSubscriberBeforeConnect, times(2)).onSubscribe(any());
+        verify(spiedSubscriberAfterConnect, times(2)).onSubscribe(any());
 
         // verify interactions
         verify(sourceNext, times(1)).accept(1);
@@ -584,8 +584,8 @@ public class ObservableReplayTest extends RxJavaTest {
         replay.connect();
         replay.subscribe(mockObserverAfterConnect);
 
-        verify(mockObserverBeforeConnect).onSubscribe((Disposable)any());
-        verify(mockObserverAfterConnect).onSubscribe((Disposable)any());
+        verify(mockObserverBeforeConnect).onSubscribe(any());
+        verify(mockObserverAfterConnect).onSubscribe(any());
 
         mockScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
@@ -642,8 +642,8 @@ public class ObservableReplayTest extends RxJavaTest {
         replay.connect();
         replay.subscribe(mockObserverAfterConnect);
 
-        verify(mockObserverBeforeConnect).onSubscribe((Disposable)any());
-        verify(mockObserverAfterConnect).onSubscribe((Disposable)any());
+        verify(mockObserverBeforeConnect).onSubscribe(any());
+        verify(mockObserverAfterConnect).onSubscribe(any());
 
         mockScheduler.advanceTimeBy(1, TimeUnit.SECONDS);
         // verify interactions
@@ -666,13 +666,13 @@ public class ObservableReplayTest extends RxJavaTest {
     }
 
     private static void verifyObserverMock(Observer<Integer> mock, int numSubscriptions, int numItemsExpected) {
-        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
+        verify(mock, times(numItemsExpected)).onNext(notNull());
         verify(mock, times(numSubscriptions)).onComplete();
         verifyNoMoreInteractions(mock);
     }
 
     private static void verifyObserver(Observer<Integer> mock, int numSubscriptions, int numItemsExpected, Throwable error) {
-        verify(mock, times(numItemsExpected)).onNext((Integer) notNull());
+        verify(mock, times(numItemsExpected)).onNext(notNull());
         verify(mock, times(numSubscriptions)).onError(error);
         verifyNoMoreInteractions(mock);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
@@ -214,7 +214,7 @@ public class ObservableRetryTest extends RxJavaTest {
         }).subscribe(to);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onSubscribe((Disposable)notNull());
+        inOrder.verify(observer).onSubscribe(notNull());
         inOrder.verify(observer, never()).onNext("beginningEveryTime");
         inOrder.verify(observer, never()).onNext("onSuccessOnly");
         inOrder.verify(observer, times(1)).onComplete();
@@ -234,7 +234,7 @@ public class ObservableRetryTest extends RxJavaTest {
         }).subscribe(observer);
 
         InOrder inOrder = inOrder(observer);
-        inOrder.verify(observer).onSubscribe((Disposable)notNull());
+        inOrder.verify(observer).onSubscribe(notNull());
         inOrder.verify(observer, never()).onNext("beginningEveryTime");
         inOrder.verify(observer, never()).onNext("onSuccessOnly");
         inOrder.verify(observer, never()).onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeTest.java
@@ -126,7 +126,7 @@ public class ObservableTakeTest extends RxJavaTest {
 
         source.take(1).subscribe(observer);
 
-        verify(observer).onSubscribe((Disposable)notNull());
+        verify(observer).onSubscribe(notNull());
         verify(observer, times(1)).onNext("one");
         // even though onError is called we take(1) so shouldn't see it
         verify(observer, never()).onError(any(Throwable.class));
@@ -153,7 +153,7 @@ public class ObservableTakeTest extends RxJavaTest {
         }
 
         System.out.println("TestObservable thread finished");
-        verify(observer).onSubscribe((Disposable)notNull());
+        verify(observer).onSubscribe(notNull());
         verify(observer, times(1)).onNext("one");
         verify(observer, never()).onNext("two");
         verify(observer, never()).onNext("three");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -366,7 +366,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
         assertFalse("CoundDownLatch timeout", latchTimeout.get());
 
         InOrder inOrder = inOrder(o);
-        inOrder.verify(o).onSubscribe((Disposable)notNull());
+        inOrder.verify(o).onSubscribe(notNull());
         inOrder.verify(o).onNext(1);
         inOrder.verify(o).onNext(2);
         inOrder.verify(o, never()).onNext(3);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayTest.java
@@ -253,7 +253,7 @@ public class SingleDelayTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeCompletableToSingle(new Function<Completable, Single<Object>>() {
             @Override
             public Single<Object> apply(Completable c) throws Exception {
-                return c.andThen(Single.just((Object)1));
+                return c.andThen(Single.just(1));
             }
         });
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
@@ -64,7 +64,7 @@ public class SingleMiscTest extends RxJavaTest {
         Single<Number> source = Single.just(1d)
                 .cast(Number.class);
         source.test()
-        .assertResult((Number)1d);
+        .assertResult(1d);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOfTypeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOfTypeTest.java
@@ -37,7 +37,7 @@ public class SingleOfTypeTest extends RxJavaTest {
         .ofType(Number.class)
         .test();
         // don't make this fluent, target type required!
-        to.assertResult((Number)1);
+        to.assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipArrayTest.java
@@ -221,7 +221,7 @@ public class SingleZipArrayTest extends RxJavaTest {
         AtomicReference<SingleObserver<? super Integer>> emitter = new AtomicReference<>();
 
         TestObserver<List<Object>> to = Single.zipArray(Arrays::asList,
-                (SingleSource<Integer>)o -> emitter.set(o), Single.<Integer>never())
+                        o -> emitter.set(o), Single.<Integer>never())
         .test();
 
         emitter.get().onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
@@ -205,7 +205,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void errorCallableReturnsNull() {
-        Maybe.error(Functions.justSupplier((Throwable)null))
+        Maybe.error(Functions.justSupplier(null))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -479,7 +479,7 @@ public class MaybeTest extends RxJavaTest {
     public void cast() {
         TestObserver<Number> to = Maybe.just(1).cast(Number.class).test();
         // don'n inline this due to the generic type
-        to.assertResult((Number)1);
+        to.assertResult(1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
@@ -465,7 +465,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void currentStateMethodsNormalSomeStart() {
-        BehaviorProcessor<Object> as = BehaviorProcessor.createDefault((Object)1);
+        BehaviorProcessor<Object> as = BehaviorProcessor.createDefault(1);
 
         assertTrue(as.hasValue());
         assertFalse(as.hasThrowable());
@@ -646,7 +646,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void subscribeOnNextRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final BehaviorProcessor<Object> p = BehaviorProcessor.createDefault((Object)1);
+            final BehaviorProcessor<Object> p = BehaviorProcessor.createDefault(1);
 
             final TestSubscriber[] ts = { null };
 
@@ -676,7 +676,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void firstBackpressured() {
-        BehaviorProcessor<Object> p = BehaviorProcessor.createDefault((Object)1);
+        BehaviorProcessor<Object> p = BehaviorProcessor.createDefault(1);
 
         p.test(0L, false).assertFailure(MissingBackpressureException.class);
 

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
@@ -130,10 +130,10 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         inOrderD.verify(observerD).onNext(4711);
         inOrderD.verify(observerD).onComplete();
 
-        verify(observerA).onSubscribe((Subscription)notNull());
-        verify(observerB).onSubscribe((Subscription)notNull());
-        verify(observerC).onSubscribe((Subscription)notNull());
-        verify(observerD).onSubscribe((Subscription)notNull());
+        verify(observerA).onSubscribe(notNull());
+        verify(observerB).onSubscribe(notNull());
+        verify(observerC).onSubscribe(notNull());
+        verify(observerD).onSubscribe(notNull());
         Mockito.verifyNoMoreInteractions(observerA);
         Mockito.verifyNoMoreInteractions(observerB);
         Mockito.verifyNoMoreInteractions(observerC);
@@ -155,7 +155,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         processor.onError(new RuntimeException());
 
         processor.subscribe(subscriber);
-        verify(subscriber).onSubscribe((Subscription)notNull());
+        verify(subscriber).onSubscribe(notNull());
         verify(subscriber, times(1)).onNext("one");
         verify(subscriber, times(1)).onError(testException);
         verifyNoMoreInteractions(subscriber);

--- a/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
@@ -465,7 +465,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
     @Test
     public void currentStateMethodsNormalSomeStart() {
-        BehaviorSubject<Object> as = BehaviorSubject.createDefault((Object)1);
+        BehaviorSubject<Object> as = BehaviorSubject.createDefault(1);
 
         assertTrue(as.hasValue());
         assertFalse(as.hasThrowable());
@@ -616,7 +616,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
     @Test
     public void subscribeOnNextRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final BehaviorSubject<Object> p = BehaviorSubject.createDefault((Object)1);
+            final BehaviorSubject<Object> p = BehaviorSubject.createDefault(1);
 
             final TestObserver[] to = { null };
 

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectTest.java
@@ -127,10 +127,10 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         inOrderD.verify(observerD).onNext(4711);
         inOrderD.verify(observerD).onComplete();
 
-        verify(observerA).onSubscribe((Disposable)notNull());
-        verify(observerB).onSubscribe((Disposable)notNull());
-        verify(observerC).onSubscribe((Disposable)notNull());
-        verify(observerD).onSubscribe((Disposable)notNull());
+        verify(observerA).onSubscribe(notNull());
+        verify(observerB).onSubscribe(notNull());
+        verify(observerC).onSubscribe(notNull());
+        verify(observerD).onSubscribe(notNull());
         Mockito.verifyNoMoreInteractions(observerA);
         Mockito.verifyNoMoreInteractions(observerB);
         Mockito.verifyNoMoreInteractions(observerC);
@@ -152,7 +152,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         subject.onError(new RuntimeException());
 
         subject.subscribe(observer);
-        verify(observer).onSubscribe((Disposable)notNull());
+        verify(observer).onSubscribe(notNull());
         verify(observer, times(1)).onNext("one");
         verify(observer, times(1)).onError(testException);
         verifyNoMoreInteractions(observer);

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -89,7 +89,7 @@ public enum TestHelper {
                 s.request(Long.MAX_VALUE);
                 return null;
             }
-        }).when(w).onSubscribe((Subscription)any());
+        }).when(w).onSubscribe(any());
 
         return w;
     }


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080