### PR TITLE
4.x: Unit test lambdaification 14 of N

### DIFF
--- a/docs/How-To-Use-RxJava.md
+++ b/docs/How-To-Use-RxJava.md
@@ -19,12 +19,7 @@ public static void hello(String... args) {
 If your platform doesn't support Java 8 lambdas (yet), you have to create an inner class of ```Consumer``` manually:
 ```java
 public static void hello(String... args) {
-  Flowable.fromArray(args).subscribe(new Consumer<String>() {
-      @Override
-      public void accept(String s) {
-          System.out.println("Hello " + s + "!");
-      }
-  });
+  Flowable.fromArray(args).subscribe((Consumer<String>) s -> System.out.println("Hello " + s + "!"));
 }
 ```
 

--- a/src/jmh/java/io/reactivex/rxjava4/core/BinaryFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/BinaryFlatMapPerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.functions.Function;
 
 @SuppressWarnings("exports")
@@ -85,47 +83,17 @@ public class BinaryFlatMapPerf {
 
         // --------------------------------------------------------------------------
 
-        singleFlatMapPublisher = Single.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return arrayFlowable;
-            }
-        });
+        singleFlatMapPublisher = Single.just(1).flatMapPublisher(_ -> arrayFlowable);
 
-        singleFlatMapHidePublisher = Single.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return arrayFlowableHide;
-            }
-        });
+        singleFlatMapHidePublisher = Single.just(1).flatMapPublisher(_ -> arrayFlowableHide);
 
-        singleFlattenAsPublisher = Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<? extends Integer>>() {
-            @Override
-            public Iterable<? extends Integer> apply(Integer v) {
-                return list;
-            }
-        });
+        singleFlattenAsPublisher = Single.just(1).flattenAsFlowable(_ -> list);
 
-        maybeFlatMapPublisher = Maybe.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return arrayFlowable;
-            }
-        });
+        maybeFlatMapPublisher = Maybe.just(1).flatMapPublisher(_ -> arrayFlowable);
 
-        maybeFlatMapHidePublisher = Maybe.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return arrayFlowableHide;
-            }
-        });
+        maybeFlatMapHidePublisher = Maybe.just(1).flatMapPublisher(_ -> arrayFlowableHide);
 
-        maybeFlattenAsPublisher = Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<? extends Integer>>() {
-            @Override
-            public Iterable<? extends Integer> apply(Integer v) {
-                return list;
-            }
-        });
+        maybeFlattenAsPublisher = Maybe.just(1).flattenAsFlowable(_ -> list);
 
         completableFlatMapPublisher = Completable.complete().andThen(listFlowable);
 
@@ -133,47 +101,17 @@ public class BinaryFlatMapPerf {
 
         // --------------------------------------------------------------------------
 
-        singleFlatMapObservable = Single.just(1).flatMapObservable(new Function<Integer, Observable<? extends Integer>>() {
-            @Override
-            public Observable<? extends Integer> apply(Integer v) {
-                return arrayObservable;
-            }
-        });
+        singleFlatMapObservable = Single.just(1).flatMapObservable((Function<Integer, Observable<? extends Integer>>) _ -> arrayObservable);
 
-        singleFlatMapHideObservable = Single.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return arrayObservableHide;
-            }
-        });
+        singleFlatMapHideObservable = Single.just(1).flatMapObservable((Function<Integer, Observable<Integer>>) _ -> arrayObservableHide);
 
-        singleFlattenAsObservable = Single.just(1).flattenAsObservable(new Function<Integer, Iterable<? extends Integer>>() {
-            @Override
-            public Iterable<? extends Integer> apply(Integer v) {
-                return list;
-            }
-        });
+        singleFlattenAsObservable = Single.just(1).flattenAsObservable(_ -> list);
 
-        maybeFlatMapObservable = Maybe.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return arrayObservable;
-            }
-        });
+        maybeFlatMapObservable = Maybe.just(1).flatMapObservable((Function<Integer, Observable<Integer>>) _ -> arrayObservable);
 
-        maybeFlatMapHideObservable = Maybe.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return arrayObservableHide;
-            }
-        });
+        maybeFlatMapHideObservable = Maybe.just(1).flatMapObservable((Function<Integer, Observable<Integer>>) _ -> arrayObservableHide);
 
-        maybeFlattenAsObservable = Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<? extends Integer>>() {
-            @Override
-            public Iterable<? extends Integer> apply(Integer v) {
-                return list;
-            }
-        });
+        maybeFlattenAsObservable = Maybe.just(1).flattenAsObservable(_ -> list);
 
         completableFlatMapObservable = Completable.complete().andThen(listObservable);
 

--- a/src/jmh/java/io/reactivex/rxjava4/core/CallableAsyncPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/CallableAsyncPerf.java
@@ -67,12 +67,7 @@ public class CallableAsyncPerf {
 
         Scheduler s2 = new SingleScheduler();
 
-        Callable<Integer> c = new Callable<Integer>() {
-            @Override
-            public Integer call() {
-                return 1;
-            }
-        };
+        Callable<Integer> c = () -> 1;
 
         subscribeOnFlowable = Flowable.fromCallable(c).subscribeOn(s);
 

--- a/src/jmh/java/io/reactivex/rxjava4/core/EachTypeFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/EachTypeFlatMapPerf.java
@@ -48,39 +48,14 @@ public class EachTypeFlatMapPerf {
         bpRange = Flowable.range(1, times);
         nbpRange = Observable.range(1, times);
 
-        bpRangeMapJust = bpRange.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
-        nbpRangeMapJust = nbpRange.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        bpRangeMapJust = bpRange.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v));
+        nbpRangeMapJust = nbpRange.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v));
 
-        bpRangeMapRange = bpRange.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.range(v, 2);
-            }
-        });
-        nbpRangeMapRange = nbpRange.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.range(v, 2);
-            }
-        });
+        bpRangeMapRange = bpRange.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.range(v, 2));
+        nbpRangeMapRange = nbpRange.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.range(v, 2));
 
         singleJust = Single.just(1);
-        singleJustMapJust = singleJust.flatMap(new Function<Integer, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        singleJustMapJust = singleJust.flatMap((Function<Integer, Single<Integer>>) v -> Single.just(v));
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/core/FlatMapJustPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/FlatMapJustPerf.java
@@ -40,19 +40,9 @@ public class FlatMapJustPerf {
     public void setup() {
         Integer[] array = new Integer[times];
 
-        flowable = Flowable.fromArray(array).flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        flowable = Flowable.fromArray(array).flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v));
 
-        observable = Observable.fromArray(array).flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        observable = Observable.fromArray(array).flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v));
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/core/FlattenCrossMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/FlattenCrossMapPerf.java
@@ -46,19 +46,9 @@ public class FlattenCrossMapPerf {
 
         final Iterable<Integer> list = Arrays.asList(arrayInner);
 
-        flowable = Flowable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return list;
-            }
-        });
+        flowable = Flowable.fromArray(array).flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> list);
 
-        observable = Observable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return list;
-            }
-        });
+        observable = Observable.fromArray(array).flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> list);
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/core/FlattenJustPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/FlattenJustPerf.java
@@ -43,19 +43,9 @@ public class FlattenJustPerf {
 
         final Iterable<Integer> singletonList = Collections.singletonList(1);
 
-        flowable = Flowable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return singletonList;
-            }
-        });
+        flowable = Flowable.fromArray(array).flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> singletonList);
 
-        observable = Observable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return singletonList;
-            }
-        });
+        observable = Observable.fromArray(array).flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> singletonList);
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/core/FlattenRangePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/FlattenRangePerf.java
@@ -43,19 +43,9 @@ public class FlattenRangePerf {
 
         final Iterable<Integer> list = Arrays.asList(1, 2);
 
-        flowable = Flowable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return list;
-            }
-        });
+        flowable = Flowable.fromArray(array).flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> list);
 
-        observable = Observable.fromArray(array).flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return list;
-            }
-        });
+        observable = Observable.fromArray(array).flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> list);
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/core/ObservableFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/ObservableFlatMapPerf.java
@@ -47,12 +47,7 @@ public class ObservableFlatMapPerf {
         Observable<Integer> outer = Observable.fromArray(mainArray);
         final Observable<Integer> inner = Observable.fromArray(innerArray);
 
-        source = outer.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t) {
-                return inner;
-            }
-        });
+        source = outer.flatMap((Function<Integer, Observable<Integer>>) _ -> inner);
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableConcatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableConcatMapCompletablePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableConcatMapCompletablePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.empty();
-            }
-        });
+        flowablePlain = source.concatMap(_ -> Flowable.empty());
 
-        flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Completable.complete().toFlowable();
-            }
-        });
+        flowableConvert = source.concatMap(_ -> Completable.complete().toFlowable());
 
-        flowableDedicated = source.concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) {
-                return Completable.complete();
-            }
-        });
+        flowableDedicated = source.concatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableConcatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableConcatMapMaybeEmptyPerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableConcatMapMaybeEmptyPerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.empty();
-            }
-        });
+        flowablePlain = source.concatMap(_ -> Flowable.empty());
 
-        concatMapToFlowableEmpty = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Maybe.<Integer>empty().toFlowable();
-            }
-        });
+        concatMapToFlowableEmpty = source.concatMap(_ -> Maybe.<Integer>empty().toFlowable());
 
-        flowableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<? extends Integer>>() {
-            @Override
-            public Maybe<? extends Integer> apply(Integer v) {
-                return Maybe.empty();
-            }
-        });
+        flowableDedicated = source.concatMapMaybe((Function<Integer, Maybe<? extends Integer>>) _ -> Maybe.empty());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableFlatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableFlatMapCompletablePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableFlatMapCompletablePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.empty();
-            }
-        });
+        flowablePlain = source.flatMap(_ -> Flowable.empty());
 
-        flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Completable.complete().toFlowable();
-            }
-        });
+        flowableConvert = source.flatMap(_ -> Completable.complete().toFlowable());
 
-        flowableDedicated = source.flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) {
-                return Completable.complete();
-            }
-        });
+        flowableDedicated = source.flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableFlatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableFlatMapMaybeEmptyPerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableFlatMapMaybeEmptyPerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.empty();
-            }
-        });
+        flowablePlain = source.flatMap(_ -> Flowable.empty());
 
-        flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Maybe.<Integer>empty().toFlowable();
-            }
-        });
+        flowableConvert = source.flatMap(_ -> Maybe.<Integer>empty().toFlowable());
 
-        flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.empty();
-            }
-        });
+        flowableDedicated = source.flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> Maybe.empty());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableFlatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableFlatMapMaybePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableFlatMapMaybePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        flowablePlain = source.flatMap(v -> Flowable.just(v));
 
-        flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Maybe.just(v).toFlowable();
-            }
-        });
+        flowableConvert = source.flatMap(v -> Maybe.just(v).toFlowable());
 
-        flowableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.just(v);
-            }
-        });
+        flowableDedicated = source.flatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v));
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableFlatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableFlatMapSinglePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableFlatMapSinglePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        flowablePlain = source.flatMap(v -> Flowable.just(v));
 
-        flowableConvert = source.flatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Single.just(v).toFlowable();
-            }
-        });
+        flowableConvert = source.flatMap(v -> Single.just(v).toFlowable());
 
-        flowableDedicated = source.flatMapSingle(new Function<Integer, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        flowableDedicated = source.flatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v));
     }
 
     @Benchmark

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
@@ -245,20 +245,14 @@ public class FlowableRefCountTest extends RxJavaTest {
     public void connectUnsubscribeRaceCondition() throws InterruptedException {
         final AtomicInteger subUnsubCount = new AtomicInteger();
         Flowable<Long> f = synchronousInterval()
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                            System.out.println("******************************* Unsubscribe received");
-                            // when we are unsubscribed
-                            subUnsubCount.decrementAndGet();
-                    }
+                .doOnCancel(() -> {
+                        System.out.println("******************************* Unsubscribe received");
+                        // when we are unsubscribed
+                        subUnsubCount.decrementAndGet();
                 })
-                .doOnSubscribe(new Consumer<Subscription>() {
-                    @Override
-                    public void accept(Subscription s) {
-                            System.out.println("******************************* SUBSCRIBE received");
-                            subUnsubCount.incrementAndGet();
-                    }
+                .doOnSubscribe(_ -> {
+                        System.out.println("******************************* SUBSCRIBE received");
+                        subUnsubCount.incrementAndGet();
                 });
 
         TestSubscriberEx<Long> s = new TestSubscriberEx<>();
@@ -282,32 +276,29 @@ public class FlowableRefCountTest extends RxJavaTest {
     }
 
     private Flowable<Long> synchronousInterval() {
-        return Flowable.unsafeCreate(new Publisher<Long>() {
-            @Override
-            public void subscribe(Subscriber<? super Long> subscriber) {
-                final AtomicBoolean cancel = new AtomicBoolean();
-                subscriber.onSubscribe(new Subscription() {
-                    @Override
-                    public void request(long n) {
+        return Flowable.unsafeCreate(subscriber -> {
+            final AtomicBoolean cancel = new AtomicBoolean();
+            subscriber.onSubscribe(new Subscription() /* NFI */ {
+                @Override
+                public void request(long n) {
 
-                    }
-
-                    @Override
-                    public void cancel() {
-                        cancel.set(true);
-                    }
-
-                });
-                for (;;) {
-                    if (cancel.get()) {
-                        break;
-                    }
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {
-                    }
-                    subscriber.onNext(1L);
                 }
+
+                @Override
+                public void cancel() {
+                    cancel.set(true);
+                }
+
+            });
+            for (;;) {
+                if (cancel.get()) {
+                    break;
+                }
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                }
+                subscriber.onNext(1L);
             }
         });
     }
@@ -316,22 +307,19 @@ public class FlowableRefCountTest extends RxJavaTest {
     public void onlyFirstShouldSubscribeAndLastUnsubscribe() {
         final AtomicInteger subscriptionCount = new AtomicInteger();
         final AtomicInteger unsubscriptionCount = new AtomicInteger();
-        Flowable<Integer> flowable = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> subscriber) {
-                subscriptionCount.incrementAndGet();
-                subscriber.onSubscribe(new Subscription() {
-                    @Override
-                    public void request(long n) {
+        Flowable<Integer> flowable = Flowable.unsafeCreate(subscriber -> {
+            subscriptionCount.incrementAndGet();
+            subscriber.onSubscribe(new Subscription() /* NFI */ {
+                @Override
+                public void request(long n) {
 
-                    }
+                }
 
-                    @Override
-                    public void cancel() {
-                        unsubscriptionCount.incrementAndGet();
-                    }
-                });
-            }
+                @Override
+                public void cancel() {
+                    unsubscriptionCount.incrementAndGet();
+                }
+            });
         });
         Flowable<Integer> refCounted = flowable.publish().refCount();
 
@@ -355,12 +343,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         // subscribe list1
         final List<Long> list1 = new ArrayList<>();
-        Disposable d1 = interval.subscribe(new Consumer<Long>() {
-            @Override
-            public void accept(Long t1) {
-                list1.add(t1);
-            }
-        });
+        Disposable d1 = interval.subscribe(t1 -> list1.add(t1));
 
         s.advanceTimeBy(200, TimeUnit.MILLISECONDS);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLastTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLastTest.java
@@ -117,13 +117,7 @@ public class FlowableSkipLastTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.skipLast(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.skipLast(1));
     }
 
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipTest.java
@@ -145,12 +145,7 @@ public class FlowableSkipTest extends RxJavaTest {
         final AtomicLong requests = new AtomicLong(0);
         TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.interval(100, TimeUnit.MILLISECONDS)
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long n) {
-                        requests.addAndGet(n);
-                    }
-                }).skip(4).subscribe(ts);
+                .doOnRequest(n -> requests.addAndGet(n)).skip(4).subscribe(ts);
         Thread.sleep(100);
         ts.request(1);
         ts.request(1);
@@ -177,13 +172,7 @@ public class FlowableSkipTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.skip(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.skip(1));
     }
 
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipUntilTest.java
@@ -163,18 +163,8 @@ public class FlowableSkipUntilTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.skipUntil(Flowable.never());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.skipUntil(Flowable.never()));
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return Flowable.never().skipUntil(f);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> Flowable.never().skipUntil(f));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastOneTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastOneTest.java
@@ -64,12 +64,7 @@ public class FlowableTakeLastOneTest extends RxJavaTest {
     @Test
     public void unsubscribesFromUpstream() {
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
-        Action unsubscribeAction = new Action() {
-            @Override
-            public void run() {
-                unsubscribed.set(true);
-            }
-        };
+        Action unsubscribeAction = () -> unsubscribed.set(true);
 
         Flowable.just(1).concatWith(Flowable.<Integer>never())
         .doOnCancel(unsubscribeAction)
@@ -92,12 +87,7 @@ public class FlowableTakeLastOneTest extends RxJavaTest {
     public void takeLastZeroProcessesAllItemsButIgnoresThem() {
         final AtomicInteger upstreamCount = new AtomicInteger();
         final int num = 10;
-        long count = Flowable.range(1, num).doOnNext(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t) {
-                upstreamCount.incrementAndGet();
-            }})
+        long count = Flowable.range(1, num).doOnNext(_ -> upstreamCount.incrementAndGet())
             .takeLast(0).count().blockingGet();
         assertEquals(num, upstreamCount.get());
         assertEquals(0L, count);
@@ -148,12 +138,7 @@ public class FlowableTakeLastOneTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.takeLast(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.takeLast(1));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTest.java
@@ -141,12 +141,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
                 .empty()
                 .count()
                 .toFlowable()
-                .filter(new Predicate<Long>() {
-                    @Override
-                    public boolean test(Long v) {
-                        return false;
-                    }
-                })
+                .filter(_ -> false)
                 .toList()
                 .blockingGet().size());
     }
@@ -317,12 +312,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.takeLast(5);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.takeLast(5));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.schedulers.*;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -298,19 +297,9 @@ public class FlowableTakeLastTimedTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = pp.takeLast(1, TimeUnit.DAYS).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -326,12 +315,7 @@ public class FlowableTakeLastTimedTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                return f.takeLast(1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.takeLast(1, TimeUnit.SECONDS));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest2.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest2.java
@@ -197,12 +197,7 @@ public class FlowableTakeTest2 extends RxJavaTest implements LongConsumer, Actio
                     .take(5)
                     .test(0L);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(3);
