### PR TITLE
4.x: Unit test lambdaification 10 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelayTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 import java.util.concurrent.locks.LockSupport;
 
@@ -122,14 +123,11 @@ public class FlowableDelayTest extends RxJavaTest {
     @Test
     public void delayWithError() {
         Flowable<Long> source = Flowable.interval(1L, TimeUnit.SECONDS, scheduler)
-        .map(new Function<Long, Long>() {
-            @Override
-            public Long apply(Long value) {
-                if (value == 1L) {
-                    throw new RuntimeException("error!");
-                }
-                return value;
+        .map(value -> {
+            if (value == 1L) {
+                throw new RuntimeException("error!");
             }
+            return value;
         });
         Flowable<Long> delayed = source.delay(1L, TimeUnit.SECONDS, scheduler);
         delayed.subscribe(subscriber);
@@ -241,12 +239,7 @@ public class FlowableDelayTest extends RxJavaTest {
             delays.add(delay);
         }
 
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return delays.get(t1);
-            }
-        };
+        Function<Integer, Flowable<Integer>> delayFunc = t1 -> delays.get(t1);
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -271,13 +264,7 @@ public class FlowableDelayTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> delay;
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
 
@@ -297,13 +284,7 @@ public class FlowableDelayTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> delay;
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
 
@@ -322,12 +303,8 @@ public class FlowableDelayTest extends RxJavaTest {
     public void delayWithFlowableDelayFunctionThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> {
+            throw new TestException();
         };
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -346,13 +323,7 @@ public class FlowableDelayTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> delay;
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
 
@@ -370,13 +341,7 @@ public class FlowableDelayTest extends RxJavaTest {
     public void delayWithFlowableSubscriptionNormal() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> delay;
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -399,19 +364,10 @@ public class FlowableDelayTest extends RxJavaTest {
     public void delayWithFlowableSubscriptionFunctionThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
-        Supplier<Flowable<Integer>> subFunc = new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() {
-                throw new TestException();
-            }
+        Supplier<Flowable<Integer>> subFunc = () -> {
+            throw new TestException();
         };
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> delay;
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -433,19 +389,8 @@ public class FlowableDelayTest extends RxJavaTest {
     public void delayWithFlowableSubscriptionThrows() {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
-        Supplier<Flowable<Integer>> subFunc = new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() {
-                return delay;
-            }
-        };
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Supplier<Flowable<Integer>> subFunc = () -> delay;
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> delay;
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -467,13 +412,7 @@ public class FlowableDelayTest extends RxJavaTest {
     public void delayWithFlowableEmptyDelayer() {
         PublishProcessor<Integer> source = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return Flowable.empty();
-            }
-        };
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> Flowable.empty();
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
 
@@ -493,19 +432,8 @@ public class FlowableDelayTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> sdelay = PublishProcessor.create();
         final PublishProcessor<Integer> delay = PublishProcessor.create();
-        Supplier<Flowable<Integer>> subFunc = new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() {
-                return sdelay;
-            }
-        };
-        Function<Integer, Flowable<Integer>> delayFunc = new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Supplier<Flowable<Integer>> subFunc = () -> sdelay;
+        Function<Integer, Flowable<Integer>> delayFunc = _ -> delay;
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -530,12 +458,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         final Flowable<Long> delayer = Flowable.timer(500L, TimeUnit.MILLISECONDS, scheduler);
 
-        Function<Long, Flowable<Long>> delayFunc = new Function<Long, Flowable<Long>>() {
-            @Override
-            public Flowable<Long> apply(Long t1) {
-                return delayer;
-            }
-        };
+        Function<Long, Flowable<Long>> delayFunc = _ -> delayer;
 
         Flowable<Long> delayed = source.delay(delayFunc);
         delayed.subscribe(subscriber);
@@ -584,13 +507,7 @@ public class FlowableDelayTest extends RxJavaTest {
             subjects.add(PublishProcessor.<Integer> create());
         }
 
-        Flowable<Integer> result = source.delay(new Function<Integer, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return subjects.get(t1);
-            }
-        });
+        Flowable<Integer> result = source.delay((Function<Integer, Flowable<Integer>>) t1 -> subjects.get(t1));
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -619,14 +536,7 @@ public class FlowableDelayTest extends RxJavaTest {
     public void delayEmitsEverything() {
         Flowable<Integer> source = Flowable.range(1, 5);
         Flowable<Integer> delayed = source.delay(500L, TimeUnit.MILLISECONDS, scheduler);
-        delayed = delayed.doOnEach(new Consumer<Notification<Integer>>() {
-
-            @Override
-            public void accept(Notification<Integer> t1) {
-                System.out.println(t1);
-            }
-
-        });
+        delayed = delayed.doOnEach(t1 -> System.out.println(t1));
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         delayed.subscribe(ts);
         // all will be delivered after 500ms since range does not delay between them
@@ -640,7 +550,7 @@ public class FlowableDelayTest extends RxJavaTest {
         Flowable.range(1, Flowable.bufferSize() * 2)
                 .delay(100, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
 
                     int c;
 
@@ -669,7 +579,7 @@ public class FlowableDelayTest extends RxJavaTest {
                 .delaySubscription(100, TimeUnit.MILLISECONDS)
                 .delay(100, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
 
                     int c;
 
@@ -695,16 +605,9 @@ public class FlowableDelayTest extends RxJavaTest {
     public void backpressureWithSelectorDelay() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, Flowable.bufferSize() * 2)
-                .delay(new Function<Integer, Flowable<Long>>() {
-
-                    @Override
-                    public Flowable<Long> apply(Integer i) {
-                        return Flowable.timer(100, TimeUnit.MILLISECONDS);
-                    }
-
-                })
+                .delay((Function<Integer, Flowable<Long>>) _ -> Flowable.timer(100, TimeUnit.MILLISECONDS))
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
 
                     int c;
 
@@ -730,22 +633,10 @@ public class FlowableDelayTest extends RxJavaTest {
     public void backpressureWithSelectorDelayAndSubscriptionDelay() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.range(1, Flowable.bufferSize() * 2)
-                .delay(Flowable.defer(new Supplier<Flowable<Long>>() {
-
-                    @Override
-                    public Flowable<Long> get() {
-                        return Flowable.timer(500, TimeUnit.MILLISECONDS);
-                    }
-                }), new Function<Integer, Flowable<Long>>() {
-
-                    @Override
-                    public Flowable<Long> apply(Integer i) {
-                        return Flowable.timer(100, TimeUnit.MILLISECONDS);
-                    }
-
-                })
+                .delay(Flowable.defer((Supplier<Flowable<Long>>) () -> Flowable.timer(500, TimeUnit.MILLISECONDS)),
+                        (Function<Integer, Flowable<Long>>) _ -> Flowable.timer(100, TimeUnit.MILLISECONDS))
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
 
                     int c;
 
@@ -798,12 +689,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> get() {
-                return pp;
-            }
-        })).subscribe(ts);
+        source.delaySubscription(Flowable.defer((Supplier<Publisher<Integer>>) () -> pp)).subscribe(ts);
 
         ts.assertNoValues();
         ts.assertNoErrors();
@@ -824,12 +710,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> get() {
-                return pp;
-            }
-        })).subscribe(ts);
+        source.delaySubscription(Flowable.defer((Supplier<Publisher<Integer>>) () -> pp)).subscribe(ts);
 
         ts.assertNoValues();
         ts.assertNoErrors();
@@ -851,12 +732,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        source.delaySubscription(Flowable.defer(new Supplier<Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> get() {
-                return pp;
-            }
-        })).subscribe(ts);
+        source.delaySubscription(Flowable.defer((Supplier<Publisher<Integer>>) () -> pp)).subscribe(ts);
 
         ts.assertNoValues();
         ts.assertNoErrors();
@@ -876,12 +752,7 @@ public class FlowableDelayTest extends RxJavaTest {
         final AtomicBoolean subscribed = new AtomicBoolean(false);
 
         Flowable.just(1)
-        .doOnSubscribe(new Consumer<Object>() {
-            @Override
-            public void accept(Object o) {
-                subscribed.set(true);
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.set(true))
         .delaySubscription(delayUntil)
         .takeUntil(interrupt)
         .subscribe();
@@ -924,12 +795,9 @@ public class FlowableDelayTest extends RxJavaTest {
 
         Flowable.<String>error(new Exception())
                 .delay(0, TimeUnit.MILLISECONDS, Schedulers.newThread())
-                .doOnError(new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable throwable) throws Exception {
-                        thread.set(Thread.currentThread());
-                        latch.countDown();
-                    }
+                .doOnError(_ -> {
+                    thread.set(Thread.currentThread());
+                    latch.countDown();
                 })
                 .onErrorResumeWith(Flowable.<String>empty())
                 .subscribe();
@@ -948,19 +816,9 @@ public class FlowableDelayTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.delay(1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.delay(1, TimeUnit.SECONDS));
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.delay(Functions.justFunction(Flowable.never()));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.delay(Functions.justFunction(Flowable.never())));
     }
 
     @Test
@@ -969,7 +827,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         Flowable.empty()
         .delay(1, TimeUnit.MILLISECONDS, scheduler)
-        .subscribe(new DisposableSubscriber<Object>() {
+        .subscribe(new DisposableSubscriber<Object>() /* NFI */ {
             @Override
             public void onNext(Object value) {
             }
@@ -998,7 +856,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         Flowable.error(new TestException())
         .delay(1, TimeUnit.MILLISECONDS, scheduler)
-        .subscribe(new DisposableSubscriber<Object>() {
+        .subscribe(new DisposableSubscriber<Object>() /* NFI */ {
             @Override
             public void onNext(Object value) {
             }
@@ -1023,12 +881,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
     @Test
     public void itemDelayReturnsNull() {
-        Flowable.just(1).delay(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer t) throws Exception {
-                return null;
-            }
-        })
+        Flowable.just(1).delay(_ -> null)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The itemDelay returned a null Publisher");
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDematerializeTest.java
@@ -50,11 +50,8 @@ public class FlowableDematerializeTest extends RxJavaTest {
     public void selectorCrash() {
         Flowable.just(1, 2)
         .materialize()
-        .dematerialize(new Function<Notification<Integer>, Notification<Object>>() {
-            @Override
-            public Notification<Object> apply(Notification<Integer> v) throws Exception {
-                throw new TestException();
-            }
+        .dematerialize(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -64,12 +61,7 @@ public class FlowableDematerializeTest extends RxJavaTest {
     public void selectorNull() {
         Flowable.just(1, 2)
         .materialize()
-        .dematerialize(new Function<Notification<Integer>, Notification<Object>>() {
-            @Override
-            public Notification<Object> apply(Notification<Integer> v) throws Exception {
-                return null;
-            }
-        })
+        .dematerialize(_ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -189,19 +181,15 @@ public class FlowableDematerializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Notification<Object>>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Notification<Object>> f) throws Exception {
-                return f.dematerialize(Functions.<Notification<Object>>identity());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Notification<Object>>, Flowable<Object>>) f ->
+        f.dematerialize(Functions.<Notification<Object>>identity()));
     }
 
     @Test
     public void eventsAfterDematerializedTerminal() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Notification<Object>>() {
+            new Flowable<Notification<Object>>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Notification<Object>> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -224,7 +212,7 @@ public class FlowableDematerializeTest extends RxJavaTest {
 
     @Test
     public void notificationInstanceAfterDispose() {
-        new Flowable<Notification<Object>>() {
+        new Flowable<Notification<Object>>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Notification<Object>> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -240,7 +228,7 @@ public class FlowableDematerializeTest extends RxJavaTest {
     @Test
     @SuppressWarnings("unchecked")
     public void nonNotificationInstanceAfterDispose() {
-        new Flowable<Object>() {
+        new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDetachTest.java
@@ -137,12 +137,7 @@ public class FlowableDetachTest extends RxJavaTest {
 
         TestSubscriber<Object> ts = new TestSubscriber<>(0);
 
-        Flowable.unsafeCreate(new Publisher<Object>() {
-            @Override
-            public void subscribe(Subscriber<? super Object> t) {
-                subscriber.set(t);
-            }
-        }).onTerminateDetach().subscribe(ts);
+        Flowable.unsafeCreate(t -> subscriber.set(t)).onTerminateDetach().subscribe(ts);
 
         ts.request(2);
 
@@ -164,11 +159,6 @@ public class FlowableDetachTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.onTerminateDetach();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) Flowable::onTerminateDetach);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctTest.java
@@ -40,14 +40,11 @@ public class FlowableDistinctTest extends RxJavaTest {
     Subscriber<String> w;
 
     // nulls lead to exceptions
-    final Function<String, String> TO_UPPER_WITH_EXCEPTION = new Function<String, String>() {
-        @Override
-        public String apply(String s) {
-            if (s.equals("x")) {
-                return "XX";
-            }
-            return s.toUpperCase();
+    final Function<String, String> TO_UPPER_WITH_EXCEPTION = s -> {
+        if (s.equals("x")) {
+            return "XX";
         }
+        return s.toUpperCase();
     };
 
     @Before
@@ -145,7 +142,7 @@ public class FlowableDistinctTest extends RxJavaTest {
     public void fusedClear() {
         Flowable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
         .distinct()
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 QueueSubscription<?> qs = (QueueSubscription<?>)s;
@@ -174,11 +171,8 @@ public class FlowableDistinctTest extends RxJavaTest {
     @Test
     public void collectionSupplierThrows() {
         Flowable.just(1)
-        .distinct(Functions.identity(), new Supplier<Collection<Object>>() {
-            @Override
-            public Collection<Object> get() throws Exception {
-                throw new TestException();
-            }
+        .distinct(Functions.identity(), (Supplier<Collection<Object>>) () -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -187,12 +181,7 @@ public class FlowableDistinctTest extends RxJavaTest {
     @Test
     public void collectionSupplierIsNull() {
         Flowable.just(1)
-        .distinct(Functions.identity(), new Supplier<Collection<Object>>() {
-            @Override
-            public Collection<Object> get() throws Exception {
-                return null;
-            }
-        })
+        .distinct(Functions.identity(), (Supplier<Collection<Object>>) () -> null)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(NullPointerException.class)
         .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
@@ -202,7 +191,7 @@ public class FlowableDistinctTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctUntilChangedTest.java
@@ -41,14 +41,11 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
     Subscriber<String> w2;
 
     // nulls lead to exceptions
-    final Function<String, String> TO_UPPER_WITH_EXCEPTION = new Function<String, String>() {
-        @Override
-        public String apply(String s) {
-            if (s.equals("x")) {
-                return "xx";
-            }
-            return s.toUpperCase();
+    final Function<String, String> TO_UPPER_WITH_EXCEPTION = s -> {
+        if (s.equals("x")) {
+            return "xx";
         }
+        return s.toUpperCase();
     };
 
     @Before
@@ -114,12 +111,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
     @Test
     public void directComparer() {
         Flowable.fromArray(1, 2, 2, 3, 2, 4, 1, 1, 2)
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) {
-                return a.equals(b);
-            }
-        })
+        .distinctUntilChanged(Integer::equals)
         .test()
         .assertResult(1, 2, 3, 2, 4, 1, 2);
     }
@@ -127,18 +119,8 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
     @Test
     public void directComparerConditional() {
         Flowable.fromArray(1, 2, 2, 3, 2, 4, 1, 1, 2)
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) {
-                return a.equals(b);
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        })
+        .distinctUntilChanged(Integer::equals)
+        .filter(_ -> true)
         .test()
         .assertResult(1, 2, 3, 2, 4, 1, 2);
     }
@@ -146,12 +128,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
     @Test
     public void directComparerFused() {
         Flowable.fromArray(1, 2, 2, 3, 2, 4, 1, 1, 2)
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) {
-                return a.equals(b);
-            }
-        })
+        .distinctUntilChanged(Integer::equals)
         .to(TestHelper.<Integer>testSubscriber(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertFuseable()
         .assertFusionMode(QueueFuseable.SYNC)
@@ -161,29 +138,16 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
     @Test
     public void directComparerConditionalFused() {
         Flowable.fromArray(1, 2, 2, 3, 2, 4, 1, 1, 2)
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) {
-                return a.equals(b);
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        })
+        .distinctUntilChanged(Integer::equals)
+        .filter(_ -> true)
         .to(TestHelper.<Integer>testSubscriber(Long.MAX_VALUE, QueueFuseable.ANY, false))
         .assertFuseable()
         .assertFusionMode(QueueFuseable.SYNC)
         .assertResult(1, 2, 3, 2, 4, 1, 2);
     }
 
-    private static final Function<String, String> THROWS_NON_FATAL = new Function<String, String>() {
-        @Override
-        public String apply(String s) {
-            throw new RuntimeException();
-        }
+    private static final Function<String, String> THROWS_NON_FATAL = _ -> {
+        throw new RuntimeException();
     };
 
     @Test
@@ -191,12 +155,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
         Flowable<String> src = Flowable.just("a", "b", "null", "c");
         final AtomicBoolean errorOccurred = new AtomicBoolean(false);
         src
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable t) {
-                errorOccurred.set(true);
-            }
-        })
+        .doOnError(_ -> errorOccurred.set(true))
         .distinctUntilChanged(THROWS_NON_FATAL)
         .subscribe(w);
         Assert.assertFalse(errorOccurred.get());
@@ -208,12 +167,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
 
         TestSubscriber<String> ts = TestSubscriber.create();
 
-        source.distinctUntilChanged(new BiPredicate<String, String>() {
-            @Override
-            public boolean test(String a, String b) {
-                return a.compareToIgnoreCase(b) == 0;
-            }
-        })
+        source.distinctUntilChanged((a, b) -> a.compareToIgnoreCase(b) == 0)
         .subscribe(ts);
 
         ts.assertValues("a", "b", "A", "C");
@@ -227,11 +181,8 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
 
         TestSubscriber<String> ts = TestSubscriber.create();
 
-        source.distinctUntilChanged(new BiPredicate<String, String>() {
-            @Override
-            public boolean test(String a, String b) {
-                throw new TestException();
-            }
+        source.distinctUntilChanged((_, _) -> {
+            throw new TestException();
         })
         .subscribe(ts);
 
@@ -245,12 +196,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 2, 3, 3, 4, 5)
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) throws Exception {
-                return a.equals(b);
-            }
-        })
+        .distinctUntilChanged(Integer::equals)
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -266,12 +212,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) throws Exception {
-                return a.equals(b);
-            }
-        })
+        .distinctUntilChanged(Integer::equals)
         .subscribe(ts);
 
         TestHelper.emit(up, 1, 2, 2, 3, 3, 4, 5);
@@ -287,7 +228,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 public void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -298,11 +239,8 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
                     s.onComplete();
                 }
             }
-            .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-                @Override
-                public boolean test(Integer a, Integer b) throws Exception {
-                    throw new TestException();
-                }
+            .distinctUntilChanged((_, _) -> {
+                throw new TestException();
             })
             .test()
             .assertFailure(TestException.class, 1);
@@ -323,12 +261,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
 
         PublishProcessor<Mutable> pp = PublishProcessor.create();
 
-        TestSubscriber<Mutable> ts = pp.distinctUntilChanged(new Function<Mutable, Object>() {
-            @Override
-            public Object apply(Mutable m) throws Exception {
-                return m.value;
-            }
-        })
+        TestSubscriber<Mutable> ts = pp.distinctUntilChanged((Function<Mutable, Object>) m1 -> m1.value)
         .test();
 
         pp.onNext(m);
@@ -343,12 +276,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
     public void conditionalNormal() {
         Flowable.just(1, 2, 1, 3, 3, 4, 3, 5, 5)
         .distinctUntilChanged()
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .test()
         .assertResult(2, 4);
     }
@@ -357,12 +285,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
     public void conditionalNormal2() {
         Flowable.just(1, 2, 1, 3, 3, 4, 3, 5, 5).hide()
         .distinctUntilChanged()
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .test()
         .assertResult(2, 4);
     }
@@ -373,12 +296,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = up.hide()
         .distinctUntilChanged()
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .test();
 
         TestHelper.emit(up, 1, 2, 1, 3, 3, 4, 3, 5, 5);
@@ -390,18 +308,10 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
     @Test
     public void conditionalSelectorCrash() {
         Flowable.just(1, 2, 1, 3, 3, 4, 3, 5, 5)
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) throws Exception {
-                throw new TestException();
-            }
+        .distinctUntilChanged((_, _) -> {
+            throw new TestException();
         })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .test()
         .assertFailure(TestException.class);
     }
@@ -412,12 +322,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
 
         Flowable.just(1, 2, 1, 3, 3, 4, 3, 5, 5)
         .distinctUntilChanged()
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         ts.assertFusionMode(QueueFuseable.SYNC)
@@ -431,12 +336,7 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
 
         up
         .distinctUntilChanged()
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         TestHelper.emit(up, 1, 2, 1, 3, 3, 4, 3, 5, 5);
@@ -447,11 +347,6 @@ public class FlowableDistinctUntilChangedTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.distinctUntilChanged().filter(Functions.alwaysTrue());
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.distinctUntilChanged().filter(Functions.alwaysTrue()), false, 1, 1, 1);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoAfterNextTest.java
@@ -32,14 +32,9 @@ public class FlowableDoAfterNextTest extends RxJavaTest {
 
     final List<Integer> values = new ArrayList<>();
 
-    final Consumer<Integer> afterNext = new Consumer<Integer>() {
-        @Override
-        public void accept(Integer e) throws Exception {
-            values.add(-e);
-        }
-    };
+    final Consumer<Integer> afterNext = e -> values.add(-e);
 
-    final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+    final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);
@@ -229,11 +224,8 @@ public class FlowableDoAfterNextTest extends RxJavaTest {
     @Test
     public void consumerThrows() {
         Flowable.just(1, 2)
-        .doAfterNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                throw new TestException();
-            }
+        .doAfterNext(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class, 1);
@@ -242,11 +234,8 @@ public class FlowableDoAfterNextTest extends RxJavaTest {
     @Test
     public void consumerThrowsConditional() {
         Flowable.just(1, 2)
-        .doAfterNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                throw new TestException();
-            }
+        .doAfterNext(_ -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .test()
@@ -256,11 +245,8 @@ public class FlowableDoAfterNextTest extends RxJavaTest {
     @Test
     public void consumerThrowsConditional2() {
         Flowable.just(1, 2).hide()
-        .doAfterNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                throw new TestException();
-            }
+        .doAfterNext(_ -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoFinallyTest.java
@@ -82,18 +82,8 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                return f.doFinally(FlowableDoFinallyTest.this);
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                return f.doFinally(FlowableDoFinallyTest.this).filter(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.doFinally(FlowableDoFinallyTest.this));
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.doFinally(FlowableDoFinallyTest.this).filter(Functions.alwaysTrue()));
     }
 
     @Test
@@ -303,11 +293,8 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .doFinally(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doFinally(() -> {
+                throw new TestException();
             })
             .test()
             .assertResult(1)
@@ -324,11 +311,8 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .doFinally(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doFinally(() -> {
+                throw new TestException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -345,7 +329,7 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
     public void clearIsEmpty() {
         Flowable.range(1, 5)
         .doFinally(this)
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -392,7 +376,7 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
         Flowable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -439,37 +423,12 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
         final List<String> list = new ArrayList<>();
 
         Flowable.error(new TestException())
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add("cancel");
-            }
-        })
-        .doFinally(new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add("finally");
-            }
-        })
+        .doOnCancel(() -> list.add("cancel"))
+        .doFinally(() -> list.add("finally"))
         .subscribe(
-                new Consumer<Object>() {
-                    @Override
-                    public void accept(Object v) throws Exception {
-                        list.add("onNext");
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        list.add("onError");
-                    }
-                },
-                new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        list.add("onComplete");
-                    }
-                });
+                _ -> list.add("onNext"),
+                _ -> list.add("onError"),
+                () -> list.add("onComplete"));
 
         assertEquals(Arrays.asList("onError", "finally"), list);
     }
@@ -479,37 +438,12 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
         final List<String> list = new ArrayList<>();
 
         Flowable.just(1)
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add("cancel");
-            }
-        })
-        .doFinally(new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add("finally");
-            }
-        })
+        .doOnCancel(() -> list.add("cancel"))
+        .doFinally(() -> list.add("finally"))
         .subscribe(
-                new Consumer<Object>() {
-                    @Override
-                    public void accept(Object v) throws Exception {
-                        list.add("onNext");
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        list.add("onError");
-                    }
-                },
-                new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        list.add("onComplete");
-                    }
-                });
+                _ -> list.add("onNext"),
+                _ -> list.add("onError"),
+                () -> list.add("onComplete"));
 
         assertEquals(Arrays.asList("onNext", "onComplete", "finally"), list);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -73,14 +73,11 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnEachWithError() {
         Flowable<String> base = Flowable.just("one", "fail", "two", "three", "fail");
-        Flowable<String> errs = base.map(new Function<String, String>() {
-            @Override
-            public String apply(String s) {
-                if ("fail".equals(s)) {
-                    throw new RuntimeException("Forced Failure");
-                }
-                return s;
+        Flowable<String> errs = base.map(s -> {
+            if ("fail".equals(s)) {
+                throw new RuntimeException("Forced Failure");
             }
+            return s;
         });
 
         Flowable<String> doOnEach = errs.doOnEach(sideEffectSubscriber);
@@ -102,12 +99,9 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnEachWithErrorInCallback() {
         Flowable<String> base = Flowable.just("one", "two", "fail", "three");
-        Flowable<String> doOnEach = base.doOnNext(new Consumer<String>() {
-            @Override
-            public void accept(String s) {
-                if ("fail".equals(s)) {
-                    throw new RuntimeException("Forced Failure");
-                }
+        Flowable<String> doOnEach = base.doOnNext(s -> {
+            if ("fail".equals(s)) {
+                throw new RuntimeException("Forced Failure");
             }
         });
 
@@ -128,19 +122,9 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         for (int i = 0; i < expectedCount; i++) {
             Flowable
                     .just(Boolean.TRUE, Boolean.FALSE)
-                    .takeWhile(new Predicate<Boolean>() {
-                        @Override
-                        public boolean test(Boolean value) {
-                            return value;
-                        }
-                    })
+                    .takeWhile(value -> value)
                     .toList()
-                    .doOnSuccess(new Consumer<List<Boolean>>() {
-                        @Override
-                        public void accept(List<Boolean> booleans) {
-                            count.incrementAndGet();
-                        }
-                    })
+                    .doOnSuccess(_ -> count.incrementAndGet())
                     .subscribe();
         }
         assertEquals(expectedCount, count.get());
@@ -154,19 +138,9 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         for (int i = 0; i < expectedCount; i++) {
             Flowable
                     .just(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE)
-                    .takeWhile(new Predicate<Boolean>() {
-                        @Override
-                        public boolean test(Boolean value) {
-                            return value;
-                        }
-                    })
+                    .takeWhile(value -> value)
                     .toList()
-                    .doOnSuccess(new Consumer<List<Boolean>>() {
-                        @Override
-                        public void accept(List<Boolean> booleans) {
-                            count.incrementAndGet();
-                        }
-                    })
+                    .doOnSuccess(_ -> count.incrementAndGet())
                     .subscribe();
         }
         assertEquals(expectedCount, count.get());
@@ -177,11 +151,8 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
         Flowable.error(new TestException())
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) {
-                throw new TestException();
-            }
+        .doOnError(_ -> {
+            throw new TestException();
         }).subscribe(ts);
 
         ts.assertNoValues();
@@ -201,21 +172,15 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Object>() {
-                @Override
-                public void subscribe(Subscriber<? super Object> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
-                }
+            Flowable.fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+                s.onError(new IOException());
+                s.onComplete();
             })
-            .doOnNext(new Consumer<Object>() {
-                @Override
-                public void accept(Object e) throws Exception {
-                    throw new TestException();
-                }
+            .doOnNext(_ -> {
+                throw new TestException();
             })
             .test()
             .assertFailure(TestException.class);
@@ -231,18 +196,12 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Object>() {
-                @Override
-                public void subscribe(Subscriber<? super Object> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onError(new TestException());
-                }
+            Flowable.fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onError(new TestException());
             })
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            .doAfterTerminate(() -> {
+                throw new IOException();
             })
             .test()
             .assertFailure(TestException.class);
@@ -258,18 +217,12 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Object>() {
-                @Override
-                public void subscribe(Subscriber<? super Object> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onComplete();
-                }
+            Flowable.fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onComplete();
             })
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            .doAfterTerminate(() -> {
+                throw new IOException();
             })
             .test()
             .assertResult();
@@ -282,18 +235,12 @@ public class FlowableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void onCompleteCrash() {
-        Flowable.fromPublisher(new Publisher<Object>() {
-            @Override
-            public void subscribe(Subscriber<? super Object> s) {
-                s.onSubscribe(new BooleanSubscription());
-                s.onComplete();
-            }
+        Flowable.fromPublisher(s -> {
+            s.onSubscribe(new BooleanSubscription());
+            s.onComplete();
         })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new IOException();
-            }
+        .doOnComplete(() -> {
+            throw new IOException();
         })
         .test()
         .assertFailure(IOException.class);
@@ -304,21 +251,15 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Object>() {
-                @Override
-                public void subscribe(Subscriber<? super Object> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
-                }
+            Flowable.fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+                s.onError(new IOException());
+                s.onComplete();
             })
-            .doOnNext(new Consumer<Object>() {
-                @Override
-                public void accept(Object e) throws Exception {
-                    throw new TestException();
-                }
+            .doOnNext(_ -> {
+                throw new TestException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -335,22 +276,16 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Object>() {
-                @Override
-                public void subscribe(Subscriber<? super Object> s) {
-                    ConditionalSubscriber<? super Object> cs = (ConditionalSubscriber<? super Object>)s;
-                    cs.onSubscribe(new BooleanSubscription());
-                    cs.tryOnNext(1);
-                    cs.tryOnNext(2);
-                    cs.onError(new IOException());
-                    cs.onComplete();
-                }
+            Flowable.fromPublisher(s -> {
+                ConditionalSubscriber<? super Object> cs = (ConditionalSubscriber<? super Object>)s;
+                cs.onSubscribe(new BooleanSubscription());
+                cs.tryOnNext(1);
+                cs.tryOnNext(2);
+                cs.onError(new IOException());
+                cs.onComplete();
             })
-            .doOnNext(new Consumer<Object>() {
-                @Override
-                public void accept(Object e) throws Exception {
-                    throw new TestException();
-                }
+            .doOnNext(_ -> {
+                throw new TestException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -367,18 +302,12 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Object>() {
-                @Override
-                public void subscribe(Subscriber<? super Object> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onError(new TestException());
-                }
+            Flowable.fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onError(new TestException());
             })
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            .doAfterTerminate(() -> {
+                throw new IOException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -394,12 +323,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     public void onCompleteAfter() {
         final int[] call = { 0 };
         Flowable.just(1)
-        .doAfterTerminate(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
+        .doAfterTerminate(() -> call[0]++)
         .test()
         .assertResult(1);
 
@@ -411,18 +335,12 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Object>() {
-                @Override
-                public void subscribe(Subscriber<? super Object> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onComplete();
-                }
+            Flowable.fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onComplete();
             })
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            .doAfterTerminate(() -> {
+                throw new IOException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -436,18 +354,12 @@ public class FlowableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void onCompleteCrashConditional() {
-        Flowable.fromPublisher(new Publisher<Object>() {
-            @Override
-            public void subscribe(Subscriber<? super Object> s) {
-                s.onSubscribe(new BooleanSubscription());
-                s.onComplete();
-            }
+        Flowable.fromPublisher(s -> {
+            s.onSubscribe(new BooleanSubscription());
+            s.onComplete();
         })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new IOException();
-            }
+        .doOnComplete(() -> {
+            throw new IOException();
         })
         .filter(Functions.alwaysTrue())
         .test()
@@ -457,11 +369,8 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     @Test
     public void onErrorOnErrorCrashConditional() {
         TestSubscriberEx<Object> ts = Flowable.error(new TestException("Outer"))
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Inner");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Inner");
         })
         .filter(Functions.alwaysTrue())
         .to(TestHelper.testConsumer())
@@ -480,18 +389,8 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         final int[] call = { 0, 0 };
 
         Flowable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -509,18 +408,10 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Flowable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .doOnNext(_ -> {
+            throw new TestException();
         })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
+        .doOnComplete(() -> call[0]++)
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -537,18 +428,8 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         final int[] call = { 0, 0 };
 
         Flowable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
@@ -567,18 +448,10 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Flowable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .doOnNext(_ -> {
+            throw new TestException();
         })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
+        .doOnComplete(() -> call[0]++)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
@@ -598,18 +471,8 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .subscribe(ts);
 
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -631,18 +494,8 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
@@ -665,18 +518,8 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up.hide()
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .filter(Functions.alwaysTrue())
         .subscribe(ts);
 
@@ -697,28 +540,18 @@ public class FlowableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.doOnEach(new TestSubscriber<>());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f ->
+            f.doOnEach(new TestSubscriber<>()));
     }
 
     @Test
     public void doOnNextDoOnErrorFused() {
         ConnectableFlowable<Integer> cf = Flowable.just(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException("First");
-            }
+        .doOnNext(_ -> {
+            throw new TestException("First");
         })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Second");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Second");
         })
         .publish();
 
@@ -734,28 +567,17 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnNextDoOnErrorCombinedFused() {
         ConnectableFlowable<Integer> cf = Flowable.just(1)
-                .compose(new FlowableTransformer<Integer, Integer>() {
-                    @Override
-                    public Publisher<Integer> apply(Flowable<Integer> v) {
-                        return new FlowableDoOnEach<>(v,
-                                new Consumer<Integer>() {
-                                    @Override
-                                    public void accept(Integer v) throws Exception {
-                                        throw new TestException("First");
-                                    }
-                                },
-                                new Consumer<Throwable>() {
-                                    @Override
-                                    public void accept(Throwable e) throws Exception {
-                                        throw new TestException("Second");
-                                    }
-                                },
-                                Functions.EMPTY_ACTION
-                                ,
-                                Functions.EMPTY_ACTION
-                        );
-                    }
-                })
+                .compose(v -> new FlowableDoOnEach<>(v,
+                        _ -> {
+                            throw new TestException("First");
+                        },
+                        _ -> {
+                            throw new TestException("Second");
+                        },
+                        Functions.EMPTY_ACTION
+                        ,
+                        Functions.EMPTY_ACTION
+                ))
         .publish();
 
         TestSubscriberEx<Integer> ts = cf.to(TestHelper.<Integer>testConsumer());
@@ -770,23 +592,14 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnNextDoOnErrorFused2() {
         ConnectableFlowable<Integer> cf = Flowable.just(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException("First");
-            }
+        .doOnNext(_ -> {
+            throw new TestException("First");
         })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Second");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Second");
         })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Third");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Third");
         })
         .publish();
 
@@ -803,17 +616,11 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnNextDoOnErrorFusedConditional() {
         ConnectableFlowable<Integer> cf = Flowable.just(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException("First");
-            }
+        .doOnNext(_ -> {
+            throw new TestException("First");
         })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Second");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Second");
         })
         .filter(Functions.alwaysTrue())
         .publish();
@@ -830,23 +637,14 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnNextDoOnErrorFusedConditional2() {
         ConnectableFlowable<Integer> cf = Flowable.just(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException("First");
-            }
+        .doOnNext(_ -> {
+            throw new TestException("First");
         })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Second");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Second");
         })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Third");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Third");
         })
         .filter(Functions.alwaysTrue())
         .publish();
@@ -864,28 +662,17 @@ public class FlowableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnNextDoOnErrorCombinedFusedConditional() {
         ConnectableFlowable<Integer> cf = Flowable.just(1)
-                .compose(new FlowableTransformer<Integer, Integer>() {
-                    @Override
-                    public Publisher<Integer> apply(Flowable<Integer> v) {
-                        return new FlowableDoOnEach<>(v,
-                                new Consumer<Integer>() {
-                                    @Override
-                                    public void accept(Integer v) throws Exception {
-                                        throw new TestException("First");
-                                    }
-                                },
-                                new Consumer<Throwable>() {
-                                    @Override
-                                    public void accept(Throwable e) throws Exception {
-                                        throw new TestException("Second");
-                                    }
-                                },
-                                Functions.EMPTY_ACTION
-                                ,
-                                Functions.EMPTY_ACTION
-                        );
-                    }
-                })
+                .compose(v -> new FlowableDoOnEach<>(v,
+                        _ -> {
+                            throw new TestException("First");
+                        },
+                        _ -> {
+                            throw new TestException("Second");
+                        },
+                        Functions.EMPTY_ACTION
+                        ,
+                        Functions.EMPTY_ACTION
+                ))
         .filter(Functions.alwaysTrue())
         .publish();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnLifecycleTest.java
@@ -33,11 +33,8 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
     @Test
     public void onSubscribeCrashed() {
         Flowable.just(1)
-        .doOnLifecycle(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                throw new TestException();
-            }
+        .doOnLifecycle(s -> {
+            throw new TestException();
         }, Functions.EMPTY_LONG_CONSUMER, Functions.EMPTY_ACTION)
         .test()
         .assertFailure(TestException.class);
@@ -47,23 +44,8 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
     public void doubleOnSubscribe() {
         final int[] calls = { 0, 0 };
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                return f
-                .doOnLifecycle(new Consumer<Subscription>() {
-                    @Override
-                    public void accept(Subscription s) throws Exception {
-                        calls[0]++;
-                    }
-                }, Functions.EMPTY_LONG_CONSUMER, new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        calls[1]++;
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f
+        .doOnLifecycle(_ -> calls[0]++, Functions.EMPTY_LONG_CONSUMER, () -> calls[1]++));
 
         assertEquals(2, calls[0]);
         assertEquals(0, calls[1]);
@@ -74,17 +56,7 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
         final int[] calls = { 0, 0 };
 
         TestHelper.checkDisposed(Flowable.just(1)
-                .doOnLifecycle(new Consumer<Subscription>() {
-                    @Override
-                    public void accept(Subscription s) throws Exception {
-                        calls[0]++;
-                    }
-                }, Functions.EMPTY_LONG_CONSUMER, new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        calls[1]++;
-                    }
-                })
+                .doOnLifecycle(_ -> calls[0]++, Functions.EMPTY_LONG_CONSUMER, () -> calls[1]++)
             );
 
         assertEquals(1, calls[0]);
@@ -97,11 +69,8 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
         try {
             Flowable.just(1)
             .doOnLifecycle(Functions.emptyConsumer(),
-                    new LongConsumer() {
-                        @Override
-                        public void accept(long v) throws Exception {
-                            throw new TestException();
-                        }
+                    _ -> {
+                        throw new TestException();
                     },
                     Functions.EMPTY_ACTION)
             .test()
@@ -120,11 +89,8 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
             Flowable.just(1)
             .doOnLifecycle(Functions.emptyConsumer(),
                     Functions.EMPTY_LONG_CONSUMER,
-                    new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            throw new TestException();
-                        }
+                    () -> {
+                        throw new TestException();
                     })
             .take(1)
             .test()
@@ -142,7 +108,7 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
         try {
             final BooleanSubscription bs = new BooleanSubscription();
 
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(bs);
@@ -150,11 +116,8 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
                     s.onComplete();
                 }
             }
-            .doOnSubscribe(new Consumer<Subscription>() {
-                @Override
-                public void accept(Subscription s) throws Exception {
-                    throw new TestException("First");
-                }
+            .doOnSubscribe(s -> {
+                throw new TestException("First");
             })
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnRequestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnRequestTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.subscribers.DefaultSubscriber;
 
 public class FlowableDoOnRequestTest extends RxJavaTest {
@@ -31,18 +30,10 @@ public class FlowableDoOnRequestTest extends RxJavaTest {
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
         Flowable.just(1).concatWith(Flowable.<Integer>never())
         //
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                        unsubscribed.set(true);
-                    }
-                })
+                .doOnCancel(() -> unsubscribed.set(true))
                 //
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long n) {
-                        // do nothing
-                    }
+                .doOnRequest(_ -> {
+                    // do nothing
                 })
                 //
                 .subscribe().dispose();
@@ -54,14 +45,9 @@ public class FlowableDoOnRequestTest extends RxJavaTest {
         final List<Long> requests = new ArrayList<>();
         Flowable.range(1, 5)
         //
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long n) {
-                        requests.add(n);
-                    }
-                })
+                .doOnRequest(n -> requests.add(n))
                 //
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnSubscribeTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 
 public class FlowableDoOnSubscribeTest extends RxJavaTest {
@@ -29,12 +28,7 @@ public class FlowableDoOnSubscribeTest extends RxJavaTest {
     @Test
     public void doOnSubscribe() throws Exception {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> f = Flowable.just(1).doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                    count.incrementAndGet();
-            }
-        });
+        Flowable<Integer> f = Flowable.just(1).doOnSubscribe(_ -> count.incrementAndGet());
 
         f.subscribe();
         f.subscribe();
@@ -45,17 +39,8 @@ public class FlowableDoOnSubscribeTest extends RxJavaTest {
     @Test
     public void doOnSubscribe2() throws Exception {
         final AtomicInteger count = new AtomicInteger();
-        Flowable<Integer> f = Flowable.just(1).doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                    count.incrementAndGet();
-            }
-        }).take(1).doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                    count.incrementAndGet();
-            }
-        });
+        Flowable<Integer> f = Flowable.just(1).doOnSubscribe(_ -> count.incrementAndGet())
+                .take(1).doOnSubscribe(_ -> count.incrementAndGet());
 
         f.subscribe();
         assertEquals(2, count.get());
@@ -67,27 +52,12 @@ public class FlowableDoOnSubscribeTest extends RxJavaTest {
         final AtomicInteger countBefore = new AtomicInteger();
         final AtomicInteger countAfter = new AtomicInteger();
         final AtomicReference<Subscriber<? super Integer>> sref = new AtomicReference<>();
-        Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new BooleanSubscription());
-                onSubscribed.incrementAndGet();
-                sref.set(s);
-            }
-
-        }).doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                    countBefore.incrementAndGet();
-            }
-        }).publish().refCount()
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                    countAfter.incrementAndGet();
-            }
-        });
+        Flowable<Integer> f = Flowable.<Integer>unsafeCreate(s -> {
+            s.onSubscribe(new BooleanSubscription());
+            onSubscribed.incrementAndGet();
+            sref.set(s);
+        }).doOnSubscribe(_ -> countBefore.incrementAndGet()).publish().refCount()
+        .doOnSubscribe(_ -> countAfter.incrementAndGet());
 
         f.subscribe();
         f.subscribe();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnUnsubscribeTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.processors.BehaviorProcessor;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
@@ -42,29 +41,17 @@ public class FlowableDoOnUnsubscribeTest extends RxJavaTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                        // Test that upper stream will be notified for un-subscription
-                        // from a child subscriber
-                            upperLatch.countDown();
-                            upperCount.incrementAndGet();
-                    }
+                .doOnCancel(() -> {
+                    // Test that upper stream will be notified for un-subscription
+                    // from a child subscriber
+                        upperLatch.countDown();
+                        upperCount.incrementAndGet();
                 })
-                .doOnNext(new Consumer<Long>() {
-                    @Override
-                    public void accept(Long aLong) {
-                            // Ensure there is at least some onNext events before un-subscription happens
-                            onNextLatch.countDown();
-                    }
-                })
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                        // Test that lower stream will be notified for a direct un-subscription
-                            lowerLatch.countDown();
-                            lowerCount.incrementAndGet();
-                    }
+                .doOnNext(_ -> onNextLatch.countDown())
+                .doOnCancel(() -> {
+                    // Test that lower stream will be notified for a direct un-subscription
+                        lowerLatch.countDown();
+                        lowerCount.incrementAndGet();
                 });
 
         List<Disposable> subscriptions = new ArrayList<>();
