### PR TITLE
4.x: Unit test lambdaification 13 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -224,12 +224,12 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
         Flowable<Flowable<String>> flowableOfFlowables = Flowable.unsafeCreate(subscriber -> {
-		    subscriber.onSubscribe(new BooleanSubscription());
-		    // simulate what would happen in a Flowable
-		    subscriber.onNext(f1);
-		    subscriber.onNext(f2);
-		    subscriber.onComplete();
-		});
+            subscriber.onSubscribe(new BooleanSubscription());
+            // simulate what would happen in a Flowable
+            subscriber.onNext(f1);
+            subscriber.onNext(f2);
+            subscriber.onComplete();
+        });
         Flowable<String> m = Flowable.mergeDelayError(flowableOfFlowables);
         m.subscribe(stringSubscriber);
 
@@ -333,9 +333,9 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         public void subscribe(final Subscriber<? super String> subscriber) {
             subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(() -> {
-			    subscriber.onNext("hello");
-			    subscriber.onComplete();
-			});
+                subscriber.onNext("hello");
+                subscriber.onComplete();
+            });
             t.start();
         }
     }
@@ -383,23 +383,23 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         public void subscribe(final Subscriber<? super String> subscriber) {
             subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(() -> {
-			    for (String s : valuesToReturn) {
-			        if (s == null) {
-			            System.out.println("throwing exception");
-			            try {
-			                Thread.sleep(100);
-			            } catch (Throwable e) {
+                for (String s : valuesToReturn) {
+                    if (s == null) {
+                        System.out.println("throwing exception");
+                        try {
+                            Thread.sleep(100);
+                        } catch (Throwable e) {
 
-			            }
-			            subscriber.onError(new NullPointerException());
-			            return;
-			        } else {
-			            subscriber.onNext(s);
-			        }
-			    }
-			    System.out.println("subscription complete");
-			    subscriber.onComplete();
-			});
+                        }
+                        subscriber.onError(new NullPointerException());
+                        return;
+                    } else {
+                        subscriber.onNext(s);
+                    }
+                }
+                System.out.println("subscription complete");
+                subscriber.onComplete();
+            });
             t.start();
         }
     }
@@ -444,11 +444,11 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
             final TestASynchronous1sDelayedFlowable f1 = new TestASynchronous1sDelayedFlowable();
             final TestASynchronous1sDelayedFlowable f2 = new TestASynchronous1sDelayedFlowable();
             Flowable<Flowable<String>> parentFlowable = Flowable.unsafeCreate(op -> {
-			    op.onSubscribe(new BooleanSubscription());
-			    op.onNext(Flowable.unsafeCreate(f1));
-			    op.onNext(Flowable.unsafeCreate(f2));
-			    op.onError(new NullPointerException("throwing exception in parent"));
-			});
+                op.onSubscribe(new BooleanSubscription());
+                op.onNext(Flowable.unsafeCreate(f1));
+                op.onNext(Flowable.unsafeCreate(f2));
+                op.onError(new NullPointerException("throwing exception in parent"));
+            });
 
             stringSubscriber = TestHelper.mockSubscriber();
 
@@ -472,14 +472,14 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         public void subscribe(final Subscriber<? super String> subscriber) {
             subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(() -> {
-			    try {
-			        Thread.sleep(100);
-			    } catch (InterruptedException e) {
-			        subscriber.onError(e);
-			    }
-			    subscriber.onNext("hello");
-			    subscriber.onComplete();
-			});
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    subscriber.onError(e);
+                }
+                subscriber.onNext("hello");
+                subscriber.onComplete();
+            });
             t.start();
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -93,19 +93,19 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
         public void subscribe(final Subscriber<? super String> t1) {
             t1.onSubscribe(new BooleanSubscription());
             new Thread(() -> {
-			    if (subscriptionCount.incrementAndGet() > maxConcurrent) {
-			        failed = true;
-			    }
-			    t1.onNext("one");
-			    t1.onNext("two");
-			    t1.onNext("three");
-			    t1.onNext("four");
-			    t1.onNext("five");
-			    // We could not decrement subscriptionCount in the unsubscribe method
-			    // as "unsubscribe" is not guaranteed to be called before the next "subscribe".
-			    subscriptionCount.decrementAndGet();
-			    t1.onComplete();
-			}).start();
+                if (subscriptionCount.incrementAndGet() > maxConcurrent) {
+                    failed = true;
+                }
+                t1.onNext("one");
+                t1.onNext("two");
+                t1.onNext("three");
+                t1.onNext("four");
+                t1.onNext("five");
+                // We could not decrement subscriptionCount in the unsubscribe method
+                // as "unsubscribe" is not guaranteed to be called before the next "subscribe".
+                subscriptionCount.decrementAndGet();
+                t1.onComplete();
+            }).start();
         }
 
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
@@ -82,12 +82,12 @@ public class FlowableMergeTest extends RxJavaTest {
         final Flowable<String> f2 = Flowable.unsafeCreate(new TestSynchronousFlowable());
 
         Flowable<Flowable<String>> flowableOfFlowables = Flowable.unsafeCreate(subscriber -> {
-		    subscriber.onSubscribe(new BooleanSubscription());
-		    // simulate what would happen in a Flowable
-		    subscriber.onNext(f1);
-		    subscriber.onNext(f2);
-		    subscriber.onComplete();
-		});
+            subscriber.onSubscribe(new BooleanSubscription());
+            // simulate what would happen in a Flowable
+            subscriber.onNext(f1);
+            subscriber.onNext(f2);
+            subscriber.onComplete();
+        });
         Flowable<String> m = Flowable.merge(flowableOfFlowables);
         m.subscribe(stringSubscriber);
 
@@ -132,45 +132,45 @@ public class FlowableMergeTest extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
 
         Flowable<Flowable<Long>> source = Flowable.unsafeCreate(subscriber -> {
-		    // verbose on purpose so I can track the inside of it
-		    final Subscription s = new Subscription() /* NFI */ {
+            // verbose on purpose so I can track the inside of it
+            final Subscription s = new Subscription() /* NFI */ {
 
-		        @Override
-		        public void request(long n) {
+                @Override
+                public void request(long n) {
 
-		        }
+                }
 
-		        @Override
-		        public void cancel() {
-		            System.out.println("*** unsubscribed");
-		            unsubscribed.set(true);
-		        }
+                @Override
+                public void cancel() {
+                    System.out.println("*** unsubscribed");
+                    unsubscribed.set(true);
+                }
 
-		    };
-		    subscriber.onSubscribe(s);
+            };
+            subscriber.onSubscribe(s);
 
-		    new Thread(() -> {
+            new Thread(() -> {
 
-			    while (!unsubscribed.get()) {
-			        subscriber.onNext(Flowable.just(1L, 2L));
-			    }
-			    System.out.println("Done looping after unsubscribe: " + unsubscribed.get());
-			    subscriber.onComplete();
+                while (!unsubscribed.get()) {
+                    subscriber.onNext(Flowable.just(1L, 2L));
+                }
+                System.out.println("Done looping after unsubscribe: " + unsubscribed.get());
+                subscriber.onComplete();
 
-			    // mark that the thread is finished
-			    latch.countDown();
-			}).start();
-		});
+                // mark that the thread is finished
+                latch.countDown();
+            }).start();
+        });
 
         final AtomicInteger count = new AtomicInteger();
         Flowable.merge(source).take(6).blockingForEach(v -> {
-		    System.out.println("Value: " + v);
-		    int c = count.incrementAndGet();
-		    if (c > 6) {
-		        fail("Should be only 6");
-		    }
+            System.out.println("Value: " + v);
+            int c = count.incrementAndGet();
+            if (c > 6) {
+                fail("Should be only 6");
+            }
 
-		});
+        });
 
         latch.await(1000, TimeUnit.MILLISECONDS);
 
@@ -357,16 +357,16 @@ public class FlowableMergeTest extends RxJavaTest {
         public void subscribe(final Subscriber<? super String> subscriber) {
             subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(() -> {
-			    onNextBeingSent.countDown();
-			    try {
-			        subscriber.onNext("hello");
-			        // I can't use a countDownLatch to prove we are actually sending 'onNext'
-			        // since it will block if synchronized and I'll deadlock
-			        subscriber.onComplete();
-			    } catch (Exception e) {
-			        subscriber.onError(e);
-			    }
-			}, "TestASynchronousFlowable");
+                onNextBeingSent.countDown();
+                try {
+                    subscriber.onNext("hello");
+                    // I can't use a countDownLatch to prove we are actually sending 'onNext'
+                    // since it will block if synchronized and I'll deadlock
+                    subscriber.onComplete();
+                } catch (Exception e) {
+                    subscriber.onError(e);
+                }
+            }, "TestASynchronousFlowable");
             t.start();
         }
     }
@@ -472,42 +472,42 @@ public class FlowableMergeTest extends RxJavaTest {
 
     private Flowable<Long> createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(final Scheduler scheduler, final AtomicBoolean unsubscribed) {
         return Flowable.unsafeCreate(child -> Flowable.interval(1, TimeUnit.SECONDS, scheduler)
-		.take(5)
-		.subscribe(new FlowableSubscriber<Long>() /* NFI */ {
-		    @Override
-		    public void onSubscribe(final Subscription s) {
-		        child.onSubscribe(new Subscription() /* NFI */ {
-		            @Override
-		            public void request(long n) {
-		                s.request(n);
-		            }
+        .take(5)
+        .subscribe(new FlowableSubscriber<Long>() /* NFI */ {
+            @Override
+            public void onSubscribe(final Subscription s) {
+                child.onSubscribe(new Subscription() /* NFI */ {
+                    @Override
+                    public void request(long n) {
+                        s.request(n);
+                    }
 
-		            @Override
-		            public void cancel() {
-		                unsubscribed.set(true);
-		                s.cancel();
-		            }
-		        });
-		    }
+                    @Override
+                    public void cancel() {
+                        unsubscribed.set(true);
+                        s.cancel();
+                    }
+                });
+            }
 
-		    @Override
-		    public void onNext(Long t) {
-		        child.onNext(t);
-		    }
+            @Override
+            public void onNext(Long t) {
+                child.onNext(t);
+            }
 
-		    @Override
-		    public void onError(Throwable t) {
-		        unsubscribed.set(true);
-		        child.onError(t);
-		    }
+            @Override
+            public void onError(Throwable t) {
+                unsubscribed.set(true);
+                child.onError(t);
+            }
 
-		    @Override
-		    public void onComplete() {
-		        unsubscribed.set(true);
-		        child.onComplete();
-		    }
+            @Override
+            public void onComplete() {
+                unsubscribed.set(true);
+                child.onComplete();
+            }
 
-		}));
+        }));
     }
 
     @Test