-                }
-            };
+            Runnable r = () -> ts.request(3);
 
             TestHelper.race(r, r);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -18,8 +18,6 @@ import static org.mockito.Mockito.*;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -65,12 +63,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f) throws Exception {
-                return f.throttleLatest(1, TimeUnit.MINUTES);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.throttleLatest(1, TimeUnit.MINUTES));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimerTest.java
@@ -28,7 +28,6 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.flowables.ConnectableFlowable;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.*;
 import io.reactivex.rxjava4.subscribers.*;
@@ -316,19 +315,9 @@ public class FlowableTimerTest extends RxJavaTest {
             Flowable.timer(1, TimeUnit.SECONDS, scheduler)
             .subscribe(ts);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-                }
-            };
+            Runnable r1 = () -> scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -355,16 +344,13 @@ public class FlowableTimerTest extends RxJavaTest {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestSubscriber<Long> ts = Flowable.timer(1, TimeUnit.MILLISECONDS, s)
-                .map(new Function<Long, Long>() {
-                    @Override
-                    public Long apply(Long v) throws Exception {
-                        try {
-                        Thread.sleep(3000);
-                        } catch (InterruptedException ex) {
-                            interrupted.set(true);
-                        }
-                        return v;
+                .map(v -> {
+                    try {
+                    Thread.sleep(3000);
+                    } catch (InterruptedException ex) {
+                        interrupted.set(true);
                     }
+                    return v;
                 })
                 .test();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToCompletableTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 import io.reactivex.rxjava4.testsupport.TestSubscriberEx;
 
@@ -83,12 +82,7 @@ public class FlowableToCompletableTest extends RxJavaTest {
     public void shouldUseUnsafeSubscribeInternallyNotSubscribe() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
-        Completable cmp = Flowable.just("Hello World!").doOnCancel(new Action() {
-
-            @Override
-            public void run() {
-                unsubscribed.set(true);
-            }}).ignoreElements();
+        Completable cmp = Flowable.just("Hello World!").doOnCancel(() -> unsubscribed.set(true)).ignoreElements();
 
         cmp.<String>toFlowable().subscribe(subscriber);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToSingleTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
 public class FlowableToSingleTest extends RxJavaTest {
@@ -73,12 +72,7 @@ public class FlowableToSingleTest extends RxJavaTest {
     public void shouldUseUnsafeSubscribeInternallyNotSubscribe() {
         TestSubscriber<String> subscriber = TestSubscriber.create();
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
-        Single<String> single = Flowable.just("Hello World!").doOnCancel(new Action() {
-
-            @Override
-            public void run() {
-                unsubscribed.set(true);
-            }}).single("");
+        Single<String> single = Flowable.just("Hello World!").doOnCancel(() -> unsubscribed.set(true)).single("");
         single.toFlowable().subscribe(subscriber);
         subscriber.assertComplete();
         Assert.assertFalse(unsubscribed.get());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatPublisherTest.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
@@ -30,12 +28,7 @@ public class MaybeConcatPublisherTest extends RxJavaTest {
 
     @Test
     public void callable() {
-        Maybe.concat(Flowable.fromCallable(new Callable<Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> call() throws Exception {
-                return Maybe.just(1);
-            }
-        }))
+        Maybe.concat(Flowable.fromCallable(() -> Maybe.just(1)))
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeContainsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeContainsTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.processors.PublishProcessor;
@@ -69,12 +68,7 @@ public class MaybeContainsTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Object>, SingleSource<Boolean>>() {
-            @Override
-            public SingleSource<Boolean> apply(Maybe<Object> f) throws Exception {
-                return f.contains(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle(f -> f.contains(1));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCountTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.processors.PublishProcessor;
@@ -64,12 +63,7 @@ public class MaybeCountTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Object>, SingleSource<Long>>() {
-            @Override
-            public SingleSource<Long> apply(Maybe<Object> f) throws Exception {
-                return f.count();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle(f -> f.count());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -23,7 +23,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -108,12 +107,7 @@ public class MaybeDelaySubscriptionTest extends RxJavaTest {
 
     @Test
     public void withPublisherDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.delaySubscription(Flowable.just(1));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(m -> m.delaySubscription(Flowable.just(1)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayTest.java
@@ -89,12 +89,7 @@ public class MaybeDelayTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
-                return f.delay(100, TimeUnit.MILLISECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Object>, Maybe<Object>>) f -> f.delay(100, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDetachTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -33,12 +32,7 @@ public class MaybeDetachTest extends RxJavaTest {
     @Test
     public void doubleSubscribe() {
 
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.onTerminateDetach();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(m -> m.onTerminateDetach());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeEqualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeEqualTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.BiPredicate;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class MaybeEqualTest extends RxJavaTest {
@@ -29,11 +28,8 @@ public class MaybeEqualTest extends RxJavaTest {
 
     @Test
     public void predicateThrows() {
-        Maybe.sequenceEqual(Maybe.just(1), Maybe.just(2), new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) throws Exception {
-                throw new TestException();
-            }
+        Maybe.sequenceEqual(Maybe.just(1), Maybe.just(2), (_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeErrorTest.java
@@ -17,17 +17,13 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Supplier;
 
 public class MaybeErrorTest extends RxJavaTest {
 
     @Test
     public void errorSupplierThrows() {
-        Maybe.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() throws Exception {
-                throw new TestException();
-            }
+        Maybe.error(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFilterSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFilterSingleTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.subjects.PublishSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -39,11 +38,6 @@ public class MaybeFilterSingleTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToMaybe(new Function<Single<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Single<Object> v) throws Exception {
-                return v.filter(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe(v -> v.filter(Functions.alwaysTrue()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapNotificationTest.java
@@ -34,14 +34,9 @@ public class MaybeFlatMapNotificationTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Maybe<Integer> m) throws Exception {
-                return m
-                        .flatMap(Functions.justFunction(Maybe.just(1)),
-                                Functions.justFunction(Maybe.just(1)), Functions.justSupplier(Maybe.just(1)));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, MaybeSource<Integer>>) m -> m
+                .flatMap(Functions.justFunction(Maybe.just(1)),
+                        Functions.justFunction(Maybe.just(1)), Functions.justSupplier(Maybe.just(1))));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromCompletableTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertSame;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamCompletableSource;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -52,11 +51,6 @@ public class MaybeFromCompletableTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletableToMaybe(new Function<Completable, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Completable v) throws Exception {
-                return Maybe.fromCompletable(v);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletableToMaybe(v -> Maybe.fromCompletable(v));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromSingleTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertSame;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamSingleSource;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -52,11 +51,6 @@ public class MaybeFromSingleTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToMaybe(new Function<Single<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Single<Object> v) throws Exception {
-                return Maybe.fromSingle(v);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe(v -> Maybe.fromSingle(v));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeHideTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeHideTest.java
@@ -59,12 +59,7 @@ public class MaybeHideTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposedMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.hide();
-            }
-        });
+        TestHelper.checkDisposedMaybe(m -> m.hide());
     }
 
     @Test
@@ -76,11 +71,6 @@ public class MaybeHideTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
-                return f.hide();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Object>, Maybe<Object>>) f -> f.hide());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeIgnoreElementTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeIgnoreElementTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.maybe;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -38,11 +37,6 @@ public class MaybeIgnoreElementTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> v) throws Exception {
-                return v.ignoreElement().toMaybe();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(v -> v.ignoreElement().toMaybe());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMapTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.maybe;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -24,11 +23,6 @@ public class MaybeMapTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.map(Functions.identity());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(m -> m.map(Functions.identity()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMaterializeTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.subjects.MaybeSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -50,12 +49,7 @@ public class MaybeMaterializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Object>, SingleSource<Notification<Object>>>() {
-            @Override
-            public SingleSource<Notification<Object>> apply(Maybe<Object> v) throws Exception {
-                return v.materialize();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle(v -> v.materialize());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -140,19 +140,9 @@ public class MaybeMergeArrayTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps1.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> ps1.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps2.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> ps2.onError(ex);
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeTest.java
@@ -48,12 +48,7 @@ public class MaybeMergeTest extends RxJavaTest {
         Maybe<Integer>[] sources = new Maybe[3];
         for (int i = 0; i < 3; i++) {
             final int j = i + 1;
-            sources[i] = Maybe.fromCallable(new Callable<Integer>() {
-                @Override
-                public Integer call() throws Exception {
-                    return count.incrementAndGet() - j;
-                }
-            })
+            sources[i] = Maybe.fromCallable(() -> count.incrementAndGet() - j)
             .subscribeOn(Schedulers.cached());
         }
 
@@ -74,19 +69,11 @@ public class MaybeMergeTest extends RxJavaTest {
         Maybe<Integer>[] sources = new Maybe[3];
         for (int i = 0; i < 3; i++) {
             final int j = i + 1;
-            sources[i] = Maybe.fromCallable(new Callable<Integer>() {
-                @Override
-                public Integer call() throws Exception {
-                    return count.incrementAndGet() - j;
-                }
-            })
+            sources[i] = Maybe.fromCallable(() -> count.incrementAndGet() - j)
             .subscribeOn(Schedulers.cached());
         }
-        sources[1] = Maybe.fromCallable(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                throw new TestException("" + count.incrementAndGet());
-            }
+        sources[1] = Maybe.fromCallable((Callable<Integer>) () -> {
+            throw new TestException("" + count.incrementAndGet());
         })
         .subscribeOn(Schedulers.cached());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOfTypeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOfTypeTest.java
@@ -69,12 +69,7 @@ public class MaybeOfTypeTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposedMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Maybe<Object> m) throws Exception {
-                return m.ofType(Object.class);
-            }
-        });
+        TestHelper.checkDisposedMaybe((Function<Maybe<Object>, Maybe<Object>>) m -> m.ofType(Object.class));
     }
 
     @Test
@@ -86,11 +81,6 @@ public class MaybeOfTypeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
-                return f.ofType(Object.class);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Object>, Maybe<Object>>) f -> f.ofType(Object.class));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimerTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -40,16 +39,13 @@ public class MaybeTimerTest extends RxJavaTest {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Long> to = Maybe.timer(1, TimeUnit.MILLISECONDS, s)
-                .map(new Function<Long, Long>() {
-                    @Override
-                    public Long apply(Long v) throws Exception {
-                        try {
-                        Thread.sleep(3000);
-                        } catch (InterruptedException ex) {
-                            interrupted.set(true);
-                        }
-                        return v;
+                .map(v -> {
+                    try {
+                    Thread.sleep(3000);
+                    } catch (InterruptedException ex) {
+                        interrupted.set(true);
                     }
+                    return v;
                 })
                 .test();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToCompletableTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertSame;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -47,11 +46,6 @@ public class MaybeToCompletableTest extends RxJavaTest {
 
     @Test
     public void doubleSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToCompletable(new Function<Maybe<Object>, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Maybe<Object> m) throws Exception {
-                return m.ignoreElement();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToCompletable(m -> m.ignoreElement());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToFlowableTest.java
@@ -16,10 +16,7 @@ package io.reactivex.rxjava4.internal.operators.maybe;
 import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -34,11 +31,6 @@ public class MaybeToFlowableTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(new Function<Maybe<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Maybe<Object> m) throws Exception {
-                return m.toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(m -> m.toFlowable());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToObservableTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertSame;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -33,11 +32,6 @@ public class MaybeToObservableTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToObservable(new Function<Maybe<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.toObservable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToObservable(m -> m.toObservable());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToSingleTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -42,11 +41,6 @@ public class MaybeToSingleTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.toSingle();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle(m -> m.toSingle());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/CompletableAndThenPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/CompletableAndThenPublisherTest.java
@@ -68,11 +68,6 @@ public class CompletableAndThenPublisherTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletableToFlowable(new Function<Completable, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Completable m) throws Exception {
-                return m.andThen(Flowable.never());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletableToFlowable((Function<Completable, Publisher<Object>>) m -> m.andThen(Flowable.never()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletableTest.java
@@ -46,12 +46,7 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
     public void simple2() {
         final AtomicInteger counter = new AtomicInteger();
         Flowable.range(1, 5)
-        .concatMapCompletable(Functions.justFunction(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.incrementAndGet();
-            }
-        })))
+        .concatMapCompletable(Functions.justFunction(Completable.fromAction(() -> counter.incrementAndGet())))
         .test()
         .assertResult();
 
@@ -94,12 +89,7 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
     public void innerErrorDelayed() {
         TestObserverEx<Void> to = Flowable.range(1, 5)
         .concatMapCompletableDelayError(
-                new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        return Completable.error(new TestException());
-                    }
-                }
+                _ -> Completable.error(new TestException())
         )
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class)
@@ -111,11 +101,8 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void mapperCrash() {
         Flowable.just(1)
-        .concatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMapCompletable(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -204,15 +191,12 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
         final CompletableSubject cs2 = CompletableSubject.create();
 
         TestObserver<Void> to = pp.concatMapCompletableDelayError(
-                new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        if (v == 1) {
-                            return cs;
-                        }
-                        return cs2;
-                    }
-                }, true, 32
+                        v -> {
+                            if (v == 1) {
+                                return cs;
+                            }
+                            return cs2;
+                        }, true, 32
         )
         .test();
 
@@ -247,14 +231,8 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowableToCompletable(
-                new Function<Flowable<Object>, Completable>() {
-                    @Override
-                    public Completable apply(Flowable<Object> f)
-                            throws Exception {
-                        return f.concatMapCompletable(
-                                Functions.justFunction(Completable.complete()));
-                    }
-                }
+                f -> f.concatMapCompletable(
+                        Functions.justFunction(Completable.complete()))
         );
     }
 
@@ -309,28 +287,13 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
 
                 pp.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        cs.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> cs.onError(ex);
 
                 TestHelper.race(r1, r2);
 
-                to.assertError(new Predicate<Throwable>() {
-                    @Override
-                    public boolean test(Throwable e) throws Exception {
-                        return e instanceof TestException || e instanceof CompositeException;
-                    }
-                })
+                to.assertError(e -> e instanceof TestException || e instanceof CompositeException)
                 .assertNotComplete();
 
                 if (!errors.isEmpty()) {
@@ -355,19 +318,11 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(2);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(2);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cs.onComplete();
-                    to.dispose();
-                }
+            Runnable r2 = () -> {
+                cs.onComplete();
+                to.dispose();
             };
 
             TestHelper.race(r1, r2);
@@ -397,17 +352,12 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream -> upstream.concatMapCompletable(new Function<Integer, Completable>() {
             @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return upstream.concatMapCompletable(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                });
+            public Completable apply(Integer v) throws Throwable {
+                return Completable.complete().hide();
             }
-        });
+        }));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/MaybeFlatMapObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/MaybeFlatMapObservableTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.*;
@@ -68,11 +67,8 @@ public class MaybeFlatMapObservableTest extends RxJavaTest {
 
     @Test
     public void mapperCrash() {
-        Maybe.just(1).flatMapObservable(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        Maybe.just(1).flatMapObservable(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/MaybeFlatMapPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/MaybeFlatMapPublisherTest.java
@@ -16,11 +16,8 @@ package io.reactivex.rxjava4.internal.operators.mixed;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.subjects.MaybeSubject;
@@ -70,11 +67,8 @@ public class MaybeFlatMapPublisherTest extends RxJavaTest {
 
     @Test
     public void mapperCrash() {
-        Maybe.just(1).flatMapPublisher(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        Maybe.just(1).flatMapPublisher(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -82,11 +76,6 @@ public class MaybeFlatMapPublisherTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(new Function<Maybe<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Maybe<Object> m) throws Exception {
-                return m.flatMapPublisher(Functions.justFunction(Flowable.never()));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(m -> m.flatMapPublisher(Functions.justFunction(Flowable.never())));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableNextTest.java
@@ -23,7 +23,6 @@ import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.internal.operators.observable.BlockingObservableNext.NextObserver;
@@ -244,30 +243,21 @@ public class BlockingObservableNextTest extends RxJavaTest {
                 final CountDownLatch timeHasPassed = new CountDownLatch(COUNT);
                 final AtomicBoolean running = new AtomicBoolean(true);
                 final AtomicInteger count = new AtomicInteger(0);
-                final Observable<Integer> obs = Observable.unsafeCreate(new ObservableSource<Integer>() {
-
-                    @Override
-                    public void subscribe(final Observer<? super Integer> o) {
-                        o.onSubscribe(Disposable.empty());
-                        task.replace(Schedulers.single().scheduleDirect(new Runnable() {
-
-                            @Override
-                            public void run() {
-                                try {
-                                    while (running.get() && !task.isDisposed()) {
-                                        o.onNext(count.incrementAndGet());
-                                        timeHasPassed.countDown();
-                                    }
-                                    o.onComplete();
-                                } catch (Throwable e) {
-                                    o.onError(e);
-                                } finally {
-                                    finished.countDown();
-                                }
+                final Observable<Integer> obs = Observable.unsafeCreate(o -> {
+                    o.onSubscribe(Disposable.empty());
+                    task.replace(Schedulers.single().scheduleDirect(() -> {
+                        try {
+                            while (running.get() && !task.isDisposed()) {
+                                o.onNext(count.incrementAndGet());
+                                timeHasPassed.countDown();
                             }
-                        }));
-                    }
-
+                            o.onComplete();
+                        } catch (Throwable e) {
+                            o.onError(e);
+                        } finally {
+                            finished.countDown();
+                        }
+                    }));
                 });
 
                 Iterator<Integer> it = next(obs).iterator();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToFutureTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.exceptions.TestException;
 
 public class BlockingObservableToFutureTest extends RxJavaTest {
@@ -59,14 +58,10 @@ public class BlockingObservableToFutureTest extends RxJavaTest {
 
     @Test
     public void toFutureWithException() {
-        Observable<String> obs = Observable.unsafeCreate(new ObservableSource<String>() {
-
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onNext("one");
-                observer.onError(new TestException());
-            }
+        Observable<String> obs = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onNext("one");
+            observer.onError(new TestException());
         });
 
         Future<String> f = obs.toFuture();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToIteratorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToIteratorTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.internal.operators.observable.BlockingObservableIterable.BlockingObservableIterator;
@@ -52,14 +51,10 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void toIteratorWithException() {
-        Observable<String> obs = Observable.unsafeCreate(new ObservableSource<String>() {
-
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onNext("one");
-                observer.onError(new TestException());
-            }
+        Observable<String> obs = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onNext("one");
+            observer.onError(new TestException());
         });
 
         Iterator<String> it = obs.blockingIterable().iterator();
@@ -126,12 +121,7 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
         final Iterator<Integer> it = PublishSubject.<Integer>create()
                 .blockingIterable().iterator();
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                ((Disposable)it).dispose();
-            }
-        }, 1, TimeUnit.SECONDS);
+        Schedulers.single().scheduleDirect(() -> ((Disposable)it).dispose(), 1, TimeUnit.SECONDS);
 
         assertFalse(it.hasNext());
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithCompletableTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.CompletableSubject;
 
@@ -31,12 +30,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
-        .concatWith(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.onNext(100);
-            }
-        }))
+        .concatWith(Completable.fromAction(() -> to.onNext(100)))
         .subscribe(to);
 
         to.assertResult(1, 2, 3, 4, 5, 100);
@@ -47,12 +41,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.<Integer>error(new TestException())
-        .concatWith(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.onNext(100);
-            }
-        }))
+        .concatWith(Completable.fromAction(() -> to.onNext(100)))
         .subscribe(to);
 
         to.assertFailure(TestException.class);
@@ -74,12 +63,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
-        .concatWith(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.onNext(100);
-            }
-        }))
+        .concatWith(Completable.fromAction(() -> to.onNext(100)))
         .take(3)
         .subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCountTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.observable;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class ObservableCountTest extends RxJavaTest {
@@ -30,18 +29,8 @@ public class ObservableCountTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Long>>() {
-            @Override
-            public ObservableSource<Long> apply(Observable<Object> o) throws Exception {
-                return o.count().toObservable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.count().toObservable());
 
-        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Object>, SingleSource<Long>>() {
-            @Override
-            public SingleSource<Long> apply(Observable<Object> o) throws Exception {
-                return o.count();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(o -> o.count());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDetachTest.java
@@ -19,7 +19,6 @@ import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -108,11 +107,6 @@ public class ObservableDetachTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.onTerminateDetach();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.onTerminateDetach());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableElementAtTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableElementAtTest.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.subjects.PublishSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -186,26 +185,11 @@ public class ObservableElementAtTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.elementAt(0).toObservable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.elementAt(0).toObservable());
 
-        TestHelper.checkDoubleOnSubscribeObservableToMaybe(new Function<Observable<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.elementAt(0);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservableToMaybe(o -> o.elementAt(0));
 
-        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.elementAt(0, 1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(o -> o.elementAt(0, 1));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 import io.reactivex.rxjava4.operators.ScalarSupplier;
 import io.reactivex.rxjava4.schedulers.Schedulers;
@@ -69,12 +68,7 @@ public class ObservableFromTest extends RxJavaTest {
 
     @Test
     public void fromPublisherDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowableToObservable(new Function<Flowable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Flowable<Object> f) throws Exception {
-                return f.toObservable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToObservable(f -> f.toObservable());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
@@ -231,19 +231,9 @@ public class AbstractDirectTaskTest extends RxJavaTest {
                 }
             };
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    task.dispose();
-                }
-            };
+            Runnable r1 = () -> task.dispose();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    task.setFuture(ft);
-                }
-            };
+            Runnable r2 = () -> task.setFuture(ft);
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/BlockingSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/BlockingSchedulerTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.Flowable;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.disposables.Disposable;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -40,21 +39,13 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    Flowable.range(1, 5)
-                    .subscribeOn(scheduler)
-                    .doAfterTerminate(new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            scheduler.shutdown();
-                        }
-                    })
-                    .subscribe(ts);
+            scheduler.execute(() -> {
+                Flowable.range(1, 5)
+                .subscribeOn(scheduler)
+                .doAfterTerminate(() -> scheduler.shutdown())
+                .subscribe(ts);
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertResult(1, 2, 3, 4, 5);
@@ -70,21 +61,13 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final var scheduler = Schedulers.createBlocking();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    Flowable.range(1, 5)
-                    .subscribeOn(scheduler.scheduler())
-                    .doAfterTerminate(new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            scheduler.shutdown();
-                        }
-                    })
-                    .subscribe(ts);
+            scheduler.execute(() -> {
+                Flowable.range(1, 5)
+                .subscribeOn(scheduler.scheduler())
+                .doAfterTerminate(() -> scheduler.shutdown())
+                .subscribe(ts);
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertResult(1, 2, 3, 4, 5);
@@ -100,22 +83,14 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    Flowable.range(1, 5)
-                    .subscribeOn(scheduler)
-                    .delay(100, TimeUnit.MILLISECONDS, scheduler)
-                    .doAfterTerminate(new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            scheduler.shutdown();
-                        }
-                    })
-                    .subscribe(ts);
+            scheduler.execute(() -> {
+                Flowable.range(1, 5)
+                .subscribeOn(scheduler)
+                .delay(100, TimeUnit.MILLISECONDS, scheduler)
+                .doAfterTerminate(() -> scheduler.shutdown())
+                .subscribe(ts);
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertResult(1, 2, 3, 4, 5);
@@ -130,18 +105,10 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            scheduler.shutdown();
-                            throw new IllegalArgumentException();
-                        }
-                    });
-                }
-            });
+            scheduler.execute(() -> scheduler.scheduleDirect(() -> {
+                scheduler.shutdown();
+                throw new IllegalArgumentException();
+            }));
 
             TestHelper.assertError(errors, 0, IllegalArgumentException.class);
         } finally {
@@ -154,19 +121,13 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    final Worker worker = scheduler.createWorker();
-                    worker.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            worker.dispose();
-                            scheduler.shutdown();
-                            throw new IllegalArgumentException();
-                        }
-                    });
-                }
+            scheduler.execute(() -> {
+                final Worker worker = scheduler.createWorker();
+                worker.schedule(() -> {
+                    worker.dispose();
+                    scheduler.shutdown();
+                    throw new IllegalArgumentException();
+                });
             });
 
             TestHelper.assertError(errors, 0, IllegalArgumentException.class);
@@ -180,27 +141,21 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    ts.onSubscribe(new BooleanSubscription());
+            scheduler.execute(() -> {
+                ts.onSubscribe(new BooleanSubscription());
 
-                    scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            ts.onNext(1);
-                            ts.onNext(2);
-                            ts.onNext(3);
-                            ts.onNext(4);
-                            ts.onNext(5);
-                            ts.onComplete();
+                scheduler.scheduleDirect(() -> {
+                    ts.onNext(1);
+                    ts.onNext(2);
+                    ts.onNext(3);
+                    ts.onNext(4);
+                    ts.onNext(5);
+                    ts.onComplete();
 
-                            scheduler.shutdown();
-                        }
-                    });
+                    scheduler.shutdown();
+                });
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertResult(1, 2, 3, 4, 5);
@@ -218,27 +173,21 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    ts.onSubscribe(new BooleanSubscription());
+            scheduler.execute(() -> {
+                ts.onSubscribe(new BooleanSubscription());
 
-                    scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            ts.onNext(1);
-                            ts.onNext(2);
-                            ts.onNext(3);
-                            ts.onNext(4);
-                            ts.onNext(5);
-                            ts.onComplete();
+                scheduler.scheduleDirect(() -> {
+                    ts.onNext(1);
+                    ts.onNext(2);
+                    ts.onNext(3);
+                    ts.onNext(4);
+                    ts.onNext(5);
+                    ts.onComplete();
 
-                            scheduler.shutdown();
-                        }
-                    }, 100, TimeUnit.MILLISECONDS);
+                    scheduler.shutdown();
+                }, 100, TimeUnit.MILLISECONDS);
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertResult(1, 2, 3, 4, 5);
@@ -253,36 +202,25 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    ts.onSubscribe(new BooleanSubscription());
+            scheduler.execute(() -> {
+                ts.onSubscribe(new BooleanSubscription());
 
-                    Disposable d = scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            ts.onNext(1);
-                            ts.onNext(2);
-                            ts.onNext(3);
-                            ts.onNext(4);
-                            ts.onNext(5);
-                            ts.onComplete();
-                        }
-                    }, 100, TimeUnit.MILLISECONDS);
+                Disposable d = scheduler.scheduleDirect(() -> {
+                    ts.onNext(1);
+                    ts.onNext(2);
+                    ts.onNext(3);
+                    ts.onNext(4);
+                    ts.onNext(5);
+                    ts.onComplete();
+                }, 100, TimeUnit.MILLISECONDS);
 
-                    assertFalse(d.isDisposed());
-                    d.dispose();
-                    assertTrue(d.isDisposed());
+                assertFalse(d.isDisposed());
+                d.dispose();
+                assertTrue(d.isDisposed());
 
-                    scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            scheduler.shutdown();
-                        }
-                    });
+                scheduler.scheduleDirect(() -> scheduler.shutdown());
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertEmpty();
@@ -297,36 +235,25 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    ts.onSubscribe(new BooleanSubscription());
+            scheduler.execute(() -> {
+                ts.onSubscribe(new BooleanSubscription());
 
-                    Disposable d = scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            ts.onNext(1);
-                            ts.onNext(2);
-                            ts.onNext(3);
-                            ts.onNext(4);
-                            ts.onNext(5);
-                            ts.onComplete();
-                        }
-                    });
+                Disposable d = scheduler.scheduleDirect(() -> {
+                    ts.onNext(1);
+                    ts.onNext(2);
+                    ts.onNext(3);
+                    ts.onNext(4);
+                    ts.onNext(5);
+                    ts.onComplete();
+                });
 
-                    assertFalse(d.isDisposed());
-                    d.dispose();
-                    assertTrue(d.isDisposed());
+                assertFalse(d.isDisposed());
+                d.dispose();
+                assertTrue(d.isDisposed());
 
-                    scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            scheduler.shutdown();
-                        }
-                    });
+                scheduler.scheduleDirect(() -> scheduler.shutdown());
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertEmpty();
@@ -341,40 +268,31 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
+            scheduler.execute(() -> {
 
-                    ts.onSubscribe(new BooleanSubscription());
+                ts.onSubscribe(new BooleanSubscription());
 
-                    final Worker w = scheduler.createWorker();
+                final Worker w = scheduler.createWorker();
 
-                    Disposable d = w.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            ts.onNext(1);
-                            ts.onNext(2);
-                            ts.onNext(3);
-                            ts.onNext(4);
-                            ts.onNext(5);
-                            ts.onComplete();
-                        }
-                    }, 100, TimeUnit.MILLISECONDS);
+                Disposable d = w.schedule(() -> {
+                    ts.onNext(1);
+                    ts.onNext(2);
+                    ts.onNext(3);
+                    ts.onNext(4);
+                    ts.onNext(5);
+                    ts.onComplete();
+                }, 100, TimeUnit.MILLISECONDS);
 
-                    assertFalse(d.isDisposed());
-                    d.dispose();
-                    assertTrue(d.isDisposed());
+                assertFalse(d.isDisposed());
+                d.dispose();
+                assertTrue(d.isDisposed());
 
-                    w.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            w.dispose();
-                            scheduler.shutdown();
-                        }
-                    });
+                w.schedule(() -> {
+                    w.dispose();
+                    scheduler.shutdown();
+                });
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertEmpty();
@@ -389,42 +307,33 @@ public class BlockingSchedulerTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
+            scheduler.execute(() -> {
 
-                    ts.onSubscribe(new BooleanSubscription());
+                ts.onSubscribe(new BooleanSubscription());
 
-                    final Worker w = scheduler.createWorker();
+                final Worker w = scheduler.createWorker();
 
-                    Disposable d = w.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            ts.onNext(1);
-                            ts.onNext(2);
-                            ts.onNext(3);
-                            ts.onNext(4);
-                            ts.onNext(5);
-                            ts.onComplete();
-                        }
-                    });
+                Disposable d = w.schedule(() -> {
+                    ts.onNext(1);
+                    ts.onNext(2);
+                    ts.onNext(3);
+                    ts.onNext(4);
+                    ts.onNext(5);
+                    ts.onComplete();
+                });
 
-                    assertFalse(d.isDisposed());
-                    d.dispose();
-                    assertTrue(d.isDisposed());
+                assertFalse(d.isDisposed());
+                d.dispose();
+                assertTrue(d.isDisposed());
 
-                    w.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            w.dispose();
-                            scheduler.shutdown();
+                w.schedule(() -> {
+                    w.dispose();
+                    scheduler.shutdown();
 
-                            assertTrue(w.isDisposed());
-                        }
-                    });
+                    assertTrue(w.isDisposed());
+                });
 
-                    ts.assertEmpty();
-                }
+                ts.assertEmpty();
             });
 
             ts.assertEmpty();
@@ -440,14 +349,11 @@ public class BlockingSchedulerTest {
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
 
-            Schedulers.single().scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    scheduler.scheduleDirect(Functions.EMPTY_RUNNABLE);
-                    scheduler.shutdown();
-                    scheduler.shutdown();
-                    assertTrue(scheduler.scheduleDirect(Functions.EMPTY_RUNNABLE).isDisposed());
-                }
+            Schedulers.single().scheduleDirect(() -> {
+                scheduler.scheduleDirect(Functions.EMPTY_RUNNABLE);
+                scheduler.shutdown();
+                scheduler.shutdown();
+                assertTrue(scheduler.scheduleDirect(Functions.EMPTY_RUNNABLE).isDisposed());
             }, 500, TimeUnit.MILLISECONDS);
 
             scheduler.execute(() -> { });
@@ -464,12 +370,9 @@ public class BlockingSchedulerTest {
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
 
-            Schedulers.single().scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    scheduler.shutdown.set(true);
-                    scheduler.thread.interrupt();
-                }
+            Schedulers.single().scheduleDirect(() -> {
+                scheduler.shutdown.set(true);
+                scheduler.thread.interrupt();
             }, 500, TimeUnit.MILLISECONDS);
 
             scheduler.execute(() -> { });
@@ -486,31 +389,22 @@ public class BlockingSchedulerTest {
         try {
             final BlockingCurrentThreadScheduler scheduler = new BlockingCurrentThreadScheduler();
 
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
+            scheduler.execute(() -> {
 
-                    final Disposable d = scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                Thread.sleep(2000);
-                            } catch (InterruptedException ex) {
-                                // ignored
-                                Thread.currentThread().interrupt();
-                            }
-                            scheduler.shutdown();
-                        }
-                    });
+                final Disposable d = scheduler.scheduleDirect(() -> {
+                    try {
+                        Thread.sleep(2000);
+                    } catch (InterruptedException ex) {
+                        // ignored
+                        Thread.currentThread().interrupt();
+                    }
+                    scheduler.shutdown();
+                });
 
-                    Schedulers.single().scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            d.dispose();
-                            d.dispose();
-                        }
-                    }, 500, TimeUnit.MILLISECONDS);
-                }
+                Schedulers.single().scheduleDirect(() -> {
+                    d.dispose();
+                    d.dispose();
+                }, 500, TimeUnit.MILLISECONDS);
             });
 
             assertTrue(errors.toString(), errors.isEmpty());