@@ -102,28 +89,16 @@ public class FlowableDoOnUnsubscribeTest extends RxJavaTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                        // Test that upper stream will be notified for un-subscription
-                            upperLatch.countDown();
-                            upperCount.incrementAndGet();
-                    }
+                .doOnCancel(() -> {
+                    // Test that upper stream will be notified for un-subscription
+                        upperLatch.countDown();
+                        upperCount.incrementAndGet();
                 })
-                .doOnNext(new Consumer<Long>() {
-                    @Override
-                    public void accept(Long aLong) {
-                            // Ensure there is at least some onNext events before un-subscription happens
-                            onNextLatch.countDown();
-                    }
-                })
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                        // Test that lower stream will be notified for un-subscription
-                            lowerLatch.countDown();
-                            lowerCount.incrementAndGet();
-                    }
+                .doOnNext(_ -> onNextLatch.countDown())
+                .doOnCancel(() -> {
+                    // Test that lower stream will be notified for un-subscription
+                        lowerLatch.countDown();
+                        lowerCount.incrementAndGet();
                 })
                 .publish()
                 .refCount();
@@ -156,12 +131,9 @@ public class FlowableDoOnUnsubscribeTest extends RxJavaTest {
         final AtomicInteger cancelCalled = new AtomicInteger();
 
         final BehaviorProcessor<Integer> p = BehaviorProcessor.create();
-        p.doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                cancelCalled.incrementAndGet();
-                p.onNext(2);
-            }
+        p.doOnCancel(() -> {
+            cancelCalled.incrementAndGet();
+            p.onNext(2);
         })
         .firstOrError()
         .subscribe()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableElementAtTest.java