@@ -533,30 +533,30 @@ public class FlowableMergeTest extends RxJavaTest {
     public void concurrencyWithSleeping() {
 
         Flowable<Integer> f = Flowable.unsafeCreate(s -> {
-		    Worker inner = Schedulers.newThread().createWorker();
-		    final AsyncSubscription as = new AsyncSubscription();
-		    as.setSubscription(new BooleanSubscription());
-		    as.setResource(inner);
+            Worker inner = Schedulers.newThread().createWorker();
+            final AsyncSubscription as = new AsyncSubscription();
+            as.setSubscription(new BooleanSubscription());
+            as.setResource(inner);
 
-		    s.onSubscribe(as);
+            s.onSubscribe(as);
 
-		    inner.schedule(() -> {
-			    try {
-			        for (int i = 0; i < 100; i++) {
-			            s.onNext(1);
-			            try {
-			                Thread.sleep(1);
-			            } catch (InterruptedException e) {
-			                e.printStackTrace();
-			            }
-			        }
-			    } catch (Exception e) {
-			        s.onError(e);
-			    }
-			    as.dispose();
-			    s.onComplete();
-			});
-		});
+            inner.schedule(() -> {
+                try {
+                    for (int i = 0; i < 100; i++) {
+                        s.onNext(1);
+                        try {
+                            Thread.sleep(1);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                } catch (Exception e) {
+                    s.onError(e);
+                }
+                as.dispose();
+                s.onComplete();
+            });
+        });
 
         for (int i = 0; i < 10; i++) {
             Flowable<Integer> merge = Flowable.merge(f, f, f);
@@ -574,27 +574,27 @@ public class FlowableMergeTest extends RxJavaTest {
     @Test
     public void concurrencyWithBrokenOnCompleteContract() {
         Flowable<Integer> f = Flowable.unsafeCreate(s -> {
-		    Worker inner = Schedulers.newThread().createWorker();
-		    final AsyncSubscription as = new AsyncSubscription();
-		    as.setSubscription(new BooleanSubscription());
-		    as.setResource(inner);
+            Worker inner = Schedulers.newThread().createWorker();
+            final AsyncSubscription as = new AsyncSubscription();
+            as.setSubscription(new BooleanSubscription());
+            as.setResource(inner);
 
-		    s.onSubscribe(as);
+            s.onSubscribe(as);
 
-		    inner.schedule(() -> {
-			    try {
-			        for (int i = 0; i < 10000; i++) {
-			            s.onNext(i);
-			        }
-			    } catch (Exception e) {
-			        s.onError(e);
-			    }
-			    as.dispose();
-			    s.onComplete();
-			    s.onComplete();
-			    s.onComplete();
-			});
-		});
+            inner.schedule(() -> {
+                try {
+                    for (int i = 0; i < 10000; i++) {
+                        s.onNext(i);
+                    }
+                } catch (Exception e) {
+                    s.onError(e);
+                }
+                as.dispose();
+                s.onComplete();
+                s.onComplete();
+                s.onComplete();
+            });
+        });
 
         for (int i = 0; i < 10; i++) {
             Flowable<Integer> merge = Flowable.merge(f.onBackpressureBuffer(), f.onBackpressureBuffer(), f.onBackpressureBuffer());
@@ -920,20 +920,20 @@ public class FlowableMergeTest extends RxJavaTest {
     private Flowable<Integer> createInfiniteFlowable(final AtomicInteger generated) {
         Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
-		    @Override
-		    public void remove() {
-		    }
+            @Override
+            public void remove() {
+            }
 
-		    @Override
-		    public Integer next() {
-		        return generated.getAndIncrement();
-		    }
+            @Override
+            public Integer next() {
+                return generated.getAndIncrement();
+            }
 
-		    @Override
-		    public boolean hasNext() {
-		        return true;
-		    }
-		});
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+        });
         return flowable;
     }
 
@@ -942,17 +942,17 @@ public class FlowableMergeTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable<Flowable<Integer>> os = Flowable.range(1, 10000)
         .map(i -> Flowable.<Integer>unsafeCreate(s -> {
-		    s.onSubscribe(new BooleanSubscription());
-		    if (i < 500) {
-		        try {
-		            Thread.sleep(1);
-		        } catch (InterruptedException e) {
-		            e.printStackTrace();
-		        }
-		    }
-		    s.onNext(i);
-		    s.onComplete();
-		}).subscribeOn(Schedulers.computation()).cache());
+            s.onSubscribe(new BooleanSubscription());
+            if (i < 500) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            s.onNext(i);
+            s.onComplete();
+        }).subscribeOn(Schedulers.computation()).cache());
         Flowable.merge(os).subscribe(ts);
         ts.awaitDone(10, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1068,14 +1068,14 @@ public class FlowableMergeTest extends RxJavaTest {
             Flowable.range(1, 2)
                     // produce many integers per second
                     .flatMap((Function<Integer, Flowable<Integer>>) number -> Flowable.range(1, Integer.MAX_VALUE)
-					        .doOnRequest(n -> messages.add(">>>>>>>> A requested[" + number + "]: " + n))
-					        // pause a bit
-					        .doOnNext(pauseForMs(3))
-					        // buffer on backpressure
-					        .onBackpressureBuffer()
-					        // do in parallel
-					        .subscribeOn(Schedulers.computation())
-					        .doOnRequest(n -> messages.add(">>>>>>>> B requested[" + number + "]: " + n)))
+                            .doOnRequest(n -> messages.add(">>>>>>>> A requested[" + number + "]: " + n))
+                            // pause a bit
+                            .doOnNext(pauseForMs(3))
+                            // buffer on backpressure
+                            .onBackpressureBuffer()
+                            // do in parallel
+                            .subscribeOn(Schedulers.computation())
+                            .doOnRequest(n -> messages.add(">>>>>>>> B requested[" + number + "]: " + n)))
                     // take a number bigger than 2* Flowable.bufferSize() (used by OperatorMerge)
                     .take(Flowable.bufferSize() * 2 + 1)
                     // log count
@@ -1139,12 +1139,12 @@ public class FlowableMergeTest extends RxJavaTest {
 
     private static Consumer<Integer> pauseForMs(final long time) {
         return _ -> {
-		    try {
-		        Thread.sleep(time);
-		    } catch (InterruptedException e) {
-		        throw new RuntimeException(e);
-		    }
-		};
+            try {
+                Thread.sleep(time);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
     }
 
     Function<Integer, Flowable<Integer>> toScalar = Flowable::just;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -107,9 +107,9 @@ public class FlowableMergeWithCompletableTest extends RxJavaTest {
             TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
 
             Runnable r1 = () -> {
-			    pp.onNext(1);
-			    pp.onComplete();
-			};
+                pp.onNext(1);
+                pp.onComplete();
+            };
 
             Runnable r2 = () -> cs.onComplete();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithMaybeTest.java
@@ -132,9 +132,9 @@ public class FlowableMergeWithMaybeTest extends RxJavaTest {
             TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
 
             Runnable r1 = () -> {
-			    pp.onNext(1);
-			    pp.onComplete();
-			};
+                pp.onNext(1);
+                pp.onComplete();
+            };
 
             Runnable r2 = () -> cs.onSuccess(1);
 
@@ -407,7 +407,7 @@ public class FlowableMergeWithMaybeTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancel() {
         TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
-        	upstream.mergeWith(Maybe.just(1).hide()));
+            upstream.mergeWith(Maybe.just(1).hide()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -128,9 +128,9 @@ public class FlowableMergeWithSingleTest extends RxJavaTest {
             TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
 
             Runnable r1 = () -> {
-			    pp.onNext(1);
-			    pp.onComplete();
-			};
+                pp.onNext(1);
+                pp.onComplete();
+            };
 
             Runnable r2 = () -> cs.onSuccess(1);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
@@ -100,18 +100,18 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
         // assert subscribe is on main thread
         obs = obs.doOnNext(_ -> {
-		    String threadName = Thread.currentThread().getName();
-		    System.out.println("Source ThreadName: " + threadName + "  Expected => " + parentThreadName);
-		    assertEquals(parentThreadName, threadName);
-		});
+            String threadName = Thread.currentThread().getName();
+            System.out.println("Source ThreadName: " + threadName + "  Expected => " + parentThreadName);
+            assertEquals(parentThreadName, threadName);
+        });
 
         // assert observe is on new thread
         obs.observeOn(Schedulers.newThread()).doOnNext(_ -> {
-		    String threadName = Thread.currentThread().getName();
-		    boolean correctThreadName = threadName.startsWith("RxNewThreadScheduler");
-		    System.out.println("ObserveOn ThreadName: " + threadName + "  Correct => " + correctThreadName);
-		    assertTrue(correctThreadName);
-		}).doAfterTerminate(() -> completedLatch.countDown()).subscribe(subscriber);
+            String threadName = Thread.currentThread().getName();
+            boolean correctThreadName = threadName.startsWith("RxNewThreadScheduler");
+            System.out.println("ObserveOn ThreadName: " + threadName + "  Correct => " + correctThreadName);
+            assertTrue(correctThreadName);
+        }).doAfterTerminate(() -> completedLatch.countDown()).subscribe(subscriber);
 
         if (!completedLatch.await(1000, TimeUnit.MILLISECONDS)) {
             fail("timed out waiting");
@@ -199,11 +199,11 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
         Flowable.range(1, 100000).map(t1 -> t1 * _multiple).observeOn(Schedulers.newThread())
         .blockingForEach(t1 -> {
-		    assertEquals(count.incrementAndGet() * _multiple, t1.intValue());
-		    // FIXME toBlocking methods run on the current thread
-		    String name = Thread.currentThread().getName();
-		    assertFalse("Wrong thread name: " + name, name.startsWith("Rx"));
-		});
+            assertEquals(count.incrementAndGet() * _multiple, t1.intValue());
+            // FIXME toBlocking methods run on the current thread
+            String name = Thread.currentThread().getName();
+            assertFalse("Wrong thread name: " + name, name.startsWith("Rx"));
+        });
 
     }
 