@@ -529,30 +423,12 @@ public class BlockingSchedulerTest {
 
             final int[] counter = { 0 };
 
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    Schedulers.single().scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            for (int i = 0; i < n; i++) {
-                                scheduler.scheduleDirect(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        counter[0]++;
-                                    }
-                                });
-                            }
-                            scheduler.scheduleDirect(new Runnable() {
-                                @Override
-                                public void run() {
-                                    scheduler.shutdown();
-                                }
-                            });
-                        }
-                    });
+            scheduler.execute(() -> Schedulers.single().scheduleDirect(() -> {
+                for (int i = 0; i < n; i++) {
+                    scheduler.scheduleDirect(() -> counter[0]++);
                 }
-            });
+                scheduler.scheduleDirect(() -> scheduler.shutdown());
+            }));
 
             assertEquals(n, counter[0]);
             assertTrue(errors.toString(), errors.isEmpty());
@@ -571,24 +447,11 @@ public class BlockingSchedulerTest {
 
             final int[] counter = { 0 };
 
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    for (int i = 0; i < n; i++) {
-                        scheduler.scheduleDirect(new Runnable() {
-                            @Override
-                            public void run() {
-                                counter[0]++;
-                            }
-                        }, i, TimeUnit.MILLISECONDS);
-                    }
-                    scheduler.scheduleDirect(new Runnable() {
-                        @Override
-                        public void run() {
-                            scheduler.shutdown();
-                        }
-                    }, n + 10, TimeUnit.MILLISECONDS);
+            scheduler.execute(() -> {
+                for (int i = 0; i < n; i++) {
+                    scheduler.scheduleDirect(() -> counter[0]++, i, TimeUnit.MILLISECONDS);
                 }
+                scheduler.scheduleDirect(() -> scheduler.shutdown(), n + 10, TimeUnit.MILLISECONDS);
             });
 
             assertEquals(n, counter[0]);
@@ -607,26 +470,11 @@ public class BlockingSchedulerTest {
             final Thread t0 = Thread.currentThread();
             final Thread[] t1 = { null };
 
-            scheduler.execute(new Action() {
-                @Override
-                public void run() throws Exception {
-                    Flowable.just(1)
-                    .subscribeOn(Schedulers.cached())
-                    .observeOn(scheduler)
-                    .doAfterTerminate(new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            scheduler.shutdown();
-                        }
-                    })
-                    .subscribe(new Consumer<Integer>() {
-                        @Override
-                        public void accept(Integer v) throws Exception {
-                            t1[0] = Thread.currentThread();
-                        }
-                    });
-                }
-            });
+            scheduler.execute(() -> Flowable.just(1)
+            .subscribeOn(Schedulers.cached())
+            .observeOn(scheduler)
+            .doAfterTerminate(() -> scheduler.shutdown())
+            .subscribe(_ -> t1[0] = Thread.currentThread()));
 
             assertSame(t0, t1[0]);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