@@ -74,12 +74,7 @@ public class FlowableElementAtTest extends RxJavaTest {
     public void elementAtConstrainsUpstreamRequests() {
         final List<Long> requests = new ArrayList<>();
         Flowable.fromArray(1, 2, 3, 4)
-            .doOnRequest(new LongConsumer() {
-                @Override
-                public void accept(long n) throws Throwable {
-                    requests.add(n);
-                }
-            })
+            .doOnRequest(n -> requests.add(n))
             .elementAt(2)
             .blockingGet()
                 .intValue();
@@ -90,12 +85,7 @@ public class FlowableElementAtTest extends RxJavaTest {
     public void elementAtWithDefaultConstrainsUpstreamRequests() {
         final List<Long> requests = new ArrayList<>();
         Flowable.fromArray(1, 2, 3, 4)
-            .doOnRequest(new LongConsumer() {
-                @Override
-                public void accept(long n) throws Throwable {
-                    requests.add(n);
-                }
-            })
+            .doOnRequest(n -> requests.add(n))
             .elementAt(2, 100)
             .blockingGet()
                 .intValue();
@@ -221,26 +211,11 @@ public class FlowableElementAtTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                return f.elementAt(0).toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.elementAt(0).toFlowable());
 
-        TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Flowable<Object> f) throws Exception {
-                return f.elementAt(0);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToMaybe((Function<Flowable<Object>, Maybe<Object>>) f -> f.elementAt(0));
 
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<Object>>() {
-            @Override
-            public Single<Object> apply(Flowable<Object> f) throws Exception {
-                return f.elementAt(0, 1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle((Function<Flowable<Object>, Single<Object>>) f -> f.elementAt(0, 1));
     }
 
     @Test
@@ -278,7 +253,7 @@ public class FlowableElementAtTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -299,33 +274,13 @@ public class FlowableElementAtTest extends RxJavaTest {
             RxJavaPlugins.reset();
         }
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.elementAt(0);
-            }
-        }, false, null, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.elementAt(0), false, null, 1);
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.elementAt(0, 1);
-            }
-        }, false, null, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.elementAt(0, 1), false, null, 1, 1);
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.elementAt(0).toFlowable();
-            }
-        }, false, null, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.elementAt(0).toFlowable(), false, null, 1);
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.elementAt(0, 1).toFlowable();
-            }
-        }, false, null, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.elementAt(0, 1).toFlowable(), false, null, 1, 1);
     }
 
     @Test