@@ -217,11 +217,11 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
         Flowable.range(1, 100000).map(t1 -> t1 * _multiple).observeOn(Schedulers.computation())
         .blockingForEach(t1 -> {
-		    assertEquals(count.incrementAndGet() * _multiple, t1.intValue());
-		    // FIXME toBlocking methods run on the caller's thread
-		    String name = Thread.currentThread().getName();
-		    assertFalse("Wrong thread name: " + name, name.startsWith("Rx"));
-		});
+            assertEquals(count.incrementAndGet() * _multiple, t1.intValue());
+            // FIXME toBlocking methods run on the caller's thread
+            String name = Thread.currentThread().getName();
+            assertFalse("Wrong thread name: " + name, name.startsWith("Rx"));
+        });
     }
 
     /**
@@ -239,22 +239,22 @@ public class FlowableObserveOnTest extends RxJavaTest {
         final int _multiple = 99;
 
         Flowable.range(1, 10000).map(t1 -> {
-		    if (randomIntFrom0to100() > 98) {
-		        try {
-		            Thread.sleep(2);
-		        } catch (InterruptedException e) {
-		            e.printStackTrace();
-		        }
-		    }
-		    return t1 * _multiple;
-		}).observeOn(Schedulers.computation())
+            if (randomIntFrom0to100() > 98) {
+                try {
+                    Thread.sleep(2);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            return t1 * _multiple;
+        }).observeOn(Schedulers.computation())
         .blockingForEach(t1 -> {
-		    assertEquals(count.incrementAndGet() * _multiple, t1.intValue());
+            assertEquals(count.incrementAndGet() * _multiple, t1.intValue());
 //                assertTrue(name.startsWith("RxComputationThreadPool"));
-		    // FIXME toBlocking now runs its methods on the caller thread
-		    String name = Thread.currentThread().getName();
-		    assertFalse("Wrong thread name: " + name, name.startsWith("Rx"));
-		});
+            // FIXME toBlocking now runs its methods on the caller thread
+            String name = Thread.currentThread().getName();
+            assertFalse("Wrong thread name: " + name, name.startsWith("Rx"));
+        });
     }
 
     @Test
@@ -357,20 +357,20 @@ public class FlowableObserveOnTest extends RxJavaTest {
         final AtomicInteger generated = new AtomicInteger();
         Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
-		    @Override
-		    public void remove() {
-		    }
+            @Override
+            public void remove() {
+            }
 
-		    @Override
-		    public Integer next() {
-		        return generated.getAndIncrement();
-		    }
+            @Override
+            public Integer next() {
+                return generated.getAndIncrement();
+            }
 
-		    @Override
-		    public boolean hasNext() {
-		        return true;
-		    }
-		});
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+        });
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() /* NFI */ {
             @Override
@@ -402,20 +402,20 @@ public class FlowableObserveOnTest extends RxJavaTest {
         final AtomicInteger generated = new AtomicInteger();
         Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
-		    @Override
-		    public void remove() {
-		    }
+            @Override
+            public void remove() {
+            }
 
-		    @Override
-		    public Integer next() {
-		        return generated.getAndIncrement();
-		    }
+            @Override
+            public Integer next() {
+                return generated.getAndIncrement();
+            }
 
-		    @Override
-		    public boolean hasNext() {
-		        return true;
-		    }
-		});
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+        });
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() /* NFI */ {
             @Override
@@ -441,20 +441,20 @@ public class FlowableObserveOnTest extends RxJavaTest {
         final AtomicInteger generated = new AtomicInteger();
         Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
-		    @Override
-		    public void remove() {
-		    }
+            @Override
+            public void remove() {
+            }
 
-		    @Override
-		    public Integer next() {
-		        return generated.getAndIncrement();
-		    }
+            @Override
+            public Integer next() {
+                return generated.getAndIncrement();
+            }
 
-		    @Override
-		    public boolean hasNext() {
-		        return true;
-		    }
-		});
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+        });
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         flowable
@@ -471,13 +471,13 @@ public class FlowableObserveOnTest extends RxJavaTest {
     public void queueFullEmitsError() {
         final CountDownLatch latch = new CountDownLatch(1);
         Flowable<Integer> flowable = Flowable.unsafeCreate(subscriber -> {
-		    subscriber.onSubscribe(new BooleanSubscription());
-		    for (int i = 0; i < Flowable.bufferSize() + 10; i++) {
-		        subscriber.onNext(i);
-		    }
-		    latch.countDown();
-		    subscriber.onComplete();
-		});
+            subscriber.onSubscribe(new BooleanSubscription());
+            for (int i = 0; i < Flowable.bufferSize() + 10; i++) {
+                subscriber.onNext(i);
+            }
+            latch.countDown();
+            subscriber.onComplete();
+        });
 
         TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() /* NFI */ {
 
@@ -585,13 +585,13 @@ public class FlowableObserveOnTest extends RxJavaTest {
         Flowable.interval(0, 1, TimeUnit.MICROSECONDS)
                 .observeOn(Schedulers.computation())
                 .map(t1 -> {
-				    System.out.println(t1);
-				    try {
-				        Thread.sleep(100);
-				    } catch (InterruptedException e) {
-				    }
-				    return t1 + " slow value";
-				}).subscribe(ts);
+                    System.out.println(t1);
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                    }
+                    return t1 + " slow value";
+                }).subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         System.out.println("Errors: " + ts.errors());
@@ -604,15 +604,15 @@ public class FlowableObserveOnTest extends RxJavaTest {
         Flowable<Long> timer = Flowable.interval(0, 1, TimeUnit.MICROSECONDS)
                 .doOnEach(_ -> {
 //                        System.out.println("BEFORE " + n);
-				})
+                })
                 .observeOn(Schedulers.newThread())
                 .doOnEach(_ -> {
-				    try {
-				        Thread.sleep(100);
-				    } catch (InterruptedException e) {
-				    }
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                    }
 //                        System.out.println("AFTER " + n);
-				});
+                });
 
         TestSubscriberEx<Long> ts = new TestSubscriberEx<>();
 
@@ -849,10 +849,10 @@ public class FlowableObserveOnTest extends RxJavaTest {
         Flowable.range(1, 5).concatWith(Flowable.<Integer>error(new TestException()))
         .observeOn(Schedulers.computation(), true)
         .doOnNext(v -> {
-		    if (v == 1) {
-		        Thread.sleep(100);
-		    }
-		})
+            if (v == 1) {
+                Thread.sleep(100);
+            }
+        })
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class, 1, 2, 3, 4, 5);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferStrategyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferStrategyTest.java
@@ -96,16 +96,16 @@ public class FlowableOnBackpressureBufferStrategyTest extends RxJavaTest {
     }
 
     private static final Flowable<Long> send500ValuesAndComplete = Flowable.unsafeCreate(s -> {
-	    BooleanSubscription bs = new BooleanSubscription();
-	    s.onSubscribe(bs);
-	    long i = 0;
-	    while (!bs.isCancelled() && i < 500) {
-	        s.onNext(i++);
-	    }
-	    if (!bs.isCancelled()) {
-	        s.onComplete();
-	    }
-	});
+        BooleanSubscription bs = new BooleanSubscription();
+        s.onSubscribe(bs);
+        long i = 0;
+        while (!bs.isCancelled() && i < 500) {
+            s.onNext(i++);
+        }
+        if (!bs.isCancelled()) {
+            s.onComplete();
+        }
+    });
 
     @Test(expected = IllegalArgumentException.class)
     public void backpressureBufferNegativeCapacity() throws InterruptedException {
@@ -147,15 +147,15 @@ public class FlowableOnBackpressureBufferStrategyTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.onBackpressureBuffer(8, Functions.EMPTY_ACTION, BackpressureOverflowStrategy.ERROR));
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.onBackpressureBuffer(8, Functions.EMPTY_ACTION, BackpressureOverflowStrategy.ERROR));
     }
 
     @Test
     public void overflowCrashes() {
         Flowable.range(1, 20)
         .onBackpressureBuffer(8, () -> {
-		    throw new TestException();
-		}, BackpressureOverflowStrategy.DROP_OLDEST)
+            throw new TestException();
+        }, BackpressureOverflowStrategy.DROP_OLDEST)
         .test(0L)
         .assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -151,17 +151,17 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
     }
 
     static final Flowable<Long> infinite = Flowable.unsafeCreate(s -> {
-	    BooleanSubscription bs = new BooleanSubscription();
-	    s.onSubscribe(bs);
-	    long i = 0;
-	    while (!bs.isCancelled()) {
-	        s.onNext(i++);
-	    }
-	});
+        BooleanSubscription bs = new BooleanSubscription();
+        s.onSubscribe(bs);
+        long i = 0;
+        while (!bs.isCancelled()) {
+            s.onNext(i++);
+        }
+    });
 
     private static final Action THROWS_NON_FATAL = () -> {
-	    throw new RuntimeException();
-	};
+        throw new RuntimeException();
+    };
 
     @Test
     public void nonFatalExceptionThrownByOnOverflowIsNotReportedByUpstream() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -121,31 +121,31 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
     }
 
     static final Flowable<Long> infinite = Flowable.unsafeCreate(s -> {
-	    BooleanSubscription bs = new BooleanSubscription();
-	    s.onSubscribe(bs);
-	    long i = 0;
-	    while (!bs.isCancelled()) {
-	        s.onNext(i++);
-	    }
-	});
+        BooleanSubscription bs = new BooleanSubscription();
+        s.onSubscribe(bs);
+        long i = 0;
+        while (!bs.isCancelled()) {
+            s.onNext(i++);
+        }
+    });
 
     private static Flowable<Long> range(final long n) {
         return Flowable.unsafeCreate(s -> {
-		    BooleanSubscription bs = new BooleanSubscription();
-		    s.onSubscribe(bs);
-		    for (long i = 0; i < n; i++) {
-		        if (bs.isCancelled()) {
-		            break;
-		        }
-		        s.onNext(i);
-		    }
-		    s.onComplete();
-		});
+            BooleanSubscription bs = new BooleanSubscription();
+            s.onSubscribe(bs);
+            for (long i = 0; i < n; i++) {
+                if (bs.isCancelled()) {
+                    break;
+                }
+                s.onNext(i);
+            }
+            s.onComplete();
+        });
     }
 
     private static final Consumer<Long> THROW_NON_FATAL = _ -> {
-	    throw new RuntimeException();
-	};
+        throw new RuntimeException();
+    };
 
     @Test
     public void nonFatalExceptionFromOverflowActionIsNotReportedFromUpstreamOperator() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorResumeNextViaFlowableTest.java
