### PR TITLE
4.x: Unit test lambdaification 11 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnLifecycleTest.java
@@ -22,7 +22,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -33,7 +32,7 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
     @Test
     public void onSubscribeCrashed() {
         Flowable.just(1)
-        .doOnLifecycle(s -> {
+        .doOnLifecycle(_ -> {
             throw new TestException();
         }, Functions.EMPTY_LONG_CONSUMER, Functions.EMPTY_ACTION)
         .test()
@@ -116,7 +115,7 @@ public class FlowableDoOnLifecycleTest extends RxJavaTest {
                     s.onComplete();
                 }
             }
-            .doOnSubscribe(s -> {
+            .doOnSubscribe(_ -> {
                 throw new TestException("First");
             })
             .to(TestHelper.<Integer>testConsumer())

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.*;
 
 import org.junit.*;
@@ -44,19 +43,9 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 2)
-        .reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) {
-                return Math.max(a, b);
-            }
-        })
+        .reduce(Math::max)
         .toFlowable()
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .subscribe(ts);
 
         ts.assertValues(2, 3)
@@ -64,12 +53,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         .assertComplete();
     }
 
-    final Function<Integer, Iterable<Integer>> mapper = new Function<Integer, Iterable<Integer>>() {
-        @Override
-        public Iterable<Integer> apply(Integer v) {
-            return Arrays.asList(v, v + 1);
-        }
-    };
+    final Function<Integer, Iterable<Integer>> mapper = v -> Arrays.asList(v, v + 1);
 
     @Test
     public void normal() {
@@ -145,12 +129,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
         int n = 1000 * 1000;
 
-        Flowable.range(1, n).concatMapIterable(mapper).concatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        })
+        Flowable.range(1, n).concatMapIterable(mapper).concatMap((Function<Integer, Flowable<Integer>>) Flowable::just)
         .subscribe(ts);
 
         ts.assertValueCount(n * 2);
@@ -211,35 +190,25 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorHasNextThrowsImmediately() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = new Iterable<Integer>() {
+        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        throw new TestException();
-                    }
+            public boolean hasNext() {
+                throw new TestException();
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         };
 
         Flowable.range(1, 2)
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return it;
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) _ -> it)
         .subscribe(ts);
 
         ts.assertNoValues();
@@ -251,35 +220,25 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorHasNextThrowsImmediatelyJust() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = new Iterable<Integer>() {
+        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        throw new TestException();
-                    }
+            public boolean hasNext() {
+                throw new TestException();
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         };
 
         Flowable.just(1)
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return it;
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) _ -> it)
         .subscribe(ts);
 
         ts.assertNoValues();
@@ -291,39 +250,29 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorHasNextThrowsSecondCall() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = new Iterable<Integer>() {
+        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+            int count;
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
-                    @Override
-                    public boolean hasNext() {
-                        if (++count >= 2) {
-                            throw new TestException();
-                        }
-                        return true;
-                    }
+            public boolean hasNext() {
+                if (++count >= 2) {
+                    throw new TestException();
+                }
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         };
 
         Flowable.range(1, 2)
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return it;
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) _ -> it)
         .subscribe(ts);
 
         ts.assertValue(1);
@@ -335,35 +284,25 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorNextThrows() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = new Iterable<Integer>() {
+        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        throw new TestException();
-                    }
+            @Override
+            public Integer next() {
+                throw new TestException();
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         };
 
         Flowable.range(1, 2)
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return it;
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) _ -> it)
         .subscribe(ts);
 
         ts.assertNoValues();
@@ -375,37 +314,27 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorNextThrowsAndUnsubscribes() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = new Iterable<Integer>() {
+        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        throw new TestException();
-                    }
+            @Override
+            public Integer next() {
+                throw new TestException();
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         };
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         pp
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return it;
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) _ -> it)
         .subscribe(ts);
 
         pp.onNext(1);
@@ -422,12 +351,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(0, 1000)
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return (v % 2) == 0 ? Collections.singleton(1) : Collections.<Integer>emptySet();
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) v -> (v % 2) == 0 ? Collections.singleton(1) : Collections.<Integer>emptySet())
         .subscribe(ts);
 
         ts.assertValueCount(500);
@@ -440,12 +364,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>(1);
 
         Flowable.range(1, 2)
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return v == 2 ? Collections.singleton(1) : Collections.<Integer>emptySet();
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) v -> v == 2 ? Collections.singleton(1) : Collections.<Integer>emptySet())
         .subscribe(ts);
 
         ts.assertValue(1);
@@ -458,12 +377,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>(1);
 
         Flowable.range(1, 1000)
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return v == 1000 ? Collections.singleton(1) : Collections.<Integer>emptySet();
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) v -> v == 1000 ? Collections.singleton(1) : Collections.<Integer>emptySet())
         .subscribe(ts);
 
         ts.assertValue(1);
@@ -477,38 +391,28 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
         final AtomicInteger counter = new AtomicInteger();
 
-        final Iterable<Integer> it = new Iterable<Integer>() {
+        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        counter.getAndIncrement();
-                        return true;
-                    }
+            public boolean hasNext() {
+                counter.getAndIncrement();
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         };
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         pp
-        .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return it;
-            }
-        })
+        .concatMapIterable((Function<Integer, Iterable<Integer>>) _ -> it)
         .take(1)
         .subscribe(ts);
 
@@ -539,17 +443,8 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.range(1, 5)
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return Collections.singletonList(1);
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) {
-                return a * 10 + b;
-            }
-        }, 2)
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> Collections.singletonList(1),
+                (a, b) -> a * 10 + b, 2)
         .subscribe(ts)
         ;
 
@@ -561,48 +456,27 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     @Test
     public void flatMapIterablePrefetch() {
         Flowable.just(1, 2)
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer t) throws Exception {
-                return Arrays.asList(t * 10);
-            }
-        }, 1)
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) t -> Arrays.asList(t * 10), 1)
         .test()
         .assertResult(10, 20);
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(PublishProcessor.create().flatMapIterable(new Function<Object, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Object v) throws Exception {
-                return Arrays.asList(10, 20);
-            }
-        }));
+        TestHelper.checkDisposed(PublishProcessor.create()
+                .flatMapIterable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(10, 20)));
     }
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.flatMapIterable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Arrays.asList(10, 20);
-                    }
-                });
-            }
-        }, false, 1, 1, 10, 20);
+        TestHelper.checkBadSourceFlowable(f ->
+            f.flatMapIterable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(10, 20)), false, 1, 1, 10, 20);
     }
 
     @Test
     public void callableThrows() {
-        Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        Flowable.fromCallable(() -> {
+            throw new TestException();
         })
         .flatMapIterable(Functions.justFunction(Arrays.asList(1, 2, 3)))
         .test()
@@ -613,7 +487,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void fusionMethods() {
         Flowable.just(1, 2)
         .flatMapIterable(Functions.justFunction(Arrays.asList(1, 2, 3)))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
@@ -677,14 +551,11 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 3)
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                if ((v & 1) == 0) {
-                    return Collections.emptyList();
-                }
-                return Arrays.asList(1, 2);
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) v -> {
+            if ((v & 1) == 0) {
+                return Collections.emptyList();
             }
+            return Arrays.asList(1, 2);
         })
         .subscribe(ts);
 
@@ -697,14 +568,11 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 3)
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                if ((v & 1) == 1) {
-                    return Collections.emptyList();
-                }
-                return Arrays.asList(1, 2);
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) v -> {
+            if ((v & 1) == 1) {
+                return Collections.emptyList();
             }
+            return Arrays.asList(1, 2);
         })
         .subscribe(ts);
 
@@ -717,12 +585,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.just(1, 2, 3).hide()
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(1, 2);
-            }
-        })
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(1, 2))
         .subscribe(ts);
 
         ts.assertFusionMode(QueueFuseable.NONE)
@@ -732,16 +595,13 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     @Test
     public void fusedIsEmptyWithEmptySource() {
         Flowable.just(1, 2, 3)
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                if ((v & 1) == 0) {
-                    return Collections.emptyList();
-                }
-                return Arrays.asList(v);
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) v -> {
+            if ((v & 1) == 0) {
+                return Collections.emptyList();
             }
+            return Arrays.asList(v);
         })
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
@@ -781,11 +641,8 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     @Test
     public void fusedSourceCrash() {
         Flowable.range(1, 3)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map(_ -> {
+            throw new TestException();
         })
         .flatMapIterable(Functions.justFunction(Collections.emptyList()), 1)
         .test()
@@ -803,7 +660,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void overflowSource() {
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -831,34 +688,29 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 3).hide()
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> new Iterable<Integer>() /* NFI */ {
+            int count;
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new Iterable<Integer>() {
-                    int count;
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() /* NFI */ {
+
                     @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
+                    public boolean hasNext() {
+                        if (++count == 2) {
+                            ts.cancel();
+                            ts.onComplete();
+                        }
+                        return true;
+                    }
 
-                            @Override
-                            public boolean hasNext() {
-                                if (++count == 2) {
-                                    ts.cancel();
-                                    ts.onComplete();
-                                }
-                                return true;
-                            }
+                    @Override
+                    public Integer next() {
+                        return 1;
+                    }
 
-                            @Override
-                            public Integer next() {
-                                return 1;
-                            }
-
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
                     }
                 };
             }
@@ -923,37 +775,21 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void failingInnerCancelsSource() {
         final AtomicInteger counter = new AtomicInteger();
         Flowable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
+        .doOnNext(_ -> counter.getAndIncrement())
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public void accept(Integer v) throws Exception {
-                counter.getAndIncrement();
+            public boolean hasNext() {
+                return true;
             }
-        })
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
+
             @Override
-            public Iterable<Integer> apply(Integer v)
-                    throws Exception {
-                return new Iterable<Integer>() {
-                    @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
-                            @Override
-                            public boolean hasNext() {
-                                return true;
-                            }
+            public Integer next() {
+                throw new TestException();
+            }
 
-                            @Override
-                            public Integer next() {
-                                throw new TestException();
-                            }
-
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .test()
@@ -964,13 +800,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.flatMapIterable(Functions.justFunction(Collections.emptyList()));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.flatMapIterable(Functions.justFunction(Collections.emptyList())));
     }
 
     @Test
@@ -981,7 +811,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
         final AtomicLong requested = new AtomicLong();
 
-        f.onSubscribe(new QueueSubscription<Integer>() {
+        f.onSubscribe(new QueueSubscription<Integer>() /* NFI */ {
 
             @Override
             public int requestFusion(int mode) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableForEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableForEachTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class FlowableForEachTest extends RxJavaTest {
@@ -31,18 +30,8 @@ public class FlowableForEachTest extends RxJavaTest {
         final List<Object> list = new ArrayList<>();
 
         Flowable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        })
-        .forEachWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v < 3;
-            }
-        });
+        .doOnNext(v -> list.add(v))
+        .forEachWhile(v -> v < 3);
 
         assertEquals(Arrays.asList(1, 2, 3), list);
     }
@@ -52,23 +41,8 @@ public class FlowableForEachTest extends RxJavaTest {
         final List<Object> list = new ArrayList<>();
 
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(new TestException()))
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        })
-        .forEachWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                list.add(100);
-            }
-        });
+        .doOnNext(v -> list.add(v))
+        .forEachWhile(_ -> true, _ -> list.add(100));
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromActionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromActionTest.java
@@ -35,12 +35,7 @@ public class FlowableFromActionTest extends RxJavaTest {
     public void fromAction() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Flowable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        })
+        Flowable.fromAction(() -> atomicInteger.incrementAndGet())
             .test()
             .assertResult();
 
@@ -51,12 +46,7 @@ public class FlowableFromActionTest extends RxJavaTest {
     public void fromActionTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Action run = new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Action run = () -> atomicInteger.incrementAndGet();
 
         Flowable.fromAction(run)
             .test()
@@ -75,12 +65,7 @@ public class FlowableFromActionTest extends RxJavaTest {
     public void fromActionInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Flowable<Object> source = Flowable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        });
+        Flowable<Object> source = Flowable.fromAction(() -> atomicInteger.incrementAndGet());
 
         assertEquals(0, atomicInteger.get());
 