@@ -341,7 +296,7 @@ public class FlowableElementAtTest extends RxJavaTest {
     public void badSourceObservable() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -367,7 +322,7 @@ public class FlowableElementAtTest extends RxJavaTest {
     public void badSource2() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFilterTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFilterTest.java
@@ -41,13 +41,7 @@ public class FlowableFilterTest extends RxJavaTest {
     @Test
     public void filter() {
         Flowable<String> w = Flowable.just("one", "two", "three");
-        Flowable<String> flowable = w.filter(new Predicate<String>() {
-
-            @Override
-            public boolean test(String t1) {
-                return t1.equals("two");
-            }
-        });
+        Flowable<String> flowable = w.filter(t1 -> t1.equals("two"));
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -68,16 +62,10 @@ public class FlowableFilterTest extends RxJavaTest {
     @Test
     public void withBackpressure() throws InterruptedException {
         Flowable<String> w = Flowable.just("one", "two", "three");
-        Flowable<String> f = w.filter(new Predicate<String>() {
-
-            @Override
-            public boolean test(String t1) {
-                return t1.equals("three");
-            }
-        });
+        Flowable<String> f = w.filter(t1 -> t1.equals("three"));
 
         final CountDownLatch latch = new CountDownLatch(1);
-        TestSubscriber<String> ts = new TestSubscriber<String>() {
+        TestSubscriber<String> ts = new TestSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -115,16 +103,10 @@ public class FlowableFilterTest extends RxJavaTest {
     @Test
     public void withBackpressure2() throws InterruptedException {
         Flowable<Integer> w = Flowable.range(1, Flowable.bufferSize() * 2);
-        Flowable<Integer> f = w.filter(new Predicate<Integer>() {
-
-            @Override
-            public boolean test(Integer t1) {
-                return t1 > 100;
-            }
-        });
+        Flowable<Integer> f = w.filter(t1 -> t1 > 100);
 
         final CountDownLatch latch = new CountDownLatch(1);
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -161,11 +143,8 @@ public class FlowableFilterTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        pp.filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                throw new TestException();
-            }
+        pp.filter(_ -> {
+            throw new TestException();
         }).subscribe(ts);
 
         Assert.assertTrue("Not subscribed?", pp.hasSubscribers());
@@ -321,28 +300,17 @@ public class FlowableFilterTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    ConditionalSubscriber<? super Integer> cs = (ConditionalSubscriber<? super Integer>)s;
-                    cs.onSubscribe(new BooleanSubscription());
-                    cs.tryOnNext(1);
-                    cs.tryOnNext(2);
-                    cs.onError(new IOException());
-                    cs.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                ConditionalSubscriber<? super Integer> cs = (ConditionalSubscriber<? super Integer>)s;
+                cs.onSubscribe(new BooleanSubscription());
+                cs.tryOnNext(1);
+                cs.tryOnNext(2);
+                cs.onError(new IOException());
+                cs.onComplete();
             })
-            .filter(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    return true;
-                }
-            })
-            .filter(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .filter(_ -> true)
+            .filter(_ -> {
+                throw new TestException();
             })
             .test()
             .assertFailure(TestException.class);
@@ -358,28 +326,17 @@ public class FlowableFilterTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+                s.onError(new IOException());
+                s.onComplete();
             })
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .<Integer>map(_ -> {
+                throw new TestException();
             })
-            .filter(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    return true;
-                }
-            })
+            .filter(_ -> true)
             .test()
             .assertFailure(TestException.class);
 
@@ -434,21 +391,15 @@ public class FlowableFilterTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+                s.onError(new IOException());
+                s.onComplete();
             })