@@ -72,12 +72,12 @@ public class FlowableOnErrorResumeNextViaFlowableTest extends RxJavaTest {
         // Introduce map function that fails intermittently (Map does not prevent this when the observer is a
         //  rx.operator incl onErrorResumeNextViaObservable)
         w = w.map(s -> {
-		    if ("fail".equals(s)) {
-		        throw new RuntimeException("Forced Failure");
-		    }
-		    System.out.println("BadMapper:" + s);
-		    return s;
-		});
+            if ("fail".equals(s)) {
+                throw new RuntimeException("Forced Failure");
+            }
+            System.out.println("BadMapper:" + s);
+            return s;
+        });
 
         Flowable<String> flowable = w.onErrorResumeWith(resume);
 
@@ -116,22 +116,22 @@ public class FlowableOnErrorResumeNextViaFlowableTest extends RxJavaTest {
             System.out.println("TestObservable subscribed to ...");
             subscriber.onSubscribe(upstream);
             t = new Thread(() -> {
-			    try {
-			        System.out.println("running TestObservable thread");
-			        for (String s : values) {
-			            if ("fail".equals(s)) {
-			                throw new RuntimeException("Forced Failure");
-			            }
-			            System.out.println("TestObservable onNext: " + s);
-			            subscriber.onNext(s);
-			        }
-			        System.out.println("TestObservable onComplete");
-			        subscriber.onComplete();
-			    } catch (Throwable e) {
-			        System.out.println("TestObservable onError: " + e);
-			        subscriber.onError(e);
-			    }
-			});
+                try {
+                    System.out.println("running TestObservable thread");
+                    for (String s : values) {
+                        if ("fail".equals(s)) {
+                            throw new RuntimeException("Forced Failure");
+                        }
+                        System.out.println("TestObservable onNext: " + s);
+                        subscriber.onNext(s);
+                    }
+                    System.out.println("TestObservable onComplete");
+                    subscriber.onComplete();
+                } catch (Throwable e) {
+                    System.out.println("TestObservable onError: " + e);
+                    subscriber.onError(e);
+                }
+            });
             System.out.println("starting TestObservable thread");
             t.start();
             System.out.println("done starting TestObservable thread");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorResumeNextViaFunctionTest.java
@@ -41,17 +41,17 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
     public void resumeNextWithSynchronousExecution() {
         final AtomicReference<Throwable> receivedException = new AtomicReference<>();
         Flowable<String> w = Flowable.unsafeCreate(subscriber -> {
-		    subscriber.onSubscribe(new BooleanSubscription());
-		    subscriber.onNext("one");
-		    subscriber.onError(new Throwable("injected failure"));
-		    subscriber.onNext("two");
-		    subscriber.onNext("three");
-		});
+            subscriber.onSubscribe(new BooleanSubscription());
+            subscriber.onNext("one");
+            subscriber.onError(new Throwable("injected failure"));
+            subscriber.onNext("two");
+            subscriber.onNext("three");
+        });
 
         Function<Throwable, Flowable<String>> resume = t1 -> {
-		    receivedException.set(t1);
-		    return Flowable.just("twoResume", "threeResume");
-		};
+            receivedException.set(t1);
+            return Flowable.just("twoResume", "threeResume");
+        };
         Flowable<String> flowable = w.onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
@@ -74,9 +74,9 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
         Subscription s = mock(Subscription.class);
         TestFlowable w = new TestFlowable(s, "one");
         Function<Throwable, Flowable<String>> resume = t1 -> {
-		    receivedException.set(t1);
-		    return Flowable.just("twoResume", "threeResume");
-		};
+            receivedException.set(t1);
+            return Flowable.just("twoResume", "threeResume");
+        };
         Flowable<String> flowable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
@@ -107,8 +107,8 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
         Subscription s = mock(Subscription.class);
         TestFlowable w = new TestFlowable(s, "one");
         Function<Throwable, Flowable<String>> resume = _ -> {
-		    throw new RuntimeException("exception from function");
-		};
+            throw new RuntimeException("exception from function");
+        };
         Flowable<String> flowable = Flowable.unsafeCreate(w).onErrorResumeNext(resume);
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
@@ -136,12 +136,12 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
         // Introduce map function that fails intermittently (Map does not prevent this when the observer is a
         //  rx.operator incl onErrorResumeNextViaFlowable)
         w = w.map(s -> {
-		    if ("fail".equals(s)) {
-		        throw new RuntimeException("Forced Failure");
-		    }
-		    System.out.println("BadMapper:" + s);
-		    return s;
-		});
+            if ("fail".equals(s)) {
+                throw new RuntimeException("Forced Failure");
+            }
+            System.out.println("BadMapper:" + s);
+            return s;
+        });
 
         Flowable<String> flowable = w.onErrorResumeNext(_ -> Flowable.just("twoResume", "threeResume").subscribeOn(Schedulers.computation()));
 
@@ -174,17 +174,17 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
             System.out.println("TestFlowable subscribed to ...");
             subscriber.onSubscribe(new BooleanSubscription());
             t = new Thread(() -> {
-			    try {
-			        System.out.println("running TestFlowable thread");
-			        for (String s : values) {
-			            System.out.println("TestFlowable onNext: " + s);
-			            subscriber.onNext(s);
-			        }
-			        throw new RuntimeException("Forced Failure");
-			    } catch (Throwable e) {
-			        subscriber.onError(e);
-			    }
-			});
+                try {
+                    System.out.println("running TestFlowable thread");
+                    for (String s : values) {
+                        System.out.println("TestFlowable onNext: " + s);
+                        subscriber.onNext(s);
+                    }
+                    throw new RuntimeException("Forced Failure");
+                } catch (Throwable e) {
+                    subscriber.onError(e);
+                }
+            });
             System.out.println("starting TestFlowable thread");
             t.start();
             System.out.println("done starting TestFlowable thread");
@@ -248,7 +248,7 @@ public class FlowableOnErrorResumeNextViaFunctionTest extends RxJavaTest {
     @Test
     public void badOtherSource() {
         TestHelper.checkBadSourceFlowable(f -> Flowable.error(new IOException())
-		        .onErrorResumeNext(Functions.justFunction(f)), false, 1, 1, 1);
+                .onErrorResumeNext(Functions.justFunction(f)), false, 1, 1, 1);
     }
 
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorReturnTest.java
@@ -42,9 +42,9 @@ public class FlowableOnErrorReturnTest extends RxJavaTest {
         final AtomicReference<Throwable> capturedException = new AtomicReference<>();
 
         Flowable<String> flowable = w.onErrorReturn(e -> {
-		    capturedException.set(e);
-		    return "failure";
-		});
+            capturedException.set(e);
+            return "failure";
+        });
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         flowable.subscribe(subscriber);
@@ -72,9 +72,9 @@ public class FlowableOnErrorReturnTest extends RxJavaTest {
         final AtomicReference<Throwable> capturedException = new AtomicReference<>();
 
         Flowable<String> flowable = w.onErrorReturn(e -> {
-		    capturedException.set(e);
-		    throw new RuntimeException("exception from function");
-		});
+            capturedException.set(e);
+            throw new RuntimeException("exception from function");
+        });
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         flowable.subscribe(subscriber);
@@ -102,12 +102,12 @@ public class FlowableOnErrorReturnTest extends RxJavaTest {
         // Introduce map function that fails intermittently (Map does not prevent this when the observer is a
         //  rx.operator incl onErrorResumeNextViaFlowable)
         w = w.map(s -> {
-		    if ("fail".equals(s)) {
-		        throw new RuntimeException("Forced Failure");
-		    }
-		    System.out.println("BadMapper:" + s);
-		    return s;
-		});
+            if ("fail".equals(s)) {
+                throw new RuntimeException("Forced Failure");
+            }
+            System.out.println("BadMapper:" + s);
+            return s;
+        });
 
         Flowable<String> flowable = w.onErrorReturn(_ -> "resume");
 
@@ -166,17 +166,17 @@ public class FlowableOnErrorReturnTest extends RxJavaTest {
             subscriber.onSubscribe(new BooleanSubscription());
             System.out.println("TestFlowable subscribed to ...");
             t = new Thread(() -> {
-			    try {
-			        System.out.println("running TestFlowable thread");
-			        for (String s : values) {
-			            System.out.println("TestFlowable onNext: " + s);
-			            subscriber.onNext(s);
-			        }
-			        throw new RuntimeException("Forced Failure");
-			    } catch (Throwable e) {
-			        subscriber.onError(e);
-			    }
-			});
+                try {
+                    System.out.println("running TestFlowable thread");
+                    for (String s : values) {
+                        System.out.println("TestFlowable onNext: " + s);
+                        subscriber.onNext(s);
+                    }
+                    throw new RuntimeException("Forced Failure");
+                } catch (Throwable e) {
+                    subscriber.onError(e);
+                }
+            });
             System.out.println("starting TestFlowable thread");
             t.start();
             System.out.println("done starting TestFlowable thread");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
@@ -43,43 +43,27 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void publish() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        ConnectableFlowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        counter.incrementAndGet();
-                        subscriber.onNext("one");
-                        subscriber.onComplete();
-                    }
-                }).start();
-            }
+        ConnectableFlowable<String> f = Flowable.<String>unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            new Thread(() -> {
+                counter.incrementAndGet();
+                subscriber.onNext("one");
+                subscriber.onComplete();
+            }).start();
         }).publish();
 
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            assertEquals("one", v);
+            latch.countDown();
         });
 
         // subscribe again
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            assertEquals("one", v);
+            latch.countDown();
         });
 
         Disposable connection = f.connect();