@@ -30,11 +30,8 @@ public class ExecutorSchedulerDelayedRunnableTest extends RxJavaTest {
     @SuppressUndeliverable
     public void delayedRunnableCrash() {
         @SuppressWarnings("resource")
-        DelayedRunnable dl = new DelayedRunnable(new Runnable() {
-            @Override
-            public void run() {
-                throw new TestException();
-            }
+        DelayedRunnable dl = new DelayedRunnable(() -> {
+            throw new TestException();
         });
         dl.run();
     }
@@ -43,12 +40,7 @@ public class ExecutorSchedulerDelayedRunnableTest extends RxJavaTest {
     public void dispose() {
         final AtomicInteger count = new AtomicInteger();
         @SuppressWarnings("resource")
-        DelayedRunnable dl = new DelayedRunnable(new Runnable() {
-            @Override
-            public void run() {
-                count.incrementAndGet();
-            }
-        });
+        DelayedRunnable dl = new DelayedRunnable(() -> count.incrementAndGet());
 
         dl.dispose();
         dl.dispose();

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ImmediateThinSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ImmediateThinSchedulerTest.java
@@ -29,12 +29,7 @@ public class ImmediateThinSchedulerTest extends RxJavaTest {
     public void scheduleDirect() {
         final int[] count = { 0 };
 
-        ImmediateThinScheduler.INSTANCE.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                count[0]++;
-            }
-        });
+        ImmediateThinScheduler.INSTANCE.scheduleDirect(() -> count[0]++);
 
         assertEquals(1, count[0]);
     }
@@ -57,12 +52,7 @@ public class ImmediateThinSchedulerTest extends RxJavaTest {
 
         assertFalse(w.isDisposed());
 
-        w.schedule(new Runnable() {
-            @Override
-            public void run() {
-                count[0]++;
-            }
-        });
+        w.schedule(() -> count[0]++);
 
         assertEquals(1, count[0]);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/BoundedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/BoundedSubscriberTest.java
@@ -22,7 +22,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -35,27 +34,11 @@ public class BoundedSubscriberTest extends RxJavaTest {
     public void onSubscribeThrows() {
         final List<Object> received = new ArrayList<>();
 
-        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object o) throws Exception {
-                received.add(o);
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable throwable) throws Exception {
-                received.add(throwable);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(1);
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription subscription) throws Exception {
-                throw new TestException();
-            }
-        }, 128);
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(o -> received.add(o),
+                throwable -> received.add(throwable),
+                () -> received.add(1), _ -> {
+                    throw new TestException();
+                }, 128);
 
         assertFalse(subscriber.isDisposed());
 
@@ -71,27 +54,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
     public void onNextThrows() {
         final List<Object> received = new ArrayList<>();
 
-        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object o) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable throwable) throws Exception {
-                received.add(throwable);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(1);
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription subscription) throws Exception {
-                subscription.request(128);
-            }
-        }, 128);
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(_ -> {
+            throw new TestException();
+        }, throwable -> received.add(throwable), () -> received.add(1), subscription -> subscription.request(128), 128);
 
         assertFalse(subscriber.isDisposed());
 
@@ -110,27 +75,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
         try {
             final List<Object> received = new ArrayList<>();
 
-            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
-                @Override
-                public void accept(Object o) throws Exception {
-                    received.add(o);
-                }
-            }, new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable throwable) throws Exception {
-                    throw new TestException("Inner");
-                }
-            }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    received.add(1);
-                }
-            }, new Consumer<Subscription>() {
-                @Override
-                public void accept(Subscription subscription) throws Exception {
-                    subscription.request(128);
-                }
-            }, 128);
+            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(o -> received.add(o), _ -> {
+                throw new TestException("Inner");
+            }, () -> received.add(1), subscription -> subscription.request(128), 128);
 
             assertFalse(subscriber.isDisposed());
 
@@ -156,27 +103,9 @@ public class BoundedSubscriberTest extends RxJavaTest {
         try {
             final List<Object> received = new ArrayList<>();
 
-            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
-                @Override
-                public void accept(Object o) throws Exception {
-                    received.add(o);
-                }
-            }, new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable throwable) throws Exception {
-                    received.add(throwable);
-                }
-            }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
-            }, new Consumer<Subscription>() {
-                @Override
-                public void accept(Subscription subscription) throws Exception {
-                    subscription.request(128);
-                }
-            }, 128);
+            BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(o -> received.add(o), throwable -> received.add(throwable), () -> {
+                throw new TestException();
+            }, subscription -> subscription.request(128), 128);
 
             assertFalse(subscriber.isDisposed());
 
@@ -198,27 +127,11 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
         final List<Throwable> errors = new ArrayList<>();
 
-        BoundedSubscriber<Integer> s = new BoundedSubscriber<>(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                errors.add(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
+        BoundedSubscriber<Integer> s = new BoundedSubscriber<>(_ -> {
+            throw new TestException();
+        }, e -> errors.add(e), () -> {
 
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription subscription) throws Exception {
-                subscription.request(128);
-            }
-        }, 128);
+        }, subscription -> subscription.request(128), 128);
 
         pp.subscribe(s);
 
@@ -239,24 +152,10 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
         final List<Throwable> errors = new ArrayList<>();
 
-        BoundedSubscriber<Integer> s = new BoundedSubscriber<>(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                errors.add(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                throw new TestException();
-            }
+        BoundedSubscriber<Integer> s = new BoundedSubscriber<>(_ -> {
+        }, e -> errors.add(e), () -> {
+        }, _ -> {
+            throw new TestException();
         }, 128);
 
         pp.subscribe(s);
@@ -269,45 +168,22 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void badSourceOnSubscribe() {
-        Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                BooleanSubscription s1 = new BooleanSubscription();
-                s.onSubscribe(s1);
-                BooleanSubscription s2 = new BooleanSubscription();
-                s.onSubscribe(s2);
+        Flowable<Integer> source = Flowable.fromPublisher(s -> {
+            BooleanSubscription s1 = new BooleanSubscription();
+            s.onSubscribe(s1);
+            BooleanSubscription s2 = new BooleanSubscription();
+            s.onSubscribe(s2);
 
-                assertFalse(s1.isCancelled());
-                assertTrue(s2.isCancelled());
+            assertFalse(s1.isCancelled());
+            assertTrue(s2.isCancelled());
 
-                s.onNext(1);
-                s.onComplete();
-            }
+            s.onNext(1);
+            s.onComplete();
         });
 
         final List<Object> received = new ArrayList<>();
 
-        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                received.add(v);
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                s.request(128);
-            }
-        }, 128);
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(v -> received.add(v), e -> received.add(e), () -> received.add(100), s -> s.request(128), 128);
 
         source.subscribe(subscriber);
 
@@ -317,43 +193,20 @@ public class BoundedSubscriberTest extends RxJavaTest {
     @Test
     @SuppressUndeliverable
     public void badSourceEmitAfterDone() {
-        Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                BooleanSubscription s1 = new BooleanSubscription();
-                s.onSubscribe(s1);
+        Flowable<Integer> source = Flowable.fromPublisher(s -> {
+            BooleanSubscription s1 = new BooleanSubscription();
+            s.onSubscribe(s1);
 
-                s.onNext(1);
-                s.onComplete();
-                s.onNext(2);
-                s.onError(new TestException());
-                s.onComplete();
-            }
+            s.onNext(1);
+            s.onComplete();
+            s.onNext(2);
+            s.onError(new TestException());
+            s.onComplete();
         });
 
         final List<Object> received = new ArrayList<>();
 
-        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                received.add(v);
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                received.add(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                s.request(128);
-            }
-        }, 128);
+        BoundedSubscriber<Object> subscriber = new BoundedSubscriber<>(v -> received.add(v), e -> received.add(e), () -> received.add(100), s -> s.request(128), 128);
 
         source.subscribe(subscriber);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -314,14 +314,11 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
                 final AtomicInteger ready = new AtomicInteger(2);
 
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        ready.decrementAndGet();
-                        while (ready.get() != 0) { }
+                w.schedule(() -> {
+                    ready.decrementAndGet();
+                    while (ready.get() != 0) { }
 
-                        ts.request(1);
-                    }
+                    ts.request(1);
                 });
 
                 ready.decrementAndGet();
@@ -358,24 +355,18 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
                 final AtomicInteger ready = new AtomicInteger(3);
 
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        ready.decrementAndGet();
-                        while (ready.get() != 0) { }
+                w.schedule(() -> {
+                    ready.decrementAndGet();
+                    while (ready.get() != 0) { }
 
-                        ts.request(1);
-                    }
+                    ts.request(1);
                 });
 
-                w2.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        ready.decrementAndGet();
-                        while (ready.get() != 0) { }
+                w2.schedule(() -> {
+                    ready.decrementAndGet();
+                    while (ready.get() != 0) { }
 
-                        ts.request(1);
-                    }
+                    ts.request(1);
                 });
 
                 ready.decrementAndGet();

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/FlowableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/FlowableConsumersTest.java
@@ -212,11 +212,8 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
     public void onNextCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            subscribeAutoDispose(processor, composite, new Consumer<Object>() {
-                @Override
-                public void accept(Object t) throws Exception {
-                    throw new IOException();
-                }
+            subscribeAutoDispose(processor, composite, (Consumer<Object>) _ -> {
+                throw new IOException();
             }, this, this);
 
             processor.onNext(1);
@@ -233,11 +230,8 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
     public void onNextCrashOnError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            subscribeAutoDispose(processor, composite, this, new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) throws Exception {
-                    throw new IOException(t);
-                }
+            subscribeAutoDispose(processor, composite, this, t -> {
+                throw new IOException(t);
             }, this);
 
             processor.onError(new IllegalArgumentException());
@@ -257,11 +251,8 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
     public void onNextCrashNoError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            subscribeAutoDispose(processor, composite, new Consumer<Object>() {
-                @Override
-                public void accept(Object t) throws Exception {
-                    throw new IOException();
-                }
+            subscribeAutoDispose(processor, composite, (Consumer<Object>) _ -> {
+                throw new IOException();
             }, Functions.ON_ERROR_MISSING, () -> { });
 
             processor.onNext(1);
@@ -279,11 +270,8 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
     public void onCompleteCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            subscribeAutoDispose(processor, composite, this, this, new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            subscribeAutoDispose(processor, composite, this, this, () -> {
+                throw new IOException();
             });
 
             processor.onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/subscriptions/ArrayCompositeSubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscriptions/ArrayCompositeSubscriptionTest.java
@@ -100,12 +100,7 @@ public class ArrayCompositeSubscriptionTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1000);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    ac.dispose();
-                }
-            };
+            Runnable r = () -> ac.dispose();
 
             TestHelper.race(r, r);
         }
@@ -120,19 +115,9 @@ public class ArrayCompositeSubscriptionTest extends RxJavaTest {
             final BooleanSubscription s1 = new BooleanSubscription();
             final BooleanSubscription s2 = new BooleanSubscription();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ac.setResource(0, s1);
-                }
-            };
+            Runnable r1 = () -> ac.setResource(0, s1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ac.replaceResource(0, s2);
-                }
-            };
+            Runnable r2 = () -> ac.replaceResource(0, s2);
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscriptions/DeferredScalarSubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscriptions/DeferredScalarSubscriptionTest.java
@@ -57,19 +57,9 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final DeferredScalarSubscription<Integer> ds = new DeferredScalarSubscription<>(new TestSubscriber<>());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ds.complete(1);
-                }
-            };
+            Runnable r1 = () -> ds.complete(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ds.cancel();
-                }
-            };
+            Runnable r2 = () -> ds.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -84,19 +74,9 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
             ts.onSubscribe(ds);
             ds.complete(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ds.request(1);
-                }
-            };
+            Runnable r1 = () -> ds.request(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ds.value = null;
-                }
-            };
+            Runnable r2 = () -> ds.value = null;
 
             TestHelper.race(r1, r2);
 
@@ -115,19 +95,9 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
             ts.onSubscribe(ds);
             ds.complete(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ds.request(1);
-                }
-            };
+            Runnable r1 = () -> ds.request(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ds.cancel();
-                }
-            };
+            Runnable r2 = () -> ds.cancel();
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/util/BackpressureHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/BackpressureHelperTest.java
@@ -84,19 +84,9 @@ public class BackpressureHelperTest extends RxJavaTest {
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    BackpressureHelper.produced(requested, 1);
-                }
-            };
+            Runnable r1 = () -> BackpressureHelper.produced(requested, 1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    BackpressureHelper.add(requested, 1);
-                }
-            };
+            Runnable r2 = () -> BackpressureHelper.add(requested, 1);
 
             TestHelper.race(r1, r2);
         }
@@ -108,19 +98,9 @@ public class BackpressureHelperTest extends RxJavaTest {
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    BackpressureHelper.produced(requested, 1);
-                }
-            };
+            Runnable r1 = () -> BackpressureHelper.produced(requested, 1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    BackpressureHelper.addCancel(requested, 1);
-                }
-            };
+            Runnable r2 = () -> BackpressureHelper.addCancel(requested, 1);
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/util/BlockingHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/BlockingHelperTest.java
@@ -52,12 +52,7 @@ public class BlockingHelperTest extends RxJavaTest {
         final CountDownLatch cdl = new CountDownLatch(1);
         Disposable d = Disposable.empty();
 
-        Schedulers.computation().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        }, 100, TimeUnit.MILLISECONDS);
+        Schedulers.computation().scheduleDirect(() -> cdl.countDown(), 100, TimeUnit.MILLISECONDS);
 
         BlockingHelper.awaitForComplete(cdl, d);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/util/ExceptionHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/ExceptionHelperTest.java