-            .filter(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .filter(_ -> {
+                throw new TestException();
             })
             .test()
             .assertFailure(TestException.class);
@@ -464,21 +415,15 @@ public class FlowableFilterTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+                s.onError(new IOException());
+                s.onComplete();
             })
-            .filter(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .filter(_ -> {
+                throw new TestException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -495,22 +440,16 @@ public class FlowableFilterTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    ConditionalSubscriber<? super Integer> cs = (ConditionalSubscriber<? super Integer>)s;
-                    cs.onSubscribe(new BooleanSubscription());
-                    cs.tryOnNext(1);
-                    cs.tryOnNext(2);
-                    cs.onError(new IOException());
-                    cs.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                ConditionalSubscriber<? super Integer> cs = (ConditionalSubscriber<? super Integer>)s;
+                cs.onSubscribe(new BooleanSubscription());
+                cs.tryOnNext(1);
+                cs.tryOnNext(2);
+                cs.onError(new IOException());
+                cs.onComplete();
             })
-            .filter(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .filter(_ -> {
+                throw new TestException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -529,12 +468,7 @@ public class FlowableFilterTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.filter(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.filter(Functions.alwaysTrue()));
     }
 
     @Test
@@ -542,12 +476,7 @@ public class FlowableFilterTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.range(1, 5)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         ts.assertFusionMode(QueueFuseable.SYNC)
@@ -561,12 +490,7 @@ public class FlowableFilterTest extends RxJavaTest {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         TestHelper.emit(up, 1, 2, 3, 4, 5);
@@ -580,12 +504,7 @@ public class FlowableFilterTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
 
         Flowable.range(1, 5)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         ts.assertFusionMode(QueueFuseable.NONE)
@@ -595,11 +514,8 @@ public class FlowableFilterTest extends RxJavaTest {
     @Test
     public void filterThrows() {
         Flowable.range(1, 5)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .filter(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFirstTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFirstTest.java
@@ -34,12 +34,7 @@ public class FlowableFirstTest extends RxJavaTest {
 
     MaybeObserver<Object> wm;
 
-    private static final Predicate<String> IS_D = new Predicate<String>() {
-        @Override
-        public boolean test(String value) {
-            return "d".equals(value);
-        }
-    };
+    private static final Predicate<String> IS_D = "d"::equals;
 
     @Before
     public void before() {
@@ -134,12 +129,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -154,12 +144,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateAndOneElementFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -174,12 +159,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateAndEmptyFlowable() {
         Flowable<Integer> flowable = Flowable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -235,12 +215,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(8).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -255,12 +230,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateAndOneElementFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(4).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -275,12 +245,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateAndEmptyFlowable() {
         Flowable<Integer> flowable = Flowable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(2).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -369,12 +334,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicate() {
         Maybe<Integer> maybe = Flowable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement();
 
         maybe.subscribe(wm);
@@ -387,12 +347,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateAndOneElement() {
         Maybe<Integer> maybe = Flowable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement();
 
         maybe.subscribe(wm);
@@ -405,12 +360,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateAndEmpty() {
         Maybe<Integer> maybe = Flowable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement();
 
         maybe.subscribe(wm);
@@ -459,12 +409,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicate() {
         Single<Integer> single = Flowable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(8);
 
         single.subscribe(wo);
@@ -477,12 +422,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateAndOneElement() {
         Single<Integer> single = Flowable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(4);
 
         single.subscribe(wo);
@@ -495,12 +435,7 @@ public class FlowableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateAndEmpty() {
         Single<Integer> single = Flowable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(2);
 
         single.subscribe(wo);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -39,12 +39,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalFlowable() {
         Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }).toFlowable()
+        .flatMapCompletable(_ -> Completable.complete()).toFlowable()
         .test()
         .assertResult();
     }
@@ -54,11 +49,8 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = pp
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapCompletable(_ -> {
+            throw new TestException();
         }).<Integer>toFlowable()
         .test();
 
@@ -76,12 +68,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = pp
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return null;
-            }
-        }).<Integer>toFlowable()
+        .flatMapCompletable(_ -> null).<Integer>toFlowable()
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -96,12 +83,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorFlowable() {
         Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }, true, Integer.MAX_VALUE).toFlowable()
+        .flatMapCompletable(_ -> Completable.complete(), true, Integer.MAX_VALUE).toFlowable()
         .test()
         .assertResult();
     }
@@ -109,12 +91,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalAsyncFlowable() {
         Flowable.range(1, 1000)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Flowable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements();
-            }
-        }).toFlowable()
+        .flatMapCompletable(_ -> Flowable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements()).toFlowable()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult();
@@ -123,12 +100,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalAsyncFlowableMaxConcurrency() {
         Flowable.range(1, 1000)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Flowable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements();
-            }
-        }, false, 3).toFlowable()
+        .flatMapCompletable(_ -> Flowable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements(), false, 3).toFlowable()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult();
@@ -137,12 +109,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAllFlowable() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, true, Integer.MAX_VALUE).<Integer>toFlowable()
+        .flatMapCompletable(_ -> Completable.error(new TestException()), true, Integer.MAX_VALUE).<Integer>toFlowable()
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -156,12 +123,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayInnerErrorAllFlowable() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, true, Integer.MAX_VALUE).<Integer>toFlowable()
+        .flatMapCompletable(_ -> Completable.error(new TestException()), true, Integer.MAX_VALUE).<Integer>toFlowable()
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -175,12 +137,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalNonDelayErrorOuterFlowable() {
         Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }, false, Integer.MAX_VALUE).toFlowable()
+        .flatMapCompletable(_ -> Completable.complete(), false, Integer.MAX_VALUE).toFlowable()
         .test()
         .assertFailure(TestException.class);
     }
@@ -190,12 +147,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }).<Integer>toFlowable()
+        .flatMapCompletable(_ -> Completable.complete()).<Integer>toFlowable()
         .subscribe(ts);
 
         ts
@@ -207,12 +159,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normal() {
         Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        .flatMapCompletable(_ -> Completable.complete())
         .test()
         .assertResult();
     }
@@ -222,11 +169,8 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestObserver<Void> to = pp
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapCompletable(_ -> {
+            throw new TestException();
         })
         .test();
 
@@ -244,12 +188,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestObserver<Void> to = pp
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return null;
-            }
-        })
+        .flatMapCompletable(_ -> null)
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -264,12 +203,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }, true, Integer.MAX_VALUE)
+        .flatMapCompletable(_ -> Completable.complete(), true, Integer.MAX_VALUE)
         .test()
         .assertResult();
     }