@@ -97,14 +81,10 @@ public class FlowablePublishTest extends RxJavaTest {
     public void backpressureFastSlow() {
         ConnectableFlowable<Integer> is = Flowable.range(1, Flowable.bufferSize() * 2).publish();
         Flowable<Integer> fast = is.observeOn(Schedulers.computation())
-        .doOnComplete(new Action() {
-            @Override
-            public void run() {
-                System.out.println("^^^^^^^^^^^^^ completed FAST");
-            }
-        });
+        .doOnComplete(() -> System.out.println("^^^^^^^^^^^^^ completed FAST"));
 
-        Flowable<Integer> slow = is.observeOn(Schedulers.computation()).map(new Function<Integer, Integer>() {
+        Flowable<Integer> slow = is.observeOn(Schedulers.computation())
+        .map(new Function<Integer, Integer>() /* NFI */ {
             int c;
 
             @Override
@@ -119,14 +99,7 @@ public class FlowablePublishTest extends RxJavaTest {
                 return i;
             }
 
-        }).doOnComplete(new Action() {
-
-            @Override
-            public void run() {
-                System.out.println("^^^^^^^^^^^^^ completed SLOW");
-            }
-
-        });
+        }).doOnComplete(() -> System.out.println("^^^^^^^^^^^^^ completed SLOW"));
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.merge(fast, slow).subscribe(ts);
@@ -140,30 +113,10 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void takeUntilWithPublishedStreamUsingSelector() {
         final AtomicInteger emitted = new AtomicInteger();
-        Flowable<Integer> xs = Flowable.range(0, Flowable.bufferSize() * 2).doOnNext(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t1) {
-                emitted.incrementAndGet();
-            }
-
-        });
+        Flowable<Integer> xs = Flowable.range(0, Flowable.bufferSize() * 2)
+        .doOnNext(_ -> emitted.incrementAndGet());
         TestSubscriber<Integer> ts = new TestSubscriber<>();
-        xs.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> xs) {
-                return xs.takeUntil(xs.skipWhile(new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer i) {
-                        return i <= 3;
-                    }
-
-                }));
-            }
-
-        }).subscribe(ts);
+        xs.publish(xs1 -> xs1.takeUntil(xs1.skipWhile(i -> i <= 3))).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
         ts.assertValues(0, 1, 2, 3);
@@ -177,14 +130,7 @@ public class FlowablePublishTest extends RxJavaTest {
         Flowable<Integer> xs = Flowable.range(0, Flowable.bufferSize() * 2);
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ConnectableFlowable<Integer> xsp = xs.publish();
-        xsp.takeUntil(xsp.skipWhile(new Predicate<Integer>() {
-
-            @Override
-            public boolean test(Integer i) {
-                return i <= 3;
-            }
-
-        })).subscribe(ts);
+        xsp.takeUntil(xsp.skipWhile(i -> i <= 3)).subscribe(ts);
         xsp.connect();
         System.out.println(ts.values());
     }
@@ -194,18 +140,8 @@ public class FlowablePublishTest extends RxJavaTest {
         final AtomicInteger sourceEmission = new AtomicInteger();
         final AtomicBoolean sourceUnsubscribed = new AtomicBoolean();
         final Flowable<Integer> source = Flowable.range(1, 100)
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer t1) {
-                        sourceEmission.incrementAndGet();
-                    }
-                })
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                        sourceUnsubscribed.set(true);
-                    }
-                }).share();
+                .doOnNext(_ -> sourceEmission.incrementAndGet())
+                .doOnCancel(() -> sourceUnsubscribed.set(true)).share();
         ;
 
         final AtomicBoolean child1Unsubscribed = new AtomicBoolean();
@@ -213,27 +149,17 @@ public class FlowablePublishTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
+        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (values().size() == 2) {
-                    source.doOnCancel(new Action() {
-                        @Override
-                        public void run() {
-                            child2Unsubscribed.set(true);
-                        }
-                    }).take(5).subscribe(ts2);
+                    source.doOnCancel(() -> child2Unsubscribed.set(true)).take(5).subscribe(ts2);
                 }
                 super.onNext(t);
             }
         };
 
-        source.doOnCancel(new Action() {
-            @Override
-            public void run() {
-                child1Unsubscribed.set(true);
-            }
-        }).take(5)
+        source.doOnCancel(() -> child1Unsubscribed.set(true)).take(5)
         .subscribe(ts1);
 
         ts1.awaitDone(5, TimeUnit.SECONDS);
@@ -376,12 +302,9 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void connectIsIdempotent() {
         final AtomicInteger calls = new AtomicInteger();
-        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> t) {
-                t.onSubscribe(new BooleanSubscription());
-                calls.getAndIncrement();
-            }
+        Flowable<Integer> source = Flowable.unsafeCreate(t -> {
+            t.onSubscribe(new BooleanSubscription());
+            calls.getAndIncrement();
         });
 
         ConnectableFlowable<Integer> conn = source.publish();
@@ -519,11 +442,8 @@ public class FlowablePublishTest extends RxJavaTest {
     public void connectThrows() {
         ConnectableFlowable<Integer> cf = Flowable.<Integer>empty().publish();
         try {
-            cf.connect(new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                    throw new TestException();
-                }
+            cf.connect(_ -> {
+                throw new TestException();
             });
         } catch (TestException ex) {
             // expected
@@ -540,19 +460,9 @@ public class FlowablePublishTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts2);
-                }
-            };
+            Runnable r1 = () -> cf.subscribe(ts2);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -603,7 +513,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         ConnectableFlowable<Integer> cf = pp.publish();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -629,19 +539,9 @@ public class FlowablePublishTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = cf.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -651,7 +551,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -695,19 +595,9 @@ public class FlowablePublishTest extends RxJavaTest {
             final Disposable d = cf.connect();
             final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    d.dispose();
-                }
-            };
+            Runnable r1 = () -> d.dispose();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts);
-                }
-            };
+            Runnable r2 = () -> cf.subscribe(ts);
 
             TestHelper.race(r1, r2);
         }
@@ -717,12 +607,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void selectorDisconnectsIndependentSource() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return Flowable.range(1, 2);
-            }
-        })
+        pp.publish(_ -> Flowable.range(1, 2))
         .test()
         .assertResult(1, 2);
 
@@ -732,12 +617,7 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void selectorLatecommer() {
         Flowable.range(1, 5)
-        .publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return v.concatWith(v);
-            }
-        })
+        .publish(v -> v.concatWith(v))
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -754,12 +634,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void selectorInnerError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        pp.publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return Flowable.error(new TestException());
-            }
-        })
+        pp.publish(_ -> Flowable.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
 
@@ -774,12 +649,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
             cf.connect();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.test();
-                }
-            };
+            Runnable r1 = () -> cf.test();
 
             TestHelper.race(r1, r1);
         }
@@ -791,12 +661,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
             final ConnectableFlowable<Integer> cf = Flowable.<Integer>empty().publish();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.connect();
-                }
-            };
+            Runnable r1 = () -> cf.connect();
 
             TestHelper.race(r1, r1);
         }
@@ -804,11 +669,8 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void selectorCrash() {
-        Flowable.just(1).publish(new Function<Flowable<Integer>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Integer> v) throws Exception {
-                throw new TestException();
-            }
+        Flowable.just(1).publish(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -817,11 +679,8 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void pollThrows() {
         Flowable.just(1)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map(_ -> {
+            throw new TestException();
         })
         .compose(TestHelper.flowableStripBoundary())
         .publish()
@@ -833,14 +692,11 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void pollThrowsNoSubscribers() {
         ConnectableFlowable<Integer> cf = Flowable.just(1, 2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                if (v == 2) {
-                    throw new TestException();
-                }
-                return v;
+        .map(v -> {
+            if (v == 2) {
+                throw new TestException();
             }
+            return v;
         })
         .compose(TestHelper.<Integer>flowableStripBoundary())
         .publish();
@@ -855,7 +711,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void dryRunCrash() {
-        final TestSubscriber<Object> ts = new TestSubscriber<Object>(1L) {
+        final TestSubscriber<Object> ts = new TestSubscriber<Object>(1L) /* NFI */ {
             @Override
             public void onNext(Object t) {
                 super.onNext(t);
@@ -865,14 +721,11 @@ public class FlowablePublishTest extends RxJavaTest {
         };
 
         Flowable<Object> source = Flowable.range(1, 10)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                if (v == 2) {
-                    throw new TestException();
-                }
-                return v;
+        .<Object>map(v -> {
+            if (v == 2) {
+                throw new TestException();
             }
+            return v;
         })
         .publish()
         .autoConnect();
@@ -891,12 +744,9 @@ public class FlowablePublishTest extends RxJavaTest {
     public void overflowQueue() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.create(new FlowableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(FlowableEmitter<Object> s) throws Exception {
-                    for (int i = 0; i < 10; i++) {
-                        s.onNext(i);
-                    }
+            Flowable.create(s -> {
+                for (int i = 0; i < 10; i++) {
+                    s.onNext(i);
                 }
             }, BackpressureStrategy.MISSING)
             .publish(8)
@@ -916,7 +766,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void delayedUpstreamOnSubscribe() {
         final Subscriber<?>[] sub = { null };
 
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 sub[0] = s;
@@ -939,7 +789,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
             final AtomicReference<Disposable> ref = new AtomicReference<>();
 
-            final ConnectableFlowable<Integer> cf = new Flowable<Integer>() {
+            final ConnectableFlowable<Integer> cf = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -949,12 +799,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
             cf.connect();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ref.get().dispose();
-                }
-            };
+            Runnable r1 = () -> ref.get().dispose();
 
             TestHelper.race(r1, r1);
         }
@@ -964,7 +809,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void removeNotPresent() {
         final AtomicReference<PublishConnection<Integer>> ref = new AtomicReference<>();
 
-        final ConnectableFlowable<Integer> cf = new Flowable<Integer>() {
+        final ConnectableFlowable<Integer> cf = new Flowable<Integer>() /* NFI */ {
             @Override
             @SuppressWarnings("unchecked")
             protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -985,7 +830,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         cf.connect();
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1013,7 +858,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1039,12 +884,9 @@ public class FlowablePublishTest extends RxJavaTest {
     public void selectorSubscriberSwap() {
         final AtomicReference<Flowable<Integer>> ref = new AtomicReference<>();
 
-        Flowable.range(1, 5).publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> f) throws Exception {
-                ref.set(f);
-                return Flowable.never();
-            }
+        Flowable.range(1, 5).publish(f -> {
+            ref.set(f);
+            return Flowable.never();
         }).test();
 
         ref.get().take(2).test().assertResult(1, 2);
@@ -1064,12 +906,9 @@ public class FlowablePublishTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        pp.publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> f) throws Exception {
-                ref.set(f);
-                return Flowable.never();
-            }
+        pp.publish(f -> {
+            ref.set(f);
+            return Flowable.never();
         }).test();
 
         TestSubscriber<Integer> ts1 = ref.get().take(2).test();
@@ -1094,34 +933,14 @@ public class FlowablePublishTest extends RxJavaTest {
     // call a transformer only if the input is non-empty
     @Test
     public void composeIfNotEmpty() {
-        final FlowableTransformer<Integer, Integer> transformer = new FlowableTransformer<Integer, Integer>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> g) {
-                return g.map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        return v + 1;
-                    }
-                });
-            }
-        };
+        final FlowableTransformer<Integer, Integer> transformer = g -> g.map(v -> v + 1);
 
         final AtomicInteger calls = new AtomicInteger();
         Flowable.range(1, 5)
-        .publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(final Flowable<Integer> shared)
-                    throws Exception {
-                return shared.take(1).concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-                    @Override
-                    public Publisher<? extends Integer> apply(Integer first)
-                            throws Exception {
-                        calls.incrementAndGet();
-                        return transformer.apply(Flowable.just(first).concatWith(shared));
-                    }
-                });
-            }
-        })
+        .publish(shared -> shared.take(1).concatMap(first -> {
+            calls.incrementAndGet();
+            return transformer.apply(Flowable.just(first).concatWith(shared));
+        }))
         .test()
         .assertResult(2, 3, 4, 5, 6);
 
@@ -1131,34 +950,14 @@ public class FlowablePublishTest extends RxJavaTest {
     // call a transformer only if the input is non-empty
     @Test
     public void composeIfNotEmptyNotFused() {
-        final FlowableTransformer<Integer, Integer> transformer = new FlowableTransformer<Integer, Integer>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> g) {
-                return g.map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        return v + 1;
-                    }
-                });
-            }
-        };
+        final FlowableTransformer<Integer, Integer> transformer = g -> g.map(v -> v + 1);
 
         final AtomicInteger calls = new AtomicInteger();
         Flowable.range(1, 5).hide()
-        .publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(final Flowable<Integer> shared)
-                    throws Exception {
-                return shared.take(1).concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-                    @Override
-                    public Publisher<? extends Integer> apply(Integer first)
-                            throws Exception {
-                        calls.incrementAndGet();
-                        return transformer.apply(Flowable.just(first).concatWith(shared));
-                    }
-                });
-            }
-        })
+        .publish(shared -> shared.take(1).concatMap(first -> {
+            calls.incrementAndGet();
+            return transformer.apply(Flowable.just(first).concatWith(shared));
+        }))
         .test()
         .assertResult(2, 3, 4, 5, 6);
 