@@ -37,12 +37,7 @@ public class ExceptionHelperTest extends RxJavaTest {
 
             final TestException ex = new TestException();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    assertTrue(ExceptionHelper.addThrowable(error, ex));
-                }
-            };
+            Runnable r = () -> assertTrue(ExceptionHelper.addThrowable(error, ex));
 
             TestHelper.race(r, r);
         }

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTimerTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.schedulers.TestScheduler;
 
 public class MaybeTimerTest extends RxJavaTest {
@@ -30,12 +29,7 @@ public class MaybeTimerTest extends RxJavaTest {
         final TestScheduler testScheduler = new TestScheduler();
 
         final AtomicLong atomicLong = new AtomicLong();
-        Maybe.timer(2, TimeUnit.SECONDS, testScheduler).subscribe(new Consumer<Long>() {
-            @Override
-            public void accept(final Long value) throws Exception {
-                atomicLong.incrementAndGet();
-            }
-        });
+        Maybe.timer(2, TimeUnit.SECONDS, testScheduler).subscribe(_ -> atomicLong.incrementAndGet());
 
         assertEquals(0, atomicLong.get());
 

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableConcatTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableConcatTests.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.observable.ObservableCovarianceTest.*;
 
 public class ObservableConcatTests extends RxJavaTest {
@@ -145,14 +144,11 @@ public class ObservableConcatTests extends RxJavaTest {
         Media media = new Media();
         HorrorMovie horrorMovie2 = new HorrorMovie();
 
-        Observable<Movie> o1 = Observable.unsafeCreate(new ObservableSource<Movie>() {
-            @Override
-            public void subscribe(Observer<? super Movie> o) {
-                    o.onNext(horrorMovie1);
-                    o.onNext(movie);
-                    //                o.onNext(new Media()); // correctly doesn't compile
-                    o.onComplete();
-            }
+        Observable<Movie> o1 = Observable.unsafeCreate(o -> {
+                o.onNext(horrorMovie1);
+                o.onNext(movie);
+                //                o.onNext(new Media()); // correctly doesn't compile
+                o.onComplete();
         });
 
         Observable<Media> o2 = Observable.just(media, horrorMovie2);

--- a/src/test/java/io/reactivex/rxjava4/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/AsyncProcessorTest.java
@@ -25,7 +25,6 @@ import org.mockito.*;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -188,28 +187,19 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
             final AsyncProcessor<String> processor = AsyncProcessor.create();
             final AtomicReference<String> value1 = new AtomicReference<>();
 
-            processor.subscribe(new Consumer<String>() {
-
-                @Override
-                public void accept(String t1) {
-                    try {
-                        // simulate a slow observer
-                        Thread.sleep(50);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    value1.set(t1);
+            processor.subscribe(t1 -> {
+                try {
+                    // simulate a slow observer
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
-
+                value1.set(t1);
             });
 
-            Thread t1 = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    processor.onNext("value");
-                    processor.onComplete();
-                }
+            Thread t1 = new Thread(() -> {
+                processor.onNext("value");
+                processor.onComplete();
             });
 
             SubjectSubscriberThread t2 = new SubjectSubscriberThread(processor);
@@ -406,19 +396,9 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
             final TestSubscriber<Object> ts1 = p.test();
             final TestSubscriber<Object> ts2 = p.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = () -> ts1.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts2.cancel();
-                }
-            };
+            Runnable r2 = () -> ts2.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -433,21 +413,11 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriberEx<Object> ts1 = p.to(TestHelper.<Object>testConsumer());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = () -> ts1.cancel();
 
             final TestException ex = new TestException();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onError(ex);
-                }
-            };
+            Runnable r2 = () -> p.onError(ex);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
@@ -255,13 +255,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             src.onNext(v);
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
-                .flatMap(new Function<String, Flowable<String>>() {
-
-                    @Override
-                    public Flowable<String> apply(String t1) {
-                        return Flowable.just(t1 + ", " + t1);
-                    }
-                })
+                .flatMap((Function<String, Flowable<String>>) t1 -> Flowable.just(t1 + ", " + t1))
                 .subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onNext(String t) {
@@ -377,16 +371,13 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                 final CountDownLatch finish = new CountDownLatch(1);
                 final CountDownLatch start = new CountDownLatch(1);
 
-                worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            start.await();
-                        } catch (Exception e1) {
-                            e1.printStackTrace();
-                        }
-                        rs.onNext(1);
+                worker.schedule(() -> {
+                    try {
+                        start.await();
+                    } catch (Exception e1) {
+                        e1.printStackTrace();
                     }
+                    rs.onNext(1);
                 });
 
                 final AtomicReference<Object> o = new AtomicReference<>();
@@ -423,12 +414,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                     break;
                 } else {
                     Assert.assertEquals(1, o.get());
-                    worker.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            rs.onComplete();
-                        }
-                    });
+                    worker.schedule(() -> rs.onComplete());
                 }
             }
         } finally {
@@ -594,19 +580,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriber<Object> ts = p.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    p.test();
-                }
-            };
+            Runnable r1 = () -> p.test();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -621,19 +597,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             final TestSubscriber<Object> ts2 = p.test();
             final TestSubscriber<Object> ts3 = p.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = () -> ts1.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts2.cancel();
-                }
-            };
+            Runnable r2 = () -> ts2.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -650,19 +616,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriber[] ts = { null };
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts[0] = p.test();
-                }
-            };
+            Runnable r1 = () -> ts[0] = p.test();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onNext(2);
-                }
-            };
+            Runnable r2 = () -> p.onNext(2);
 
             TestHelper.race(r1, r2);
 
@@ -717,22 +673,19 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
     public void offerAsync() throws Exception {
         final BehaviorProcessor<Integer> pp = BehaviorProcessor.create();
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                while (!pp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
+        Schedulers.single().scheduleDirect(() -> {
+            while (!pp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
-
-                for (int i = 1; i <= 10; i++) {
-                    while (!pp.offer(i)) { }
-                }
-                pp.onComplete();
             }
+
+            for (int i = 1; i <= 10; i++) {
+                while (!pp.offer(i)) { }
+            }
+            pp.onComplete();
         });
 
         Thread.sleep(1);
@@ -749,19 +702,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    p.subscribe(ts);
-                }
-            };
+            Runnable r1 = () -> p.subscribe(ts);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onComplete();
-                }
-            };
+            Runnable r2 = () -> p.onComplete();
 
             TestHelper.race(r1, r2);
 
@@ -778,19 +721,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    p.subscribe(ts);
-                }
-            };
+            Runnable r1 = () -> p.subscribe(ts);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onError(ex);
-                }
-            };
+            Runnable r2 = () -> p.onError(ex);
 
             TestHelper.race(r1, r2);
 
@@ -805,21 +738,13 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriber<Integer> ts = pp.test(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int i = 0; i < 2; i++) {
-                        while (!pp.offer(i)) { }
-                    }
+            Runnable r1 = () -> {
+                for (int i1 = 0; i1 < 2; i1++) {
+                    while (!pp.offer(i1)) { }
                 }
             };
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -872,18 +797,8 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             final BehaviorSubscription<Integer> bs = new BehaviorSubscription<>(ts, bp);
             ts.onSubscribe(bs);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    bs.emitFirst();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    bs.cancel();
-                }
-            };
+            Runnable r1 = () -> bs.emitFirst();
+            Runnable r2 = () -> bs.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -901,18 +816,8 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             final BehaviorSubscription<Integer> bs = new BehaviorSubscription<>(ts, bp);
             ts.onSubscribe(bs);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    bs.emitNext(2, 0);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    bs.cancel();
-                }
-            };
+            Runnable r1 = () -> bs.emitNext(2, 0);
+            Runnable r2 = () -> bs.cancel();
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -23,7 +23,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.subscribers.*;
 
 /**
@@ -47,12 +46,9 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch latch = new CountDownLatch(1);
 
         Flowable.interval(50, TimeUnit.MILLISECONDS)
-                .map(new Function<Long, Long>() {
-                    @Override
-                    public Long apply(Long aLong) {
-                        countGenerated.incrementAndGet();
-                        return aLong;
-                    }
+                .map(aLong -> {
+                    countGenerated.incrementAndGet();
+                    return aLong;
                 })
                 .subscribeOn(getScheduler())
                 .observeOn(getScheduler())
@@ -371,14 +367,10 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
 
         Flowable<Integer> f1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
 
-        f1.subscribe(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t) {
-                System.out.println("Thread: " + Thread.currentThread().getName());
-                System.out.println("t: " + t);
-                count.incrementAndGet();
-            }
+        f1.subscribe(t -> {
+            System.out.println("Thread: " + Thread.currentThread().getName());
+            System.out.println("t: " + t);
+            count.incrementAndGet();
         });
 
         // the above should be blocking so we should see a count of 5
@@ -394,23 +386,19 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch latch = new CountDownLatch(5);
         final CountDownLatch first = new CountDownLatch(1);
 
-        f1.subscribeOn(scheduler).subscribe(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t) {
-                try {
-                    // we block the first one so we can assert this executes asynchronously with a count
-                    first.await(1000, TimeUnit.SECONDS);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException("The latch should have released if we are async.", e);
-                }
-
-                assertNotEquals(Thread.currentThread().getName(), currentThreadName);
-                System.out.println("Thread: " + Thread.currentThread().getName());
-                System.out.println("t: " + t);
-                count.incrementAndGet();
-                latch.countDown();
+        f1.subscribeOn(scheduler).subscribe(t -> {
+            try {
+                // we block the first one so we can assert this executes asynchronously with a count
+                first.await(1000, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                throw new RuntimeException("The latch should have released if we are async.", e);
             }
+
+            assertNotEquals(Thread.currentThread().getName(), currentThreadName);
+            System.out.println("Thread: " + Thread.currentThread().getName());
+            System.out.println("t: " + t);
+            count.incrementAndGet();
+            latch.countDown();
         });
 
         // assert we are async

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerTests.java
@@ -22,8 +22,6 @@ import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -65,30 +63,21 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             final Runnable thirdStepStart = mock(Runnable.class);
             final Runnable thirdStepEnd = mock(Runnable.class);
 
-            final Runnable firstAction = new Runnable() {
-                @Override
-                public void run() {
-                    firstStepStart.run();
-                    firstStepEnd.run();
-                    latch.countDown();
-                }
+            final Runnable firstAction = () -> {
+                firstStepStart.run();
+                firstStepEnd.run();
+                latch.countDown();
             };
-            final Runnable secondAction = new Runnable() {
-                @Override
-                public void run() {
-                    secondStepStart.run();
-                    inner.schedule(firstAction);
-                    secondStepEnd.run();
+            final Runnable secondAction = () -> {
+                secondStepStart.run();
+                inner.schedule(firstAction);
+                secondStepEnd.run();
 
-                }
             };
-            final Runnable thirdAction = new Runnable() {
-                @Override
-                public void run() {
-                    thirdStepStart.run();
-                    inner.schedule(secondAction);
-                    thirdStepEnd.run();
-                }
+            final Runnable thirdAction = () -> {
+                thirdStepStart.run();
+                inner.schedule(secondAction);
+                thirdStepEnd.run();
             };
 
             InOrder inOrder = inOrder(firstStepStart, firstStepEnd, secondStepStart, secondStepEnd, thirdStepStart, thirdStepEnd);
@@ -113,21 +102,8 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
         Flowable<Integer> ids = Flowable.fromIterable(Arrays.asList(1, 2)).subscribeOn(getScheduler());
 
-        Flowable<String> m = ids.flatMap(new Function<Integer, Flowable<String>>() {
-
-            @Override
-            public Flowable<String> apply(Integer id) {
-                return Flowable.fromIterable(Arrays.asList("a-" + id, "b-" + id)).subscribeOn(getScheduler())
-                        .map(new Function<String, String>() {
-
-                            @Override
-                            public String apply(String s) {
-                                return "names=>" + s;
-                            }
-                        });
-            }
-
-        });
+        Flowable<String> m = ids.flatMap((Function<Integer, Flowable<String>>) id -> Flowable.fromIterable(Arrays.asList("a-" + id, "b-" + id)).subscribeOn(getScheduler())
+                .map(s -> "names=>" + s));
 
         List<String> strings = m.toList().blockingGet();
 
@@ -144,7 +120,6 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
      *
      * @throws InterruptedException if the await is interrupted
      */
-    @SuppressWarnings("rawtypes")
     @Test
     public final void sequenceOfActions() throws InterruptedException {
         final Scheduler scheduler = getScheduler();
@@ -155,26 +130,18 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             final Runnable second = mock(Runnable.class);
 
             // make it wait until both the first and second are called
-            doAnswer(new Answer() {
-
-                @Override
-                public Object answer(InvocationOnMock invocation) throws Throwable {
-                    try {
-                        return invocation.getMock();
-                    } finally {
-                        latch.countDown();
-                    }
+            doAnswer(invocation -> {
+                try {
+                    return invocation.getMock();
+                } finally {
+                    latch.countDown();
                 }
             }).when(first).run();
-            doAnswer(new Answer() {
-
-                @Override
-                public Object answer(InvocationOnMock invocation) throws Throwable {
-                    try {
-                        return invocation.getMock();
-                    } finally {
-                        latch.countDown();
-                    }
+            doAnswer(invocation -> {
+                try {
+                    return invocation.getMock();
+                } finally {
+                    latch.countDown();
                 }
             }).when(second).run();
 
@@ -200,19 +167,10 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             final Runnable first = mock(Runnable.class);
             final Runnable second = mock(Runnable.class);
 
-            inner.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    inner.schedule(first, 30, TimeUnit.MILLISECONDS);
-                    inner.schedule(second, 10, TimeUnit.MILLISECONDS);
-                    inner.schedule(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            latch.countDown();
-                        }
-                    }, 40, TimeUnit.MILLISECONDS);
-                }
+            inner.schedule(() -> {
+                inner.schedule(first, 30, TimeUnit.MILLISECONDS);
+                inner.schedule(second, 10, TimeUnit.MILLISECONDS);
+                inner.schedule(() -> latch.countDown(), 40, TimeUnit.MILLISECONDS);
             });
 
             latch.await();
@@ -237,21 +195,12 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             final Runnable third = mock(Runnable.class);
             final Runnable fourth = mock(Runnable.class);
 
-            inner.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    inner.schedule(first);
-                    inner.schedule(second, 300, TimeUnit.MILLISECONDS);
-                    inner.schedule(third, 100, TimeUnit.MILLISECONDS);
-                    inner.schedule(fourth);
-                    inner.schedule(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            latch.countDown();
-                        }
-                    }, 400, TimeUnit.MILLISECONDS);
-                }
+            inner.schedule(() -> {
+                inner.schedule(first);
+                inner.schedule(second, 300, TimeUnit.MILLISECONDS);
+                inner.schedule(third, 100, TimeUnit.MILLISECONDS);
+                inner.schedule(fourth);
+                inner.schedule(() -> latch.countDown(), 400, TimeUnit.MILLISECONDS);
             });
 
             latch.await();
@@ -360,13 +309,9 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
         });
 
         final AtomicInteger lastValue = new AtomicInteger();
-        obs.blockingForEach(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer v) {
-                System.out.println("Value: " + v);
-                lastValue.set(v);
-            }
+        obs.blockingForEach(v -> {
+            System.out.println("Value: " + v);
+            lastValue.set(v);
         });
 
         assertEquals(42, lastValue.get());
@@ -376,23 +321,15 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
     public final void concurrentOnNextFailsValidation() throws InterruptedException {
         final int count = 10;
         final CountDownLatch latch = new CountDownLatch(count);
-        Flowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
+        Flowable<String> f = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            for (int i = 0; i < count; i++) {
+                final int v = i;
+                new Thread(() -> {
+                    subscriber.onNext("v: " + v);
 
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                for (int i = 0; i < count; i++) {
-                    final int v = i;
-                    new Thread(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            subscriber.onNext("v: " + v);
-
-                            latch.countDown();
-                        }
-                    }).start();
-                }
+                    latch.countDown();
+                }).start();
             }
         });
 
@@ -434,21 +371,11 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
         final Scheduler scheduler = getScheduler();
 
         Flowable<String> f = Flowable.fromArray("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten")
-                .flatMap(new Function<String, Flowable<String>>() {
-
-                    @Override
-                    public Flowable<String> apply(final String v) {
-                        return Flowable.unsafeCreate(new Publisher<String>() {
-
-                            @Override
-                            public void subscribe(Subscriber<? super String> subscriber) {
-                                subscriber.onSubscribe(new BooleanSubscription());
-                                subscriber.onNext("value_after_map-" + v);
-                                subscriber.onComplete();
-                            }
-                        }).subscribeOn(scheduler);
-                    }
-                });
+                .flatMap((Function<String, Flowable<String>>) v -> Flowable.unsafeCreate((Publisher<String>) subscriber -> {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    subscriber.onNext("value_after_map-" + v);
+                    subscriber.onComplete();
+                }).subscribeOn(scheduler));
 
         ConcurrentObserverValidator<String> observer = new ConcurrentObserverValidator<>();
 