@@ -93,11 +78,8 @@ public class FlowableFromActionTest extends RxJavaTest {
 
     @Test
     public void fromActionThrows() {
-        Flowable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Flowable.fromAction(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -108,12 +90,7 @@ public class FlowableFromActionTest extends RxJavaTest {
     public void callable() throws Throwable {
         final int[] counter = { 0 };
 
-        Flowable<Void> m = Flowable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter[0]++;
-            }
-        });
+        Flowable<Void> m = Flowable.fromAction(() -> counter[0]++);
 
         assertTrue(m.getClass().toString(), m instanceof Supplier);
 
@@ -129,12 +106,9 @@ public class FlowableFromActionTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestSubscriber<Object> ts = Flowable.fromAction(new Action() {
-                @Override
-                public void run() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                }
+            TestSubscriber<Object> ts = Flowable.fromAction(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
@@ -168,12 +142,7 @@ public class FlowableFromActionTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.cancel();
-            }
-        })
+        Flowable.fromAction(() -> ts.cancel())
         .subscribeWith(ts)
         .assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromArrayTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Predicate;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.operators.ScalarSupplier;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -142,12 +141,7 @@ public class FlowableFromArrayTest extends RxJavaTest {
     @Test
     public void conditionalFiltered() {
         Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .test()
         .assertResult(2, 4);
     }
@@ -156,7 +150,7 @@ public class FlowableFromArrayTest extends RxJavaTest {
     public void conditionalSlowPathCancel() {
         Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
         .filter(Functions.alwaysTrue())
-        .subscribeWith(new TestSubscriber<Integer>(5L) {
+        .subscribeWith(new TestSubscriber<Integer>(5L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -172,13 +166,8 @@ public class FlowableFromArrayTest extends RxJavaTest {
     @Test
     public void conditionalSlowPathSkipCancel() {
         Flowable.fromArray(new Integer[] { 1, 2, 3, 4, 5 })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v < 2;
-            }
-        })
-        .subscribeWith(new TestSubscriber<Integer>(5L) {
+        .filter(v -> v < 2)
+        .subscribeWith(new TestSubscriber<Integer>(5L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromCallableTest.java
@@ -21,13 +21,11 @@ import java.util.List;
 import java.util.concurrent.*;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -96,22 +94,19 @@ public class FlowableFromCallableTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.call()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.call()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Flowable<String> fromCallableFlowable = Flowable.fromCallable(func);
@@ -145,11 +140,8 @@ public class FlowableFromCallableTest extends RxJavaTest {
     public void shouldAllowToThrowCheckedException() {
         final Exception checkedException = new Exception("test exception");
 
-        Flowable<Object> fromCallableFlowable = Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw checkedException;
-            }
+        Flowable<Object> fromCallableFlowable = Flowable.fromCallable(() -> {
+            throw checkedException;
         });
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -165,18 +157,7 @@ public class FlowableFromCallableTest extends RxJavaTest {
     public void fusedFlatMapExecution() {
         final int[] calls = { 0 };
 
-        Flowable.just(1).flatMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        return ++calls[0];
-                    }
-                });
-            }
-        })
+        Flowable.just(1).flatMap(_ -> Flowable.fromCallable(() -> ++calls[0]))
         .test()
         .assertResult(1);
 
@@ -187,18 +168,7 @@ public class FlowableFromCallableTest extends RxJavaTest {
     public void fusedFlatMapExecutionHidden() {
         final int[] calls = { 0 };
 
-        Flowable.just(1).hide().flatMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        return ++calls[0];
-                    }
-                });
-            }
-        })
+        Flowable.just(1).hide().flatMap(_ -> Flowable.fromCallable(() -> ++calls[0]))
         .test()
         .assertResult(1);
 
@@ -207,36 +177,14 @@ public class FlowableFromCallableTest extends RxJavaTest {
 
     @Test
     public void fusedFlatMapNull() {
-        Flowable.just(1).flatMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        return null;
-                    }
-                });
-            }
-        })
+        Flowable.just(1).flatMap(_ -> Flowable.fromCallable(() -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void fusedFlatMapNullHidden() {
-        Flowable.just(1).hide().flatMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        return null;
-                    }
-                });
-            }
-        })
+        Flowable.just(1).hide().flatMap(_ -> Flowable.fromCallable(() -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -245,14 +193,11 @@ public class FlowableFromCallableTest extends RxJavaTest {
     public void undeliverableUponCancellation() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestSubscriber<Integer> ts = new TestSubscriber<>();
+            final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-            Flowable.fromCallable(new Callable<Integer>() {
-                @Override
-                public Integer call() throws Exception {
-                    ts.cancel();
-                    throw new TestException();
-                }
+            Flowable.fromCallable(() -> {
+                ts.cancel();
+                throw new TestException();
             })
             .subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromCompletableTest.java
@@ -36,12 +36,7 @@ public class FlowableFromCompletableTest extends RxJavaTest {
     public void fromCompletable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Flowable.fromCompletable(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        }))
+        Flowable.fromCompletable(Completable.fromAction(() -> atomicInteger.incrementAndGet()))
             .test()
             .assertResult();
 
@@ -52,12 +47,7 @@ public class FlowableFromCompletableTest extends RxJavaTest {
     public void fromCompletableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Action run = new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Action run = () -> atomicInteger.incrementAndGet();
 
         Flowable.fromCompletable(Completable.fromAction(run))
             .test()
@@ -76,12 +66,7 @@ public class FlowableFromCompletableTest extends RxJavaTest {
     public void fromCompletableInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Flowable<Object> source = Flowable.fromCompletable(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        }));
+        Flowable<Object> source = Flowable.fromCompletable(Completable.fromAction(() -> atomicInteger.incrementAndGet()));
 
         assertEquals(0, atomicInteger.get());
 
@@ -94,11 +79,8 @@ public class FlowableFromCompletableTest extends RxJavaTest {
 
     @Test
     public void fromCompletableThrows() {
-        Flowable.fromCompletable(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Flowable.fromCompletable(Completable.fromAction(() -> {
+            throw new UnsupportedOperationException();
         }))
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -111,12 +93,9 @@ public class FlowableFromCompletableTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestSubscriber<Object> ts = Flowable.fromCompletable(Completable.fromAction(new Action() {
-                @Override
-                public void run() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                }
+            TestSubscriber<Object> ts = Flowable.fromCompletable(Completable.fromAction(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
             }))
             .subscribeOn(Schedulers.single()).test();
 
@@ -151,12 +130,7 @@ public class FlowableFromCompletableTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.fromCompletable(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.cancel();
-            }
-        }))
+        Flowable.fromCompletable(Completable.fromAction(() -> ts.cancel()))
         .subscribeWith(ts)
         .assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromIterableTest.java
@@ -61,29 +61,22 @@ public class FlowableFromIterableTest extends RxJavaTest {
      */
     @Test
     public void rawIterable() {
-        Iterable<String> it = new Iterable<String>() {
+        Iterable<String> it = () -> new Iterator<String>() /* NFI */ {
+
+            int i;
 
             @Override
-            public Iterator<String> iterator() {
-                return new Iterator<String>() {
+            public boolean hasNext() {
+                return i < 3;
+            }
 
-                    int i;
+            @Override
+            public String next() {
+                return String.valueOf(++i);
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        return i < 3;
-                    }
-
-                    @Override
-                    public String next() {
-                        return String.valueOf(++i);
-                    }
-
-                    @Override
-                    public void remove() {
-                    }
-
-                };
+            @Override
+            public void remove() {
             }
 
         };
@@ -177,7 +170,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(expectedCount);
 
         f.subscribeOn(Schedulers.computation())
-        .subscribe(new DefaultSubscriber<Integer>() {
+        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -207,7 +200,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
         final AtomicBoolean completed = new AtomicBoolean(false);
 
-        Flowable.fromIterable(Collections.emptyList()).subscribe(new DefaultSubscriber<Object>() {
+        Flowable.fromIterable(Collections.emptyList()).subscribe(new DefaultSubscriber<Object>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -234,35 +227,29 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredWithBackpressure() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = new Iterable<Integer>() {
+        Iterable<Integer> iterable = () -> new Iterator<Integer>() /* NFI */ {
+
+            int count = 1;
 
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-
-                    int count = 1;
-
-                    @Override
-                    public void remove() {
-                        // ignore
-                    }
-
-                    @Override
-                    public boolean hasNext() {
-                        if (count > 1) {
-                            called.set(true);
-                            return false;
-                        }
-                        return true;
-                    }
-
-                    @Override
-                    public Integer next() {
-                        return count++;
-                    }
-
-                };
+            public void remove() {
+                // ignore
             }
+
+            @Override
+            public boolean hasNext() {
+                if (count > 1) {
+                    called.set(true);
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return count++;
+            }
+
         };
         Flowable.fromIterable(iterable).take(1).subscribe();
         assertFalse(called.get());
@@ -271,37 +258,31 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredFastPath() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = new Iterable<Integer>() {
+        Iterable<Integer> iterable = () -> new Iterator<Integer>() /* NFI */ {
 
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-
-                    @Override
-                    public void remove() {
-                        // ignore
-                    }
-
-                    int count = 1;
-
-                    @Override
-                    public boolean hasNext() {
-                        if (count > 1) {
-                            called.set(true);
-                            return false;
-                        }
-                        return true;
-                    }
-
-                    @Override
-                    public Integer next() {
-                        return count++;
-                    }
-
-                };
+            public void remove() {
+                // ignore
             }
+
+            int count = 1;
+
+            @Override
+            public boolean hasNext() {
+                if (count > 1) {
+                    called.set(true);
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return count++;
+            }
+
         };
-        Flowable.fromIterable(iterable).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.fromIterable(iterable).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -324,11 +305,8 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void getIteratorThrows() {
-        Iterable<Integer> it = new Iterable<Integer>() {
-            @Override
-            public Iterator<Integer> iterator() {
-                throw new TestException("Forced failure");
-            }
+        Iterable<Integer> it = () -> {
+            throw new TestException("Forced failure");
         };
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
@@ -342,25 +320,20 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrowsImmediately() {
-        Iterable<Integer> it = new Iterable<Integer>() {
+        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        throw new TestException("Forced failure");
-                    }
+            public boolean hasNext() {
+                throw new TestException("Forced failure");
+            }
 
-                    @Override
-                    public Integer next() {
-                        return null;
-                    }
+            @Override
+            public Integer next() {
+                return null;
+            }
 
-                    @Override
-                    public void remove() {
-                        // ignored
-                    }
-                };
+            @Override
+            public void remove() {
+                // ignored
             }
         };
 
@@ -375,29 +348,24 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrowsSecondTimeFastpath() {
-        Iterable<Integer> it = new Iterable<Integer>() {
+        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+            int count;
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
-                    @Override
-                    public boolean hasNext() {
-                        if (++count >= 2) {
-                            throw new TestException("Forced failure");
-                        }
-                        return true;
-                    }
+            public boolean hasNext() {
+                if (++count >= 2) {
+                    throw new TestException("Forced failure");
+                }
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public void remove() {
-                        // ignored
-                    }
-                };
+            @Override
+            public void remove() {
+                // ignored
             }
         };
 
@@ -412,29 +380,24 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrowsSecondTimeSlowpath() {
-        Iterable<Integer> it = new Iterable<Integer>() {
+        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+            int count;
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
-                    @Override
-                    public boolean hasNext() {
-                        if (++count >= 2) {
-                            throw new TestException("Forced failure");
-                        }
-                        return true;
-                    }
+            public boolean hasNext() {
+                if (++count >= 2) {
+                    throw new TestException("Forced failure");
+                }
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public void remove() {
-                        // ignored
-                    }
-                };
+            @Override
+            public void remove() {
+                // ignored
             }
         };
 
@@ -449,25 +412,20 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void nextThrowsFastpath() {
-        Iterable<Integer> it = new Iterable<Integer>() {
+        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        throw new TestException("Forced failure");
-                    }
+            @Override
+            public Integer next() {
+                throw new TestException("Forced failure");
+            }
 
-                    @Override
-                    public void remove() {
-                        // ignored
-                    }
-                };
+            @Override
+            public void remove() {
+                // ignored
             }
         };
 
@@ -482,25 +440,20 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void nextThrowsSlowpath() {
-        Iterable<Integer> it = new Iterable<Integer>() {
+        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        throw new TestException("Forced failure");
-                    }
+            @Override
+            public Integer next() {
+                throw new TestException("Forced failure");
+            }
 
-                    @Override
-                    public void remove() {
-                        // ignored
-                    }
-                };
+            @Override
+            public void remove() {
+                // ignored
             }
         };
 
@@ -515,25 +468,20 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void deadOnArrival() {
-        Iterable<Integer> it = new Iterable<Integer>() {
+        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        throw new NoSuchElementException();
-                    }
+            @Override
+            public Integer next() {
+                throw new NoSuchElementException();
+            }
 
-                    @Override
-                    public void remove() {
-                        // ignored
-                    }
-                };
+            @Override
+            public void remove() {
+                // ignored
             }
         };
 
@@ -553,12 +501,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.fromIterable(Arrays.asList(1, 2, 3, 4)).concatMap(
-        new Function<Integer, Flowable  <Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) {
-                return Flowable.range(v, 2);
-            }
-        }).subscribe(ts);
+        (Function<Integer, Flowable<Integer>>) v -> Flowable.range(v, 2)).subscribe(ts);
 
         ts.assertValues(1, 2, 2, 3, 3, 4, 4, 5);
         ts.assertNoErrors();
@@ -568,7 +511,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void fusedAPICalls() {
         Flowable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -724,12 +667,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r = () -> ts.request(1);
 
             Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
             .filter(Functions.alwaysTrue())
@@ -744,12 +682,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r = () -> ts.request(1);
 
             Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
             .filter(Functions.alwaysFalse())
@@ -764,19 +697,9 @@ public class FlowableFromIterableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r1 = () -> ts.request(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
             .filter(Functions.alwaysTrue())
@@ -791,19 +714,9 @@ public class FlowableFromIterableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(Long.MAX_VALUE);
-                }
-            };
+            Runnable r1 = () -> ts.request(Long.MAX_VALUE);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
             .filter(Functions.alwaysTrue())
@@ -818,19 +731,9 @@ public class FlowableFromIterableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r1 = () -> ts.request(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
             .subscribe(ts);
@@ -844,19 +747,9 @@ public class FlowableFromIterableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(Long.MAX_VALUE);
-                }
-            };
+            Runnable r1 = () -> ts.request(Long.MAX_VALUE);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
             .subscribe(ts);
@@ -879,7 +772,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void fusionClear() {
         Flowable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
@@ -933,30 +826,25 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void hasNextCancels() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+            int count;
+
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
+            public boolean hasNext() {
+                if (++count == 2) {
+                    ts.cancel();
+                }
+                return true;
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        if (++count == 2) {
-                            ts.cancel();
-                        }
-                        return true;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(ts);
@@ -970,31 +858,26 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void hasNextCancelsAndCompletesFastPath() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+            int count;
+
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
+            public boolean hasNext() {
+                if (++count == 2) {
+                    ts.cancel();
+                    return false;
+                }
+                return true;
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        if (++count == 2) {
-                            ts.cancel();
-                            return false;
-                        }
-                        return true;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(ts);
@@ -1008,31 +891,26 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void hasNextCancelsAndCompletesSlowPath() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(10L);
 
-        Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+            int count;
+
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
+            public boolean hasNext() {
+                if (++count == 2) {
+                    ts.cancel();
+                    return false;
+                }
+                return true;
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        if (++count == 2) {
-                            ts.cancel();
-                            return false;
-                        }
-                        return true;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(ts);
@@ -1046,31 +924,26 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void hasNextCancelsAndCompletesFastPathConditional() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+            int count;
+
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
+            public boolean hasNext() {
+                if (++count == 2) {
+                    ts.cancel();
+                    return false;
+                }
+                return true;
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        if (++count == 2) {
-                            ts.cancel();
-                            return false;
-                        }
-                        return true;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .filter(_ -> true)
@@ -1085,31 +958,26 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void hasNextCancelsAndCompletesSlowPathConditional() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(10);
 
-        Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+            int count;
+
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
+            public boolean hasNext() {
+                if (++count == 2) {
+                    ts.cancel();
+                    return false;
+                }
+                return true;
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        if (++count == 2) {
-                            ts.cancel();
-                            return false;
-                        }
-                        return true;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .filter(_ -> true)
@@ -1125,7 +993,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
 
         Flowable.fromIterable(Arrays.asList(1))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Subscription s) {
                 queue.set((SimpleQueue<?>)s);
@@ -1162,26 +1030,21 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void disposeWhileIteratorNext() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(10);
 
-        Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        ts.cancel();
-                        return 1;
-                    }
+            @Override
+            public Integer next() {
+                ts.cancel();
+                return 1;
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(ts);
@@ -1193,26 +1056,21 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void disposeWhileIteratorNextConditional() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(10);
 
-        Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public boolean hasNext() {
+                return true;
+            }
 
-                    @Override
-                    public Integer next() {
-                        ts.cancel();
-                        return 1;
-                    }
+            @Override
+            public Integer next() {
+                ts.cancel();
+                return 1;
+            }
 
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .filter(_ -> true)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromRunnableTest.java
@@ -36,12 +36,7 @@ public class FlowableFromRunnableTest extends RxJavaTest {
     public void fromRunnable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Flowable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        })
+        Flowable.fromRunnable(() -> atomicInteger.incrementAndGet())
             .test()
             .assertResult();
 
@@ -52,12 +47,7 @@ public class FlowableFromRunnableTest extends RxJavaTest {
     public void fromRunnableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Runnable run = new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Runnable run = () -> atomicInteger.incrementAndGet();
 
         Flowable.fromRunnable(run)
             .test()
@@ -76,12 +66,7 @@ public class FlowableFromRunnableTest extends RxJavaTest {
     public void fromRunnableInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Flowable<Object> source = Flowable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        });
+        Flowable<Object> source = Flowable.fromRunnable(() -> atomicInteger.incrementAndGet());
 
         assertEquals(0, atomicInteger.get());
 
@@ -94,11 +79,8 @@ public class FlowableFromRunnableTest extends RxJavaTest {
 
     @Test
     public void fromRunnableThrows() {
-        Flowable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                throw new UnsupportedOperationException();
-            }
+        Flowable.fromRunnable(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -109,12 +91,7 @@ public class FlowableFromRunnableTest extends RxJavaTest {
     public void callable() throws Throwable {
         final int[] counter = { 0 };
 
-        Flowable<Void> m = Flowable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                counter[0]++;
-            }
-        });
+        Flowable<Void> m = Flowable.fromRunnable(() -> counter[0]++);
 
         assertTrue(m.getClass().toString(), m instanceof Supplier);
 
@@ -130,16 +107,13 @@ public class FlowableFromRunnableTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestSubscriber<Object> ts = Flowable.fromRunnable(new Runnable() {
-                @Override
-                public void run() {
-                    cdl1.countDown();
-                    try {
-                        cdl2.await(5, TimeUnit.SECONDS);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                        throw new TestException(e);
-                    }
+            TestSubscriber<Object> ts = Flowable.fromRunnable(() -> {
+                cdl1.countDown();
+                try {
+                    cdl2.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    throw new TestException(e);
                 }
             }).subscribeOn(Schedulers.single()).test();
 
@@ -174,12 +148,7 @@ public class FlowableFromRunnableTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                ts.cancel();
-            }
-        })
+        Flowable.fromRunnable(() -> ts.cancel())
         .subscribeWith(ts)
         .assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromSourceTest.java
@@ -20,7 +20,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.Cancellable;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.subscribers.*;
@@ -490,7 +489,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void unsubscribeInline() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -537,7 +536,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void requestInline() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -557,7 +556,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void unsubscribeInlineLatest() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -576,7 +575,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void unsubscribeInlineExactLatest() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -637,7 +636,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void requestInlineLatest() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -674,7 +673,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
             this.current = t;
 
-            final ResourceSubscriber<Integer> as = new ResourceSubscriber<Integer>() {
+            final ResourceSubscriber<Integer> as = new ResourceSubscriber<Integer>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -695,12 +694,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
             processor.subscribe(as);
 
-            t.setCancellable(new Cancellable() {
-                @Override
-                public void cancel() throws Exception {
-                    as.dispose();
-                }
-            });;
+            t.setCancellable(() -> as.dispose());;
         }
 
         @Override
@@ -735,7 +729,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
         @Override
         public void subscribe(final FlowableEmitter<Integer> t) {
 
-            processor.subscribe(new FlowableSubscriber<Integer>() {
+            processor.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromSupplierTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import static java.util.concurrent.Flow.*;
 
@@ -96,22 +95,19 @@ public class FlowableFromSupplierTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.get()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.get()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Flowable<String> fromSupplierFlowable = Flowable.fromSupplier(func);
@@ -145,11 +141,8 @@ public class FlowableFromSupplierTest extends RxJavaTest {
     public void shouldAllowToThrowCheckedException() {
         final Exception checkedException = new Exception("test exception");
 
-        Flowable<Object> fromSupplierFlowable = Flowable.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                throw checkedException;
-            }
+        Flowable<Object> fromSupplierFlowable = Flowable.fromSupplier(() -> {
+            throw checkedException;
         });
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
@@ -165,18 +158,7 @@ public class FlowableFromSupplierTest extends RxJavaTest {
     public void fusedFlatMapExecution() {
         final int[] calls = { 0 };
 
-        Flowable.just(1).flatMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.fromSupplier(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return ++calls[0];
-                    }
-                });
-            }
-        })
+        Flowable.just(1).flatMap(_ -> Flowable.fromSupplier(() -> ++calls[0]))
         .test()
         .assertResult(1);
 
@@ -187,18 +169,7 @@ public class FlowableFromSupplierTest extends RxJavaTest {
     public void fusedFlatMapExecutionHidden() {
         final int[] calls = { 0 };
 
-        Flowable.just(1).hide().flatMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.fromSupplier(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return ++calls[0];
-                    }
-                });
-            }
-        })
+        Flowable.just(1).hide().flatMap(_ -> Flowable.fromSupplier(() -> ++calls[0]))
         .test()
         .assertResult(1);
 
@@ -207,36 +178,14 @@ public class FlowableFromSupplierTest extends RxJavaTest {
 
     @Test
     public void fusedFlatMapNull() {
-        Flowable.just(1).flatMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.fromSupplier(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return null;
-                    }
-                });
-            }
-        })
+        Flowable.just(1).flatMap(_ -> Flowable.fromSupplier(() -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void fusedFlatMapNullHidden() {
-        Flowable.just(1).hide().flatMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.fromSupplier(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return null;
-                    }
-                });
-            }
-        })
+        Flowable.just(1).hide().flatMap(_ -> Flowable.fromSupplier(() -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -245,14 +194,11 @@ public class FlowableFromSupplierTest extends RxJavaTest {
     public void undeliverableUponCancellation() throws Exception {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            final TestSubscriber<Integer> ts = new TestSubscriber<>();
+            final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-            Flowable.fromSupplier(new Supplier<Integer>() {
-                @Override
-                public Integer get() throws Exception {
-                    ts.cancel();
-                    throw new TestException();
-                }
+            Flowable.fromSupplier(() -> {
+                ts.cancel();
+                throw new TestException();
             })
             .subscribe(ts);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGenerateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGenerateTest.java
@@ -31,22 +31,9 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void statefulBiconsumer() {
-        Flowable.generate(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 10;
-            }
-        }, new BiConsumer<Object, Emitter<Object>>() {
-            @Override
-            public void accept(Object s, Emitter<Object> e) throws Exception {
-                e.onNext(s);
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-
-            }
-        })
+        Flowable.generate(() -> 10,
+                (BiConsumer<Object, Emitter<Object>>) (s, e) -> e.onNext(s),
+                        _ -> { })
         .take(5)
         .test()
         .assertResult(10, 10, 10, 10, 10);
@@ -54,33 +41,17 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void stateSupplierThrows() {
-        Flowable.generate(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                throw new TestException();
-            }
-        }, new BiConsumer<Object, Emitter<Object>>() {
-            @Override
-            public void accept(Object s, Emitter<Object> e) throws Exception {
-                e.onNext(s);
-            }
-        }, Functions.emptyConsumer())
+        Flowable.generate(() -> {
+            throw new TestException();
+        }, (BiConsumer<Object, Emitter<Object>>) (s, e) -> e.onNext(s), Functions.emptyConsumer())
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void generatorThrows() {
-        Flowable.generate(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new BiConsumer<Object, Emitter<Object>>() {
-            @Override
-            public void accept(Object s, Emitter<Object> e) throws Exception {
-                throw new TestException();
-            }
+        Flowable.generate(() -> 1, (BiConsumer<Object, Emitter<Object>>) (_, _) -> {
+            throw new TestException();
         }, Functions.emptyConsumer())
         .test()
         .assertFailure(TestException.class);
@@ -90,22 +61,11 @@ public class FlowableGenerateTest extends RxJavaTest {
     public void disposerThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.generate(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new BiConsumer<Object, Emitter<Object>>() {
-                @Override
-                public void accept(Object s, Emitter<Object> e) throws Exception {
-                    e.onComplete();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                    throw new TestException();
-                }
-            })
+            Flowable.generate(() -> 1,
+                    (BiConsumer<Object, Emitter<Object>>) (_, e) -> e.onComplete(),
+                            _ -> {
+                                throw new TestException();
+                            })
             .test()
             .assertResult();
 
@@ -117,33 +77,21 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Flowable.generate(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new BiConsumer<Object, Emitter<Object>>() {
-                @Override
-                public void accept(Object s, Emitter<Object> e) throws Exception {
-                    e.onComplete();
-                }
-            }, Functions.emptyConsumer()));
+        TestHelper.checkDisposed(Flowable.generate(() -> 1,
+                (BiConsumer<Object, Emitter<Object>>) (_, e) -> e.onComplete(), Functions.emptyConsumer()));
     }
 
     @Test
     public void nullError() {
         final int[] call = { 0 };
         Flowable.generate(Functions.justSupplier(1),
-        new BiConsumer<Integer, Emitter<Object>>() {
-            @Override
-            public void accept(Integer s, Emitter<Object> e) throws Exception {
-                try {
-                    e.onError(null);
-                } catch (NullPointerException ex) {
-                    call[0]++;
-                }
-            }
-        }, Functions.emptyConsumer())
+                        (_, e) -> {
+                            try {
+                                e.onError(null);
+                            } catch (NullPointerException ex) {
+                                call[0]++;
+                            }
+                        }, Functions.emptyConsumer())
         .test()
         .assertFailure(NullPointerException.class);
 
@@ -152,32 +100,14 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void badRequest() {
-        TestHelper.assertBadRequestReported(Flowable.generate(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new BiConsumer<Object, Emitter<Object>>() {
-                @Override
-                public void accept(Object s, Emitter<Object> e) throws Exception {
-                    e.onComplete();
-                }
-            }, Functions.emptyConsumer()));
+        TestHelper.assertBadRequestReported(Flowable.generate(() -> 1,
+                (BiConsumer<Object, Emitter<Object>>) (_, e) -> e.onComplete(), Functions.emptyConsumer()));
     }
 
     @Test
     public void rebatchAndTake() {
-        Flowable.generate(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new BiConsumer<Object, Emitter<Object>>() {
-            @Override
-            public void accept(Object s, Emitter<Object> e) throws Exception {
-                e.onNext(1);
-            }
-        }, Functions.emptyConsumer())
+        Flowable.generate(() -> 1,
+                (BiConsumer<Object, Emitter<Object>>) (_, e) -> e.onNext(1), Functions.emptyConsumer())
         .rebatchRequests(1)
         .take(5)
         .test()
@@ -186,17 +116,8 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        Flowable.generate(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new BiConsumer<Object, Emitter<Object>>() {
-            @Override
-            public void accept(Object s, Emitter<Object> e) throws Exception {
-                e.onNext(1);
-            }
-        }, Functions.emptyConsumer())
+        Flowable.generate(() -> 1,
+                (BiConsumer<Object, Emitter<Object>>) (_, e) -> e.onNext(1), Functions.emptyConsumer())
         .rebatchRequests(1)
         .to(TestHelper.<Object>testSubscriber(5L))
         .assertSubscribed()
@@ -207,27 +128,15 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void requestRace() {
-        Flowable<Object> source = Flowable.generate(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new BiConsumer<Object, Emitter<Object>>() {
-            @Override
-            public void accept(Object s, Emitter<Object> e) throws Exception {
-                e.onNext(1);
-            }
-        }, Functions.emptyConsumer());
+        Flowable<Object> source = Flowable.generate(() -> 1,
+                (BiConsumer<Object, Emitter<Object>>) (_, e) -> e.onNext(1), Functions.emptyConsumer());
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Object> ts = source.test(0L);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 500; j++) {
-                        ts.request(1);
-                    }
+            Runnable r = () -> {
+                for (int j = 0; j < 500; j++) {
+                    ts.request(1);
                 }
             };
 
@@ -239,12 +148,9 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void multipleOnNext() {
-        Flowable.generate(new Consumer<Emitter<Object>>() {
-            @Override
-            public void accept(Emitter<Object> e) throws Exception {
-                e.onNext(1);
-                e.onNext(2);
-            }
+        Flowable.generate(e -> {
+            e.onNext(1);
+            e.onNext(2);
         })
         .test(1)
         .assertFailure(IllegalStateException.class, 1);
@@ -254,12 +160,9 @@ public class FlowableGenerateTest extends RxJavaTest {
     public void multipleOnError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.generate(new Consumer<Emitter<Object>>() {
-                @Override
-                public void accept(Emitter<Object> e) throws Exception {
-                    e.onError(new TestException("First"));
-                    e.onError(new TestException("Second"));
-                }
+            Flowable.generate(e -> {
+                e.onError(new TestException("First"));
+                e.onError(new TestException("Second"));
             })
             .test(1)
             .assertFailure(TestException.class);
@@ -272,12 +175,9 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void multipleOnComplete() {
-        Flowable.generate(new Consumer<Emitter<Object>>() {
-            @Override
-            public void accept(Emitter<Object> e) throws Exception {
-                e.onComplete();
-                e.onComplete();
-            }
+        Flowable.generate(e -> {
+            e.onComplete();
+            e.onComplete();
         })
         .test(1)
         .assertResult();
@@ -285,12 +185,9 @@ public class FlowableGenerateTest extends RxJavaTest {
 
     @Test
     public void onNextAfterOnComplete() {
-        Flowable.generate(new Consumer<Emitter<Object>>() {
-            @Override
-            public void accept(Emitter<Object> e) throws Exception {
-                e.onComplete();
-                e.onNext(1);
-            }
+        Flowable.generate(e -> {
+            e.onComplete();
+            e.onNext(1);
         })
         .test()
         .assertResult();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -47,21 +47,9 @@ import io.reactivex.rxjava4.testsupport.*;
 
 public class FlowableGroupByTest extends RxJavaTest {
 
-    static Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>> FLATTEN_INTEGER = new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
+    static Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>> FLATTEN_INTEGER = t -> t;
 
-        @Override
-        public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> t) {
-            return t;
-        }
-
-    };
-
-    final Function<String, Integer> length = new Function<String, Integer>() {
-        @Override
-        public Integer apply(String s) {
-            return s.length();
-        }
-    };
+    final Function<String, Integer> length = String::length;
 
     @Test
     public void groupBy() {
@@ -125,20 +113,10 @@ public class FlowableGroupByTest extends RxJavaTest {
         final AtomicInteger eventCounter = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
-        grouped.flatMap(new Function<GroupedFlowable<Integer, String>, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(final GroupedFlowable<Integer, String> f) {
-                groupCounter.incrementAndGet();
-                return f.map(new Function<String, String>() {
-
-                    @Override
-                    public String apply(String v) {
-                        return "Event => key: " + f.getKey() + " value: " + v;
-                    }
-                });
-            }
-        }).subscribe(new DefaultSubscriber<String>() {
+        grouped.flatMap((Function<GroupedFlowable<Integer, String>, Flowable<String>>) f -> {
+            groupCounter.incrementAndGet();
+            return f.map(v -> "Event => key: " + f.getKey() + " value: " + v);
+        }).subscribe(new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -170,20 +148,9 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         final ConcurrentHashMap<K, Collection<V>> result = new ConcurrentHashMap<>();
 
-        flowable.doOnNext(new Consumer<GroupedFlowable<K, V>>() {
-
-            @Override
-            public void accept(final GroupedFlowable<K, V> f) {
-                result.put(f.getKey(), new ConcurrentLinkedQueue<>());
-                f.subscribe(new Consumer<V>() {
-
-                    @Override
-                    public void accept(V v) {
-                        result.get(f.getKey()).add(v);
-                    }
-
-                });
-            }
+        flowable.doOnNext(f -> {
+            result.put(f.getKey(), new ConcurrentLinkedQueue<>());
+            f.subscribe(v -> result.get(f.getKey()).add(v));
         }).blockingSubscribe();
 
         return result;
@@ -204,54 +171,29 @@ public class FlowableGroupByTest extends RxJavaTest {
         final int count = 100;
         final int groupCount = 2;
 
-        Flowable<Event> es = Flowable.unsafeCreate(new Publisher<Event>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super Event> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                System.out.println("*** Subscribing to EventStream ***");
-                subscribeCounter.incrementAndGet();
-                new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < count; i++) {
-                            Event e = new Event();
-                            e.source = i % groupCount;
-                            e.message = "Event-" + i;
-                            subscriber.onNext(e);
-                        }
-                        subscriber.onComplete();
-                    }
-
-                }).start();
-            }
-
+        Flowable<Event> es = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            System.out.println("*** Subscribing to EventStream ***");
+            subscribeCounter.incrementAndGet();
+            new Thread(() -> {
+                for (int i = 0; i < count; i++) {
+                    Event e = new Event();
+                    e.source = i % groupCount;
+                    e.message = "Event-" + i;
+                    subscriber.onNext(e);
+                }
+                subscriber.onComplete();
+            }).start();
         });
 
-        es.groupBy(new Function<Event, Integer>() {
+        es.groupBy(e -> e.source)
+        .flatMap((Function<GroupedFlowable<Integer, Event>, Flowable<String>>) eventGroupedFlowable -> {
+            System.out.println("GroupedFlowable Key: " + eventGroupedFlowable.getKey());
+            groupCounter.incrementAndGet();
 
-            @Override
-            public Integer apply(Event e) {
-                return e.source;
-            }
-        }).flatMap(new Function<GroupedFlowable<Integer, Event>, Flowable<String>>() {
+            return eventGroupedFlowable.map(event -> "Source: " + event.source + "  Message: " + event.message);
 
-            @Override
-            public Flowable<String> apply(GroupedFlowable<Integer, Event> eventGroupedFlowable) {
-                System.out.println("GroupedFlowable Key: " + eventGroupedFlowable.getKey());
-                groupCounter.incrementAndGet();
-
-                return eventGroupedFlowable.map(new Function<Event, String>() {
-
-                    @Override
-                    public String apply(Event event) {
-                        return "Source: " + event.source + "  Message: " + event.message;
-                    }
-                });
-
-            }
-        }).subscribe(new DefaultSubscriber<String>() {
+        }).subscribe(new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -307,33 +249,17 @@ public class FlowableGroupByTest extends RxJavaTest {
         final AtomicInteger groupCounter = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
 
-        es.groupBy(new Function<Event, Integer>() {
-
-            @Override
-            public Integer apply(Event e) {
-                return e.source;
-            }
-        })
+        es.groupBy(e -> e.source)
                 .take(1) // we want only the first group
-                .flatMap(new Function<GroupedFlowable<Integer, Event>, Flowable<String>>() {
+                .flatMap((Function<GroupedFlowable<Integer, Event>, Flowable<String>>) eventGroupedFlowable -> {
+                    System.out.println("testUnsubscribe => GroupedFlowable Key: " + eventGroupedFlowable.getKey());
+                    groupCounter.incrementAndGet();
 
-                    @Override
-                    public Flowable<String> apply(GroupedFlowable<Integer, Event> eventGroupedFlowable) {
-                        System.out.println("testUnsubscribe => GroupedFlowable Key: " + eventGroupedFlowable.getKey());
-                        groupCounter.incrementAndGet();
+                    return eventGroupedFlowable
+                            .take(20) // limit to only 20 events on this group
+                            .map(event -> "testUnsubscribe => Source: " + event.source + "  Message: " + event.message);
 
-                        return eventGroupedFlowable
-                                .take(20) // limit to only 20 events on this group
-                                .map(new Function<Event, String>() {
-
-                                    @Override
-                                    public String apply(Event event) {
-                                        return "testUnsubscribe => Source: " + event.source + "  Message: " + event.message;
-                                    }
-                                });
-
-                    }
-                }).subscribe(new DefaultSubscriber<String>() {
+                }).subscribe(new DefaultSubscriber<String>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -371,38 +297,14 @@ public class FlowableGroupByTest extends RxJavaTest {
         final AtomicInteger eventCounter = new AtomicInteger();
 
         SYNC_INFINITE_OBSERVABLE_OF_EVENT(4, subscribeCounter, sentEventCounter)
-                .groupBy(new Function<Event, Integer>() {
-
-                    @Override
-                    public Integer apply(Event e) {
-                        return e.source;
-                    }
-                })
+                .groupBy(e -> e.source)
                 // take 2 of the 4 groups
                 .take(2)
-                .flatMap(new Function<GroupedFlowable<Integer, Event>, Flowable<String>>() {
-
-                    @Override
-                    public Flowable<String> apply(GroupedFlowable<Integer, Event> eventGroupedFlowable) {
-                        return eventGroupedFlowable
-                                .map(new Function<Event, String>() {
-
-                                    @Override
-                                    public String apply(Event event) {
-                                        return "testUnsubscribe => Source: " + event.source + "  Message: " + event.message;
-                                    }
-                                });
-
-                    }
-                })
-                .take(30).subscribe(new Consumer<String>() {
-
-                    @Override
-                    public void accept(String s) {
-                        eventCounter.incrementAndGet();
-                        System.out.println("=> " + s);
-                    }
-
+                .flatMap((Function<GroupedFlowable<Integer, Event>, Flowable<String>>) eventGroupedFlowable -> eventGroupedFlowable
+                        .map(event -> "testUnsubscribe => Source: " + event.source + "  Message: " + event.message))
+                .take(30).subscribe(s -> {
+                    eventCounter.incrementAndGet();
+                    System.out.println("=> " + s);
                 });
 
         assertEquals(30, eventCounter.get());
@@ -417,45 +319,24 @@ public class FlowableGroupByTest extends RxJavaTest {
         final AtomicInteger eventCounter = new AtomicInteger();
 
         SYNC_INFINITE_OBSERVABLE_OF_EVENT(4, subscribeCounter, sentEventCounter)
-                .groupBy(new Function<Event, Integer>() {
-
-                    @Override
-                    public Integer apply(Event e) {
-                        return e.source;
-                    }
-                })
+                .groupBy(e -> e.source)
                 // take 2 of the 4 groups
                 .take(2)
-                .flatMap(new Function<GroupedFlowable<Integer, Event>, Flowable<String>>() {
-
-                    @Override
-                    public Flowable<String> apply(GroupedFlowable<Integer, Event> eventGroupedFlowable) {
-                        int numToTake = 0;
-                        if (eventGroupedFlowable.getKey() == 1) {
-                            numToTake = 10;
-                        } else if (eventGroupedFlowable.getKey() == 2) {
-                            numToTake = 5;
-                        }
-                        return eventGroupedFlowable
-                                .take(numToTake)
-                                .map(new Function<Event, String>() {
-
-                                    @Override
-                                    public String apply(Event event) {
-                                        return "testUnsubscribe => Source: " + event.source + "  Message: " + event.message;
-                                    }
-                                });
-
+                .flatMap((Function<GroupedFlowable<Integer, Event>, Flowable<String>>) eventGroupedFlowable -> {
+                    int numToTake = 0;
+                    if (eventGroupedFlowable.getKey() == 1) {
+                        numToTake = 10;
+                    } else if (eventGroupedFlowable.getKey() == 2) {
+                        numToTake = 5;
                     }
+                    return eventGroupedFlowable
+                            .take(numToTake)
+                            .map(event -> "testUnsubscribe => Source: " + event.source + "  Message: " + event.message);
+
                 })
-                .subscribe(new Consumer<String>() {
-
-                    @Override
-                    public void accept(String s) {
-                        eventCounter.incrementAndGet();
-                        System.out.println("=> " + s);
-                    }
-
+                .subscribe(s -> {
+                    eventCounter.incrementAndGet();
+                    System.out.println("=> " + s);
                 });
 
         assertEquals(15, eventCounter.get());
@@ -468,31 +349,15 @@ public class FlowableGroupByTest extends RxJavaTest {
         final AtomicInteger eventCounter = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
         Flowable.range(0, 100)
-                .groupBy(new Function<Integer, Integer>() {
-
-                    @Override
-                    public Integer apply(Integer i) {
-                        return i % 2;
+                .groupBy(i -> i % 2)
+                .flatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>) group -> {
+                    if (group.getKey() == 0) {
+                        return group.delay(100, TimeUnit.MILLISECONDS).map(t -> t * 10);
+                    } else {
+                        return group;
                     }
                 })
-                .flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
-
-                    @Override
-                    public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> group) {
-                        if (group.getKey() == 0) {
-                            return group.delay(100, TimeUnit.MILLISECONDS).map(new Function<Integer, Integer>() {
-                                @Override
-                                public Integer apply(Integer t) {
-                                    return t * 10;
-                                }
-
-                            });
-                        } else {
-                            return group;
-                        }
-                    }
-                })
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -525,14 +390,8 @@ public class FlowableGroupByTest extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger eventCounter = new AtomicInteger();
         Flowable.range(0, 100)
-                .groupBy(new Function<Integer, Integer>() {
-
-                    @Override
-                    public Integer apply(Integer i) {
-                        return i % 2;
-                    }
-                })
-                .subscribe(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() {
+                .groupBy(i -> i % 2)
+                .subscribe(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -566,47 +425,21 @@ public class FlowableGroupByTest extends RxJavaTest {
         final AtomicInteger eventCounter = new AtomicInteger();
 
         SYNC_INFINITE_OBSERVABLE_OF_EVENT(4, subscribeCounter, sentEventCounter)
-                .groupBy(new Function<Event, Integer>() {
-
-                    @Override
-                    public Integer apply(Event e) {
-                        return e.source;
+                .groupBy(e -> e.source)
+                .flatMap((Function<GroupedFlowable<Integer, Event>, Flowable<String>>) eventGroupedFlowable -> {
+                    Flowable<Event> eventStream = eventGroupedFlowable;
+                    if (eventGroupedFlowable.getKey() >= 2) {
+                        // filter these
+                        eventStream = eventGroupedFlowable.filter(_ -> false);
                     }
+
+                    return eventStream
+                            .map(event -> "testUnsubscribe => Source: " + event.source + "  Message: " + event.message);
+
                 })
-                .flatMap(new Function<GroupedFlowable<Integer, Event>, Flowable<String>>() {
-
-                    @Override
-                    public Flowable<String> apply(GroupedFlowable<Integer, Event> eventGroupedFlowable) {
-                        Flowable<Event> eventStream = eventGroupedFlowable;
-                        if (eventGroupedFlowable.getKey() >= 2) {
-                            // filter these
-                            eventStream = eventGroupedFlowable.filter(new Predicate<Event>() {
-                                @Override
-                                public boolean test(Event t1) {
-                                    return false;
-                                }
-                            });
-                        }
-
-                        return eventStream
-                                .map(new Function<Event, String>() {
-
-                                    @Override
-                                    public String apply(Event event) {
-                                        return "testUnsubscribe => Source: " + event.source + "  Message: " + event.message;
-                                    }
-                                });
-
-                    }
-                })
-                .take(30).subscribe(new Consumer<String>() {
-
-                    @Override
-                    public void accept(String s) {
-                        eventCounter.incrementAndGet();
-                        System.out.println("=> " + s);
-                    }
-
+                .take(30).subscribe(s -> {
+                    eventCounter.incrementAndGet();
+                    System.out.println("=> " + s);
                 });
 
         assertEquals(30, eventCounter.get());
@@ -618,75 +451,30 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void firstGroupsCompleteAndParentSlowToThenEmitFinalGroupsAndThenComplete() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<>();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(new BooleanSubscription());
-                sub.onNext(1);
-                sub.onNext(2);
-                sub.onNext(1);
-                sub.onNext(2);
-                try {
-                    first.await();
-                } catch (InterruptedException e) {
-                    sub.onError(e);
-                    return;
-                }
-                sub.onNext(3);
-                sub.onNext(3);
-                sub.onComplete();
+        Flowable.<Integer>unsafeCreate(sub -> {
+            sub.onSubscribe(new BooleanSubscription());
+            sub.onNext(1);
+            sub.onNext(2);
+            sub.onNext(1);
+            sub.onNext(2);
+            try {
+                first.await();
+            } catch (InterruptedException e) {
+                sub.onError(e);
+                return;
             }
-
-        }).groupBy(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t) {
-                return t;
+            sub.onNext(3);
+            sub.onNext(3);
+            sub.onComplete();
+        }).groupBy(t -> t).flatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<String>>) group -> {
+            if (group.getKey() < 3) {
+                return group.map(t1 -> "first groups: " + t1)
+                        // must take(2) so an onComplete + unsubscribe happens on these first 2 groups
+                        .take(2).doOnComplete(() -> first.countDown());
+            } else {
+                return group.map(t1 -> "last group: " + t1);
             }
-
-        }).flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(final GroupedFlowable<Integer, Integer> group) {
-                if (group.getKey() < 3) {
-                    return group.map(new Function<Integer, String>() {
-
-                        @Override
-                        public String apply(Integer t1) {
-                            return "first groups: " + t1;
-                        }
-
-                    })
-                            // must take(2) so an onComplete + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Action() {
-
-                                @Override
-                                public void run() {
-                                    first.countDown();
-                                }
-
-                            });
-                } else {
-                    return group.map(new Function<Integer, String>() {
-
-                        @Override
-                        public String apply(Integer t1) {
-                            return "last group: " + t1;
-                        }
-
-                    });
-                }
-            }
-
-        }).blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                results.add(s);
-            }
-
-        });
+        }).blockingForEach(s -> results.add(s));
 
         System.out.println("Results: " + results);
         assertEquals(6, results.size());
@@ -697,89 +485,33 @@ public class FlowableGroupByTest extends RxJavaTest {
         System.err.println("----------------------------------------------------------------------------------------------");
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<>();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(new BooleanSubscription());
-                sub.onNext(1);
-                sub.onNext(2);
-                sub.onNext(1);
-                sub.onNext(2);
-                try {
-                    first.await();
-                } catch (InterruptedException e) {
-                    sub.onError(e);
-                    return;
-                }
-                sub.onNext(3);
-                sub.onNext(3);
-                sub.onComplete();
+        Flowable.<Integer>unsafeCreate(sub -> {
+            sub.onSubscribe(new BooleanSubscription());
+            sub.onNext(1);
+            sub.onNext(2);
+            sub.onNext(1);
+            sub.onNext(2);
+            try {
+                first.await();
+            } catch (InterruptedException e) {
+                sub.onError(e);
+                return;
             }
-
-        }).groupBy(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t) {
-                return t;
+            sub.onNext(3);
+            sub.onNext(3);
+            sub.onComplete();
+        }).groupBy(t -> t).flatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<String>>) group -> {
+            if (group.getKey() < 3) {
+                return group.map(t1 -> "first groups: " + t1)
+                        // must take(2) so an onComplete + unsubscribe happens on these first 2 groups
+                        .take(2).doOnComplete(() -> first.countDown());
+            } else {
+                return group.subscribeOn(Schedulers.newThread()).delay(400, TimeUnit.MILLISECONDS)
+                        .map(t1 -> "last group: " + t1)
+                        .doOnEach(t1 -> System.err.println("subscribeOn notification => " + t1));
             }
-
-        }).flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(final GroupedFlowable<Integer, Integer> group) {
-                if (group.getKey() < 3) {
-                    return group.map(new Function<Integer, String>() {
-
-                        @Override
-                        public String apply(Integer t1) {
-                            return "first groups: " + t1;
-                        }
-
-                    })
-                            // must take(2) so an onComplete + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Action() {
-
-                                @Override
-                                public void run() {
-                                    first.countDown();
-                                }
-
-                            });
-                } else {
-                    return group.subscribeOn(Schedulers.newThread()).delay(400, TimeUnit.MILLISECONDS).map(new Function<Integer, String>() {
-
-                        @Override
-                        public String apply(Integer t1) {
-                            return "last group: " + t1;
-                        }
-
-                    }).doOnEach(new Consumer<Notification<String>>() {
-
-                        @Override
-                        public void accept(Notification<String> t1) {
-                            System.err.println("subscribeOn notification => " + t1);
-                        }
-
-                    });
-                }
-            }
-
-        }).doOnEach(new Consumer<Notification<String>>() {
-
-            @Override
-            public void accept(Notification<String> t1) {
-                System.err.println("outer notification => " + t1);
-            }
-
-        }).blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                results.add(s);
-            }
-
-        });
+        }).doOnEach(t1 -> System.err.println("outer notification => " + t1))
+        .blockingForEach(s -> results.add(s));
 
         System.out.println("Results: " + results);
         assertEquals(6, results.size());
@@ -789,75 +521,31 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void firstGroupsCompleteAndParentSlowToThenEmitFinalGroupsWhichThenObservesOnAndDelaysAndThenCompletes() throws InterruptedException {
         final CountDownLatch first = new CountDownLatch(2); // there are two groups to first complete
         final ArrayList<String> results = new ArrayList<>();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(new BooleanSubscription());
-                sub.onNext(1);
-                sub.onNext(2);
-                sub.onNext(1);
-                sub.onNext(2);
-                try {
-                    first.await();
-                } catch (InterruptedException e) {
-                    sub.onError(e);
-                    return;
-                }
-                sub.onNext(3);
-                sub.onNext(3);
-                sub.onComplete();
+        Flowable.<Integer>unsafeCreate(sub -> {
+            sub.onSubscribe(new BooleanSubscription());
+            sub.onNext(1);
+            sub.onNext(2);
+            sub.onNext(1);
+            sub.onNext(2);
+            try {
+                first.await();
+            } catch (InterruptedException e) {
+                sub.onError(e);
+                return;
             }
-
-        }).groupBy(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t) {
-                return t;
+            sub.onNext(3);
+            sub.onNext(3);
+            sub.onComplete();
+        }).groupBy(t -> t).flatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<String>>) group -> {
+            if (group.getKey() < 3) {
+                return group.map(t1 -> "first groups: " + t1)
+                        // must take(2) so an onComplete + unsubscribe happens on these first 2 groups
+                        .take(2).doOnComplete(() -> first.countDown());
+            } else {
+                return group.observeOn(Schedulers.newThread()).delay(400, TimeUnit.MILLISECONDS)
+                        .map(t1 -> "last group: " + t1);
             }
-
-        }).flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(final GroupedFlowable<Integer, Integer> group) {
-                if (group.getKey() < 3) {
-                    return group.map(new Function<Integer, String>() {
-
-                        @Override
-                        public String apply(Integer t1) {
-                            return "first groups: " + t1;
-                        }
-
-                    })
-                            // must take(2) so an onComplete + unsubscribe happens on these first 2 groups
-                            .take(2).doOnComplete(new Action() {
-
-                                @Override
-                                public void run() {
-                                    first.countDown();
-                                }
-
-                            });
-                } else {
-                    return group.observeOn(Schedulers.newThread()).delay(400, TimeUnit.MILLISECONDS).map(new Function<Integer, String>() {
-
-                        @Override
-                        public String apply(Integer t1) {
-                            return "last group: " + t1;
-                        }
-
-                    });
-                }
-            }
-
-        }).blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                results.add(s);
-            }
-
-        });
+        }).blockingForEach(s -> results.add(s));
 
         System.out.println("Results: " + results);
         assertEquals(6, results.size());
@@ -866,55 +554,19 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void groupsWithNestedSubscribeOn() throws InterruptedException {
         final ArrayList<String> results = new ArrayList<>();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(new BooleanSubscription());
-                sub.onNext(1);
-                sub.onNext(2);
-                sub.onNext(1);
-                sub.onNext(2);
-                sub.onComplete();
-            }
-
-        }).groupBy(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t) {
-                return t;
-            }
-
-        }).flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(final GroupedFlowable<Integer, Integer> group) {
-                return group.subscribeOn(Schedulers.newThread()).map(new Function<Integer, String>() {
-
-                    @Override
-                    public String apply(Integer t1) {
-                        System.out.println("Received: " + t1 + " on group : " + group.getKey());
-                        return "first groups: " + t1;
-                    }
-
-                });
-            }
-
-        }).doOnEach(new Consumer<Notification<String>>() {
-
-            @Override
-            public void accept(Notification<String> t1) {
-                System.out.println("notification => " + t1);
-            }
-
-        }).blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                results.add(s);
-            }
-
-        });
+        Flowable.<Integer>unsafeCreate(sub -> {
+            sub.onSubscribe(new BooleanSubscription());
+            sub.onNext(1);
+            sub.onNext(2);
+            sub.onNext(1);
+            sub.onNext(2);
+            sub.onComplete();
+        }).groupBy(t -> t).flatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<String>>) group ->
+            group.subscribeOn(Schedulers.newThread()).map(t1 -> {
+                System.out.println("Received: " + t1 + " on group : " + group.getKey());
+                return "first groups: " + t1;
+            })).doOnEach(t1 -> System.out.println("notification => " + t1))
+        .blockingForEach(s -> results.add(s));
 
         System.out.println("Results: " + results);
         assertEquals(4, results.size());
@@ -923,47 +575,16 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void groupsWithNestedObserveOn() throws InterruptedException {
         final ArrayList<String> results = new ArrayList<>();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(new BooleanSubscription());
-                sub.onNext(1);
-                sub.onNext(2);
-                sub.onNext(1);
-                sub.onNext(2);
-                sub.onComplete();
-            }
-
-        }).groupBy(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t) {
-                return t;
-            }
-
-        }).flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(final GroupedFlowable<Integer, Integer> group) {
-                return group.observeOn(Schedulers.newThread()).delay(400, TimeUnit.MILLISECONDS).map(new Function<Integer, String>() {
-
-                    @Override
-                    public String apply(Integer t1) {
-                        return "first groups: " + t1;
-                    }
-
-                });
-            }
-
-        }).blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                results.add(s);
-            }
-
-        });
+        Flowable.<Integer>unsafeCreate(sub -> {
+            sub.onSubscribe(new BooleanSubscription());
+            sub.onNext(1);
+            sub.onNext(2);
+            sub.onNext(1);
+            sub.onNext(2);
+            sub.onComplete();
+        }).groupBy(t -> t).flatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<String>>) group ->
+        group.observeOn(Schedulers.newThread()).delay(400, TimeUnit.MILLISECONDS).map(t1 -> "first groups: " + t1))
+        .blockingForEach(s -> results.add(s));
 
         System.out.println("Results: " + results);
         assertEquals(4, results.size());
@@ -984,25 +605,20 @@ public class FlowableGroupByTest extends RxJavaTest {
     };
 
     Flowable<Event> SYNC_INFINITE_OBSERVABLE_OF_EVENT(final int numGroups, final AtomicInteger subscribeCounter, final AtomicInteger sentEventCounter) {
-        return Flowable.unsafeCreate(new Publisher<Event>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super Event> op) {
-                BooleanSubscription bs = new BooleanSubscription();
-                op.onSubscribe(bs);
-                subscribeCounter.incrementAndGet();
-                int i = 0;
-                while (!bs.isCancelled()) {
-                    i++;
-                    Event e = new Event();
-                    e.source = i % numGroups;
-                    e.message = "Event-" + i;
-                    op.onNext(e);
-                    sentEventCounter.incrementAndGet();
-                }
-                op.onComplete();
+        return Flowable.unsafeCreate(op -> {
+            BooleanSubscription bs = new BooleanSubscription();
+            op.onSubscribe(bs);
+            subscribeCounter.incrementAndGet();
+            int i = 0;
+            while (!bs.isCancelled()) {
+                i++;
+                Event e = new Event();
+                e.source = i % numGroups;
+                e.message = "Event-" + i;
+                op.onNext(e);
+                sentEventCounter.incrementAndGet();
             }
-
+            op.onComplete();
         });
     };
 
@@ -1028,21 +644,9 @@ public class FlowableGroupByTest extends RxJavaTest {
         verify(f2, never()).onError(Mockito.<Throwable> any());
     }
 
-    private static Function<Long, Boolean> IS_EVEN = new Function<Long, Boolean>() {
+    private static Function<Long, Boolean> IS_EVEN = n -> n % 2 == 0;
 
-        @Override
-        public Boolean apply(Long n) {
-            return n % 2 == 0;
-        }
-    };
-
-    private static Function<Integer, Boolean> IS_EVEN2 = new Function<Integer, Boolean>() {
-
-        @Override
-        public Boolean apply(Integer n) {
-            return n % 2 == 0;
-        }
-    };
+    private static Function<Integer, Boolean> IS_EVEN2 = n -> n % 2 == 0;
 
     @Test
     public void groupByBackpressure() throws InterruptedException {
@@ -1051,72 +655,40 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         Flowable.range(1, 4000)
                 .groupBy(IS_EVEN2)
-                .flatMap(new Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>() {
-
-                    @Override
-                    public Flowable<String> apply(final GroupedFlowable<Boolean, Integer> g) {
-                        return g.observeOn(Schedulers.computation()).map(new Function<Integer, String>() {
-
-                            @Override
-                            public String apply(Integer l) {
-                                if (g.getKey()) {
-                                    try {
-                                        Thread.sleep(1);
-                                    } catch (InterruptedException e) {
-                                    }
-                                    return l + " is even.";
-                                } else {
-                                    return l + " is odd.";
-                                }
-                            }
-
-                        });
+                .flatMap((Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>) g ->
+                g.observeOn(Schedulers.computation()).map(l -> {
+                    if (g.getKey()) {
+                        try {
+                            Thread.sleep(1);
+                        } catch (InterruptedException e) {
+                        }
+                        return l + " is even.";
+                    } else {
+                        return l + " is odd.";
                     }
-
-                }).subscribe(ts);
+                })).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
     }
 
     <T, R> Function<T, R> just(final R value) {
-        return new Function<T, R>() {
-            @Override
-            public R apply(T t1) {
-                return value;
-            }
-        };
+        return _ -> value;
     }
 
     <T> Function<Integer, T> fail(T dummy) {
-        return new Function<Integer, T>() {
-            @Override
-            public T apply(Integer t1) {
-                throw new RuntimeException("Forced failure");
-            }
+        return _ -> {
+            throw new RuntimeException("Forced failure");
         };
     }
 
     <T, R> Function<T, R> fail2(R dummy2) {
-        return new Function<T, R>() {
-            @Override
-            public R apply(T t1) {
-                throw new RuntimeException("Forced failure");
-            }
+        return _ -> {
+            throw new RuntimeException("Forced failure");
         };
     }
 
-    Function<Integer, Integer> dbl = new Function<Integer, Integer>() {
-        @Override
-        public Integer apply(Integer t1) {
-            return t1 * 2;
-        }
-    };
-    Function<Integer, Integer> identity = new Function<Integer, Integer>() {
-        @Override
-        public Integer apply(Integer v) {
-            return v;
-        }
-    };
+    Function<Integer, Integer> dbl = t1 -> t1 * 2;
+    Function<Integer, Integer> identity = v -> v;
 
     @Test
     public void normalBehavior() {
@@ -1142,36 +714,23 @@ public class FlowableGroupByTest extends RxJavaTest {
          * qux
          *
          */
-        Function<String, String> keysel = new Function<String, String>() {
-            @Override
-            public String apply(String t1) {
-                return t1.trim().toLowerCase();
-            }
-        };
-        Function<String, String> valuesel = new Function<String, String>() {
-            @Override
-            public String apply(String t1) {
-                return t1 + t1;
-            }
-        };
+        Function<String, String> keysel = t1 -> t1.trim().toLowerCase();
+        Function<String, String> valuesel = t1 -> t1 + t1;
 
         Flowable<String> m = source.groupBy(keysel, valuesel)
-        .flatMap(new Function<GroupedFlowable<String, String>, Publisher<String>>() {
-            @Override
-            public Publisher<String> apply(final GroupedFlowable<String, String> g) {
-                System.out.println("-----------> NEXT: " + g.getKey());
-                return g.take(2).map(new Function<String, String>() {
+        .flatMap((Function<GroupedFlowable<String, String>, Publisher<String>>) g -> {
+            System.out.println("-----------> NEXT: " + g.getKey());
+            return g.take(2).map(new Function<String, String>() /* NFI */{
 
-                    int count;
+                int count;
 
-                    @Override
-                    public String apply(String v) {
-                        System.out.println(v);
-                        return g.getKey() + "-" + count++;
-                    }
+                @Override
+                public String apply(String v) {
+                    System.out.println(v);
+                    return g.getKey() + "-" + count++;
+                }
 
-                });
-            }
+            });
         });
 
         TestSubscriber<String> ts = new TestSubscriber<>();
@@ -1235,12 +794,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         Flowable<GroupedFlowable<Integer, Integer>> m = source.groupBy(identity, dbl);
 
-        m.subscribe(new Consumer<GroupedFlowable<Integer, Integer>>() {
-            @Override
-            public void accept(GroupedFlowable<Integer, Integer> t1) {
-                inner.set(t1);
-            }
-        });
+        m.subscribe(t1 -> inner.set(t1));
 
         inner.get().subscribe();
 
@@ -1272,54 +826,29 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void groupByBackpressure3() throws InterruptedException {
         TestSubscriber<String> ts = new TestSubscriber<>();
 
-        Flowable.range(1, 4000).groupBy(IS_EVEN2).flatMap(new Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>() {
+        Flowable.range(1, 4000).groupBy(IS_EVEN2).flatMap((Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>) g ->
+        g.doOnComplete(() -> System.out.println("//////////////////// COMPLETED-A"))
+        .observeOn(Schedulers.computation()).map(new Function<Integer, String>() /* NFI */ {
+
+            int c;
 
             @Override
-            public Flowable<String> apply(final GroupedFlowable<Boolean, Integer> g) {
-                return g.doOnComplete(new Action() {
-
-                    @Override
-                    public void run() {
-                        System.out.println("//////////////////// COMPLETED-A");
-                    }
-
-                }).observeOn(Schedulers.computation()).map(new Function<Integer, String>() {
-
-                    int c;
-
-                    @Override
-                    public String apply(Integer l) {
-                        if (g.getKey()) {
-                            if (c++ < 400) {
-                                try {
-                                    Thread.sleep(1);
-                                } catch (InterruptedException e) {
-                                }
-                            }
-                            return l + " is even.";
-                        } else {
-                            return l + " is odd.";
+            public String apply(Integer l) {
+                if (g.getKey()) {
+                    if (c++ < 400) {
+                        try {
+                            Thread.sleep(1);
+                        } catch (InterruptedException e) {
                         }
                     }
-
-                }).doOnComplete(new Action() {
-
-                    @Override
-                    public void run() {
-                        System.out.println("//////////////////// COMPLETED-B");
-                    }
-
-                });
+                    return l + " is even.";
+                } else {
+                    return l + " is odd.";
+                }
             }
 
-        }).doOnEach(new Consumer<Notification<String>>() {
-
-            @Override
-            public void accept(Notification<String> t1) {
-                System.out.println("NEXT: " + t1);
-            }
-
-        }).subscribe(ts);
+        }).doOnComplete(() -> System.out.println("//////////////////// COMPLETED-B")))
+        .doOnEach(t1 -> System.out.println("NEXT: " + t1)).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
     }
@@ -1330,34 +859,21 @@ public class FlowableGroupByTest extends RxJavaTest {
         TestSubscriber<String> ts = new TestSubscriber<>();
 
         Flowable.range(1, 4000)
-            .doOnNext(new Consumer<Integer>() {
-                @Override
-                public void accept(Integer v) {
-                    System.out.println("testgroupByBackpressure2 >> " + v);
-                }
-            })
+            .doOnNext(v -> System.out.println("testgroupByBackpressure2 >> " + v))
             .groupBy(IS_EVEN2)
-            .flatMap(new Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>() {
-                @Override
-                public Flowable<String> apply(final GroupedFlowable<Boolean, Integer> g) {
-                    return g.take(2)
-                            .observeOn(Schedulers.computation())
-                            .map(new Function<Integer, String>() {
-                                @Override
-                                public String apply(Integer l) {
-                                    if (g.getKey()) {
-                                        try {
-                                            Thread.sleep(1);
-                                        } catch (InterruptedException e) {
-                                        }
-                                        return l + " is even.";
-                                    } else {
-                                        return l + " is odd.";
-                                    }
-                                }
-                            });
-                }
-            }, new FlatMapConfig(4000)) // a lot of groups are created due to take(2)
+            .flatMap((Function<GroupedFlowable<Boolean, Integer>, Flowable<String>>) g -> g.take(2)
+                    .observeOn(Schedulers.computation())
+                    .map(l -> {
+                        if (g.getKey()) {
+                            try {
+                                Thread.sleep(1);
+                            } catch (InterruptedException e) {
+                            }
+                            return l + " is even.";
+                        } else {
+                            return l + " is odd.";
+                        }
+                    }), new FlatMapConfig(4000)) // a lot of groups are created due to take(2)
             .subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -1368,25 +884,10 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void groupByWithNullKey() {
         final String[] key = new String[]{"uninitialized"};
         final List<String> values = new ArrayList<>();
-        Flowable.just("a", "b", "c").groupBy(new Function<String, String>() {
-
-            @Override
-            public String apply(String value) {
-                return null;
-            }
-        }).subscribe(new Consumer<GroupedFlowable<String, String>>() {
-
-            @Override
-            public void accept(GroupedFlowable<String, String> groupedFlowable) {
-                key[0] = groupedFlowable.getKey();
-                groupedFlowable.subscribe(new Consumer<String>() {
-
-                    @Override
-                    public void accept(String s) {
-                        values.add(s);
-                    }
-                });
-            }
+        Flowable.just("a", "b", "c").<String>groupBy(_ -> null)
+        .subscribe(groupedFlowable -> {
+            key[0] = groupedFlowable.getKey();
+            groupedFlowable.subscribe(s -> values.add(s));
         });
         assertNull(key[0]);
         assertEquals(Arrays.asList("a", "b", "c"), values);
@@ -1396,22 +897,11 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void groupByUnsubscribe() {
         final Subscription s = mock(Subscription.class);
         Flowable<Integer> f = Flowable.unsafeCreate(
-                new Publisher<Integer>() {
-                    @Override
-                    public void subscribe(Subscriber<? super Integer> subscriber) {
-                        subscriber.onSubscribe(s);
-                    }
-                }
+                subscriber -> subscriber.onSubscribe(s)
         );
         TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        f.groupBy(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer integer) {
-                return null;
-            }
-        }).subscribe(ts);
+        f.groupBy(_ -> null).subscribe(ts);
 
         ts.cancel();
 
@@ -1425,7 +915,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         final TestSubscriberEx<Integer> inner2 = new TestSubscriberEx<>();
 
         final TestSubscriberEx<GroupedFlowable<Integer, Integer>> outer
-                = new TestSubscriberEx<>(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() {
+                = new TestSubscriberEx<>(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -1444,23 +934,14 @@ public class FlowableGroupByTest extends RxJavaTest {
                 }
             }
         });
-        Flowable.unsafeCreate(
-                new Publisher<Integer>() {
-                    @Override
-                    public void subscribe(Subscriber<? super Integer> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        subscriber.onNext(0);
-                        subscriber.onNext(1);
-                        subscriber.onError(e);
-                    }
+        Flowable.<Integer>unsafeCreate(
+                subscriber -> {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext(0);
+                    subscriber.onNext(1);
+                    subscriber.onError(e);
                 }
-        ).groupBy(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer i) {
-                return i % 2;
-            }
-        }).subscribe(outer);
+        ).groupBy(i -> i % 2).subscribe(outer);
         assertEquals(Arrays.asList(e), outer.errors());
         assertEquals(Arrays.asList(e), inner1.errors());
         assertEquals(Arrays.asList(e), inner2.errors());
@@ -1472,20 +953,10 @@ public class FlowableGroupByTest extends RxJavaTest {
         Flowable
                 .just(1, 2, 3)
                 // group into one group
-                .groupBy(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer t) {
-                        return 1;
-                    }
-                })
+                .groupBy(_ -> 1)
                 // flatten
-                .concatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> g) {
-                        return g;
-                    }
-                })
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .concatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>) g -> g)
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -1529,12 +1000,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         for (int j = 0; j < 1000; j++) {
             Flowable.merge(
                     Flowable.range(0, n)
-                    .groupBy(new Function<Integer, Object>() {
-                        @Override
-                        public Object apply(Integer i) {
-                            return i % (Flowable.bufferSize() + 2);
-                        }
-                    })
+                    .groupBy(i -> i % (Flowable.bufferSize() + 2))
                     .observeOn(Schedulers.computation(), false, n)
             , n)
             .blockingLast();
@@ -1546,12 +1012,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         for (int j = 0; j < 1000; j++) {
             Flowable.merge(
                     Flowable.range(0, 500)
-                    .groupBy(new Function<Integer, Object>() {
-                        @Override
-                        public Object apply(Integer i) {
-                            return i % (Flowable.bufferSize() + 2);
-                        }
-                    })
+                    .groupBy(i -> i % (Flowable.bufferSize() + 2))
                     .observeOn(Schedulers.computation())
             ).blockingLast();
         }
@@ -1566,18 +1027,8 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        pp.groupBy(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) {
-                        return v;
-                    }
-                })
-                .doOnNext(new Consumer<GroupedFlowable<Integer, Integer>>() {
-                    @Override
-                    public void accept(GroupedFlowable<Integer, Integer> g) {
-                        g.subscribe();
-                    }
-                }) // this will request Long.MAX_VALUE
+        pp.groupBy(v -> v)
+                .doOnNext(GroupedFlowable::subscribe) // this will request Long.MAX_VALUE
                 .subscribe(ts)
                 ;
         ts.request(1);
@@ -1594,18 +1045,8 @@ public class FlowableGroupByTest extends RxJavaTest {
         TestSubscriber<GroupedFlowable<Integer, Integer>> ts = new TestSubscriber<>(1);
 
         Flowable.fromArray(1, 2)
-                .groupBy(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) {
-                        return v;
-                    }
-                })
-                .doOnNext(new Consumer<GroupedFlowable<Integer, Integer>>() {
-                    @Override
-                    public void accept(GroupedFlowable<Integer, Integer> g) {
-                        g.subscribe();
-                    }
-                }) // this will request Long.MAX_VALUE
+                .groupBy(v -> v)
+                .doOnNext(GroupedFlowable::subscribe) // this will request Long.MAX_VALUE
                 .subscribe(ts)
                 ;
         ts.assertValueCount(1)
@@ -1621,18 +1062,8 @@ public class FlowableGroupByTest extends RxJavaTest {
         final TestSubscriber<Object> ts2 = new TestSubscriber<>(0L);
 
         Flowable.range(1, Flowable.bufferSize() * 2)
-        .groupBy(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) {
-                return 1;
-            }
-        })
-        .doOnNext(new Consumer<GroupedFlowable<Object, Integer>>() {
-            @Override
-            public void accept(GroupedFlowable<Object, Integer> g) {
-                g.subscribe(ts2);
-            }
-        })
+        .<Integer>groupBy(_ -> 1)
+        .doOnNext(g -> g.subscribe(ts2))
         .subscribe(ts1);
 
         ts1.assertValueCount(1);
@@ -1656,23 +1087,8 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         final TestSubscriberEx<GroupedFlowable<Integer, Integer>> ts2 = new TestSubscriberEx<GroupedFlowable<Integer, Integer>>().setInitialFusionMode(QueueFuseable.ANY);
 
-        Flowable.range(1, 10).groupBy(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) {
-                return 1;
-            }
-        }, new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) {
-                return v + 1;
-            }
-        })
-        .doOnNext(new Consumer<GroupedFlowable<Integer, Integer>>() {
-            @Override
-            public void accept(GroupedFlowable<Integer, Integer> g) {
-                g.subscribe(ts1);
-            }
-        })
+        Flowable.range(1, 10).groupBy(_ -> 1, v -> v + 1)
+        .doOnNext(g -> g.subscribe(ts1))
         .subscribe(ts2);
 
         ts1
@@ -1694,12 +1110,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void keySelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .groupBy(Functions.<Integer>identity(), true)
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
-                return g;
-            }
-        })
+        .flatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>) g -> g)
         .test()
         .assertFailure(TestException.class, 1);
     }