@@ -1168,34 +967,14 @@ public class FlowablePublishTest extends RxJavaTest {
     // call a transformer only if the input is non-empty
     @Test
     public void composeIfNotEmptyIsEmpty() {
-        final FlowableTransformer<Integer, Integer> transformer = new FlowableTransformer<Integer, Integer>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> g) {
-                return g.map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        return v + 1;
-                    }
-                });
-            }
-        };
+        final FlowableTransformer<Integer, Integer> transformer = g -> g.map(v -> v + 1);
 
         final AtomicInteger calls = new AtomicInteger();
         Flowable.<Integer>empty().hide()
-        .publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(final Flowable<Integer> shared)
-                    throws Exception {
-                return shared.take(1).concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-                    @Override
-                    public Publisher<? extends Integer> apply(Integer first)
-                            throws Exception {
-                        calls.incrementAndGet();
-                        return transformer.apply(Flowable.just(first).concatWith(shared));
-                    }
-                });
-            }
-        })
+        .publish(shared -> shared.take(1).concatMap(first -> {
+            calls.incrementAndGet();
+            return transformer.apply(Flowable.just(first).concatWith(shared));
+        }))
         .test()
         .assertResult();
 
@@ -1208,15 +987,12 @@ public class FlowablePublishTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriber<Integer> ts = pp.publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> f) throws Exception {
-                ref.set(f);
-                return Flowable.never();
-            }
+        final TestSubscriber<Integer> ts = pp.publish(f -> {
+            ref.set(f);
+            return Flowable.<Integer>never();
         }).test();
 
-        ref.get().subscribe(new TestSubscriber<Integer>() {
+        ref.get().subscribe(new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1234,15 +1010,12 @@ public class FlowablePublishTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriber<Integer> ts = pp.publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> f) throws Exception {
-                ref.set(f);
-                return Flowable.never();
-            }
+        final TestSubscriber<Integer> ts = pp.publish(f -> {
+            ref.set(f);
+            return Flowable.<Integer>never();
         }).test();
 
-        ref.get().subscribe(new TestSubscriber<Integer>(1L) {
+        ref.get().subscribe(new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1262,30 +1035,17 @@ public class FlowablePublishTest extends RxJavaTest {
 
             final AtomicReference<Flowable<Integer>> ref = new AtomicReference<>();
 
-            pp.publish(new Function<Flowable<Integer>, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Flowable<Integer> f) throws Exception {
-                    ref.set(f);
-                    return Flowable.never();
-                }
+            pp.publish(f -> {
+                ref.set(f);
+                return Flowable.<Integer>never();
             }).test();
 
             final TestSubscriber<Integer> ts1 = ref.get().test();
             TestSubscriber<Integer> ts2 = ref.get().test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r2 = () -> ts1.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -1303,7 +1063,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         final AtomicReference<InnerSubscription<Integer>> ref = new AtomicReference<>();
 
-        cf.subscribe(new FlowableSubscriber<Integer>() {
+        cf.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Subscription s) {
@@ -1343,15 +1103,12 @@ public class FlowablePublishTest extends RxJavaTest {
     public void boundaryFusion() {
         Flowable.range(1, 10000)
         .observeOn(Schedulers.single())
-        .map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer t) throws Exception {
-                String name = Thread.currentThread().getName();
-                if (name.contains("RxSingleScheduler")) {
-                    return "RxSingleScheduler";
-                }
-                return name;
+        .map(_ -> {
+            String name = Thread.currentThread().getName();
+            if (name.contains("RxSingleScheduler")) {
+                return "RxSingleScheduler";
             }
+            return name;
         })
         .share()
         .observeOn(Schedulers.computation())
@@ -1369,53 +1126,24 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void splitCombineSubscriberChangeAfterOnNext() {
         Flowable<Integer> source = Flowable.range(0, 20)
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription v) throws Exception {
-                System.out.println("Subscribed");
-            }
-        })
+        .doOnSubscribe(_ -> System.out.println("Subscribed"))
         .publish(10)
         .refCount()
         ;
 
-        Flowable<Integer> evenNumbers = source.filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        });
+        Flowable<Integer> evenNumbers = source.filter(v -> v % 2 == 0);
 
-        Flowable<Integer> oddNumbers = source.filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 != 0;
-            }
-        });
+        Flowable<Integer> oddNumbers = source.filter(v -> v % 2 != 0);
 
         final Single<Integer> getNextOdd = oddNumbers.first(0);
 
-        TestSubscriber<List<Integer>> ts = evenNumbers.concatMap(new Function<Integer, Publisher<List<Integer>>>() {
-            @Override
-            public Publisher<List<Integer>> apply(Integer v) throws Exception {
-                return Single.zip(
-                        Single.just(v), getNextOdd,
-                        new BiFunction<Integer, Integer, List<Integer>>() {
-                            @Override
-                            public List<Integer> apply(Integer a, Integer b) throws Exception {
-                                return Arrays.asList( a, b );
-                            }
-                        }
-                )
-                .toFlowable();
-            }
-        })
-        .takeWhile(new Predicate<List<Integer>>() {
-            @Override
-            public boolean test(List<Integer> v) throws Exception {
-                return v.get(0) < 20;
-            }
-        })
+        TestSubscriber<List<Integer>> ts = evenNumbers.concatMap(
+            v -> Single.zip(
+                Single.just(v), getNextOdd,
+                (BiFunction<Integer, Integer, List<Integer>>) Arrays::asList
+        )
+        .toFlowable())
+        .takeWhile(v -> v.get(0) < 20)
         .test();
 
         ts
@@ -1440,43 +1168,19 @@ public class FlowablePublishTest extends RxJavaTest {
         .refCount()
         ;
 
-        Flowable<Integer> evenNumbers = source.filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        });
+        Flowable<Integer> evenNumbers = source.filter(v -> v % 2 == 0);
 
-        Flowable<Integer> oddNumbers = source.filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 != 0;
-            }
-        });
+        Flowable<Integer> oddNumbers = source.filter(v -> v % 2 != 0);
 
         final Single<Integer> getNextOdd = oddNumbers.first(0);
 
-        TestSubscriber<List<Integer>> ts = evenNumbers.concatMap(new Function<Integer, Publisher<List<Integer>>>() {
-            @Override
-            public Publisher<List<Integer>> apply(Integer v) throws Exception {
-                return Single.zip(
-                        Single.just(v), getNextOdd,
-                        new BiFunction<Integer, Integer, List<Integer>>() {
-                            @Override
-                            public List<Integer> apply(Integer a, Integer b) throws Exception {
-                                return Arrays.asList( a, b );
-                            }
-                        }
-                )
-                .toFlowable();
-            }
-        })
-        .takeWhile(new Predicate<List<Integer>>() {
-            @Override
-            public boolean test(List<Integer> v) throws Exception {
-                return v.get(0) < 20;
-            }
-        })
+        TestSubscriber<List<Integer>> ts = evenNumbers.concatMap(
+            v -> Single.zip(
+                Single.just(v), getNextOdd,
+                (BiFunction<Integer, Integer, List<Integer>>) Arrays::asList
+        )
+        .toFlowable())
+        .takeWhile(v -> v.get(0) < 20)
         .test();
 
         ts