@@ -513,12 +440,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
         final CountDownLatch cdl = new CountDownLatch(1);
 
-        s.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        });
+        s.scheduleDirect(() -> cdl.countDown());
 
         assertTrue(cdl.await(5, TimeUnit.SECONDS));
     }
@@ -529,12 +451,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
         final CountDownLatch cdl = new CountDownLatch(1);
 
-        s.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        }, 50, TimeUnit.MILLISECONDS);
+        s.scheduleDirect(() -> cdl.countDown(), 50, TimeUnit.MILLISECONDS);
 
         assertTrue(cdl.await(5, TimeUnit.SECONDS));
     }
@@ -549,12 +466,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
         final CountDownLatch cdl = new CountDownLatch(5);
 
-        Disposable d = s.schedulePeriodicallyDirect(new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        }, 10, 10, TimeUnit.MILLISECONDS);
+        Disposable d = s.schedulePeriodicallyDirect(() -> cdl.countDown(), 10, 10, TimeUnit.MILLISECONDS);
 
         try {
             assertTrue(cdl.await(5, TimeUnit.SECONDS));
@@ -639,17 +551,9 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
         try {
             final CountDownLatch decoratedCalled = new CountDownLatch(1);
 
-            RxJavaPlugins.setScheduleHandler(new Function<Runnable, Runnable>() {
-                @Override
-                public Runnable apply(final Runnable actual) throws Exception {
-                    return new Runnable() {
-                        @Override
-                        public void run() {
-                            decoratedCalled.countDown();
-                            actual.run();
-                        }
-                    };
-                }
+            RxJavaPlugins.setScheduleHandler(actual -> (Runnable) () -> {
+                decoratedCalled.countDown();
+                actual.run();
             });
 
             scheduleCall.run();
@@ -662,22 +566,12 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
     @Test
     public void scheduleDirectDecoratesRunnable() throws InterruptedException {
-        assertRunnableDecorated(new Runnable() {
-            @Override
-            public void run() {
-                getScheduler().scheduleDirect(Functions.EMPTY_RUNNABLE);
-            }
-        });
+        assertRunnableDecorated((Runnable) () -> getScheduler().scheduleDirect(Functions.EMPTY_RUNNABLE));
     }
 
     @Test
     public void scheduleDirectWithDelayDecoratesRunnable() throws InterruptedException {
-        assertRunnableDecorated(new Runnable() {
-            @Override
-            public void run() {
-                getScheduler().scheduleDirect(Functions.EMPTY_RUNNABLE, 1, TimeUnit.MILLISECONDS);
-            }
-        });
+        assertRunnableDecorated((Runnable) () -> getScheduler().scheduleDirect(Functions.EMPTY_RUNNABLE, 1, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -691,12 +585,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
         final AtomicReference<Disposable> disposable = new AtomicReference<>();
 
         try {
-            assertRunnableDecorated(new Runnable() {
-                @Override
-                public void run() {
-                    disposable.set(scheduler.schedulePeriodicallyDirect(Functions.EMPTY_RUNNABLE, 1, 10000, TimeUnit.MILLISECONDS));
-                }
-            });
+            assertRunnableDecorated((Runnable) () -> disposable.set(scheduler.schedulePeriodicallyDirect(Functions.EMPTY_RUNNABLE, 1, 10000, TimeUnit.MILLISECONDS)));
         } finally {
             disposable.get().dispose();
         }
@@ -711,12 +600,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
         }
 
         final CountDownLatch cdl = new CountDownLatch(1);
-        Runnable countDownRunnable = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        Runnable countDownRunnable = () -> cdl.countDown();
         Disposable disposable = s.schedulePeriodicallyDirect(countDownRunnable, 100, 100, TimeUnit.MILLISECONDS);
         SchedulerRunnableIntrospection wrapper = (SchedulerRunnableIntrospection) disposable;
 
@@ -733,12 +617,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             return;
         }
         final CountDownLatch cdl = new CountDownLatch(1);
-        Runnable countDownRunnable = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        Runnable countDownRunnable = () -> cdl.countDown();
         Disposable disposable = scheduler.scheduleDirect(countDownRunnable, 100, TimeUnit.MILLISECONDS);
         SchedulerRunnableIntrospection wrapper = (SchedulerRunnableIntrospection) disposable;
         assertSame(countDownRunnable, wrapper.getWrappedRunnable());

--- a/src/test/java/io/reactivex/rxjava4/schedulers/CachedThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/CachedThreadSchedulerTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.disposables.Disposable;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.schedulers.CachedScheduler;
 import io.reactivex.rxjava4.testsupport.SuppressUndeliverable;
 
@@ -41,22 +40,12 @@ public class CachedThreadSchedulerTest extends AbstractSchedulerConcurrencyTests
 
         Flowable<Integer> f1 = Flowable.just(1, 2, 3, 4, 5);
         Flowable<Integer> f2 = Flowable.just(6, 7, 8, 9, 10);
-        Flowable<String> f = Flowable.merge(f1, f2).map(new Function<Integer, String>() {
-
-            @Override
-            public String apply(Integer t) {
-                assertTrue(Thread.currentThread().getName().startsWith("RxCachedThreadScheduler"));
-                return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
-            }
+        Flowable<String> f = Flowable.merge(f1, f2).map(t -> {
+            assertTrue(Thread.currentThread().getName().startsWith("RxCachedThreadScheduler"));
+            return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
         });
 
-        f.subscribeOn(Schedulers.cached()).blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String t) {
-                System.out.println("t: " + t);
-            }
-        });
+        f.subscribeOn(Schedulers.cached()).blockingForEach(t -> System.out.println("t: " + t));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ComputationSchedulerTests.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.disposables.Disposable;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.schedulers.ComputationScheduler;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.SuppressUndeliverable;
@@ -96,22 +95,12 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     public final void computationThreadPool1() {
         Flowable<Integer> f1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
         Flowable<Integer> f2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
-        Flowable<String> f = Flowable.<Integer> merge(f1, f2).map(new Function<Integer, String>() {
-
-            @Override
-            public String apply(Integer t) {
-                assertTrue(Thread.currentThread().getName().startsWith("RxComputationThreadPool"));
-                return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
-            }
+        Flowable<String> f = Flowable.<Integer> merge(f1, f2).map(t -> {
+            assertTrue(Thread.currentThread().getName().startsWith("RxComputationThreadPool"));
+            return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
         });
 
-        f.subscribeOn(Schedulers.computation()).blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String t) {
-                System.out.println("t: " + t);
-            }
-        });
+        f.subscribeOn(Schedulers.computation()).blockingForEach(t -> System.out.println("t: " + t));
     }
 
     @Test
@@ -121,23 +110,13 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
 
         Flowable<Integer> f1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
         Flowable<Integer> f2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
-        Flowable<String> f = Flowable.<Integer> merge(f1, f2).subscribeOn(Schedulers.computation()).map(new Function<Integer, String>() {
-
-            @Override
-            public String apply(Integer t) {
-                assertNotEquals(Thread.currentThread().getName(), currentThreadName);
-                assertTrue(Thread.currentThread().getName().startsWith("RxComputationThreadPool"));
-                return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
-            }
+        Flowable<String> f = Flowable.<Integer> merge(f1, f2).subscribeOn(Schedulers.computation()).map(t -> {
+            assertNotEquals(Thread.currentThread().getName(), currentThreadName);
+            assertTrue(Thread.currentThread().getName().startsWith("RxComputationThreadPool"));
+            return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
         });
 
-        f.blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String t) {
-                System.out.println("t: " + t);
-            }
-        });
+        f.blockingForEach(t -> System.out.println("t: " + t));
     }
 
     @Test
@@ -166,12 +145,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     public void shutdownRejects() {
         final int[] calls = { 0 };
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                calls[0]++;
-            }
-        };
+        Runnable r = () -> calls[0]++;
 
         Scheduler s = new ComputationScheduler();
         s.shutdown();
@@ -202,15 +176,12 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
         CountDownLatch latch = new CountDownLatch(1);
 
         // #3 thread's uncaught exception handler
-        Scheduler computationScheduler = new ComputationScheduler(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setUncaughtExceptionHandler((_, _) -> {
-                    latch.countDown();
-                });
-                return t;
-            }
+        Scheduler computationScheduler = new ComputationScheduler(r -> {
+            Thread t = new Thread(r);
+            t.setUncaughtExceptionHandler((_, _) -> {
+                latch.countDown();
+            });
+            return t;
         });
 
         // #2 RxJava exception handler
@@ -248,15 +219,12 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
         CountDownLatch latch = new CountDownLatch(1);
 
         // #3 thread's uncaught exception handler
-        Scheduler computationScheduler = new ComputationScheduler(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setUncaughtExceptionHandler((_, _) -> {
-                    latch.countDown();
-                });
-                return t;
-            }
+        Scheduler computationScheduler = new ComputationScheduler(r -> {
+            Thread t = new Thread(r);
+            t.setUncaughtExceptionHandler((_, _) -> {
+                latch.countDown();
+            });
+            return t;
         });
 
         // #2 RxJava exception handler
@@ -291,12 +259,9 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     public void periodicTaskShouldStopOnError() throws Exception {
         AtomicInteger repeatCount = new AtomicInteger();
 
-        Schedulers.computation().schedulePeriodicallyDirect(new Runnable() {
-            @Override
-            public void run() {
-                repeatCount.incrementAndGet();
-                throw new OutOfMemoryError();
-            }
+        Schedulers.computation().schedulePeriodicallyDirect(() -> {
+            repeatCount.incrementAndGet();
+            throw new OutOfMemoryError();
         }, 0, 1, TimeUnit.MILLISECONDS);
 
         Thread.sleep(200);
@@ -309,12 +274,9 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
     public void periodicTaskShouldStopOnError2() throws Exception {
         AtomicInteger repeatCount = new AtomicInteger();
 
-        Schedulers.computation().schedulePeriodicallyDirect(new Runnable() {
-            @Override
-            public void run() {
-                repeatCount.incrementAndGet();
-                throw new OutOfMemoryError();
-            }
+        Schedulers.computation().schedulePeriodicallyDirect(() -> {
+            repeatCount.incrementAndGet();
+            throw new OutOfMemoryError();
         }, 0, 1, TimeUnit.NANOSECONDS);
 
         Thread.sleep(200);

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerFairTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerFairTest.java
@@ -94,12 +94,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
     @Test
     public void cancelledTasksDontRun() {
         final AtomicInteger calls = new AtomicInteger();
-        Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                calls.getAndIncrement();
-            }
-        };
+        Runnable task = () -> calls.getAndIncrement();
         TestExecutor exec = new TestExecutor();
         Scheduler custom = Schedulers.from(exec, false, true);
         Worker w = custom.createWorker();
@@ -123,12 +118,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
     @Test
     public void cancelledWorkerDoesntRunTasks() {
         final AtomicInteger calls = new AtomicInteger();
-        Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                calls.getAndIncrement();
-            }
-        };
+        Runnable task = () -> calls.getAndIncrement();
         TestExecutor exec = new TestExecutor();
         Scheduler custom = Schedulers.from(exec, false, true);
         Worker w = custom.createWorker();
@@ -145,21 +135,11 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
     @Test
     public void plainExecutor() throws Exception {
-        Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                r.run();
-            }
-        }, false, true);
+        Scheduler s = Schedulers.from(r -> r.run(), false, true);
 
         final CountDownLatch cdl = new CountDownLatch(5);
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        Runnable r = () -> cdl.countDown();
 
         s.scheduleDirect(r);
 
@@ -234,12 +214,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
             final CountDownLatch cdl = new CountDownLatch(8);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cdl.countDown();
-                }
-            };
+            Runnable r = () -> cdl.countDown();
 
             s.scheduleDirect(r);
 
@@ -268,12 +243,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
             final CountDownLatch cdl = new CountDownLatch(8);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cdl.countDown();
-                }
-            };
+            Runnable r = () -> cdl.countDown();
 
             s.schedule(r);
 
@@ -304,12 +274,9 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
                 final AtomicInteger c = new AtomicInteger(2);
 
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        c.decrementAndGet();
-                        while (c.get() != 0) { }
-                    }
+                w.schedule(() -> {
+                    c.decrementAndGet();
+                    while (c.get() != 0) { }
                 });
 
                 c.decrementAndGet();
@@ -323,12 +290,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
     @Test
     public void runnableDisposed() {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                r.run();
-            }
-        }, false, true);
+        final Scheduler s = Schedulers.from(r -> r.run(), false, true);
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
 
         assertTrue(d.isDisposed());
@@ -336,12 +298,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
     @Test
     public void runnableDisposedAsync() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        }, false, true);
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start(), false, true);
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
 
         while (!d.isDisposed()) {
@@ -361,17 +318,9 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
     @Test
     public void runnableDisposedAsyncCrash() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        }, false, true);
-        Disposable d = s.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                throw new IllegalStateException();
-            }
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start(), false, true);
+        Disposable d = s.scheduleDirect(() -> {
+            throw new IllegalStateException();
         });
 
         while (!d.isDisposed()) {
@@ -381,12 +330,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
     @Test
     public void runnableDisposedAsyncTimed() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        }, false, true);
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start(), false, true);
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE, 1, TimeUnit.MILLISECONDS);
 
         while (!d.isDisposed()) {
@@ -413,12 +357,7 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
     public void unwrapScheduleDirectTaskAfterDispose() {
         Scheduler scheduler = getScheduler();
         final CountDownLatch cdl = new CountDownLatch(1);
-        Runnable countDownRunnable = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        Runnable countDownRunnable = () -> cdl.countDown();
         Disposable disposable = scheduler.scheduleDirect(countDownRunnable, 100, TimeUnit.MILLISECONDS);
         SchedulerRunnableIntrospection wrapper = (SchedulerRunnableIntrospection) disposable;
         assertSame(countDownRunnable, wrapper.getWrappedRunnable());
@@ -436,25 +375,10 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriber<Integer> ts = pp
-            .publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Flowable<Integer> v) throws Throwable {
-                    return Flowable.merge(
-                            v.filter(new Predicate<Integer>() {
-                                @Override
-                                public boolean test(Integer w) throws Throwable {
-                                    return w % 2 == 0;
-                                }
-                            }).observeOn(sch, false, 1).hide(),
-                            v.filter(new Predicate<Integer>() {
-                                @Override
-                                public boolean test(Integer w) throws Throwable {
-                                    return w % 2 != 0;
-                                }
-                            }).observeOn(sch, false, 1).hide()
-                    );
-                }
-            })
+            .publish((Function<Flowable<Integer>, Flowable<Integer>>) v -> Flowable.merge(
+                    v.filter(w -> w % 2 == 0).observeOn(sch, false, 1).hide(),
+                    v.filter(w -> w % 2 != 0).observeOn(sch, false, 1).hide()
+            ))
             .test();
 
             for (int i = 1; i < 11; i++) {
@@ -479,25 +403,10 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriber<Integer> ts = pp
-            .publish(new Function<Flowable<Integer>, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Flowable<Integer> v) throws Throwable {
-                    return Flowable.merge(
-                            v.filter(new Predicate<Integer>() {
-                                @Override
-                                public boolean test(Integer w) throws Throwable {
-                                    return w % 2 == 0;
-                                }
-                            }).delay(0, TimeUnit.SECONDS, sch).hide(),
-                            v.filter(new Predicate<Integer>() {
-                                @Override
-                                public boolean test(Integer w) throws Throwable {
-                                    return w % 2 != 0;
-                                }
-                            }).delay(0, TimeUnit.SECONDS, sch).hide()
-                    );
-                }
-            })
+            .publish((Function<Flowable<Integer>, Flowable<Integer>>) v -> Flowable.merge(
+                    v.filter(w -> w % 2 == 0).delay(0, TimeUnit.SECONDS, sch).hide(),
+                    v.filter(w -> w % 2 != 0).delay(0, TimeUnit.SECONDS, sch).hide()
+            ))
             .test();
 
             for (int i = 1; i < 11; i++) {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerInterruptibleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerInterruptibleTest.java
@@ -91,12 +91,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
     @Test
     public void cancelledTasksDontRun() {
         final AtomicInteger calls = new AtomicInteger();
-        Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                calls.getAndIncrement();
-            }
-        };
+        Runnable task = () -> calls.getAndIncrement();
         TestExecutor exec = new TestExecutor();
         Scheduler custom = Schedulers.from(exec, true);
         Worker w = custom.createWorker();
@@ -120,12 +115,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
     @Test
     public void cancelledWorkerDoesntRunTasks() {
         final AtomicInteger calls = new AtomicInteger();
-        Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                calls.getAndIncrement();
-            }
-        };
+        Runnable task = () -> calls.getAndIncrement();
         TestExecutor exec = new TestExecutor();
         Scheduler custom = Schedulers.from(exec, true);
         Worker w = custom.createWorker();