@@ -1709,12 +1120,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void keyAndValueSelectorAndDelayError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true)
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
-                return g;
-            }
-        })
+        .flatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>) g -> g)
         .test()
         .assertFailure(TestException.class, 1);
     }
@@ -1725,12 +1131,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         Flowable.just(1)
         .groupBy(Functions.justFunction(1))
-        .doOnNext(new Consumer<GroupedFlowable<Integer, Integer>>() {
-            @Override
-            public void accept(GroupedFlowable<Integer, Integer> g) throws Exception {
-                TestHelper.checkDisposed(g);
-            }
-        })
+        .doOnNext(TestHelper::checkDisposed)
         .test();
     }
 
@@ -1738,7 +1139,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void reentrantComplete() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1760,7 +1161,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void reentrantCompleteCancel() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1804,12 +1205,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> f) throws Exception {
-                return f.groupBy(Functions.justFunction(1));
-            }
-        }, false, 1, 1, (Object[])null);
+        TestHelper.checkBadSourceFlowable(f -> f.groupBy(Functions.justFunction(1)), false, 1, 1, (Object[])null);
     }
 
     @Test
@@ -1831,29 +1227,14 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<GroupedFlowable<Integer, Object>>>() {
-            @Override
-            public Publisher<GroupedFlowable<Integer, Object>> apply(Flowable<Object> f) throws Exception {
-                return f.groupBy(Functions.justFunction(1));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.groupBy(Functions.justFunction(1)));
     }
 
     @Test
     public void nullKeyTakeInner() {
         Flowable.just(1)
-        .groupBy(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                return null;
-            }
-        })
-        .flatMap(new Function<GroupedFlowable<Object, Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(GroupedFlowable<Object, Integer> g) throws Exception {
-                return g.take(1);
-            }
-        })
+        .groupBy(_ -> null)
+        .flatMap((Function<GroupedFlowable<Object, Integer>, Publisher<Integer>>) g -> g.take(1))
         .test()
         .assertResult(1);
     }
