### PR TITLE
Fix Scheduler.toExecutorService() NullPointerException from null worker store

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Scheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Scheduler.java
@@ -389,7 +389,7 @@ public abstract class Scheduler {
      * @since 4.0.0
      */
     public ExecutorService toExecutorService() {
-        return new SchedulerToExecutorService(this, null);
+        return new SchedulerToExecutorService(this, new AtomicReference<>());
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava4/core/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/SchedulerTest.java
@@ -20,7 +20,11 @@ import static org.junit.Assert.assertTrue;
 import org.junit.After;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import io.reactivex.rxjava4.schedulers.Schedulers;
 
 public class SchedulerTest {
     private static final String DRIFT_USE_NANOTIME = "rx4.scheduler.use-nanotime";
@@ -70,4 +74,19 @@ public class SchedulerTest {
         assertEquals(300_000_000_000L, Scheduler.computeClockDrift(5, null));
     }
 
+    @Test
+    public void toExecutorServiceWithoutWorkerExecutes() throws Exception {
+        // The no-arg toExecutorService() must return a usable ExecutorService that falls back to
+        // scheduleDirect() when there is no worker; it previously passed null for the worker store,
+        // so every method threw NullPointerException on first use.
+        ExecutorService exec = Schedulers.single().toExecutorService();
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+            exec.execute(latch::countDown);
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
+            assertFalse(exec.isShutdown());
+        } finally {
+            exec.shutdown();
+        }
+    }
 }


### PR DESCRIPTION
The no-arg `Scheduler.toExecutorService()` passes `null` for the `SchedulerToExecutorService` worker store, so every method (`execute`/`submit`/`shutdown`/`isShutdown`/…) throws `NullPointerException` on first use via `workerStore.get()`:

```java
Schedulers.single().toExecutorService().execute(() -> {}); // NullPointerException
```

The `toExecutorService(boolean)` overload one method below already does it correctly, passing `new AtomicReference<>()`. This change makes the no-arg version consistent: with no worker present, the methods fall back to `scheduler.scheduleDirect(...)` as intended.

Adds a regression test (`SchedulerTest.toExecutorServiceWithoutWorkerExecutes`) that fails before the change (NPE) and passes after.