@@ -277,12 +211,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalAsync() {
         Flowable.range(1, 1000)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Flowable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements();
-            }
-        })
+        .flatMapCompletable(_ -> Flowable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult();
@@ -291,12 +220,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAll() {
         TestObserverEx<Void> to = Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, true, Integer.MAX_VALUE)
+        .flatMapCompletable(_ -> Completable.error(new TestException()), true, Integer.MAX_VALUE)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -310,12 +234,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayInnerErrorAll() {
         TestObserverEx<Void> to = Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, true, Integer.MAX_VALUE)
+        .flatMapCompletable(_ -> Completable.error(new TestException()), true, Integer.MAX_VALUE)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -329,12 +248,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalNonDelayErrorOuter() {
         Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }, false, Integer.MAX_VALUE)
+        .flatMapCompletable(_ -> Completable.complete(), false, Integer.MAX_VALUE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -344,12 +258,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        .flatMapCompletable(_ -> Completable.complete())
         .<Integer>toFlowable()
         .subscribe(ts);
 
@@ -362,23 +271,13 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void disposed() {
         TestHelper.checkDisposed(Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }));
+        .flatMapCompletable(_ -> Completable.complete()));
     }
 
     @Test
     public void normalAsyncMaxConcurrency() {
         Flowable.range(1, 1000)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Flowable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements();
-            }
-        }, false, 3)
+        .flatMapCompletable(_ -> Flowable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements(), false, 3)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult();
@@ -387,40 +286,20 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void disposedFlowable() {
         TestHelper.checkDisposed(Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }).toFlowable());
+        .flatMapCompletable(_ -> Completable.complete()).toFlowable());
     }
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.flatMapCompletable(new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        return Completable.complete();
-                    }
-                });
-            }
-        }, false, 1, null);
+        TestHelper.checkBadSourceFlowable(f -> f.flatMapCompletable(_ -> Completable.complete()), false, 1, null);
     }
 
     @Test
     public void fusedInternalsFlowable() {
         Flowable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        .flatMapCompletable(_ -> Completable.complete())
         .toFlowable()
-        .subscribe(new FlowableSubscriber<Object>() {
+        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 QueueSubscription<?> qs = (QueueSubscription<?>)s;
@@ -450,21 +329,16 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void innerObserverFlowable() {
         Flowable.range(1, 3)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
+        .flatMapCompletable(_ -> new Completable() /* NFI */ {
             @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return new Completable() {
-                    @Override
-                    protected void subscribeActual(CompletableObserver observer) {
-                        observer.onSubscribe(Disposable.empty());
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposable.empty());
 
-                        assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable)observer).isDisposed());
 
-                        ((Disposable)observer).dispose();
+                ((Disposable)observer).dispose();
 
-                        assertTrue(((Disposable)observer).isDisposed());
-                    }
-                };
+                assertTrue(((Disposable)observer).isDisposed());
             }
         })
         .toFlowable()
@@ -473,37 +347,22 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void badSourceFlowable() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.flatMapCompletable(new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        return Completable.complete();
-                    }
-                }).toFlowable();
-            }
-        }, false, 1, null);
+        TestHelper.checkBadSourceFlowable(f -> f.flatMapCompletable(_ -> Completable.complete()).toFlowable(), false, 1, null);
     }
 
     @Test
     public void innerObserver() {
         Flowable.range(1, 3)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
+        .flatMapCompletable(_ -> new Completable() /* NFI */ {
             @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return new Completable() {
-                    @Override
-                    protected void subscribeActual(CompletableObserver observer) {
-                        observer.onSubscribe(Disposable.empty());
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposable.empty());
 
-                        assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable)observer).isDisposed());
 
-                        ((Disposable)observer).dispose();
+                ((Disposable)observer).dispose();
 
-                        assertTrue(((Disposable)observer).isDisposed());
-                    }
-                };
+                assertTrue(((Disposable)observer).isDisposed());
             }
         })
         .test();
@@ -512,14 +371,11 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void delayErrorMaxConcurrency() {
         Flowable.range(1, 3)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                if (v == 2) {
-                    return Completable.error(new TestException());
-                }
-                return Completable.complete();
+        .flatMapCompletable(v -> {
+            if (v == 2) {
+                return Completable.error(new TestException());
             }
+            return Completable.complete();
         }, true, 1)
         .toFlowable()
         .test()
@@ -529,14 +385,11 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void delayErrorMaxConcurrencyCompletable() {
         Flowable.range(1, 3)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                if (v == 2) {
-                    return Completable.error(new TestException());
-                }
-                return Completable.complete();
+        .flatMapCompletable(v -> {
+            if (v == 2) {
+                return Completable.error(new TestException());
             }
+            return Completable.complete();
         }, true, 1)
         .test()
         .assertFailure(TestException.class);
@@ -561,32 +414,14 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return upstream.flatMapCompletable(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            upstream.flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return upstream.flatMapCompletable(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            upstream.flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -39,12 +39,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normal() {
         Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -52,12 +47,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalEmpty() {
         Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.empty();
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty())
         .test()
         .assertResult();
     }
@@ -65,12 +55,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }, true, Integer.MAX_VALUE)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, true, Integer.MAX_VALUE)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -78,12 +63,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalAsync() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v).subscribeOn(Schedulers.computation()))
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertSubscribed()
@@ -97,12 +77,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalAsyncMaxConcurrency() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v).subscribeOn(Schedulers.computation());
-            }
-        }, false, 3)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v).subscribeOn(Schedulers.computation()), false, 3)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertSubscribed()
@@ -116,12 +91,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalAsyncMaxConcurrency1() {
         Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v).subscribeOn(Schedulers.computation());
-            }
-        }, false, 1)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v).subscribeOn(Schedulers.computation()), false, 1)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -132,11 +102,8 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = pp
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> {
+            throw new TestException();
         })
         .test();
 
@@ -154,12 +121,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = pp
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return null;
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> null)
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -174,12 +136,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAll() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.error(new TestException());
-            }
-        }, true, Integer.MAX_VALUE)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.error(new TestException()), true, Integer.MAX_VALUE)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -193,12 +150,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalBackpressured() {
         Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just)
         .rebatchRequests(1)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -207,12 +159,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalMaxConcurrent1Backpressured() {
         Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }, false, 1)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, false, 1)
         .rebatchRequests(1)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -221,12 +168,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalMaxConcurrent2Backpressured() {
         Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }, false, 2)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, false, 2)
         .rebatchRequests(1)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -235,12 +177,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void takeAsync() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v).subscribeOn(Schedulers.computation()))
         .take(2)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -255,12 +192,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void take() {
         Flowable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just)
         .take(2)
         .test()
         .assertResult(1, 2);
@@ -269,41 +201,21 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void middleError() {
         Flowable.fromArray(new String[]{"1", "a", "2"})
-        .flatMapMaybe(new Function<String, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(final String s) throws NumberFormatException {
-                //return Maybe.just(Integer.valueOf(s)); //This works
-                return Maybe.fromCallable(new Callable<Integer>() {
-                    @Override
-                    public Integer call() throws NumberFormatException {
-                        return Integer.valueOf(s);
-                    }
-                });
-            }
-        })
+        .flatMapMaybe((Function<String, MaybeSource<Integer>>) s -> Maybe.fromCallable(() -> Integer.valueOf(s)))
         .test()
         .assertFailure(NumberFormatException.class, 1);
     }
 
     @Test
     public void disposed() {
-        TestHelper.checkDisposed(PublishProcessor.<Integer>create().flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.<Integer>empty();
-            }
-        }));
+        TestHelper.checkDisposed(PublishProcessor.<Integer>create()
+                .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.<Integer>empty()));
     }
 
     @Test
     public void asyncFlatten() {
         Flowable.range(1, 1000)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(1).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(1).subscribeOn(Schedulers.computation()))
         .take(500)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -316,12 +228,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void asyncFlattenNone() {
         Flowable.range(1, 1000)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.<Integer>empty().subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.<Integer>empty().subscribeOn(Schedulers.computation()))
         .take(500)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -331,12 +238,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void asyncFlattenNoneMaxConcurrency() {
         Flowable.range(1, 1000)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.<Integer>empty().subscribeOn(Schedulers.computation());
-            }
-        }, false, 128)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.<Integer>empty().subscribeOn(Schedulers.computation()), false, 128)
         .take(500)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -346,12 +248,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void asyncFlattenErrorMaxConcurrency() {
         Flowable.range(1, 1000)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.<Integer>error(new TestException()).subscribeOn(Schedulers.computation());
-            }
-        }, true, 128)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.<Integer>error(new TestException()).subscribeOn(Schedulers.computation()), true, 128)
         .take(500)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -363,14 +260,11 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = Flowable.range(1, 2)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                if (v == 2) {
-                    return pp.singleElement();
-                }
-                return Maybe.error(new TestException());
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v == 2) {
+                return pp.singleElement();
             }
+            return Maybe.error(new TestException());
         }, true, Integer.MAX_VALUE)
         .test();
 
@@ -386,14 +280,11 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = Flowable.range(1, 2)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                if (v == 2) {
-                    return pp.singleElement();
-                }
-                return Maybe.error(new TestException());
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v == 2) {
+                return pp.singleElement();
             }
+            return Maybe.error(new TestException());
         }, true, Integer.MAX_VALUE)
         .test();
 
@@ -405,19 +296,14 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Object> f) throws Exception {
-                return f.flatMapMaybe(Functions.justFunction(Maybe.just(2)));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Integer>>) f -> f.flatMapMaybe(Functions.justFunction(Maybe.just(2))));
     }
 
     @Test
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -440,7 +326,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .flatMapMaybe(Functions.justFunction(new Maybe<Integer>() {
+            .flatMapMaybe(Functions.justFunction(new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -462,7 +348,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -474,12 +360,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         };
 
         Flowable.just(pp1, pp2)
-                .flatMapMaybe(new Function<PublishProcessor<Integer>, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(PublishProcessor<Integer> v) throws Exception {
-                        return v.singleElement();
-                    }
-                })
+                .flatMapMaybe((Function<PublishProcessor<Integer>, MaybeSource<Integer>>) PublishProcessor::singleElement)
         .subscribe(ts);
 
         pp1.onNext(1);
@@ -494,7 +375,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
         final PublishProcessor<Integer> pp3 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -506,12 +387,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         };
 
         Flowable.just(pp1, pp2, pp3)
-                .flatMapMaybe(new Function<PublishProcessor<Integer>, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(PublishProcessor<Integer> v) throws Exception {
-                        return v.singleElement();
-                    }
-                })
+                .flatMapMaybe((Function<PublishProcessor<Integer>, MaybeSource<Integer>>) PublishProcessor::singleElement)
         .subscribe(ts);
 
         pp1.onNext(1);
@@ -526,21 +402,16 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     public void disposeInner() {
         final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Object>>() {
+        Flowable.just(1).flatMapMaybe((Function<Integer, MaybeSource<Object>>) _ -> new Maybe<Object>() /* NFI */ {
             @Override
-            public MaybeSource<Object> apply(Integer v) throws Exception {
-                return new Maybe<Object>() {
-                    @Override
-                    protected void subscribeActual(MaybeObserver<? super Object> observer) {
-                        observer.onSubscribe(Disposable.empty());
+            protected void subscribeActual(MaybeObserver<? super Object> observer) {
+                observer.onSubscribe(Disposable.empty());
 
-                        assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable)observer).isDisposed());
 
-                        ts.cancel();
+                ts.cancel();
 
-                        assertTrue(((Disposable)observer).isDisposed());
-                    }
-                };
+                assertTrue(((Disposable)observer).isDisposed());
             }
         })
         .subscribe(ts);
@@ -596,18 +467,8 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>never())
             .flatMapMaybe(Functions.justFunction(Maybe.just(2))).test(0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> ts.request(1);
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -615,32 +476,14 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.flatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.flatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -39,12 +39,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normal() {
         Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -52,12 +47,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        }, true, Integer.MAX_VALUE)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, true, Integer.MAX_VALUE)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -65,12 +55,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalAsync() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v).subscribeOn(Schedulers.computation()))
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertSubscribed()
@@ -84,12 +69,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalAsyncMaxConcurrency() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v).subscribeOn(Schedulers.computation());
-            }
-        }, false, 3)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v).subscribeOn(Schedulers.computation()), false, 3)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertSubscribed()
@@ -102,12 +82,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalAsyncMaxConcurrency1() {
         Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v).subscribeOn(Schedulers.computation());