@@ -1863,12 +1244,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void groupError() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .groupBy(Functions.justFunction(1), true)
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
-                return g.hide();
-            }
-        })
+        .flatMap((Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>) GroupedFlowable::hide)
         .test()
         .assertFailure(TestException.class, 1);
     }
@@ -1877,12 +1253,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void groupComplete() {
         Flowable.just(1)
         .groupBy(Functions.justFunction(1), true)
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
-                return g.hide();
-            }
-        })
+        .flatMap((Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>) GroupedFlowable::hide)
         .test()
         .assertResult(1);
     }
@@ -1891,13 +1262,9 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void mapFactoryThrows() {
         final IOException ex = new IOException("boo");
         Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory =  //
-                new Function<Consumer<Object>, Map<Integer, Object>>() {
-
-                    @Override
-                    public Map<Integer, Object> apply(final Consumer<Object> notify) throws Exception {
-                        throw ex;
-                    }
-                };
+                _ -> {
+            throw ex;
+        };
         Flowable.just(1)
         .groupBy(Functions.<Integer>identity(), Functions.identity(), true, 16, evictingMapFactory)
         .test()
@@ -1906,27 +1273,11 @@ public class FlowableGroupByTest extends RxJavaTest {
     }
     // -----------------------------------------------------------------------------------------------------------------------
 
-    private static final Function<Integer, Integer> mod5 = new Function<Integer, Integer>() {
-
-        @Override
-        public Integer apply(Integer n) throws Exception {
-            return n % 5;
-        }
-    };
+    private static final Function<Integer, Integer> mod5 = n -> n % 5;
 
     private static Function<GroupedFlowable<Integer, Integer>, Publisher<? extends Integer>> addCompletedKey(
             final List<Integer> completed) {
-        return new Function<GroupedFlowable<Integer, Integer>, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(final GroupedFlowable<Integer, Integer> g) throws Exception {
-                return g.doOnComplete(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        completed.add(g.getKey());
-                    }
-                });
-            }
-        };
+        return g -> g.doOnComplete(() -> completed.add(g.getKey()));
     }
 
     private static final class TestTicker extends Ticker {
@@ -1966,12 +1317,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         TestSubscriber<Integer> ts = subject
                 .toFlowable(BackpressureStrategy.BUFFER)
                 .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true, 16, evictingMapFactory)