@@ -1498,11 +1202,8 @@ public class FlowablePublishTest extends RxJavaTest {
     public void altConnectCrash() {
         try {
             new FlowablePublish<>(Flowable.<Integer>empty(), 128)
-            .connect(new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable t) throws Exception {
-                    throw new TestException();
-                }
+            .connect(_ -> {
+                throw new TestException();
             });
             fail("Should have thrown");
         } catch (TestException expected) {
@@ -1516,12 +1217,7 @@ public class FlowablePublishTest extends RxJavaTest {
             final ConnectableFlowable<Integer> cf =
                     new FlowablePublish<>(Flowable.<Integer>never(), 128);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cf.connect();
-                }
-            };
+            Runnable r = () -> cf.connect();
 
             TestHelper.race(r, r);
         }
@@ -1530,11 +1226,8 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void fusedPollCrash() {
         Flowable.range(1, 5)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map(_ -> {
+            throw new TestException();
         })
         .compose(TestHelper.flowableStripBoundary())
         .publish()
@@ -1583,7 +1276,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void overflowQueueRefCount() {
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -1602,7 +1295,7 @@ public class FlowablePublishTest extends RxJavaTest {
     public void doubleErrorRefCount() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -1725,7 +1418,7 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void crossCancelOnComplete() {
         TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -1752,7 +1445,7 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void crossCancelOnError() {
         TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeLongTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 import io.reactivex.rxjava4.subscribers.*;
@@ -52,12 +51,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
         final AtomicInteger count = new AtomicInteger();
 
-        Flowable.rangeLong(1, 1000).doOnNext(new Consumer<Long>() {
-            @Override
-            public void accept(Long t1) {
-                count.incrementAndGet();
-            }
-        })
+        Flowable.rangeLong(1, 1000).doOnNext(_ -> count.incrementAndGet())
         .take(3).subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(1L);
@@ -203,7 +197,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
     public void requestOverflow() {
         final AtomicInteger count = new AtomicInteger();
         int n = 10;
-        Flowable.rangeLong(1, n).subscribe(new DefaultSubscriber<Long>() {
+        Flowable.rangeLong(1, n).subscribe(new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -231,7 +225,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
     @Test
     public void emptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Flowable.rangeLong(1, 0).subscribe(new DefaultSubscriber<Long>() {
+        Flowable.rangeLong(1, 0).subscribe(new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -389,7 +383,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void slowPathCancel() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(2L) {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(2L) /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -406,7 +400,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void fastPathCancel() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>() /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -423,7 +417,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalSlowPathCancel() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -441,7 +435,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalFastPathCancel() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>() /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -459,7 +453,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalRequestOneByOne() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -468,12 +462,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
         };
 
         Flowable.rangeLong(1L, 5L)
-        .filter(new Predicate<Long>() {
-            @Override
-            public boolean test(Long v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         ts.assertResult(2L, 4L);
@@ -481,7 +470,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalRequestOneByOne2() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -498,7 +487,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void fastPathCancelExact() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>() /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -517,7 +506,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalFastPathCancelExact() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>() {
+        TestSubscriber<Long> ts = new TestSubscriber<Long>() /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -529,12 +518,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
         };
 
         Flowable.rangeLong(1L, 5L)
-        .filter(new Predicate<Long>() {
-            @Override
-            public boolean test(Long v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         ts.assertResult(2L, 4L);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 import io.reactivex.rxjava4.subscribers.*;
@@ -52,12 +51,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
         final AtomicInteger count = new AtomicInteger();
 
-        Flowable.range(1, 1000).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t1) {
-                count.incrementAndGet();
-            }
-        })
+        Flowable.range(1, 1000).doOnNext(_ -> count.incrementAndGet())
         .take(3).subscribe(subscriber);
 
         verify(subscriber, times(1)).onNext(1);
@@ -203,7 +197,7 @@ public class FlowableRangeTest extends RxJavaTest {
     public void requestOverflow() {
         final AtomicInteger count = new AtomicInteger();
         int n = 10;
-        Flowable.range(1, n).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(1, n).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -231,7 +225,7 @@ public class FlowableRangeTest extends RxJavaTest {
     @Test
     public void emptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Flowable.range(1, 0).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(1, 0).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -400,7 +394,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void slowPathCancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -417,7 +411,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void fastPathCancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -434,7 +428,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalSlowPathCancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -452,7 +446,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalFastPathCancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -470,7 +464,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalRequestOneByOne() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -479,12 +473,7 @@ public class FlowableRangeTest extends RxJavaTest {
         };
 
         Flowable.range(1, 5)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         ts.assertResult(2, 4);
@@ -492,7 +481,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalRequestOneByOne2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -509,7 +498,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void fastPathCancelExact() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -528,7 +517,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalFastPathCancelExact() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -540,12 +529,7 @@ public class FlowableRangeTest extends RxJavaTest {
         };
 
         Flowable.range(1, 5)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(ts);
 
         ts.assertResult(2, 4);
@@ -553,7 +537,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalCancel1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -573,7 +557,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalCancel2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.*;
@@ -45,23 +46,13 @@ public class FlowableReduceTest extends RxJavaTest {
         singleObserver = TestHelper.mockSingleObserver();
     }
 
-    BiFunction<Integer, Integer, Integer> sum = new BiFunction<Integer, Integer, Integer>() {
-        @Override
-        public Integer apply(Integer t1, Integer t2) {
-            return t1 + t2;
-        }
-    };
+    BiFunction<Integer, Integer, Integer> sum = (t1, t2) -> t1 + t2;
 
     @Test
     public void aggregateAsIntSumFlowable() {
 
         Flowable<Integer> result = Flowable.just(1, 2, 3, 4, 5).reduce(0, sum).toFlowable()
-                .map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) {
-                        return v;
-                    }
-                });
+                .map(v -> v);
 
         result.subscribe(subscriber);
 
@@ -74,12 +65,7 @@ public class FlowableReduceTest extends RxJavaTest {
     public void aggregateAsIntSumSourceThrowsFlowable() {
         Flowable<Integer> result = Flowable.concat(Flowable.just(1, 2, 3, 4, 5),
                 Flowable.<Integer> error(new TestException()))
-                .reduce(0, sum).toFlowable().map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) {
-                        return v;
-                    }
-                });
+                .reduce(0, sum).toFlowable().map(v -> v);
 
         result.subscribe(subscriber);
 
@@ -90,20 +76,12 @@ public class FlowableReduceTest extends RxJavaTest {
 
     @Test
     public void aggregateAsIntSumAccumulatorThrowsFlowable() {
-        BiFunction<Integer, Integer, Integer> sumErr = new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                throw new TestException();
-            }
+        BiFunction<Integer, Integer, Integer> sumErr = (_, _) -> {
+            throw new TestException();
         };
 
         Flowable<Integer> result = Flowable.just(1, 2, 3, 4, 5)
-                .reduce(0, sumErr).toFlowable().map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) {
-                        return v;
-                    }
-                });
+                .reduce(0, sumErr).toFlowable().map(v -> v);
 
         result.subscribe(subscriber);
 
@@ -115,12 +93,8 @@ public class FlowableReduceTest extends RxJavaTest {
     @Test
     public void aggregateAsIntSumResultSelectorThrowsFlowable() {
 
-        Function<Integer, Integer> error = new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Integer> error = _ -> {
+            throw new TestException();
         };
 
         Flowable<Integer> result = Flowable.just(1, 2, 3, 4, 5)
@@ -146,12 +120,7 @@ public class FlowableReduceTest extends RxJavaTest {
     public void aggregateAsIntSum() {
 
         Single<Integer> result = Flowable.just(1, 2, 3, 4, 5).reduce(0, sum)
-                .map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) {
-                        return v;
-                    }
-                });
+                .map(v -> v);
 
         result.subscribe(singleObserver);
 
@@ -163,12 +132,7 @@ public class FlowableReduceTest extends RxJavaTest {
     public void aggregateAsIntSumSourceThrows() {
         Single<Integer> result = Flowable.concat(Flowable.just(1, 2, 3, 4, 5),
                 Flowable.<Integer> error(new TestException()))
-                .reduce(0, sum).map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) {
-                        return v;
-                    }
-                });
+                .reduce(0, sum).map(v -> v);
 
         result.subscribe(singleObserver);
 
@@ -178,20 +142,12 @@ public class FlowableReduceTest extends RxJavaTest {
 
     @Test
     public void aggregateAsIntSumAccumulatorThrows() {
-        BiFunction<Integer, Integer, Integer> sumErr = new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                throw new TestException();
-            }
+        BiFunction<Integer, Integer, Integer> sumErr = (_, _) -> {
+            throw new TestException();
         };
 
         Single<Integer> result = Flowable.just(1, 2, 3, 4, 5)
-                .reduce(0, sumErr).map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) {
-                        return v;
-                    }
-                });
+                .reduce(0, sumErr).map(v -> v);
 
         result.subscribe(singleObserver);
 
@@ -202,12 +158,8 @@ public class FlowableReduceTest extends RxJavaTest {
     @Test
     public void aggregateAsIntSumResultSelectorThrows() {
 
-        Function<Integer, Integer> error = new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Integer> error = _ -> {
+            throw new TestException();
         };
 
         Single<Integer> result = Flowable.just(1, 2, 3, 4, 5)
@@ -242,21 +194,15 @@ public class FlowableReduceTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable.<Integer>fromPublisher(new Publisher<Integer>() {
-                @Override
-                public void subscribe(Subscriber<? super Integer> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onNext(1);
-                    s.onNext(1);
-                    s.onError(new TestException("Source"));
-                    s.onComplete();
-                }
+            Flowable.<Integer>fromPublisher(s -> {
+                s.onSubscribe(new BooleanSubscription());
+                s.onNext(1);
+                s.onNext(1);
+                s.onError(new TestException("Source"));
+                s.onComplete();
             })
-            .reduce(new BiFunction<Integer, Integer, Integer>() {
-                @Override
-                public Integer apply(Integer a, Integer b) throws Exception {
-                    throw new TestException("Reducer");
-                }
+            .reduce((_, _) -> {
+                throw new TestException("Reducer");
             })
             .toFlowable()
             .to(TestHelper.<Integer>testConsumer())
@@ -274,12 +220,7 @@ public class FlowableReduceTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = Flowable.just(1)
         .concatWith(Flowable.<Integer>never())
-        .reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }).toFlowable()
+        .reduce((a, b) -> a + b).toFlowable()
         .test();
 
         ts.assertEmpty();
@@ -313,12 +254,7 @@ public class FlowableReduceTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Flowable<Integer> f) throws Exception {
-                return f.reduce(sum);
-            }
-        });
+        TestHelper.<Integer, Integer>checkDoubleOnSubscribeFlowableToMaybe(f -> f.reduce(sum));
     }
 
     @Test
@@ -357,32 +293,19 @@ public class FlowableReduceTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.reduce(sum);
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.reduce(sum), false, 1, 1, 1);
     }
 
     @Test
     public void badSourceFlowable() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.reduce(sum).toFlowable();
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.reduce(sum).toFlowable(), false, 1, 1, 1);
     }
 
     @Test
     public void reducerThrows() {
         Flowable.just(1, 2)
-        .reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                throw new TestException();
-            }
+        .reduce((_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -396,32 +319,15 @@ public class FlowableReduceTest extends RxJavaTest {
     public void shouldReduceTo10Events() {
         final AtomicInteger count = new AtomicInteger();
 
-        Flowable.range(0, 10).flatMap(new Function<Integer, Publisher<String>>() {
-            @Override
-            public Publisher<String> apply(final Integer x) throws Exception {
-                return Flowable.range(0, 2)
-                    .map(new Function<Integer, String>() {
-                    @Override
-                    public String apply(Integer y) throws Exception {
-                        return blockingOp(x, y);
-                    }
-                }).subscribeOn(Schedulers.cached())
-                .reduce(new BiFunction<String, String, String>() {
-                    @Override
-                    public String apply(String l, String r) throws Exception {
-                        return l + "_" + r;
-                    }
-                })
-                .doOnSuccess(new Consumer<String>() {
-                    @Override
-                    public void accept(String s) throws Exception {
-                        count.incrementAndGet();
-                        System.out.println("Completed with " + s);
-                    }
-                })
-                .toFlowable();
-            }
-        }
+        Flowable.range(0, 10).flatMap((Function<Integer, Publisher<String>>) x ->
+            Flowable.range(0, 2)
+            .map(y -> blockingOp(x, y)).subscribeOn(Schedulers.cached())
+            .reduce((l, r) -> l + "_" + r)
+            .doOnSuccess(s -> {
+                count.incrementAndGet();
+                System.out.println("Completed with " + s);
+            })
+        .toFlowable()
         ).blockingLast();
 
         assertEquals(10, count.get());
@@ -435,33 +341,14 @@ public class FlowableReduceTest extends RxJavaTest {
     public void shouldReduceTo10EventsFlowable() {
         final AtomicInteger count = new AtomicInteger();
 
-        Flowable.range(0, 10).flatMap(new Function<Integer, Publisher<String>>() {
-            @Override
-            public Publisher<String> apply(final Integer x) throws Exception {
-                return Flowable.range(0, 2)
-                    .map(new Function<Integer, String>() {
-                    @Override
-                    public String apply(Integer y) throws Exception {
-                        return blockingOp(x, y);
-                    }
-                }).subscribeOn(Schedulers.cached())
-                .reduce(new BiFunction<String, String, String>() {
-                    @Override
-                    public String apply(String l, String r) throws Exception {
-                        return l + "_" + r;
-                    }
-                })
-                .toFlowable()
-                .doOnNext(new Consumer<String>() {
-                    @Override
-                    public void accept(String s) throws Exception {
-                        count.incrementAndGet();
-                        System.out.println("Completed with " + s);
-                    }
-                })
-                ;
-            }
-        }
+        Flowable.range(0, 10).flatMap((Function<Integer, Publisher<String>>) x -> Flowable.range(0, 2)
+            .map(y -> blockingOp(x, y)).subscribeOn(Schedulers.cached())
+            .reduce((l, r) -> l + "_" + r)
+            .toFlowable()
+            .doOnNext(s -> {
+                count.incrementAndGet();
+                System.out.println("Completed with " + s);
+            })
         ).blockingLast();
 
         assertEquals(10, count.get());
@@ -478,35 +365,19 @@ public class FlowableReduceTest extends RxJavaTest {
 
     @Test
     public void seedDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Integer>, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Flowable<Integer> f)
-                    throws Exception {
-                return f.reduce(0, new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a;
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(f -> f.reduce(0, (a, _) -> a));
     }
 
     @Test
     public void seedDisposed() {
-        TestHelper.checkDisposed(PublishProcessor.<Integer>create().reduce(0, new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a;
-                    }
-                }));
+        TestHelper.checkDisposed(PublishProcessor.<Integer>create().reduce(0, (a, _) -> a));
     }
 
     @Test
     public void seedBadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -516,12 +387,7 @@ public class FlowableReduceTest extends RxJavaTest {
                     subscriber.onComplete();
                 }
             }
-            .reduce(0, new BiFunction<Integer, Integer, Integer>() {
-                @Override
-                public Integer apply(Integer a, Integer b) throws Exception {
-                    return a;
-                }
-            })
+            .reduce(0, (a, _) -> a)
             .test()
             .assertResult(0);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceWithSingleTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.BiFunction;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -25,12 +24,7 @@ public class FlowableReduceWithSingleTest extends RxJavaTest {
     @Test
     public void normal() {
         Flowable.range(1, 5)
-        .reduceWith(Functions.justSupplier(1), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        .reduceWith(Functions.justSupplier(1), (a, b) -> a + b)
         .test()
         .assertResult(16);
     }
@@ -38,11 +32,6 @@ public class FlowableReduceWithSingleTest extends RxJavaTest {
     @Test
     public void disposed() {
         TestHelper.checkDisposed(Flowable.range(1, 5)
-        .reduceWith(Functions.justSupplier(1), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }));
+        .reduceWith(Functions.justSupplier(1), (a, b) -> a + b));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
@@ -67,27 +67,12 @@ public class FlowableRefCountTest extends RxJavaTest {
         final AtomicInteger subscribeCount = new AtomicInteger();
         final AtomicInteger nextCount = new AtomicInteger();
         Flowable<Long> r = Flowable.interval(0, 20, TimeUnit.MILLISECONDS)
-                .doOnSubscribe(new Consumer<Subscription>() {
-                    @Override
-                    public void accept(Subscription s) {
-                        subscribeCount.incrementAndGet();
-                    }
-                })
-                .doOnNext(new Consumer<Long>() {
-                    @Override
-                    public void accept(Long l) {
-                        nextCount.incrementAndGet();
-                    }
-                })
+                .doOnSubscribe(_ -> subscribeCount.incrementAndGet())
+                .doOnNext(_ -> nextCount.incrementAndGet())
                 .publish().refCount();
 
         final AtomicInteger receivedCount = new AtomicInteger();
-        Disposable d1 = r.subscribe(new Consumer<Long>() {
-            @Override
-            public void accept(Long l) {
-                receivedCount.incrementAndGet();
-            }
-        });
+        Disposable d1 = r.subscribe(_ -> receivedCount.incrementAndGet());
 
         Disposable d2 = r.subscribe();
 
@@ -129,27 +114,12 @@ public class FlowableRefCountTest extends RxJavaTest {
         final AtomicInteger subscribeCount = new AtomicInteger();
         final AtomicInteger nextCount = new AtomicInteger();
         Flowable<Integer> r = Flowable.just(1, 2, 3, 4, 5, 6, 7, 8, 9)
-                .doOnSubscribe(new Consumer<Subscription>() {
-                    @Override
-                    public void accept(Subscription s) {
-                        subscribeCount.incrementAndGet();
-                    }
-                })
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer l) {
-                        nextCount.incrementAndGet();
-                    }
-                })
+                .doOnSubscribe(_ -> subscribeCount.incrementAndGet())
+                .doOnNext(_ -> nextCount.incrementAndGet())
                 .publish().refCount();
 
         final AtomicInteger receivedCount = new AtomicInteger();
-        Disposable d1 = r.subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer l) {
-                receivedCount.incrementAndGet();
-            }
-        });
+        Disposable d1 = r.subscribe(_ -> receivedCount.incrementAndGet());
 
         Disposable d2 = r.subscribe();
 
@@ -175,23 +145,15 @@ public class FlowableRefCountTest extends RxJavaTest {
     public void refCountSynchronousTake() {
         final AtomicInteger nextCount = new AtomicInteger();
         Flowable<Integer> r = Flowable.just(1, 2, 3, 4, 5, 6, 7, 8, 9)
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer l) {
-                            System.out.println("onNext --------> " + l);
-                            nextCount.incrementAndGet();
-                    }
+                .doOnNext(l -> {
+                        System.out.println("onNext --------> " + l);
+                        nextCount.incrementAndGet();
                 })
                 .take(4)
                 .publish().refCount();
 
         final AtomicInteger receivedCount = new AtomicInteger();
-        r.subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer l) {
-                receivedCount.incrementAndGet();
-            }
-        });
+        r.subscribe(_ -> receivedCount.incrementAndGet());
 
         System.out.println("onNext: " + nextCount.get());
 
@@ -204,21 +166,15 @@ public class FlowableRefCountTest extends RxJavaTest {
         final AtomicInteger subscribeCount = new AtomicInteger();
         final AtomicInteger unsubscribeCount = new AtomicInteger();
         Flowable<Long> r = Flowable.interval(0, 1, TimeUnit.MILLISECONDS)
-                .doOnSubscribe(new Consumer<Subscription>() {
-                    @Override
-                    public void accept(Subscription s) {
-                            System.out.println("******************************* Subscribe received");
-                            // when we are subscribed
-                            subscribeCount.incrementAndGet();
-                    }
+                .doOnSubscribe(_ -> {
+                        System.out.println("******************************* Subscribe received");
+                        // when we are subscribed
+                        subscribeCount.incrementAndGet();
                 })
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                            System.out.println("******************************* Unsubscribe received");
-                            // when we are unsubscribed
-                            unsubscribeCount.incrementAndGet();
-                    }
+                .doOnCancel(() -> {
+                        System.out.println("******************************* Unsubscribe received");
+                        // when we are unsubscribed
+                        unsubscribeCount.incrementAndGet();
                 })
                 .publish().refCount();
 
@@ -249,21 +205,15 @@ public class FlowableRefCountTest extends RxJavaTest {
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
 
         Flowable<Long> f = synchronousInterval()
-                .doOnSubscribe(new Consumer<Subscription>() {
-                    @Override
-                    public void accept(Subscription s) {
-                            System.out.println("******************************* Subscribe received");
-                            // when we are subscribed
-                            subscribeLatch.countDown();
-                    }
+                .doOnSubscribe(_ -> {
+                        System.out.println("******************************* Subscribe received");
+                        // when we are subscribed
+                        subscribeLatch.countDown();
                 })
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                            System.out.println("******************************* Unsubscribe received");
-                            // when we are unsubscribed
-                            unsubscribeLatch.countDown();
-                    }
+                .doOnCancel(() -> {
+                        System.out.println("******************************* Unsubscribe received");
+                        // when we are unsubscribed
+                        unsubscribeLatch.countDown();
                 });
 
         TestSubscriberEx<Long> s = new TestSubscriberEx<>();


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080