-            }
-        }, false, 1)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v).subscribeOn(Schedulers.computation()), false, 1)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -118,11 +93,8 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = pp
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> {
+            throw new TestException();
         })
         .test();
 
@@ -140,12 +112,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = pp
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return null;
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> null)
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -160,12 +127,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAll() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10).concatWith(Flowable.<Integer>error(new TestException()))
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.error(new TestException());
-            }
-        }, true, Integer.MAX_VALUE)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.error(new TestException()), true, Integer.MAX_VALUE)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -179,12 +141,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalBackpressured() {
         Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just)
         .rebatchRequests(1)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -193,12 +150,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalMaxConcurrent1Backpressured() {
         Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        }, false, 1)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, false, 1)
         .rebatchRequests(1)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -207,12 +159,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalMaxConcurrent2Backpressured() {
         Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        }, false, 2)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, false, 2)
         .rebatchRequests(1)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -221,12 +168,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void takeAsync() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v).subscribeOn(Schedulers.computation()))
         .take(2)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -241,12 +183,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void take() {
         Flowable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just)
         .take(2)
         .test()
         .assertResult(1, 2);
@@ -255,18 +192,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void middleError() {
         Flowable.fromArray(new String[]{"1", "a", "2"})
-        .flatMapSingle(new Function<String, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(final String s) throws NumberFormatException {
-                //return Single.just(Integer.valueOf(s)); //This works
-                return Single.fromCallable(new Callable<Integer>() {
-                    @Override
-                    public Integer call() throws NumberFormatException {
-                        return Integer.valueOf(s);
-                    }
-                });
-            }
-        })
+        .flatMapSingle((Function<String, SingleSource<Integer>>) s -> Single.fromCallable(() -> Integer.valueOf(s)))
         .test()
         .assertFailure(NumberFormatException.class, 1);
     }
@@ -274,12 +200,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void asyncFlatten() {
         Flowable.range(1, 1000)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(1).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.just(1).subscribeOn(Schedulers.computation()))
         .take(500)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -294,14 +215,11 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = Flowable.range(1, 2)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                if (v == 2) {
-                    return pp.singleOrError();
-                }
-                return Single.error(new TestException());
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
+            if (v == 2) {
+                return pp.singleOrError();
             }
+            return Single.error(new TestException());
         }, true, Integer.MAX_VALUE)
         .test();
 
@@ -314,29 +232,21 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void disposed() {
-        TestHelper.checkDisposed(PublishProcessor.<Integer>create().flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.<Integer>just(1);
-            }
-        }));
+        TestHelper.checkDisposed(PublishProcessor.<Integer>create()
+                .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.<Integer>just(1)));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Object> f) throws Exception {
-                return f.flatMapSingle(Functions.justFunction(Single.just(2)));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Integer>>) f ->
+            f.flatMapSingle(Functions.justFunction(Single.just(2))));
     }
 
     @Test
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -359,7 +269,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .flatMapSingle(Functions.justFunction(new Single<Integer>() {
+            .flatMapSingle(Functions.justFunction(new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -381,7 +291,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -393,12 +303,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         };
 
         Flowable.just(pp1, pp2)
-                .flatMapSingle(new Function<PublishProcessor<Integer>, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(PublishProcessor<Integer> v) throws Exception {
-                        return v.singleOrError();
-                    }
-                })
+                .flatMapSingle((Function<PublishProcessor<Integer>, SingleSource<Integer>>) PublishProcessor::singleOrError)
         .subscribe(ts);
 
         pp1.onNext(1);
@@ -411,21 +316,16 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     public void disposeInner() {
         final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.just(1).flatMapSingle(new Function<Integer, SingleSource<Object>>() {
+        Flowable.just(1).flatMapSingle((Function<Integer, SingleSource<Object>>) _ -> new Single<Object>() /* NFI */ {
             @Override
-            public SingleSource<Object> apply(Integer v) throws Exception {
-                return new Single<Object>() {
-                    @Override
-                    protected void subscribeActual(SingleObserver<? super Object> observer) {
-                        observer.onSubscribe(Disposable.empty());
+            protected void subscribeActual(SingleObserver<? super Object> observer) {
+                observer.onSubscribe(Disposable.empty());
 
-                        assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable)observer).isDisposed());
 
-                        ts.cancel();
+                ts.cancel();
 
-                        assertTrue(((Disposable)observer).isDisposed());
-                    }
-                };
+                assertTrue(((Disposable)observer).isDisposed());
             }
         })
         .subscribe(ts);
@@ -481,18 +381,8 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>never())
             .flatMapSingle(Functions.justFunction(Single.just(2))).test(0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> ts.request(1);
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -501,12 +391,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void asyncFlattenErrorMaxConcurrency() {
         Flowable.range(1, 1000)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.<Integer>error(new TestException()).subscribeOn(Schedulers.computation());
-            }
-        }, true, 128)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.<Integer>error(new TestException()).subscribeOn(Schedulers.computation()), true, 128)
         .take(500)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -515,32 +400,14 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.flatMapSingle(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+        upstream.flatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.flatMapSingle(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.flatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -45,19 +46,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
         final List<Integer> list = Arrays.asList(1, 2, 3);
 
-        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer t1) {
-                return list;
-            }
-        };
-        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 | t2;
-            }
-        };
+        Function<Integer, List<Integer>> func = _ -> list;
+        BiFunction<Integer, Integer, Integer> resFunc = (t1, t2) -> t1 | t2;
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
@@ -76,19 +66,10 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void collectionFunctionThrows() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, List<Integer>> func = _ -> {
+            throw new TestException();
         };
-        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 | t2;
-            }
-        };
+        BiFunction<Integer, Integer, Integer> resFunc = (t1, t2) -> t1 | t2;
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
@@ -105,18 +86,9 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
         final List<Integer> list = Arrays.asList(1, 2, 3);
 
-        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer t1) {
-                return list;
-            }
-        };
-        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                throw new TestException();
-            }
+        Function<Integer, List<Integer>> func = _ -> list;
+        BiFunction<Integer, Integer, Integer> resFunc = (_, _) -> {
+            throw new TestException();
         };
 
         List<Integer> source = Arrays.asList(16, 32, 64);
@@ -132,19 +104,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void mergeError() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Function<Integer, Flowable<Integer>> func = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return Flowable.error(new TestException());
-            }
-        };
-        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 | t2;
-            }
-        };
+        Function<Integer, Flowable<Integer>> func = _ -> Flowable.error(new TestException());
+        BiFunction<Integer, Integer, Integer> resFunc = (t1, t2) -> t1 | t2;
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
@@ -156,23 +117,11 @@ public class FlowableFlatMapTest extends RxJavaTest {
     }
 
     <T, R> Function<T, R> just(final R value) {
-        return new Function<T, R>() {
-
-            @Override
-            public R apply(T t1) {
-                return value;
-            }
-        };
+        return _ -> value;
     }
 
     <R> Supplier<R> just0(final R value) {
-        return new Supplier<R>() {
-
-            @Override
-            public R get() {
-                return value;
-            }
-        };
+        return () -> value;
     }
 
     @Test
@@ -223,20 +172,14 @@ public class FlowableFlatMapTest extends RxJavaTest {
     }
 
     <R> Supplier<R> funcThrow0(R r) {
-        return new Supplier<R>() {
-            @Override
-            public R get() {
-                throw new TestException();
-            }
+        return () -> {
+            throw new TestException();
         };
     }
 
     <T, R> Function<T, R> funcThrow(T t, R r) {
-        return new Function<T, R>() {
-            @Override
-            public R apply(T t) {
-                throw new TestException();
-            }
+        return _ -> {
+            throw new TestException();
         };
     }
 
@@ -315,22 +258,16 @@ public class FlowableFlatMapTest extends RxJavaTest {
     }
 
     private static <T> Flowable<T> composer(Flowable<T> source, final AtomicInteger subscriptionCount, final int m) {
-        return source.doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) {
-                    int n = subscriptionCount.getAndIncrement();
-                    if (n >= m) {
-                        Assert.fail("Too many subscriptions! " + (n + 1));
-                    }
-            }
-        }).doOnComplete(new Action() {
-            @Override
-            public void run() {
-                    int n = subscriptionCount.decrementAndGet();
-                    if (n < 0) {
-                        Assert.fail("Too many unsubscriptions! " + (n - 1));
-                    }
-            }
+        return source.doOnSubscribe(_ -> {
+                int n = subscriptionCount.getAndIncrement();
+                if (n >= m) {
+                    Assert.fail("Too many subscriptions! " + (n + 1));
+                }
+        }).doOnComplete(() -> {
+                int n = subscriptionCount.decrementAndGet();
+                if (n < 0) {
+                    Assert.fail("Too many unsubscriptions! " + (n - 1));
+                }
         });
     }
 
@@ -339,13 +276,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
         final int m = 4;
         final AtomicInteger subscriptionCount = new AtomicInteger();
         Flowable<Integer> source = Flowable.range(1, 10)
-        .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return composer(Flowable.range(t1 * 10, 2), subscriptionCount, m)
-                        .subscribeOn(Schedulers.computation());
-            }
-        }, new FlatMapConfig(m));
+        .flatMap((Function<Integer, Flowable<Integer>>) t1 -> composer(Flowable.range(t1 * 10, 2), subscriptionCount, m)
+                .subscribeOn(Schedulers.computation()), new FlatMapConfig(m));
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
@@ -365,18 +297,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
         final int m = 4;
         final AtomicInteger subscriptionCount = new AtomicInteger();
         Flowable<Integer> source = Flowable.range(1, 10)
-            .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return composer(Flowable.range(t1 * 10, 2), subscriptionCount, m)
-                        .subscribeOn(Schedulers.computation());
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 * 1000 + t2;
-            }
-        }, m);
+            .flatMap((Function<Integer, Flowable<Integer>>) t1 -> composer(Flowable.range(t1 * 10, 2), subscriptionCount, m)
+                    .subscribeOn(Schedulers.computation()), (t1, t2) -> t1 * 1000 + t2, m);
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
@@ -453,7 +375,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
             }
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.range(0, 1000)
-            .flatMap(new Function<Integer, Flowable<Integer>>() {
+            .flatMap(new Function<Integer, Flowable<Integer>>() /* NFI */ {
                 final Random rnd = new Random();
                 @Override
                 public Flowable<Integer> apply(Integer t) {
@@ -491,12 +413,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         for (int i = 0; i < 1000; i++) {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            Flowable.range(1, 1000).flatMap(new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer t) {
-                    return Flowable.just(1).subscribeOn(Schedulers.computation());
-                }
-            }).subscribe(ts);
+            Flowable.range(1, 1000).flatMap((Function<Integer, Flowable<Integer>>) _ -> Flowable.just(1).subscribeOn(Schedulers.computation())).subscribe(ts);
 
             ts.awaitDone(5, TimeUnit.SECONDS);
             ts.assertNoErrors();
@@ -510,12 +427,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         for (final int n : new int[] { 1, 1000, 1000000 }) {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            Flowable.just(1, 2).flatMap(new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer t) {
-                    return Flowable.range(1, n);
-                }
-            }).subscribe(ts);
+            Flowable.just(1, 2).flatMap((Function<Integer, Flowable<Integer>>) _ -> Flowable.range(1, n)).subscribe(ts);
 
             System.out.println("flatMapTwoNestedSync >> @ " + n);
             ts.assertNoErrors();
@@ -529,12 +441,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(0, 4 * Flowable.bufferSize())
-        .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return (v & 1) == 0 ? Flowable.<Integer>empty() : Flowable.just(v);
-            }
-        })
+        .flatMap((Function<Integer, Flowable<Integer>>) v -> (v & 1) == 0 ? Flowable.<Integer>empty() : Flowable.just(v))
         .subscribe(ts);
 
         ts.assertValueCount(2 * Flowable.bufferSize());