-                .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
-                        return g;
-                    }
-                })
+                .flatMap((Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>) g -> g)
                 .test();
         RuntimeException ex = new RuntimeException();
         //ensure coverage of the code that clears the evicted queue
@@ -2009,59 +1355,25 @@ public class FlowableGroupByTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final TestTicker testTicker = new TestTicker();
 
-        Function<Consumer<Object>, Map<Integer, Object>> mapFactory = new Function<Consumer<Object>, Map<Integer, Object>>() {
-            @Override
-            public Map<Integer, Object> apply(final Consumer<Object> action) throws Exception {
-                return CacheBuilder.newBuilder() //
-                        .expireAfterAccess(Duration.ofSeconds(5)).removalListener(new RemovalListener<Object, Object>() {
-                            @Override
-                            public void onRemoval(RemovalNotification<Object, Object> notification) {
-                                try {
-                                    action.accept(notification.getValue());
-                                } catch (Throwable ex) {
-                                    throw new RuntimeException(ex);
-                                }
-                            }
-                        }).ticker(testTicker) //
-                        .<Integer, Object>build().asMap();
-            }
-        };
+        Function<Consumer<Object>, Map<Integer, Object>> mapFactory = action -> CacheBuilder.newBuilder() //
+                .expireAfterAccess(Duration.ofSeconds(5)).removalListener(notification -> {
+                    try {
+                        action.accept(notification.getValue());
+                    } catch (Throwable ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }).ticker(testTicker) //
+                .<Integer, Object>build().asMap();
 
         final List<String> list = new CopyOnWriteArrayList<>();
         Flowable<Integer> stream = source //
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        list.add("Source canceled");
-                    }
-                })
+                .doOnCancel(() -> list.add("Source canceled"))
                 .<Integer, Integer>groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), false,
                         Flowable.bufferSize(), mapFactory) //