@@ -142,21 +132,11 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
     @Test
     public void plainExecutor() throws Exception {
-        Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                r.run();
-            }
-        }, true);
+        Scheduler s = Schedulers.from(r -> r.run(), true);
 
         final CountDownLatch cdl = new CountDownLatch(5);
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        Runnable r = () -> cdl.countDown();
 
         s.scheduleDirect(r);
 
@@ -231,12 +211,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             final CountDownLatch cdl = new CountDownLatch(8);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cdl.countDown();
-                }
-            };
+            Runnable r = () -> cdl.countDown();
 
             s.scheduleDirect(r);
 
@@ -265,12 +240,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             final CountDownLatch cdl = new CountDownLatch(8);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cdl.countDown();
-                }
-            };
+            Runnable r = () -> cdl.countDown();
 
             s.schedule(r);
 
@@ -301,12 +271,9 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 final AtomicInteger c = new AtomicInteger(2);
 
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        c.decrementAndGet();
-                        while (c.get() != 0) { }
-                    }
+                w.schedule(() -> {
+                    c.decrementAndGet();
+                    while (c.get() != 0) { }
                 });
 
                 c.decrementAndGet();
@@ -320,12 +287,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
     @Test
     public void runnableDisposed() {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                r.run();
-            }
-        }, true);
+        final Scheduler s = Schedulers.from(r -> r.run(), true);
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
 
         assertTrue(d.isDisposed());
@@ -333,12 +295,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
     @Test
     public void runnableDisposedAsync() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        }, true);
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start(), true);
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
 
         while (!d.isDisposed()) {
@@ -358,17 +315,9 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
     @Test
     public void runnableDisposedAsyncCrash() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        }, true);
-        Disposable d = s.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                throw new IllegalStateException();
-            }
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start(), true);
+        Disposable d = s.scheduleDirect(() -> {
+            throw new IllegalStateException();
         });
 
         while (!d.isDisposed()) {
@@ -378,12 +327,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
     @Test
     public void runnableDisposedAsyncTimed() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        }, true);
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start(), true);
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE, 1, TimeUnit.MILLISECONDS);
 
         while (!d.isDisposed()) {
@@ -410,12 +354,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
     public void unwrapScheduleDirectTaskAfterDispose() {
         Scheduler scheduler = getScheduler();
         final CountDownLatch cdl = new CountDownLatch(1);
-        Runnable countDownRunnable = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        Runnable countDownRunnable = () -> cdl.countDown();
         Disposable disposable = scheduler.scheduleDirect(countDownRunnable, 100, TimeUnit.MILLISECONDS);
         SchedulerRunnableIntrospection wrapper = (SchedulerRunnableIntrospection) disposable;
         assertSame(countDownRunnable, wrapper.getWrappedRunnable());
@@ -432,17 +371,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
         final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-        Disposable d = scheduler.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
-                }
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException ex) {
-                    isInterrupted.set(true);
-                }
+        Disposable d = scheduler.scheduleDirect(() -> {
+            if (sync.decrementAndGet() != 0) {
+                while (sync.get() != 0) { }
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ex) {
+                isInterrupted.set(true);
             }
         });
 
@@ -473,17 +409,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-            Disposable d = worker.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ex) {
-                        isInterrupted.set(true);
-                    }
+            Disposable d = worker.schedule(() -> {
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    isInterrupted.set(true);
                 }
             });
 
@@ -516,17 +449,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-            Disposable d = scheduler.scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ex) {
-                        isInterrupted.set(true);
-                    }
+            Disposable d = scheduler.scheduleDirect(() -> {
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    isInterrupted.set(true);
                 }
             });
 
@@ -562,17 +492,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-                Disposable d = worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (sync.decrementAndGet() != 0) {
-                            while (sync.get() != 0) { }
-                        }
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException ex) {
-                            isInterrupted.set(true);
-                        }
+                Disposable d = worker.schedule(() -> {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
                     }
                 });
 
@@ -608,17 +535,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-            Disposable d = scheduler.scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ex) {
-                        isInterrupted.set(true);
-                    }
+            Disposable d = scheduler.scheduleDirect(() -> {
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    isInterrupted.set(true);
                 }
             });
 
@@ -654,17 +578,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-                Disposable d = worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (sync.decrementAndGet() != 0) {
-                            while (sync.get() != 0) { }
-                        }
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException ex) {
-                            isInterrupted.set(true);
-                        }
+                Disposable d = worker.schedule(() -> {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
                     }
                 });
 
@@ -700,17 +621,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-            Disposable d = scheduler.scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ex) {
-                        isInterrupted.set(true);
-                    }
+            Disposable d = scheduler.scheduleDirect(() -> {
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    isInterrupted.set(true);
                 }
             });
 
@@ -746,17 +664,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-                Disposable d = worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (sync.decrementAndGet() != 0) {
-                            while (sync.get() != 0) { }
-                        }
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException ex) {
-                            isInterrupted.set(true);
-                        }
+                Disposable d = worker.schedule(() -> {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
                     }
                 });
 
@@ -792,17 +707,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-            Disposable d = scheduler.scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ex) {
-                        isInterrupted.set(true);
-                    }
+            Disposable d = scheduler.scheduleDirect(() -> {
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    isInterrupted.set(true);
                 }
             }, 1, TimeUnit.MILLISECONDS);
 
@@ -838,17 +750,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-                Disposable d = worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (sync.decrementAndGet() != 0) {
-                            while (sync.get() != 0) { }
-                        }
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException ex) {
-                            isInterrupted.set(true);
-                        }
+                Disposable d = worker.schedule(() -> {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
                     }
                 }, 1, TimeUnit.MILLISECONDS);
 
@@ -884,17 +793,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-            Disposable d = scheduler.scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ex) {
-                        isInterrupted.set(true);
-                    }
+            Disposable d = scheduler.scheduleDirect(() -> {
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    isInterrupted.set(true);
                 }
             }, 1, TimeUnit.MILLISECONDS);
 
@@ -930,17 +836,14 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 final AtomicBoolean isInterrupted = new AtomicBoolean();
 
-                Disposable d = worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (sync.decrementAndGet() != 0) {
-                            while (sync.get() != 0) { }
-                        }
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException ex) {
-                            isInterrupted.set(true);
-                        }
+                Disposable d = worker.schedule(() -> {
+                    if (sync.decrementAndGet() != 0) {
+                        while (sync.get() != 0) { }
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        isInterrupted.set(true);
                     }
                 }, 1, TimeUnit.MILLISECONDS);
 

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerTest.java
@@ -62,12 +62,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
         int n = 100 * 1000;
         if (periodic) {
             final CountDownLatch cdl = new CountDownLatch(n);
-            final Runnable action = new Runnable() {
-                @Override
-                public void run() {
-                    cdl.countDown();
-                }
-            };
+            final Runnable action = () -> cdl.countDown();
             for (int i = 0; i < n; i++) {
                 if (i % 50000 == 0) {
                     System.out.println("  -> still scheduling: " + i);
@@ -177,12 +172,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
     @Test
     public void cancelledTasksDontRun() {
         final AtomicInteger calls = new AtomicInteger();
-        Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                calls.getAndIncrement();
-            }
-        };
+        Runnable task = () -> calls.getAndIncrement();
         TestExecutor exec = new TestExecutor();
         Scheduler custom = Schedulers.from(exec);
         Worker w = custom.createWorker();
@@ -206,12 +196,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
     @Test
     public void cancelledWorkerDoesntRunTasks() {
         final AtomicInteger calls = new AtomicInteger();
-        Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                calls.getAndIncrement();
-            }
-        };
+        Runnable task = () -> calls.getAndIncrement();
         TestExecutor exec = new TestExecutor();
         Scheduler custom = Schedulers.from(exec);
         Worker w = custom.createWorker();
@@ -228,21 +213,11 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
     @Test
     public void plainExecutor() throws Exception {
-        Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                r.run();
-            }
-        });
+        Scheduler s = Schedulers.from(r -> r.run());
 
         final CountDownLatch cdl = new CountDownLatch(5);
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        Runnable r = () -> cdl.countDown();
 
         s.scheduleDirect(r);
 
@@ -317,12 +292,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
             final CountDownLatch cdl = new CountDownLatch(8);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cdl.countDown();
-                }
-            };
+            Runnable r = () -> cdl.countDown();
 
             s.scheduleDirect(r);
 
@@ -351,12 +321,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
             final CountDownLatch cdl = new CountDownLatch(8);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cdl.countDown();
-                }
-            };
+            Runnable r = () -> cdl.countDown();
 
             s.schedule(r);
 
@@ -387,12 +352,9 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
                 final AtomicInteger c = new AtomicInteger(2);
 
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        c.decrementAndGet();
-                        while (c.get() != 0) { }
-                    }
+                w.schedule(() -> {
+                    c.decrementAndGet();
+                    while (c.get() != 0) { }
                 });
 
                 c.decrementAndGet();
@@ -406,12 +368,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
     @Test
     public void runnableDisposed() {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                r.run();
-            }
-        });
+        final Scheduler s = Schedulers.from(r -> r.run());
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
 
         assertTrue(d.isDisposed());
@@ -419,12 +376,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
     @Test
     public void runnableDisposedAsync() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        });
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start());
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE);
 
         while (!d.isDisposed()) {
@@ -444,17 +396,9 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
     @Test
     public void runnableDisposedAsyncCrash() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        });
-        Disposable d = s.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                throw new IllegalStateException();
-            }
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start());
+        Disposable d = s.scheduleDirect(() -> {
+            throw new IllegalStateException();
         });
 
         while (!d.isDisposed()) {
@@ -464,12 +408,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
     @Test
     public void runnableDisposedAsyncTimed() throws Exception {
-        final Scheduler s = Schedulers.from(new Executor() {
-            @Override
-            public void execute(Runnable r) {
-                new Thread(r).start();
-            }
-        });
+        final Scheduler s = Schedulers.from(r -> new Thread(r).start());
         Disposable d = s.scheduleDirect(Functions.EMPTY_RUNNABLE, 1, TimeUnit.MILLISECONDS);
 
         while (!d.isDisposed()) {
@@ -496,12 +435,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
     public void unwrapScheduleDirectTaskAfterDispose() {
         Scheduler scheduler = getScheduler();
         final CountDownLatch cdl = new CountDownLatch(1);
-        Runnable countDownRunnable = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        Runnable countDownRunnable = () -> cdl.countDown();
         Disposable disposable = scheduler.scheduleDirect(countDownRunnable, 100, TimeUnit.MILLISECONDS);
         SchedulerRunnableIntrospection wrapper = (SchedulerRunnableIntrospection) disposable;
         assertSame(countDownRunnable, wrapper.getWrappedRunnable());

--- a/src/test/java/io/reactivex/rxjava4/schedulers/FailOnBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/FailOnBlockingTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
@@ -32,14 +31,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -58,14 +54,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLast();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLast();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -84,14 +77,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingIterable().iterator().next();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingIterable().iterator().next();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -110,14 +100,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingSubscribe();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingSubscribe();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -136,14 +123,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingSingle();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingSingle();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -162,14 +146,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingForEach(Functions.emptyConsumer());
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingForEach(Functions.emptyConsumer());
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -188,14 +169,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLatest().iterator().hasNext();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLatest().iterator().hasNext();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -214,14 +192,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingNext().iterator().hasNext();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingNext().iterator().hasNext();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -240,14 +215,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Flowable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).toFuture().get();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).toFuture().get();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -266,14 +238,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
+                Observable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -292,14 +261,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLast();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLast();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -318,14 +284,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingIterable().iterator().next();
+                Observable.just(1).delay(10, TimeUnit.SECONDS).blockingIterable().iterator().next();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -344,14 +307,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingSubscribe();
+                Observable.just(1).delay(10, TimeUnit.SECONDS).blockingSubscribe();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -370,14 +330,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingSingle();
+                Observable.just(1).delay(10, TimeUnit.SECONDS).blockingSingle();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -396,14 +353,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingForEach(Functions.emptyConsumer());
+                Observable.just(1).delay(10, TimeUnit.SECONDS).blockingForEach(Functions.emptyConsumer());
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -422,14 +376,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingLatest().iterator().hasNext();
+                Observable.just(1).delay(10, TimeUnit.SECONDS).blockingLatest().iterator().hasNext();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -448,14 +399,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingNext().iterator().hasNext();
+                Observable.just(1).delay(10, TimeUnit.SECONDS).blockingNext().iterator().hasNext();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -474,14 +422,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.computation())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).toFuture().get();
+                Observable.just(1).delay(10, TimeUnit.SECONDS).toFuture().get();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -500,14 +445,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.single())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Observable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
+                Observable.just(1).delay(10, TimeUnit.SECONDS).blockingFirst();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -526,14 +468,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Single.just(1)
             .subscribeOn(Schedulers.single())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Single.just(1).delay(10, TimeUnit.SECONDS).blockingGet();
+                Single.just(1).delay(10, TimeUnit.SECONDS).blockingGet();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -552,14 +491,11 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Maybe.just(1)
             .subscribeOn(Schedulers.single())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Maybe.just(1).delay(10, TimeUnit.SECONDS).blockingGet();
+                Maybe.just(1).delay(10, TimeUnit.SECONDS).blockingGet();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -578,12 +514,7 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Completable.complete()
             .subscribeOn(Schedulers.single())
-            .doOnComplete(new Action() {
-                @Override
-                public void run() throws Exception {
-                    Completable.complete().delay(10, TimeUnit.SECONDS).blockingAwait();
-                }
-            })
+            .doOnComplete(() -> Completable.complete().delay(10, TimeUnit.SECONDS).blockingAwait())
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertFailure(IllegalStateException.class);
@@ -601,12 +532,7 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Completable.complete()
             .subscribeOn(Schedulers.single())
-            .doOnComplete(new Action() {
-                @Override
-                public void run() throws Exception {
-                    Completable.complete().delay(10, TimeUnit.SECONDS).blockingAwait();
-                }
-            })
+            .doOnComplete(() -> Completable.complete().delay(10, TimeUnit.SECONDS).blockingAwait())
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertFailure(IllegalStateException.class);
@@ -624,12 +550,7 @@ public class FailOnBlockingTest extends RxJavaTest {
 
             Observable.just(1)
             .subscribeOn(Schedulers.cached())
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
-                    return Observable.just(2).delay(100, TimeUnit.MILLISECONDS).blockingFirst();
-                }
-            })
+            .map(_ -> Observable.just(2).delay(100, TimeUnit.MILLISECONDS).blockingFirst())
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(2);
@@ -642,23 +563,15 @@ public class FailOnBlockingTest extends RxJavaTest {
     @Test
     public void failWithCustomHandler() {
         try {
-            RxJavaPlugins.setOnBeforeBlocking(new BooleanSupplier() {
-                @Override
-                public boolean getAsBoolean() throws Exception {
-                    return true;
-                }
-            });
+            RxJavaPlugins.setOnBeforeBlocking(() -> true);
             RxJavaPlugins.setFailOnNonBlockingScheduler(true);
 
             Flowable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
+            .map(v -> {
 
-                    Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLast();
+                Flowable.just(1).delay(10, TimeUnit.SECONDS).blockingLast();
 
-                    return v;
-                }
+                return v;
             })
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -669,12 +582,7 @@ public class FailOnBlockingTest extends RxJavaTest {
         }
 
         Flowable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return Flowable.just(2).delay(100, TimeUnit.MILLISECONDS).blockingLast();
-            }
-        })
+        .map(_ -> Flowable.just(2).delay(100, TimeUnit.MILLISECONDS).blockingLast())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(2);

--- a/src/test/java/io/reactivex/rxjava4/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/AsyncSubjectTest.java
@@ -26,7 +26,6 @@ import org.mockito.*;
 import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 import io.reactivex.rxjava4.testsupport.*;
@@ -188,28 +187,19 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
             final AsyncSubject<String> subject = AsyncSubject.create();
             final AtomicReference<String> value1 = new AtomicReference<>();
 
-            subject.subscribe(new Consumer<String>() {
-
-                @Override
-                public void accept(String t1) {
-                    try {
-                        // simulate a slow observer
-                        Thread.sleep(50);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    value1.set(t1);
+            subject.subscribe(t1 -> {
+                try {
+                    // simulate a slow observer
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
-
+                value1.set(t1);
             });
 
-            Thread t1 = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    subject.onNext("value");
-                    subject.onComplete();
-                }
+            Thread t1 = new Thread(() -> {
+                subject.onNext("value");
+                subject.onComplete();
             });
 
             SubjectSubscriberThread t2 = new SubjectSubscriberThread(subject);
@@ -400,19 +390,9 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
             final TestObserver<Object> to1 = p.test();
             final TestObserver<Object> to2 = p.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to1.dispose();
-                }
-            };
+            Runnable r1 = () -> to1.dispose();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to2.dispose();
-                }
-            };
+            Runnable r2 = () -> to2.dispose();
 
             TestHelper.race(r1, r2);
         }