@@ -554,12 +461,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(0, 4 * Flowable.bufferSize())
-        .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return (v & 1) == 0 ? Flowable.<Integer>empty() : Flowable.range(v, 2);
-            }
-        })
+        .flatMap((Function<Integer, Flowable<Integer>>) v -> (v & 1) == 0 ? Flowable.<Integer>empty() : Flowable.range(v, 2))
         .subscribe(ts);
 
         ts.assertValueCount(4 * Flowable.bufferSize());
@@ -581,12 +483,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(0, 4 * Flowable.bufferSize())
-        .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return (v & 1) == 0 ? Flowable.<Integer>empty() : Flowable.just(v);
-            }
-        }, new FlatMapConfig(16))
+        .flatMap((Function<Integer, Flowable<Integer>>) v -> (v & 1) == 0 ? Flowable.<Integer>empty() : Flowable.just(v), new FlatMapConfig(16))
         .subscribe(ts);
 
         ts.assertValueCount(2 * Flowable.bufferSize());
@@ -606,12 +503,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(0, 4 * Flowable.bufferSize())
-        .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return (v & 1) == 0 ? Flowable.<Integer>empty() : Flowable.range(v, 2);
-            }
-        }, new FlatMapConfig(16))
+        .flatMap((Function<Integer, Flowable<Integer>>) v -> (v & 1) == 0 ? Flowable.<Integer>empty() : Flowable.range(v, 2), new FlatMapConfig(16))
         .subscribe(ts);
 
         ts.assertValueCount(4 * Flowable.bufferSize());
@@ -635,17 +527,9 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        pp.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer t) {
-                throw new TestException();
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1;
-            }
-        }).subscribe(ts);
+        pp.flatMap((Function<Integer, Publisher<Integer>>) _ -> {
+            throw new TestException();
+        }, (t1, _) -> t1).subscribe(ts);
 
         Assert.assertTrue("Not subscribed?", pp.hasSubscribers());
 
@@ -659,17 +543,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapper() {
         Flowable.just(1)
-        .flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(v * 10);
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true)
+        .flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v * 10),
+                (a, b) -> a + b, true)
         .test()
         .assertResult(11);
     }
@@ -677,17 +552,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapperWithError() {
         Flowable.just(1)
-        .flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(v * 10).concatWith(Flowable.<Integer>error(new TestException()));
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true)
+        .flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v * 10).concatWith(Flowable.<Integer>error(new TestException())),
+                (a, b) -> a + b, true)
         .test()
         .assertFailure(TestException.class, 11);
     }
@@ -695,29 +561,16 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapperMaxConcurrency() {
         Flowable.just(1, 2)
-        .flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(v * 10);
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true, 1)
+        .flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v * 10),
+                (a, b) -> a + b, true, 1)
         .test()
         .assertResult(11, 22);
     }
 
     @Test
     public void flatMapEmpty() {
-        assertSame(Flowable.empty(), Flowable.empty().flatMap(new Function<Object, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Object v) throws Exception {
-                return Flowable.just(v);
-            }
-        }));
+        assertSame(Flowable.empty(), Flowable.empty()
+                .flatMap((Function<Object, Publisher<Object>>) Flowable::just));
     }
 
     @Test
@@ -743,11 +596,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
     @Test
     public void mergeScalarError() {
-        Flowable.merge(Flowable.just(Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        Flowable.merge(Flowable.just(Flowable.fromCallable(() -> {
+            throw new TestException();
         })).hide())
         .test()
         .assertFailure(TestException.class);
@@ -757,7 +607,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void scalarReentrant() {
         final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -780,7 +630,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void scalarReentrant2() {
         final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -806,19 +656,9 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = Flowable.merge(Flowable.just(pp)).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -827,17 +667,9 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void fusedInnerThrows() {
         Flowable.just(1).hide()
-        .flatMap(new Function<Integer, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Integer v) throws Exception {
-                return Flowable.range(1, 2).map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer w) throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        })
+        .flatMap((Function<Integer, Flowable<Object>>) _ -> Flowable.range(1, 2).map(_ -> {
+            throw new TestException();
+        }))
         .test()
         .assertFailure(TestException.class);
     }
@@ -845,17 +677,9 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void fusedInnerThrows2() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 2).hide()
-        .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(1, 2).map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer w) throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        }, new FlatMapConfig(true))
+        .flatMap((Function<Integer, Flowable<Integer>>) _ -> Flowable.range(1, 2).map(_ -> {
+            throw new TestException();
+        }), new FlatMapConfig(true))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -877,25 +701,15 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void noCrossBoundaryFusion() {
         for (int i = 0; i < 500; i++) {
-            TestSubscriber<Object> ts = Flowable.merge(
-                    Flowable.just(1).observeOn(Schedulers.single()).map(new Function<Integer, Object>() {
-                        @Override
-                        public Object apply(Integer v) throws Exception {
-                            return Thread.currentThread().getName().substring(0, 4);
-                        }
-                    }),
-                    Flowable.just(1).observeOn(Schedulers.computation()).map(new Function<Integer, Object>() {
-                        @Override
-                        public Object apply(Integer v) throws Exception {
-                            return Thread.currentThread().getName().substring(0, 4);
-                        }
-                    })
+            TestSubscriber<String> ts = Flowable.merge(
+                    Flowable.just(1).observeOn(Schedulers.single()).map(_ -> Thread.currentThread().getName().substring(0, 4)),
+                    Flowable.just(1).observeOn(Schedulers.computation()).map(_ -> Thread.currentThread().getName().substring(0, 4))
             )
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertValueCount(2);
 
-            List<Object> list = ts.values();
+            List<String> list = ts.values();
 
             assertTrue(list.toString(), list.contains("RxSi"));
             assertTrue(list.toString(), list.contains("RxCo"));
@@ -912,18 +726,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
                 final TestSubscriber<Integer> ts = pp.flatMap(Functions.<Flowable<Integer>>identity()).test(0);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ts.cancel();
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onComplete();
-                    }
-                };
+                Runnable r1 = () -> ts.cancel();
+                Runnable r2 = () -> pp.onComplete();
 
                 TestHelper.race(r1, r2);
 
@@ -948,19 +752,11 @@ public class FlowableFlatMapTest extends RxJavaTest {
                     final PublishProcessor<Integer> just = PublishProcessor.create();
                     pp.onNext(just);
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            ts.request(1);
-                            ts.cancel();
-                        }
+                    Runnable r1 = () -> {
+                        ts.request(1);
+                        ts.cancel();
                     };
-                    Runnable r2 = new Runnable() {
-                        @Override
-                        public void run() {
-                            just.onNext(1);
-                        }
-                    };
+                    Runnable r2 = () -> just.onNext(1);
 
                     TestHelper.race(r1, r2);
 
@@ -975,36 +771,17 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void iterableMapperFunctionReturnsNull() {
         Flowable.just(1)
-        .flatMapIterable(new Function<Integer, Iterable<Object>>() {
-            @Override
-            public Iterable<Object> apply(Integer v) throws Exception {
-                return null;
-            }
-        }, new BiFunction<Integer, Object, Object>() {
-            @Override
-            public Object apply(Integer v, Object w) throws Exception {
-                return v;
-            }
-        })
-        .to(TestHelper.<Object>testConsumer())
+        .flatMapIterable((Function<Integer, Iterable<Object>>) _ -> null,
+                (v, _) -> v)
+        .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The mapper returned a null Iterable");
     }
 
     @Test
     public void combinerMapperFunctionReturnsNull() {
         Flowable.just(1)
-        .flatMap(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) throws Exception {
-                return null;
-            }
-        }, new BiFunction<Integer, Object, Object>() {
-            @Override
-            public Object apply(Integer v, Object w) throws Exception {
-                return v;
-            }
-        })
-        .to(TestHelper.<Object>testConsumer())
+        .flatMap((Function<Integer, Publisher<Object>>) _ -> null, (v, _) -> v)
+        .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The mapper returned a null Publisher");
     }
 
@@ -1012,39 +789,24 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void failingFusedInnerCancelsSource() {
         final AtomicInteger counter = new AtomicInteger();
         Flowable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
+        .doOnNext(_ -> counter.getAndIncrement())
+        .flatMap((Function<Integer, Publisher<Integer>>) _ ->
+        Flowable.<Integer>fromIterable(() -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public void accept(Integer v) throws Exception {
-                counter.getAndIncrement();
+            public boolean hasNext() {
+                return true;
             }
-        })
-        .flatMap(new Function<Integer, Publisher<Integer>>() {
+
             @Override
-            public Publisher<Integer> apply(Integer v)
-                    throws Exception {
-                return Flowable.<Integer>fromIterable(new Iterable<Integer>() {
-                    @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
-                            @Override
-                            public boolean hasNext() {
-                                return true;
-                            }
-
-                            @Override
-                            public Integer next() {
-                                throw new TestException();
-                            }
-
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                });
+            public Integer next() {
+                throw new TestException();
             }
-        })
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        }))
         .test()
         .assertFailure(TestException.class);
 
@@ -1059,21 +821,13 @@ public class FlowableFlatMapTest extends RxJavaTest {
         PublishProcessor<Integer> pp4 = PublishProcessor.create();
 
         TestSubscriber<Integer> ts = Flowable.just(pp1, pp2, pp3, pp4)
-        .flatMap(new Function<PublishProcessor<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(PublishProcessor<Integer> v) throws Exception {
-                return v;
-            }
-        }, new FlatMapConfig(2))
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (v == 1) {
-                    // this will make sure the drain loop detects two completed
-                    // inner sources and replaces them with fresh ones
-                    pp1.onComplete();
-                    pp2.onComplete();
-                }
+        .flatMap((Function<PublishProcessor<Integer>, Flowable<Integer>>) v -> v, new FlatMapConfig(2))
+        .doOnNext(v -> {
+            if (v == 1) {
+                // this will make sure the drain loop detects two completed
+                // inner sources and replaces them with fresh ones
+                pp1.onComplete();
+                pp2.onComplete();
             }
         })
         .test();
@@ -1093,32 +847,14 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.flatMap(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+        upstream.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.flatMap(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Throwable {
-                        return Flowable.just(v).hide();
-                    }
-                }, new FlatMapConfig(true));
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+        upstream.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v).hide(), new FlatMapConfig(true)));
     }
 
     @Test
@@ -1175,7 +911,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void signalsAfterMapperCrash() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Subscriber<? super @NonNull Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -1382,7 +1118,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
     @Test
     public void scalarInnerOuterOverflow() {
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Subscriber<@NonNull ? super @NonNull Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -1399,7 +1135,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void scalarInnerOuterOverflowSlowPath() {
         AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<>();
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Subscriber<@NonNull ? super @NonNull Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -1422,7 +1158,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void innerFastPathEmitOverflow() {
         Flowable.just(1)
         .hide()
-        .flatMap(_ -> new Flowable<Integer>() {
+        .flatMap(_ -> new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Subscriber<@NonNull ? super @NonNull Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080