-                .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<? extends Integer>>() {
-                    @Override
-                    public Publisher<? extends Integer> apply(GroupedFlowable<Integer, Integer> group)
-                            throws Exception {
-                        return group //
-                                .doOnComplete(new Action() {
-                                    @Override
-                                    public void run() throws Exception {
-                                        list.add("Group completed");
-                                    }
-                                }).doOnCancel(new Action() {
-                                    @Override
-                                    public void run() throws Exception {
-                                        list.add("Group canceled");
-                                    }
-                                });
-                    }
-                });
+                .flatMap(group -> group //
+                        .doOnComplete(() -> list.add("Group completed")).doOnCancel(() -> list.add("Group canceled")));
         TestSubscriber<Integer> ts = stream //
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        list.add("Outer group by canceled");
-                    }
-                }).test();
+                .doOnCancel(() -> list.add("Outer group by canceled")).test();
 
         // Send 3 in the same group and wait for them to be seen
         source.onNext(1);
@@ -2194,45 +1506,32 @@ public class FlowableGroupByTest extends RxJavaTest {
     private static Function<Consumer<Object>, Map<Integer, Object>> createEvictingMapFactoryGuava(final int maxSize,
             final AtomicReference<Cache<Integer, Object>> cacheOut) {
         Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory =  //
-                new Function<Consumer<Object>, Map<Integer, Object>>() {
-
-            @Override
-            public Map<Integer, Object> apply(final Consumer<Object> notify) throws Exception {
-                Cache<Integer, Object> cache = CacheBuilder.newBuilder() //
-                        .maximumSize(maxSize) //
-                        .removalListener(new RemovalListener<Integer, Object>() {
-                            @Override
-                            public void onRemoval(RemovalNotification<Integer, Object> notification) {
-                                try {
-                                    notify.accept(notification.getValue());
-                                } catch (Throwable e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }})
-                        .<Integer, Object> build();
-                cacheOut.set(cache);
-                return cache.asMap();
-            }};
+                notify -> {
+            Cache<Integer, Object> cache = CacheBuilder.newBuilder() //
+                    .maximumSize(maxSize) //
+                    .removalListener(notification -> {
+                        try {
+                            notify.accept(notification.getValue());
+                        } catch (Throwable e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .<Integer, Object> build();
+            cacheOut.set(cache);
+            return cache.asMap();
+        };
         return evictingMapFactory;
     }
 
     private static Function<Consumer<Object>, Map<Integer, Object>> createEvictingMapFactorySynchronousOnly(final int maxSize) {
         Function<Consumer<Object>, Map<Integer, Object>> evictingMapFactory =  //
-                new Function<Consumer<Object>, Map<Integer, Object>>() {
-
-                    @Override
-                    public Map<Integer, Object> apply(final Consumer<Object> notify) throws Exception {
-                        return new SingleThreadEvictingHashMap<>(maxSize, new Consumer<Object>() {
-                            @Override
-                            public void accept(Object object) {
-                                try {
-                                    notify.accept(object);
-                                } catch (Throwable e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
-                        });
-                    }};
+                notify -> new SingleThreadEvictingHashMap<>(maxSize, object -> {
+                    try {
+                        notify.accept(object);
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+                });
         return evictingMapFactory;
     }
 
@@ -2241,19 +1540,9 @@ public class FlowableGroupByTest extends RxJavaTest {
     @Test
     public void cancellationOfUpstreamWhenGroupedFlowableCompletes() {
         final AtomicBoolean cancelled = new AtomicBoolean();
-        Flowable.just(1).repeat().doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                cancelled.set(true);
-            }
-        })
+        Flowable.just(1).repeat().doOnCancel(() -> cancelled.set(true))
         .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity()) //
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(GroupedFlowable<Integer, Integer> g) throws Exception {
-                return g.first(0).toFlowable();
-            }
-        })
+        .flatMap(g -> g.first(0).toFlowable())
         .take(4) //
         .test() //
         .assertComplete();
@@ -2268,36 +1557,17 @@ public class FlowableGroupByTest extends RxJavaTest {
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            pp.groupBy(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    return v % 10;
-                }
-            }, Functions.<Integer>identity(), false, 2048)
-            .flatMap(new Function<GroupedFlowable<Integer, Integer>, GroupedFlowable<Integer, Integer>>() {
-                @Override
-                public GroupedFlowable<Integer, Integer> apply(GroupedFlowable<Integer, Integer> v)
-                        throws Throwable {
-                    return v;
-                }
-            })
+            pp.groupBy(v -> v % 10, Functions.<Integer>identity(), false, 2048)
+            .flatMap((Function<GroupedFlowable<Integer, Integer>, GroupedFlowable<Integer, Integer>>) v -> v)
             .subscribe(ts);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 1000; j++) {
-                        pp.onNext(j);
-                    }
+            Runnable r1 = () -> {
+                for (int j = 0; j < 1000; j++) {
+                    pp.onNext(j);
                 }
             };
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -2310,18 +1580,8 @@ public class FlowableGroupByTest extends RxJavaTest {
         final List<GroupedFlowable<Integer, Integer>> groups = new ArrayList<>();
 
         Flowable.range(1, 1000)
-        .groupBy(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Throwable {
-                return v % 10;
-            }
-        })
-        .doOnNext(new Consumer<GroupedFlowable<Integer, Integer>>() {
-            @Override
-            public void accept(GroupedFlowable<Integer, Integer> v) throws Throwable {
-                groups.add(v);
-            }
-        })
+        .groupBy(v -> v % 10)
+        .doOnNext(v -> groups.add(v))
         .test()
         .assertValueCount(1000)
         .assertComplete()
@@ -2340,18 +1600,10 @@ public class FlowableGroupByTest extends RxJavaTest {
         final TestSubscriber<Object> ts2 = new TestSubscriber<>();
 
         Flowable.just(1)
-        .groupBy(Functions.<Integer>identity(), new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Throwable {
-                throw new TestException();
-            }
+        .groupBy(Functions.<Integer>identity(), _ -> {
+            throw new TestException();
         })
-        .doOnNext(new Consumer<GroupedFlowable<Integer, Object>>() {
-            @Override
-            public void accept(GroupedFlowable<Integer, Object> g) throws Throwable {
-                g.subscribe(ts2);
-            }
-        })
+        .doOnNext(g -> g.subscribe(ts2))
         .subscribe(ts1);
 
         ts1.assertValueCount(1)
@@ -2367,21 +1619,13 @@ public class FlowableGroupByTest extends RxJavaTest {
         final TestSubscriber<Object> ts2 = new TestSubscriber<>();
 
         Flowable.just(1, 2)
-        .groupBy(Functions.justFunction(1), new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Throwable {
-                if (v == 2) {
-                    throw new TestException();
-                }
-                return v;
+        .groupBy(Functions.justFunction(1), v -> {
+            if (v == 2) {
+                throw new TestException();
             }
+            return v;
         })
-        .doOnNext(new Consumer<GroupedFlowable<Integer, Object>>() {
-            @Override
-            public void accept(GroupedFlowable<Integer, Object> g) throws Throwable {
-                g.subscribe(ts2);
-            }
-        })
+        .doOnNext(g -> g.subscribe(ts2))
         .subscribe(ts1);
 
         ts1.assertValueCount(1)
@@ -2395,25 +1639,15 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void fusedParallelGroupProcessing() {
         Flowable.range(0, 500000)
         .subscribeOn(Schedulers.single())
-        .groupBy(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer i) throws Throwable {
-                return i % 2;
-            }
-        })
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) {
-                return g.getKey() == 0
-                    ? g
-                        .parallel()
-                        .runOn(Schedulers.computation())
-                        .map(Functions.<Integer>identity())
-                        .sequential()
-                    : g.map(Functions.<Integer>identity()) // no need to use hide
-                ;
-            }
-        })
+        .groupBy(i -> i % 2)
+        .flatMap((Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>) g -> g.getKey() == 0
+            ? g
+                .parallel()
+                .runOn(Schedulers.computation())
+                .map(Functions.<Integer>identity())
+                .sequential()
+            : g.map(Functions.<Integer>identity()) // no need to use hide
+        )
         .test()
         .awaitDone(20, TimeUnit.SECONDS)
         .assertValueCount(500000)
@@ -2425,11 +1659,8 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void valueSelectorCrashAndMissingBackpressure() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriberEx<GroupedFlowable<Integer, Integer>> ts = pp.groupBy(Functions.justFunction(1), new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t) throws Throwable {
-                throw new TestException();
-            }
+        TestSubscriberEx<GroupedFlowable<Integer, Object>> ts = pp.groupBy(Functions.justFunction(1), _ -> {
+            throw new TestException();
         })
         .subscribeWith(new TestSubscriberEx<>(0L));
 
@@ -2444,12 +1675,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void fusedGroupClearedOnCancel() {
         Flowable.just(1)
         .groupBy(Functions.<Integer>identity())
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Throwable {
-                return g.observeOn(ImmediateThinScheduler.INSTANCE).take(1);
-            }
-        })
+        .flatMap((Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>) g -> g.observeOn(ImmediateThinScheduler.INSTANCE).take(1))
         .test()
         .assertResult(1);
     }
@@ -2458,19 +1684,9 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void fusedGroupClearedOnCancelDelayed() {
         Flowable.range(1, 100)
         .groupBy(Functions.<Integer, Integer>justFunction(1))
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) throws Throwable {
-                return g.observeOn(Schedulers.cached())
-                        .doOnNext(new Consumer<Integer>() {
-                            @Override
-                            public void accept(Integer v) throws Throwable {
-                                Thread.sleep(100);
-                            }
-                        })
-                        .take(1);
-            }
-        })
+        .flatMap((Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>) g -> g.observeOn(Schedulers.cached())
+                .doOnNext(_ -> Thread.sleep(100))
+                .take(1))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertNoErrors()
@@ -2483,26 +1699,13 @@ public class FlowableGroupByTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
         final AtomicBoolean done = new AtomicBoolean();
         Flowable.range(1, 1000)
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer v) throws Exception {
-                        counter.getAndIncrement();
-                    }
-                })
+                .doOnNext(_ -> counter.getAndIncrement())
                 .groupBy(Functions.justFunction(1))
-                .subscribe(new Consumer<GroupedFlowable<Integer, Integer>>() {
-                    @Override
-                    public void accept(GroupedFlowable<Integer, Integer> v) throws Exception {
-                        TestSubscriber<Integer> ts = TestSubscriber.create(0L);
-                        tss.add(ts);
-                        v.subscribe(ts);
-                    }
-                }, Functions.emptyConsumer(), new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        done.set(true);
-                    }
-                });
+                .subscribe(v -> {
+                    TestSubscriber<Integer> ts = TestSubscriber.create(0L);
+                    tss.add(ts);
+                    v.subscribe(ts);
+                }, Functions.emptyConsumer(), () -> done.set(true));
 
         while (!done.get()) {
             tss.remove(0).cancel();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -37,43 +37,18 @@ public class FlowableGroupJoinTest extends RxJavaTest {
 
     Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-    BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {
-        @Override
-        public Integer apply(Integer t1, Integer t2) {
-            return t1 + t2;
-        }
-    };
+    BiFunction<Integer, Integer, Integer> add = (t1, t2) -> t1 + t2;
 
     <T> Function<Integer, Flowable<T>> just(final Flowable<T> flowable) {
-        return new Function<Integer, Flowable<T>>() {
-            @Override
-            public Flowable<T> apply(Integer t1) {
-                return flowable;
-            }
-        };
+        return _ -> flowable;
     }
 
     <T, R> Function<T, Flowable<R>> just2(final Flowable<R> flowable) {
-        return new Function<T, Flowable<R>>() {
-            @Override
-            public Flowable<R> apply(T t1) {
-                return flowable;
-            }
-        };
+        return _ -> flowable;
     }
 
-    BiFunction<Integer, Flowable<Integer>, Flowable<Integer>> add2 = new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
-        @Override
-        public Flowable<Integer> apply(final Integer leftValue, Flowable<Integer> rightValues) {
-            return rightValues.map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer rightValue) throws Throwable {
-                    return add.apply(leftValue, rightValue);
-                }
-            });
-        }
-
-    };
+    BiFunction<Integer, Flowable<Integer>, Flowable<Integer>> add2 = (leftValue, rightValues) ->
+    rightValues.map(rightValue -> add.apply(leftValue, rightValue));
 
     @Before
     public void before() {
@@ -164,28 +139,14 @@ public class FlowableGroupJoinTest extends RxJavaTest {
                 source2,
                 just2(Flowable.<Object> never()),
                 just2(Flowable.<Object> never()),
-                new BiFunction<Person, Flowable<PersonFruit>, PPF>() {
-                    @Override
-                    public PPF apply(Person t1, Flowable<PersonFruit> t2) {
-                        return new PPF(t1, t2);
-                    }
-                });
+                (t1, t2) -> new PPF(t1, t2));
 
         q.subscribe(
-                new FlowableSubscriber<PPF>() {
+                new FlowableSubscriber<PPF>() /* NFI */ {
                     @Override
                     public void onNext(final PPF ppf) {
-                        ppf.fruits.filter(new Predicate<PersonFruit>() {
-                            @Override
-                            public boolean test(PersonFruit t1) {
-                                return ppf.person.id == t1.personId;
-                            }
-                        }).subscribe(new Consumer<PersonFruit>() {
-                            @Override
-                            public void accept(PersonFruit t1) {
-                                subscriber.onNext(Arrays.asList(ppf.person.name, t1.fruit));
-                            }
-                        });
+                        ppf.fruits.filter(t1 -> ppf.person.id == t1.personId)
+                        .subscribe(t1 -> subscriber.onNext(Arrays.asList(ppf.person.name, t1.fruit)));
                     }
 
                     @Override
@@ -295,11 +256,8 @@ public class FlowableGroupJoinTest extends RxJavaTest {
         PublishProcessor<Integer> source1 = PublishProcessor.create();
         PublishProcessor<Integer> source2 = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> fail = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                throw new RuntimeException("Forced failure");
-            }
+        Function<Integer, Flowable<Integer>> fail = _ -> {
+            throw new RuntimeException("Forced failure");
         };
 
         Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
@@ -319,11 +277,8 @@ public class FlowableGroupJoinTest extends RxJavaTest {
         PublishProcessor<Integer> source1 = PublishProcessor.create();
         PublishProcessor<Integer> source2 = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> fail = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                throw new RuntimeException("Forced failure");
-            }
+        Function<Integer, Flowable<Integer>> fail = _ -> {
+            throw new RuntimeException("Forced failure");
         };
 
         Flowable<Flowable<Integer>> m = source1.groupJoin(source2,
@@ -343,11 +298,8 @@ public class FlowableGroupJoinTest extends RxJavaTest {
         PublishProcessor<Integer> source1 = PublishProcessor.create();
         PublishProcessor<Integer> source2 = PublishProcessor.create();
 
-        BiFunction<Integer, Flowable<Integer>, Integer> fail = new BiFunction<Integer, Flowable<Integer>, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Flowable<Integer> t2) {
-                throw new RuntimeException("Forced failure");
-            }
+        BiFunction<Integer, Flowable<Integer>, Integer> fail = (_, _) -> {
+            throw new RuntimeException("Forced failure");
         };
 
         Flowable<Integer> m = source1.groupJoin(source2,
@@ -367,24 +319,9 @@ public class FlowableGroupJoinTest extends RxJavaTest {
     public void dispose() {
         TestHelper.checkDisposed(Flowable.just(1).groupJoin(
             Flowable.just(2),
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer left) throws Exception {
-                    return Flowable.never();
-                }
-            },
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer right) throws Exception {
-                    return Flowable.never();
-                }
-            },
-            new BiFunction<Integer, Flowable<Integer>, Object>() {
-                @Override
-                public Object apply(Integer r, Flowable<Integer> l) throws Exception {
-                    return l;
-                }
-            }
+            (Function<Integer, Flowable<Object>>) _ -> Flowable.never(),
+            (Function<Integer, Flowable<Object>>) _ -> Flowable.never(),
+            (_, l) -> l
         ));
     }
 
@@ -393,24 +330,9 @@ public class FlowableGroupJoinTest extends RxJavaTest {
         Flowable.just(1)
         .groupJoin(
             Flowable.just(2),
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer left) throws Exception {
-                    return Flowable.empty();
-                }
-            },
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer right) throws Exception {
-                    return Flowable.never();
-                }
-            },
-            new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer r, Flowable<Integer> l) throws Exception {
-                    return l;
-                }
-            }
+            (Function<Integer, Flowable<Object>>) _ -> Flowable.empty(),
+            (Function<Integer, Flowable<Object>>) _ -> Flowable.never(),
+            (_, l) -> l
         )
         .flatMap(Functions.<Flowable<Integer>>identity())
         .test()