@@ -427,21 +407,11 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
 
             final TestObserverEx<Object> to1 = p.to(TestHelper.testConsumer());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to1.dispose();
-                }
-            };
+            Runnable r1 = () -> to1.dispose();
 
             final TestException ex = new TestException();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onError(ex);
-                }
-            };
+            Runnable r2 = () -> p.onError(ex);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
@@ -255,13 +255,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             System.out.printf("Turn: %d%n", i);
             src.firstElement()
                 .toObservable()
-                .flatMap(new Function<String, Observable<String>>() {
-
-                    @Override
-                    public Observable<String> apply(String t1) {
-                        return Observable.just(t1 + ", " + t1);
-                    }
-                })
+                .flatMap((Function<String, Observable<String>>) t1 -> Observable.just(t1 + ", " + t1))
                 .subscribe(new DefaultObserver<String>() {
                     @Override
                     public void onNext(String t) {
@@ -377,16 +371,13 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
                 final CountDownLatch finish = new CountDownLatch(1);
                 final CountDownLatch start = new CountDownLatch(1);
 
-                worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            start.await();
-                        } catch (Exception e1) {
-                            e1.printStackTrace();
-                        }
-                        rs.onNext(1);
+                worker.schedule(() -> {
+                    try {
+                        start.await();
+                    } catch (Exception e1) {
+                        e1.printStackTrace();
                     }
+                    rs.onNext(1);
                 });
 
                 final AtomicReference<Object> o = new AtomicReference<>();
@@ -423,12 +414,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
                     break;
                 } else {
                     Assert.assertEquals(1, o.get());
-                    worker.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            rs.onComplete();
-                        }
-                    });
+                    worker.schedule(() -> rs.onComplete());
                 }
             }
         } finally {
@@ -594,19 +580,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
             final TestObserver<Object> to = p.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    p.test();
-                }
-            };
+            Runnable r1 = () -> p.test();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = () -> to.dispose();
 
             TestHelper.race(r1, r2);
         }
@@ -620,19 +596,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
             final TestObserver[] to = { null };
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to[0] = p.test();
-                }
-            };
+            Runnable r1 = () -> to[0] = p.test();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onNext(2);
-                }
-            };
+            Runnable r2 = () -> p.onNext(2);
 
             TestHelper.race(r1, r2);
 
@@ -681,19 +647,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
             final TestObserver<Object> to = new TestObserver<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    p.subscribe(to);
-                }
-            };
+            Runnable r1 = () -> p.subscribe(to);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onComplete();
-                }
-            };
+            Runnable r2 = () -> p.onComplete();
 
             TestHelper.race(r1, r2);
 
@@ -710,19 +666,9 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    p.subscribe(to);
-                }
-            };
+            Runnable r1 = () -> p.subscribe(to);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onError(ex);
-                }
-            };
+            Runnable r2 = () -> p.onError(ex);
 
             TestHelper.race(r1, r2);
 
@@ -771,18 +717,8 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             final BehaviorDisposable<Integer> bd = new BehaviorDisposable<>(to, bs);
             to.onSubscribe(bd);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    bd.emitFirst();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    bd.dispose();
-                }
-            };
+            Runnable r1 = () -> bd.emitFirst();
+            Runnable r2 = () -> bd.dispose();
 
             TestHelper.race(r1, r2);
         }
@@ -800,18 +736,8 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             final BehaviorDisposable<Integer> bd = new BehaviorDisposable<>(to, bs);
             to.onSubscribe(bd);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    bd.emitNext(2, 0);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    bd.dispose();
-                }
-            };
+            Runnable r1 = () -> bd.emitNext(2, 0);
+            Runnable r2 = () -> bd.dispose();
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/subjects/CompletableSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/CompletableSubjectTest.java
@@ -211,19 +211,9 @@ public class CompletableSubjectTest extends RxJavaTest {
 
             final TestObserver<Void> to = cs.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cs.test();
-                }
-            };
+            Runnable r1 = () -> cs.test();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = () -> to.dispose();
             TestHelper.race(r1, r2);
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/AllTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/AllTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.Predicate;
 
 @Test
 public class AllTckTest extends BaseTck<Boolean> {
@@ -25,12 +24,7 @@ public class AllTckTest extends BaseTck<Boolean> {
     @Override
     public Publisher<Boolean> createFlowPublisher(final long elements) {
         return
-                Flowable.range(1, 1000).all(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer e) throws Exception {
-                        return e < 800;
-                    }
-                }).toFlowable()
+                Flowable.range(1, 1000).all(e -> e < 800).toFlowable()
             ;
     }
 

--- a/src/test/java/io/reactivex/rxjava4/tck/AnyTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/AnyTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.Predicate;
 
 @Test
 public class AnyTckTest extends BaseTck<Boolean> {
@@ -25,12 +24,7 @@ public class AnyTckTest extends BaseTck<Boolean> {
     @Override
     public Publisher<Boolean> createFlowPublisher(final long elements) {
         return
-                Flowable.range(1, 1000).any(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer e) throws Exception {
-                        return e == 500;
-                    }
-                }).toFlowable()
+                Flowable.range(1, 1000).any(e -> e == 500).toFlowable()
             ;
     }
 

--- a/src/test/java/io/reactivex/rxjava4/tck/AsyncProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/AsyncProcessorAsPublisherTckTest.java
@@ -30,27 +30,24 @@ public class AsyncProcessorAsPublisherTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final AsyncProcessor<Integer> pp = AsyncProcessor.create();
 
-        Schedulers.cached().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                while (!pp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
-
-                    if (System.currentTimeMillis() - start > 200) {
-                        return;
-                    }
+        Schedulers.cached().scheduleDirect(() -> {
+            long start = System.currentTimeMillis();
+            while (!pp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
 
-                for (int i = 0; i < elements; i++) {
-                    pp.onNext(i);
+                if (System.currentTimeMillis() - start > 200) {
+                    return;
                 }
-                pp.onComplete();
             }
+
+            for (int i = 0; i < elements; i++) {
+                pp.onNext(i);
+            }
+            pp.onComplete();
         });
         return pp;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/BehaviorProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/BehaviorProcessorAsPublisherTckTest.java
@@ -31,32 +31,29 @@ public class BehaviorProcessorAsPublisherTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final BehaviorProcessor<Integer> pp = BehaviorProcessor.create();
 
-        Schedulers.cached().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                while (!pp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
-
-                    if (System.currentTimeMillis() - start > 200) {
-                        return;
-                    }
+        Schedulers.cached().scheduleDirect(() -> {
+            long start = System.currentTimeMillis();
+            while (!pp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
 
-                for (int i = 0; i < elements; i++) {
-                    while (!pp.offer(i)) {
-                        Thread.yield();
-                        if (System.currentTimeMillis() - start > 1000) {
-                            return;
-                        }
-                    }
+                if (System.currentTimeMillis() - start > 200) {
+                    return;
                 }
-                pp.onComplete();
             }
+
+            for (int i = 0; i < elements; i++) {
+                while (!pp.offer(i)) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 1000) {
+                        return;
+                    }
+                }
+            }
+            pp.onComplete();
         });
         return pp;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/CollectTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/CollectTckTest.java
@@ -19,7 +19,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.BiConsumer;
 import io.reactivex.rxjava4.internal.functions.Functions;
 
 @Test
@@ -28,12 +27,9 @@ public class CollectTckTest extends BaseTck<List<Integer>> {
     @Override
     public Publisher<List<Integer>> createFlowPublisher(final long elements) {
         return
-                Flowable.range(1, 1000).collect(Functions.<Integer>createArrayList(128), new BiConsumer<List<Integer>, Integer>() {
-                    @Override
-                    public void accept(List<Integer> a, Integer b) throws Exception {
-                        a.add(b);
-                    }
-                }).toFlowable()
+                Flowable.range(1, 1000)
+                        .collect(Functions.<Integer>createArrayList(128),
+                                (a, b) -> a.add(b)).toFlowable()
             ;
     }
 

--- a/src/test/java/io/reactivex/rxjava4/tck/CombineLatestArrayDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/CombineLatestArrayDelayErrorTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.Function;
 
 @Test
 public class CombineLatestArrayDelayErrorTckTest extends BaseTck<Long> {
@@ -28,12 +27,7 @@ public class CombineLatestArrayDelayErrorTckTest extends BaseTck<Long> {
         return
             Flowable.combineLatestArrayDelayError(
                 new Publisher[] { Flowable.just(1L), Flowable.fromIterable(iterate(elements)) },
-                new Function<Object[], Long>() {
-                    @Override
-                    public Long apply(Object[] a) throws Exception {
-                        return (Long)a[0];
-                    }
-                }
+                    a -> (Long)a[0]
             )
         ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/CombineLatestArrayTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/CombineLatestArrayTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.Function;
 
 @Test
 public class CombineLatestArrayTckTest extends BaseTck<Long> {
@@ -28,12 +27,7 @@ public class CombineLatestArrayTckTest extends BaseTck<Long> {
         return
             Flowable.combineLatestArray(
                 new Publisher[] { Flowable.just(1L), Flowable.fromIterable(iterate(elements)) },
-                new Function<Object[], Long>() {
-                    @Override
-                    public Long apply(Object[] a) throws Exception {
-                        return (Long)a[0];
-                    }
-                }
+                    a -> (Long)a[0]
             )
         ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/CombineLatestIterableDelayErrorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/CombineLatestIterableDelayErrorTckTest.java
@@ -19,7 +19,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.Function;
 
 @Test
 public class CombineLatestIterableDelayErrorTckTest extends BaseTck<Long> {
@@ -31,12 +30,7 @@ public class CombineLatestIterableDelayErrorTckTest extends BaseTck<Long> {
                     Flowable.just(1L),
                     Flowable.fromIterable(iterate(elements))
                 ),
-                new Function<Object[], Long>() {
-                    @Override
-                    public Long apply(Object[] a) throws Exception {
-                        return (Long)a[0];
-                    }
-                }
+                    a -> (Long)a[0]
             )
         ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/CombineLatestIterableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/CombineLatestIterableTckTest.java
@@ -19,7 +19,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.Function;
 
 @Test
 public class CombineLatestIterableTckTest extends BaseTck<Long> {
@@ -31,12 +30,7 @@ public class CombineLatestIterableTckTest extends BaseTck<Long> {
                     Flowable.just(1L),
                     Flowable.fromIterable(iterate(elements))
                 ),
-                new Function<Object[], Long>() {
-                    @Override
-                    public Long apply(Object[] a) throws Exception {
-                        return (Long)a[0];
-                    }
-                }
+                    a -> (Long)a[0]
             )
         ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/ConcatMapIterableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ConcatMapIterableTckTest.java
@@ -28,12 +28,7 @@ public class ConcatMapIterableTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
                 Flowable.range(0, (int)elements)
-                .concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Integer v) throws Exception {
-                        return Collections.singletonList(v);
-                    }
-                })
+                .concatMapIterable((Function<Integer, Iterable<Integer>>) v -> Collections.singletonList(v))
             ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/ConcatMapMaybeTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ConcatMapMaybeTckTest.java
@@ -26,12 +26,7 @@ public class ConcatMapMaybeTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
                 Flowable.range(0, (int)elements)
-                .concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(v);
-                    }
-                })
+                .concatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v))
             ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/ConcatMapSingleTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ConcatMapSingleTckTest.java
@@ -26,12 +26,7 @@ public class ConcatMapSingleTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
                 Flowable.range(0, (int)elements)
-                .concatMapSingle(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Exception {
-                        return Single.just(v);
-                    }
-                })
+                .concatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v))
             ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/ConcatMapTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ConcatMapTckTest.java
@@ -26,12 +26,7 @@ public class ConcatMapTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
                 Flowable.range(0, (int)elements)
-                .concatMap(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Exception {
-                        return Flowable.just(v);
-                    }
-                })
+                .concatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v))
             ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/CreateTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/CreateTckTest.java
@@ -24,14 +24,11 @@ public class CreateTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFlowPublisher(final long elements) {
         return
-            Flowable.create(new FlowableOnSubscribe<Long>() {
-                @Override
-                public void subscribe(FlowableEmitter<Long> e) throws Exception {
-                    for (long i = 0; i < elements && !e.isCancelled(); i++) {
-                        e.onNext(i);
-                    }
-                    e.onComplete();
+            Flowable.create(e -> {
+                for (long i = 0; i < elements && !e.isCancelled(); i++) {
+                    e.onNext(i);
                 }
+                e.onComplete();
             }, BackpressureStrategy.BUFFER)
         ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/DeferTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/DeferTckTest.java
@@ -25,12 +25,7 @@ public class DeferTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFlowPublisher(final long elements) {
         return
-                Flowable.defer(new Supplier<Publisher<Long>>() {
-                    @Override
-                    public Publisher<Long> get() throws Exception {
-                        return Flowable.fromIterable(iterate(elements));
-                    }
-                }
+                Flowable.defer((Supplier<Publisher<Long>>) () -> Flowable.fromIterable(iterate(elements))
                 )
             ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/FilterTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/FilterTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.Predicate;
 
 @Test
 public class FilterTckTest extends BaseTck<Integer> {
@@ -25,12 +24,7 @@ public class FilterTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
-                Flowable.range(0, (int)elements * 2).filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer v) throws Exception {
-                        return (v & 1) == 0;
-                    }
-                })
+                Flowable.range(0, (int)elements * 2).filter(v -> (v & 1) == 0)
         ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/FlatMapTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/FlatMapTckTest.java
@@ -26,12 +26,7 @@ public class FlatMapTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
                 Flowable.range(0, (int)elements)
-                .flatMap(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v) throws Exception {
-                        return Flowable.just(v);
-                    }
-                })
+                .flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v))
             ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/FromCallableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/FromCallableTckTest.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.rxjava4.tck;
 
-import java.util.concurrent.Callable;
-
 import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
@@ -27,12 +25,7 @@ public class FromCallableTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFlowPublisher(final long elements) {
         return
-                Flowable.fromCallable(new Callable<Long>() {
-                    @Override
-                    public Long call() throws Exception {
-                        return 1L;
-                    }
-                }
+                Flowable.fromCallable(() -> 1L
                 )
             ;
     }
@@ -40,11 +33,8 @@ public class FromCallableTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return
-                Flowable.fromCallable(new Callable<Long>() {
-                    @Override
-                    public Long call() throws Exception {
-                        throw new TestException();
-                    }
+                Flowable.fromCallable(() -> {
+                    throw new TestException();
                 }
                 )
             ;

--- a/src/test/java/io/reactivex/rxjava4/tck/FromFutureTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/FromFutureTckTest.java
@@ -25,12 +25,7 @@ public class FromFutureTckTest extends BaseTck<Long> {
 
     @Override
     public Publisher<Long> createFlowPublisher(final long elements) {
-        FutureTask<Long> ft = new FutureTask<>(new Callable<Long>() {
-            @Override
-            public Long call() throws Exception {
-                return 1L;
-            }
-        });
+        FutureTask<Long> ft = new FutureTask<>(() -> 1L);
 
         ft.run();
         return Flowable.fromFuture(ft);

--- a/src/test/java/io/reactivex/rxjava4/tck/GenerateTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/GenerateTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.BiFunction;
 import io.reactivex.rxjava4.internal.functions.Functions;
 
 @Test
@@ -27,16 +26,13 @@ public class GenerateTckTest extends BaseTck<Long> {
     public Publisher<Long> createFlowPublisher(final long elements) {
         return
             Flowable.generate(Functions.justSupplier(0L),
-            new BiFunction<Long, Emitter<Long>, Long>() {
-                @Override
-                public Long apply(Long s, Emitter<Long> e) throws Exception {
-                    e.onNext(s);
-                    if (++s == elements) {
-                        e.onComplete();
-                    }
-                    return s;
-                }
-            }, Functions.<Long>emptyConsumer())
+                    (s, e) -> {
+                        e.onNext(s);
+                        if (++s == elements) {
+                            e.onComplete();
+                        }
+                        return s;
+                    }, Functions.<Long>emptyConsumer())
         ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/GroupByTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/GroupByTckTest.java
@@ -27,12 +27,7 @@ public class GroupByTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
-                Flowable.range(0, (int)elements).groupBy(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        return v & 1;
-                    }
-                })
+                Flowable.range(0, (int)elements).groupBy(v -> v & 1)
                 .flatMap((Function)Functions.identity())
         ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/MaybeFlatMapPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/MaybeFlatMapPublisherTckTest.java
@@ -25,13 +25,7 @@ public class MaybeFlatMapPublisherTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createFlowPublisher(final long elements) {
         return
-                Maybe.just(1).hide().flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v)
-                            throws Exception {
-                        return Flowable.range(0, (int)elements);
-                    }
-                })
+                Maybe.just(1).hide().flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> Flowable.range(0, (int)elements))
         ;
     }
 }


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080