@@ -422,24 +344,9 @@ public class FlowableGroupJoinTest extends RxJavaTest {
         Flowable.just(1)
         .groupJoin(
             Flowable.just(2),
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer left) throws Exception {
-                    return Flowable.error(new TestException());
-                }
-            },
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer right) throws Exception {
-                    return Flowable.never();
-                }
-            },
-            new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer r, Flowable<Integer> l) throws Exception {
-                    return l;
-                }
-            }
+            (Function<Integer, Flowable<Object>>) _ -> Flowable.error(new TestException()),
+            (Function<Integer, Flowable<Object>>) _ -> Flowable.never(),
+            (_, l) -> l
         )
         .flatMap(Functions.<Flowable<Integer>>identity())
         .test()
@@ -451,24 +358,9 @@ public class FlowableGroupJoinTest extends RxJavaTest {
         Flowable.just(1)
         .groupJoin(
             Flowable.just(2),
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer left) throws Exception {
-                    return Flowable.never();
-                }
-            },
-            new Function<Integer, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Integer right) throws Exception {
-                    return Flowable.empty();
-                }
-            },
-            new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer r, Flowable<Integer> l) throws Exception {
-                    return l;
-                }
-            }
+            (Function<Integer, Flowable<Object>>) _ -> Flowable.never(),
+            (Function<Integer, Flowable<Object>>) _ -> Flowable.empty(),
+            (_, l) -> l
         )
         .flatMap(Functions.<Flowable<Integer>>identity())
         .test()
@@ -482,24 +374,9 @@ public class FlowableGroupJoinTest extends RxJavaTest {
             Flowable.just(1)
             .groupJoin(
                 Flowable.just(2),
-                new Function<Integer, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Integer left) throws Exception {
-                        return Flowable.never();
-                    }
-                },
-                new Function<Integer, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Integer right) throws Exception {
-                        return Flowable.error(new TestException());
-                    }
-                },
-                new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer r, Flowable<Integer> l) throws Exception {
-                        return l;
-                    }
-                }
+                (Function<Integer, Flowable<Object>>) _ -> Flowable.never(),
+                (Function<Integer, Flowable<Object>>) _ -> Flowable.error(new TestException()),
+                (_, l) -> l
             )
             .flatMap(Functions.<Flowable<Integer>>identity())
             .test()
@@ -523,42 +400,17 @@ public class FlowableGroupJoinTest extends RxJavaTest {
                 TestSubscriberEx<Flowable<Integer>> ts = Flowable.just(1)
                 .groupJoin(
                     Flowable.just(2).concatWith(Flowable.<Integer>never()),
-                    new Function<Integer, Flowable<Object>>() {
-                        @Override
-                        public Flowable<Object> apply(Integer left) throws Exception {
-                            return pp1;
-                        }
-                    },
-                    new Function<Integer, Flowable<Object>>() {
-                        @Override
-                        public Flowable<Object> apply(Integer right) throws Exception {
-                            return pp2;
-                        }
-                    },
-                    new BiFunction<Integer, Flowable<Integer>, Flowable<Integer>>() {
-                        @Override
-                        public Flowable<Integer> apply(Integer r, Flowable<Integer> l) throws Exception {
-                            return l;
-                        }
-                    }
+                    (Function<Integer, Flowable<Object>>) _ -> pp1,
+                    (Function<Integer, Flowable<Object>>) _ -> pp2,
+                    (_, l) -> l
                 )
                 .to(TestHelper.<Flowable<Integer>>testConsumer());
 
                 final TestException ex1 = new TestException();
                 final TestException ex2 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -595,24 +447,9 @@ public class FlowableGroupJoinTest extends RxJavaTest {
                 TestSubscriberEx<Object> ts = pp1
                 .groupJoin(
                     pp2,
-                    new Function<Object, Flowable<Object>>() {
-                        @Override
-                        public Flowable<Object> apply(Object left) throws Exception {
-                            return Flowable.never();
-                        }
-                    },
-                    new Function<Object, Flowable<Object>>() {
-                        @Override
-                        public Flowable<Object> apply(Object right) throws Exception {
-                            return Flowable.never();
-                        }
-                    },
-                    new BiFunction<Object, Flowable<Object>, Flowable<Object>>() {
-                        @Override
-                        public Flowable<Object> apply(Object r, Flowable<Object> l) throws Exception {
-                            return l;
-                        }
-                    }
+                    (Function<Object, Flowable<Object>>) _ -> Flowable.never(),
+                    (Function<Object, Flowable<Object>>) _ -> Flowable.never(),
+                    (_, l) -> l
                 )
                 .flatMap(Functions.<Flowable<Object>>identity())
                 .to(TestHelper.<Object>testConsumer());
@@ -620,18 +457,8 @@ public class FlowableGroupJoinTest extends RxJavaTest {
                 final TestException ex1 = new TestException();
                 final TestException ex2 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -664,24 +491,9 @@ public class FlowableGroupJoinTest extends RxJavaTest {
         TestSubscriber<Object> ts = pp1
         .groupJoin(
             pp2,
-            new Function<Object, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Object left) throws Exception {
-                    return Flowable.never();
-                }
-            },
-            new Function<Object, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Object right) throws Exception {
-                    return Flowable.never();
-                }
-            },
-            new BiFunction<Object, Flowable<Object>, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Object r, Flowable<Object> l) throws Exception {
-                    return l;
-                }
-            }
+            (Function<Object, Flowable<Object>>) _ -> Flowable.never(),
+            (Function<Object, Flowable<Object>>) _ -> Flowable.never(),
+            (_, l) -> l
         )
         .flatMap(Functions.<Flowable<Object>>identity())
         .test();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableHideTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableHideTest.java
@@ -68,13 +68,7 @@ public class FlowableHideTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.hide();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) Flowable::hide);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -47,12 +47,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
         final int num = 10;
         final AtomicInteger upstreamCount = new AtomicInteger();
         long count = Flowable.range(1, num)
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer t) {
-                        upstreamCount.incrementAndGet();
-                    }
-                })
+                .doOnNext(_ -> upstreamCount.incrementAndGet())
                 .ignoreElements()
                 .toFlowable()
                 .count().blockingGet();
@@ -84,11 +79,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
     public void unsubscribesFromUpstreamFlowable() {
         final AtomicBoolean unsub = new AtomicBoolean();
         Flowable.range(1, 10).concatWith(Flowable.<Integer>never())
-        .doOnCancel(new Action() {
-            @Override
-            public void run() {
-                unsub.set(true);
-            }})
+        .doOnCancel(() -> unsub.set(true))
             .ignoreElements()
             .toFlowable()
             .subscribe().dispose();
@@ -103,25 +94,14 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
         int num = 10;
         Flowable.range(1, num)
         //
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer t) {
-                        upstreamCount.incrementAndGet();
-                    }
-                })
+                .doOnNext(_ -> upstreamCount.incrementAndGet())
                 //
                 .ignoreElements()
                 .<Integer>toFlowable()
                 //
-                .doOnNext(new Consumer<Integer>() {
-
-                    @Override
-                    public void accept(Integer t) {
-                        upstreamCount.incrementAndGet();
-                    }
-                })
+                .doOnNext(_ -> upstreamCount.incrementAndGet())
                 //
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -161,12 +141,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
         final int num = 10;
         final AtomicInteger upstreamCount = new AtomicInteger();
         Flowable.range(1, num)
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer t) {
-                        upstreamCount.incrementAndGet();
-                    }
-                })
+                .doOnNext(_ -> upstreamCount.incrementAndGet())
                 .ignoreElements()
                 .blockingAwait();
         assertEquals(num, upstreamCount.get());
@@ -196,11 +171,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
     public void unsubscribesFromUpstream() {
         final AtomicBoolean unsub = new AtomicBoolean();
         Flowable.range(1, 10).concatWith(Flowable.<Integer>never())
-        .doOnCancel(new Action() {
-            @Override
-            public void run() {
-                unsub.set(true);
-            }})
+        .doOnCancel(() -> unsub.set(true))
             .ignoreElements()
             .subscribe().dispose();
 
@@ -214,16 +185,11 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
         int num = 10;
         Flowable.range(1, num)
         //
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer t) {
-                        upstreamCount.incrementAndGet();
-                    }
-                })
+                .doOnNext(_ -> upstreamCount.incrementAndGet())
                 //
                 .ignoreElements()
                 //
-                .subscribe(new DisposableCompletableObserver() {
+                .subscribe(new DisposableCompletableObserver() /* NFI */ {
                     @Override
                     public void onComplete() {
                     }
@@ -265,7 +231,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
     @Test
     public void fusedAPICalls() {
         Flowable.just(1).hide().ignoreElements().<Integer>toFlowable()
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -328,20 +294,8 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.ignoreElements().toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.ignoreElements().toFlowable());
 
-        TestHelper.checkDoubleOnSubscribeFlowableToCompletable(new Function<Flowable<Object>, Completable>() {
-            @Override
-            public Completable apply(Flowable<Object> f)
-                    throws Exception {
-                return f.ignoreElements();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToCompletable(Flowable::ignoreElements);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableJoinTest.java
@@ -35,20 +35,10 @@ import io.reactivex.rxjava4.testsupport.*;
 public class FlowableJoinTest extends RxJavaTest {
     Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-    BiFunction<Integer, Integer, Integer> add = new BiFunction<Integer, Integer, Integer>() {
-        @Override
-        public Integer apply(Integer t1, Integer t2) {
-            return t1 + t2;
-        }
-    };
+    BiFunction<Integer, Integer, Integer> add = (t1, t2) -> t1 + t2;
 
     <T> Function<Integer, Flowable<T>> just(final Flowable<T> flowable) {
-        return new Function<Integer, Flowable<T>>() {
-            @Override
-            public Flowable<T> apply(Integer t1) {
-                return flowable;
-            }
-        };
+        return _ -> flowable;
     }
 
     @Before
@@ -239,11 +229,8 @@ public class FlowableJoinTest extends RxJavaTest {
         PublishProcessor<Integer> source1 = PublishProcessor.create();
         PublishProcessor<Integer> source2 = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> fail = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                throw new RuntimeException("Forced failure");
-            }
+        Function<Integer, Flowable<Integer>> fail = _ -> {
+            throw new RuntimeException("Forced failure");
         };
 
         Flowable<Integer> m = source1.join(source2,
@@ -263,11 +250,8 @@ public class FlowableJoinTest extends RxJavaTest {
         PublishProcessor<Integer> source1 = PublishProcessor.create();
         PublishProcessor<Integer> source2 = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> fail = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                throw new RuntimeException("Forced failure");
-            }
+        Function<Integer, Flowable<Integer>> fail = _ -> {
+            throw new RuntimeException("Forced failure");
         };
 
         Flowable<Integer> m = source1.join(source2,
@@ -287,11 +271,8 @@ public class FlowableJoinTest extends RxJavaTest {
         PublishProcessor<Integer> source1 = PublishProcessor.create();
         PublishProcessor<Integer> source2 = PublishProcessor.create();
 
-        BiFunction<Integer, Integer, Integer> fail = new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                throw new RuntimeException("Forced failure");
-            }
+        BiFunction<Integer, Integer, Integer> fail = (_, _) -> {
+            throw new RuntimeException("Forced failure");
         };
 
         Flowable<Integer> m = source1.join(source2,
@@ -311,12 +292,7 @@ public class FlowableJoinTest extends RxJavaTest {
     public void dispose() {
         TestHelper.checkDisposed(PublishProcessor.<Integer>create().join(Flowable.just(1),
                 Functions.justFunction(Flowable.never()),
-                Functions.justFunction(Flowable.never()), new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                }));
+                Functions.justFunction(Flowable.never()), (a, b) -> a + b));
     }
 
     @Test
@@ -325,12 +301,7 @@ public class FlowableJoinTest extends RxJavaTest {
                 Flowable.just(2),
                 Functions.justFunction(Flowable.never()),
                 Functions.justFunction(Flowable.never()),
-                new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                })
+                (a, b) -> a + b)
         .take(1)
         .test()
         .assertResult(3);
@@ -343,12 +314,7 @@ public class FlowableJoinTest extends RxJavaTest {
         TestSubscriber<Integer> ts = pp.join(Flowable.just(2),
                 Functions.justFunction(Flowable.never()),
                 Functions.justFunction(Flowable.empty()),
-                new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-            })
+                (a, b) -> a + b)
         .test()
         .assertEmpty();
 
@@ -361,15 +327,12 @@ public class FlowableJoinTest extends RxJavaTest {
     public void resultSelectorThrows2() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = pp.join(
+        TestSubscriber<Object> ts = pp.join(
                 Flowable.just(2),
                 Functions.justFunction(Flowable.never()),
                 Functions.justFunction(Flowable.never()),
-                new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        throw new TestException();
-                    }
+                (_, _) -> {
+                    throw new TestException();
                 })
         .test();
 
@@ -383,7 +346,7 @@ public class FlowableJoinTest extends RxJavaTest {
     public void badOuterSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -394,12 +357,7 @@ public class FlowableJoinTest extends RxJavaTest {
             .join(Flowable.just(2),
                     Functions.justFunction(Flowable.never()),
                     Functions.justFunction(Flowable.never()),
-                    new BiFunction<Integer, Integer, Integer>() {
-                        @Override
-                        public Integer apply(Integer a, Integer b) throws Exception {
-                            return a + b;
-                        }
-                })
+                    (a, b) -> a + b)
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");
 
@@ -419,7 +377,7 @@ public class FlowableJoinTest extends RxJavaTest {
             TestSubscriberEx<Integer> ts = Flowable.just(1)
             .join(Flowable.just(2),
                     Functions.justFunction(Flowable.never()),
-                    Functions.justFunction(new Flowable<Integer>() {
+                    Functions.justFunction(new Flowable<Integer>() /* NFI */ {
                         @Override
                         protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                             o[0] = subscriber;
@@ -427,12 +385,7 @@ public class FlowableJoinTest extends RxJavaTest {
                             subscriber.onError(new TestException("First"));
                         }
                     }),
-                    new BiFunction<Integer, Integer, Integer>() {
-                        @Override
-                        public Integer apply(Integer a, Integer b) throws Exception {
-                            return a + b;
-                        }
-                })
+                    (a, b) -> a + b)
             .to(TestHelper.<Integer>testConsumer());
 
             o[0].onError(new TestException("Second"));
@@ -451,13 +404,10 @@ public class FlowableJoinTest extends RxJavaTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Object> ts = pp1.join(pp2, Functions.justFunction(Flowable.never()), Functions.justFunction(Flowable.never()),
-                new BiFunction<Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                })
+        TestSubscriber<Integer> ts = pp1.join(pp2,
+                Functions.justFunction(Flowable.never()),
+                Functions.justFunction(Flowable.never()),
+                (a, b) -> a + b)
         .test(0L);
 
         pp1.onNext(1);
@@ -471,13 +421,9 @@ public class FlowableJoinTest extends RxJavaTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Object> ts = pp1.join(pp2, Functions.justFunction(Flowable.never()), Functions.justFunction(Flowable.never()),
-                new BiFunction<Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                })
+        TestSubscriber<Integer> ts = pp1.join(pp2, Functions.justFunction(Flowable.never()),
+                Functions.justFunction(Flowable.never()),
+                (a, b) -> a + b)
         .test(0L);
 
         pp2.onNext(2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableLastTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableLastTest.java
@@ -95,13 +95,7 @@ public class FlowableLastTest extends RxJavaTest {
     @Test
     public void lastWithPredicate() {
         Maybe<Integer> maybe = Flowable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
@@ -117,13 +111,7 @@ public class FlowableLastTest extends RxJavaTest {
     public void lastWithPredicateAndOneElement() {
         Maybe<Integer> maybe = Flowable.just(1, 2)
             .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                t1 -> t1 % 2 == 0)
             .lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
@@ -139,13 +127,7 @@ public class FlowableLastTest extends RxJavaTest {
     public void lastWithPredicateAndEmpty() {
         Maybe<Integer> maybe = Flowable.just(1)
             .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                }).lastElement();
+                t1 -> t1 % 2 == 0).lastElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
         maybe.subscribe(observer);
@@ -200,13 +182,7 @@ public class FlowableLastTest extends RxJavaTest {
     @Test
     public void lastOrDefaultWithPredicate() {
         Single<Integer> single = Flowable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .last(8);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
@@ -221,13 +197,7 @@ public class FlowableLastTest extends RxJavaTest {
     @Test
     public void lastOrDefaultWithPredicateAndOneElement() {
         Single<Integer> single = Flowable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .last(4);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
@@ -243,13 +213,7 @@ public class FlowableLastTest extends RxJavaTest {
     public void lastOrDefaultWithPredicateAndEmpty() {
         Single<Integer> single = Flowable.just(1)
                 .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                t1 -> t1 % 2 == 0)
                 .last(2);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
@@ -312,44 +276,14 @@ public class FlowableLastTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Flowable<Object> f) throws Exception {
-                return f.lastElement();
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.lastElement().toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToMaybe(Flowable::lastElement);
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.lastElement().toFlowable());
 
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Flowable<Object> f) throws Exception {
-                return f.lastOrError();
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.lastOrError().toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(Flowable::lastOrError);
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.lastOrError().toFlowable());
 
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Flowable<Object> f) throws Exception {
-                return f.last(2);
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.last(2).toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(f -> f.last(2));
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.last(2).toFlowable());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableLiftTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableLiftTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 import java.util.List;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
@@ -32,11 +31,8 @@ public class FlowableLiftTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .lift(new FlowableOperator<Object, Integer>() {
-                @Override
-                public Subscriber<? super Integer> apply(Subscriber<? super Object> subscriber) throws Exception {
-                    throw new TestException();
-                }
+            .lift(_ -> {
+                throw new TestException();
             })
             .test();
             fail("Should have thrown");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapNotificationTest.java
@@ -16,6 +16,8 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import org.junit.Test;
 import static java.util.concurrent.Flow.*;
 
+import java.util.concurrent.Flow.Publisher;
+
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -32,24 +34,9 @@ public class FlowableMapNotificationTest extends RxJavaTest {
         TestSubscriber<Object> ts = new TestSubscriber<>();
         Flowable.just(1)
         .flatMap(
-                new Function<Integer, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Integer item) {
-                        return Flowable.just(item + 1);
-                    }
-                },
-                new Function<Throwable, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Throwable e) {
-                        return Flowable.error(e);
-                    }
-                },
-                new Supplier<Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> get() {
-                        return Flowable.never();
-                    }
-                }
+                (Function<Integer, Flowable<Object>>) item -> Flowable.just(item + 1),
+                (Function<Throwable, Flowable<Object>>) Flowable::error,
+                (Supplier<Flowable<Object>>) Flowable::never
         ).subscribe(ts);
 
         ts.assertNoErrors();
@@ -62,24 +49,9 @@ public class FlowableMapNotificationTest extends RxJavaTest {
         TestSubscriber<Object> ts = TestSubscriber.create(0L);
 
         new FlowableMapNotification<>(Flowable.range(1, 3),
-                new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer item) {
-                        return item + 1;
-                    }
-                },
-                new Function<Throwable, Integer>() {
-                    @Override
-                    public Integer apply(Throwable e) {
-                        return 0;
-                    }
-                },
-                new Supplier<Integer>() {
-                    @Override
-                    public Integer get() {
-                        return 5;
-                    }
-                }
+                item -> item + 1,
+                _ -> 0,
+                () -> 5
         ).subscribe(ts);
 
         ts.assertNoValues();
@@ -106,24 +78,9 @@ public class FlowableMapNotificationTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         new FlowableMapNotification<>(pp,
-                new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer item) {
-                        return item + 1;
-                    }
-                },
-                new Function<Throwable, Integer>() {
-                    @Override
-                    public Integer apply(Throwable e) {
-                        return 0;
-                    }
-                },
-                new Supplier<Integer>() {
-                    @Override
-                    public Integer get() {
-                        return 5;
-                    }
-                }
+                item -> item + 1,
+                _ -> 0,
+                () -> 5
         ).subscribe(ts);
 
         ts.assertNoValues();
@@ -149,7 +106,7 @@ public class FlowableMapNotificationTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(new Flowable<Integer>() {
+        TestHelper.checkDisposed(new Flowable<Integer>() /* NFI */ {
             @SuppressWarnings({ "rawtypes", "unchecked" })
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
@@ -166,27 +123,19 @@ public class FlowableMapNotificationTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Object> f) throws Exception {
-                return f.flatMap(
-                        Functions.justFunction(Flowable.just(1)),
-                        Functions.justFunction(Flowable.just(2)),
-                        Functions.justSupplier(Flowable.just(3))
-                );
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Integer>>) f -> f.flatMap(
+                Functions.justFunction(Flowable.just(1)),
+                Functions.justFunction(Flowable.just(2)),
+                Functions.justSupplier(Flowable.just(3))
+        ));
     }
 
     @Test
     public void onErrorCrash() {
         TestSubscriberEx<Integer> ts = Flowable.<Integer>error(new TestException("Outer"))
         .flatMap(Functions.justFunction(Flowable.just(1)),
-                new Function<Throwable, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Throwable t) throws Exception {
-                        throw new TestException("Inner");
-                    }
+                (Function<Throwable, Publisher<Integer>>) _ -> {
+                    throw new TestException("Inner");
                 },
                 Functions.justSupplier(Flowable.just(3)))
         .to(TestHelper.<Integer>testConsumer())

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapTest.java
@@ -42,12 +42,7 @@ public class FlowableMapTest extends RxJavaTest {
     Subscriber<String> stringSubscriber;
     Subscriber<String> stringSubscriber2;
 
-    static final BiFunction<String, Integer, String> APPEND_INDEX = new BiFunction<String, Integer, String>() {
-        @Override
-        public String apply(String value, Integer index) {
-            return value + index;
-        }
-    };
+    static final BiFunction<String, Integer, String> APPEND_INDEX = (value, index) -> value + index;
 
     @Before
     public void before() {
@@ -61,12 +56,7 @@ public class FlowableMapTest extends RxJavaTest {
         Map<String, String> m2 = getMap("Two");
         Flowable<Map<String, String>> flowable = Flowable.just(m1, m2);
 
-        Flowable<String> m = flowable.map(new Function<Map<String, String>, String>() {
-            @Override
-            public String apply(Map<String, String> map) {
-                return map.get("firstName");
-            }
-        });
+        Flowable<String> m = flowable.map(map -> map.get("firstName"));
 
         m.subscribe(stringSubscriber);
 
@@ -82,31 +72,21 @@ public class FlowableMapTest extends RxJavaTest {
         Flowable<Integer> ids = Flowable.just(1, 2);
 
         /* now simulate the behavior to take those IDs and perform nested async calls based on them */
-        Flowable<String> m = ids.flatMap(new Function<Integer, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(Integer id) {
-                /* simulate making a nested async call which creates another Flowable */
-                Flowable<Map<String, String>> subFlowable = null;
-                if (id == 1) {
-                    Map<String, String> m1 = getMap("One");
-                    Map<String, String> m2 = getMap("Two");
-                    subFlowable = Flowable.just(m1, m2);
-                } else {
-                    Map<String, String> m3 = getMap("Three");
-                    Map<String, String> m4 = getMap("Four");
-                    subFlowable = Flowable.just(m3, m4);
-                }
-
-                /* simulate kicking off the async call and performing a select on it to transform the data */
-                return subFlowable.map(new Function<Map<String, String>, String>() {
-                    @Override
-                    public String apply(Map<String, String> map) {
-                        return map.get("firstName");
-                    }
-                });
+        Flowable<String> m = ids.flatMap((Function<Integer, Flowable<String>>) id -> {
+            /* simulate making a nested async call which creates another Flowable */
+            Flowable<Map<String, String>> subFlowable = null;
+            if (id == 1) {
+                Map<String, String> m1 = getMap("One");
+                Map<String, String> m2 = getMap("Two");
+                subFlowable = Flowable.just(m1, m2);
+            } else {
+                Map<String, String> m3 = getMap("Three");
+                Map<String, String> m4 = getMap("Four");
+                subFlowable = Flowable.just(m3, m4);
             }
 
+            /* simulate kicking off the async call and performing a select on it to transform the data */
+            return subFlowable.map(map -> map.get("firstName"));
         });
         m.subscribe(stringSubscriber);
 
@@ -130,20 +110,8 @@ public class FlowableMapTest extends RxJavaTest {
 
         Flowable<Flowable<Map<String, String>>> f = Flowable.just(flowable1, flowable2);
 
-        Flowable<String> m = f.flatMap(new Function<Flowable<Map<String, String>>, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(Flowable<Map<String, String>> f) {
-                return f.map(new Function<Map<String, String>, String>() {
-
-                    @Override
-                    public String apply(Map<String, String> map) {
-                        return map.get("firstName");
-                    }
-                });
-            }
-
-        });
+        Flowable<String> m = f.flatMap((Function<Flowable<Map<String, String>>, Flowable<String>>) f1 ->
+        f1.map(map -> map.get("firstName")));
         m.subscribe(stringSubscriber);
 
         verify(stringSubscriber, never()).onError(any(Throwable.class));
@@ -160,22 +128,12 @@ public class FlowableMapTest extends RxJavaTest {
         final List<Throwable> errors = new ArrayList<>();
 
         Flowable<String> w = Flowable.just("one", "fail", "two", "three", "fail");
-        Flowable<String> m = w.map(new Function<String, String>() {
-            @Override
-            public String apply(String s) {
-                if ("fail".equals(s)) {
-                    throw new TestException("Forced Failure");
-                }
-                return s;
+        Flowable<String> m = w.map(s -> {
+            if ("fail".equals(s)) {
+                throw new TestException("Forced Failure");
             }
-        }).doOnError(new Consumer<Throwable>() {
-
-            @Override
-            public void accept(Throwable t1) {
-                errors.add(t1);
-            }
-
-        });
+            return s;
+        }).doOnError(t1 -> errors.add(t1));
 
         m.subscribe(stringSubscriber);
         verify(stringSubscriber, times(1)).onNext("one");
@@ -190,11 +148,8 @@ public class FlowableMapTest extends RxJavaTest {
     @Test(expected = IllegalArgumentException.class)
     public void mapWithIssue417() {
         Flowable.just(1).observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer arg0) {
-                        throw new IllegalArgumentException("any error");
-                    }
+                .map(_ -> {
+                    throw new IllegalArgumentException("any error");
                 }).blockingSingle();
     }
 
@@ -205,11 +160,8 @@ public class FlowableMapTest extends RxJavaTest {
         // so map needs to handle the error by itself.
         Flowable<String> m = Flowable.just("one")
                 .observeOn(Schedulers.computation())
-                .map(new Function<String, String>() {
-                    @Override
-                    public String apply(String arg0) {
-                        throw new IllegalArgumentException("any error");
-                    }
+                .map(_ -> {
+                    throw new IllegalArgumentException("any error");
                 });
 
         // block for response, expecting exception thrown
@@ -221,14 +173,7 @@ public class FlowableMapTest extends RxJavaTest {
      */
     @Test
     public void errorPassesThruMap() {
-        assertNull(Flowable.range(1, 0).lastElement().map(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer i) {
-                return i;
-            }
-
-        }).blockingGet());
+        assertNull(Flowable.range(1, 0).lastElement().map(i -> i).blockingGet());
     }
 
     /**
@@ -236,14 +181,7 @@ public class FlowableMapTest extends RxJavaTest {
      */
     @Test(expected = IllegalStateException.class)
     public void errorPassesThruMap2() {
-        Flowable.error(new IllegalStateException()).map(new Function<Object, Object>() {
-
-            @Override
-            public Object apply(Object i) {
-                return i;
-            }
-
-        }).blockingSingle();
+        Flowable.error(new IllegalStateException()).map(i -> i).blockingSingle();
     }
 
     /**
@@ -252,14 +190,7 @@ public class FlowableMapTest extends RxJavaTest {
      */
     @Test(expected = ArithmeticException.class)
     public void mapWithErrorInFunc() {
-        Flowable.range(1, 1).lastElement().map(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer i) {
-                return i / 0;
-            }
-
-        }).blockingGet();
+        Flowable.range(1, 1).lastElement().map(i -> i / 0).blockingGet();
     }
 
     private static Map<String, String> getMap(String prefix) {
@@ -276,11 +207,8 @@ public class FlowableMapTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        pp.map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) {
-                throw new TestException();
-            }
+        pp.<Integer>map(_ -> {
+            throw new TestException();
         }).subscribe(ts);
 
         Assert.assertTrue("Not subscribed?", pp.hasSubscribers());
@@ -295,18 +223,8 @@ public class FlowableMapTest extends RxJavaTest {
     @Test
     public void mapFilter() {
         Flowable.range(1, 2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return v + 1;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        })
+        .map(v -> v + 1)
+        .filter(_ -> true)
         .test()
         .assertResult(2, 3);
     }
@@ -314,18 +232,10 @@ public class FlowableMapTest extends RxJavaTest {
     @Test
     public void mapFilterMapperCrash() {
         Flowable.range(1, 2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .<Integer>map(_ -> {
+            throw new TestException();
         })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        })
+        .filter(_ -> true)
         .test()
         .assertFailure(TestException.class);
     }
@@ -333,18 +243,8 @@ public class FlowableMapTest extends RxJavaTest {
     @Test
     public void mapFilterHidden() {
         Flowable.range(1, 2).hide()
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return v + 1;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        })
+        .map(v -> v + 1)
+        .filter(_ -> true)
         .test()
         .assertResult(2, 3);
     }
@@ -354,18 +254,8 @@ public class FlowableMapTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.range(1, 2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return v + 1;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        })
+        .map(v -> v + 1)
+        .filter(_ -> true)
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -378,18 +268,8 @@ public class FlowableMapTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.range(1, 2).hide()
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return v + 1;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        })
+        .map(v -> v + 1)
+        .filter(_ -> true)
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -402,21 +282,15 @@ public class FlowableMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+                s.onError(new IOException());
+                s.onComplete();
             })
-            .map(new Function<Integer, Object>() {
-                @Override
-                public Object apply(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .map(_ -> {
+                throw new TestException();
             })
             .test()
             .assertFailure(TestException.class);
@@ -432,18 +306,10 @@ public class FlowableMapTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
         Flowable.range(1, 2).hide()
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .<Integer>map(_ -> {
+            throw new TestException();
         })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        })
+        .filter(_ -> true)
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -456,28 +322,17 @@ public class FlowableMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onNext(2);
-                    s.onError(new IOException());
-                    s.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(2);
+                s.onError(new IOException());
+                s.onComplete();
             })
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .<Integer>map(_ -> {
+                throw new TestException();
             })
-            .filter(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    return true;
-                }
-            })
+            .filter(_ -> true)
             .test()
             .assertFailure(TestException.class);
 
@@ -494,18 +349,8 @@ public class FlowableMapTest extends RxJavaTest {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return v + 1;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        })
+        .map(v -> v + 1)
+        .filter(_ -> true)
         .subscribe(ts);
 
         up.onNext(1);
@@ -522,29 +367,18 @@ public class FlowableMapTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    ConditionalSubscriber<? super Integer> cs = (ConditionalSubscriber<? super Integer>)s;
-                    cs.onSubscribe(new BooleanSubscription());
-                    cs.tryOnNext(1);
-                    cs.tryOnNext(2);
-                    cs.onError(new IOException());
-                    cs.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                ConditionalSubscriber<? super Integer> cs = (ConditionalSubscriber<? super Integer>)s;
+                cs.onSubscribe(new BooleanSubscription());
+                cs.tryOnNext(1);
+                cs.tryOnNext(2);
+                cs.onError(new IOException());
+                cs.onComplete();
             })
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .<Integer>map(_ -> {
+                throw new TestException();
             })
-            .filter(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    return true;
-                }
-            })
+            .filter(_ -> true)
             .test()
             .assertFailure(TestException.class);
 
@@ -561,12 +395,7 @@ public class FlowableMapTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.map(Functions.identity());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.map(Functions.identity()));
     }
 
     @Test
@@ -611,12 +440,7 @@ public class FlowableMapTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> f) throws Exception {
-                return f.map(Functions.identity());
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.map(Functions.identity()), false, 1, 1, 1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMaterializeTest.java
@@ -177,11 +177,8 @@ public class FlowableMaterializeTest extends RxJavaTest {
     public void withCompletionCausingError() {
         TestSubscriberEx<Notification<Integer>> ts = new TestSubscriberEx<>();
         final RuntimeException ex = new RuntimeException("boo");
-        Flowable.<Integer>empty().materialize().doOnNext(new Consumer<Object>() {
-            @Override
-            public void accept(Object t) {
-                throw ex;
-            }
+        Flowable.<Integer>empty().materialize().doOnNext(_ -> {
+            throw ex;
         }).subscribe(ts);
         ts.assertError(ex);
         ts.assertNoValues();
@@ -236,28 +233,23 @@ public class FlowableMaterializeTest extends RxJavaTest {
         @Override
         public void subscribe(final Subscriber<? super String> subscriber) {
             subscriber.onSubscribe(new BooleanSubscription());
-            t = new Thread(new Runnable() {
+            t = new Thread(() -> {
+                for (String s : valuesToReturn) {
+                    if (s == null) {
+                        System.out.println("throwing exception");
+                        try {
+                            Thread.sleep(100);
+                        } catch (Throwable e) {
 
-                @Override
-                public void run() {
-                    for (String s : valuesToReturn) {
-                        if (s == null) {
-                            System.out.println("throwing exception");
-                            try {
-                                Thread.sleep(100);
-                            } catch (Throwable e) {
-
-                            }
-                            subscriber.onError(new NullPointerException());
-                            return;
-                        } else {
-                            subscriber.onNext(s);
                         }
+                        subscriber.onError(new NullPointerException());
+                        return;
+                    } else {
+                        subscriber.onNext(s);
                     }
-                    System.out.println("subscription complete");
-                    subscriber.onComplete();
                 }
-
+                System.out.println("subscription complete");
+                subscriber.onComplete();
             });
             t.start();
         }
@@ -289,22 +281,12 @@ public class FlowableMaterializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Notification<Object>>>() {
-            @Override
-            public Flowable<Notification<Object>> apply(Flowable<Object> f) throws Exception {
-                return f.materialize();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Notification<Object>>>) Flowable::materialize);
     }
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> f) throws Exception {
-                return f.materialize();
-            }
-        }, false, null, null, Notification.createOnComplete());
+        TestHelper.checkBadSourceFlowable(Flowable::materialize, false, null, null, Notification.createOnComplete());
     }
 
     @Test


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080