### PR TITLE
4.x: Unit test lambdaification 15 of N

### DIFF
--- a/src/jmh/java/io/reactivex/rxjava4/core/TakeUntilPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/TakeUntilPerf.java
@@ -46,22 +46,16 @@ public class TakeUntilPerf implements Consumer<Integer> {
     @Setup
     public void setup() {
 
-        flowable = Flowable.range(1, 1000 * 1000).takeUntil(Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() {
-                int c = count;
-                while (items < c) { }
-                return 1;
-            }
+        flowable = Flowable.range(1, 1000 * 1000).takeUntil(Flowable.fromCallable((Callable<Object>) () -> {
+            int c = count;
+            while (items < c) { }
+            return 1;
         }).subscribeOn(Schedulers.single()));
 
-        observable = Observable.range(1, 1000 * 1000).takeUntil(Observable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() {
-                int c = count;
-                while (items < c) { }
-                return 1;
-            }
+        observable = Observable.range(1, 1000 * 1000).takeUntil(Observable.fromCallable((Callable<Object>) () -> {
+            int c = count;
+            while (items < c) { }
+            return 1;
         }).subscribeOn(Schedulers.single()));
     }
 

--- a/src/jmh/java/io/reactivex/rxjava4/core/ToFlowablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/ToFlowablePerf.java
@@ -46,32 +46,17 @@ public class ToFlowablePerf {
 
         Flowable<Integer> source = Flowable.fromArray(array);
 
-        final BiFunction<Integer, Integer, Integer> second = new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) {
-                return b;
-            }
-        };
+        final BiFunction<Integer, Integer, Integer> second = (_, b) -> b;
 
         flowable = source.reduce(second);
 
-        flowableInner = source.concatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.range(1, 50).reduce(second).toFlowable();
-            }
-        });
+        flowableInner = source.concatMap((Function<Integer, Publisher<Integer>>) _ -> Flowable.range(1, 50).reduce(second).toFlowable());
 
         Observable<Integer> sourceObs = Observable.fromArray(array);
 
         observable = sourceObs.reduce(second).toObservable();
 
-        observableInner = sourceObs.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.range(1, 50).reduce(second).toObservable();
-            }
-        });
+        observableInner = sourceObs.concatMap((Function<Integer, Observable<Integer>>) _ -> Observable.range(1, 50).reduce(second).toObservable());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableConcatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableConcatMapMaybePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableConcatMapMaybePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        flowablePlain = source.concatMap(v -> Flowable.just(v));
 
-        flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Maybe.just(v).toFlowable();
-            }
-        });
+        flowableConvert = source.concatMap(v -> Maybe.just(v).toFlowable());
 
-        flowableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.just(v);
-            }
-        });
+        flowableDedicated = source.concatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v));
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableConcatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableConcatMapSinglePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableConcatMapSinglePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        flowablePlain = source.concatMap(v -> Flowable.just(v));
 
-        flowableConvert = source.concatMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Single.just(v).toFlowable();
-            }
-        });
+        flowableConvert = source.concatMap(v -> Single.just(v).toFlowable());
 
-        flowableDedicated = source.concatMapSingle(new Function<Integer, Single<? extends Integer>>() {
-            @Override
-            public Single<? extends Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        flowableDedicated = source.concatMapSingle((Function<Integer, Single<? extends Integer>>) v -> Single.just(v));
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableSwitchMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableSwitchMapCompletablePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableSwitchMapCompletablePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.empty();
-            }
-        });
+        flowablePlain = source.switchMap(_ -> Flowable.empty());
 
-        flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Completable.complete().toFlowable();
-            }
-        });
+        flowableConvert = source.switchMap(_ -> Completable.complete().toFlowable());
 
-        flowableDedicated = source.switchMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) {
-                return Completable.complete();
-            }
-        });
+        flowableDedicated = source.switchMapCompletable((Function<Integer, Completable>) _ -> Completable.complete());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableSwitchMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableSwitchMapMaybeEmptyPerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableSwitchMapMaybeEmptyPerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.empty();
-            }
-        });
+        flowablePlain = source.switchMap(_ -> Flowable.empty());
 
-        flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Maybe.<Integer>empty().toFlowable();
-            }
-        });
+        flowableConvert = source.switchMap(_ -> Maybe.<Integer>empty().toFlowable());
 
-        flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.empty();
-            }
-        });
+        flowableDedicated = source.switchMapMaybe((Function<Integer, Maybe<Integer>>) _ -> Maybe.empty());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableSwitchMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableSwitchMapMaybePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableSwitchMapMaybePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        flowablePlain = source.switchMap(v -> Flowable.just(v));
 
-        flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Maybe.just(v).toFlowable();
-            }
-        });
+        flowableConvert = source.switchMap(v -> Maybe.just(v).toFlowable());
 
-        flowableDedicated = source.switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.just(v);
-            }
-        });
+        flowableDedicated = source.switchMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v));
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableSwitchMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/FlowableSwitchMapSinglePerf.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.Function;
 
@@ -46,26 +44,11 @@ public class FlowableSwitchMapSinglePerf {
 
         Flowable<Integer> source = Flowable.fromArray(sourceArray);
 
-        flowablePlain = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        flowablePlain = source.switchMap(v -> Flowable.just(v));
 
-        flowableConvert = source.switchMap(new Function<Integer, Publisher<? extends Integer>>() {
-            @Override
-            public Publisher<? extends Integer> apply(Integer v) {
-                return Single.just(v).toFlowable();
-            }
-        });
+        flowableConvert = source.switchMap(v -> Single.just(v).toFlowable());
 
-        flowableDedicated = source.switchMapSingle(new Function<Integer, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        flowableDedicated = source.switchMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v));
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableConcatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableConcatMapMaybeEmptyPerf.java
@@ -45,26 +45,11 @@ public class ObservableConcatMapMaybeEmptyPerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.empty();
-            }
-        });
+        observablePlain = source.concatMap((Function<Integer, Observable<Integer>>) _ -> Observable.empty());
 
-        concatMapToObservableEmpty = source.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Maybe.<Integer>empty().toObservable();
-            }
-        });
+        concatMapToObservableEmpty = source.concatMap((Function<Integer, Observable<Integer>>) _ -> Maybe.<Integer>empty().toObservable());
 
-        observableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.empty();
-            }
-        });
+        observableDedicated = source.concatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> Maybe.empty());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableFlatMapMaybeEmptyPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableFlatMapMaybeEmptyPerf.java
@@ -45,26 +45,11 @@ public class ObservableFlatMapMaybeEmptyPerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.empty();
-            }
-        });
+        observablePlain = source.flatMap((Function<Integer, Observable<Integer>>) _ -> Observable.empty());
 
-        observableConvert = source.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Maybe.<Integer>empty().toObservable();
-            }
-        });
+        observableConvert = source.flatMap((Function<Integer, Observable<Integer>>) _ -> Maybe.<Integer>empty().toObservable());
 
-        observableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.empty();
-            }
-        });
+        observableDedicated = source.flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> Maybe.empty());
     }
 
     @Benchmark

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
@@ -725,7 +725,7 @@ public class FlowableMergeTest extends RxJavaTest {
     public void backpressureBothUpstreamAndDownstreamWithSynchronousScalarFlowables() throws InterruptedException {
         final AtomicInteger generated1 = new AtomicInteger();
         Flowable<Flowable<Integer>> f1 = createInfiniteFlowable(generated1)
-        .map((Function<Integer, Flowable<Integer>>) Flowable::just);
+        .map(Flowable::just);
 
         TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -19,8 +19,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
@@ -165,12 +163,12 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable((Function<Flowable<Integer>, Object>) Flowable::onBackpressureDrop, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(Flowable::onBackpressureDrop, false, 1, 1, 1);
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Publisher<Object>>) Flowable::onBackpressureDrop);
+        TestHelper.checkDoubleOnSubscribeFlowable(Flowable::onBackpressureDrop);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
@@ -1140,7 +1140,7 @@ public class FlowablePublishTest extends RxJavaTest {
         TestSubscriber<List<Integer>> ts = evenNumbers.concatMap(
             v -> Single.zip(
                 Single.just(v), getNextOdd,
-                (BiFunction<Integer, Integer, List<Integer>>) Arrays::asList
+                            Arrays::asList
         )
         .toFlowable())
         .takeWhile(v -> v.get(0) < 20)
@@ -1177,7 +1177,7 @@ public class FlowablePublishTest extends RxJavaTest {
         TestSubscriber<List<Integer>> ts = evenNumbers.concatMap(
             v -> Single.zip(
                 Single.just(v), getNextOdd,
-                (BiFunction<Integer, Integer, List<Integer>>) Arrays::asList
+                            Arrays::asList
         )
         .toFlowable())
         .takeWhile(v -> v.get(0) < 20)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
@@ -353,12 +353,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         // subscribe list2
         final List<Long> list2 = new ArrayList<>();
-        Disposable d2 = interval.subscribe(new Consumer<Long>() {
-            @Override
-            public void accept(Long t1) {
-                list2.add(t1);
-            }
-        });
+        Disposable d2 = interval.subscribe(t1 -> list2.add(t1));
 
         s.advanceTimeBy(300, TimeUnit.MILLISECONDS);
 
@@ -398,12 +393,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         // subscribing a new one should start over because the source should have been unsubscribed
         // subscribe list3
         final List<Long> list3 = new ArrayList<>();
-        interval.subscribe(new Consumer<Long>() {
-            @Override
-            public void accept(Long t1) {
-                list3.add(t1);
-            }
-        });
+        interval.subscribe(t1 -> list3.add(t1));
 
         s.advanceTimeBy(200, TimeUnit.MILLISECONDS);
 
@@ -460,12 +450,7 @@ public class FlowableRefCountTest extends RxJavaTest {
     public void connectDisconnectConnectAndSubjectState() {
         Flowable<Integer> f1 = Flowable.just(10);
         Flowable<Integer> f2 = Flowable.just(20);
-        Flowable<Integer> combined = Flowable.combineLatest(f1, f2, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2;
-            }
-        })
+        Flowable<Integer> combined = Flowable.combineLatest(f1, f2, (t1, t2) -> t1 + t2)
         .publish().refCount();
 
         TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
@@ -490,62 +475,22 @@ public class FlowableRefCountTest extends RxJavaTest {
             final AtomicInteger intervalSubscribed = new AtomicInteger();
             Flowable<String> interval =
                     Flowable.interval(200, TimeUnit.MILLISECONDS)
-                            .doOnSubscribe(new Consumer<Subscription>() {
-                                @Override
-                                public void accept(Subscription s) {
-                                                System.out.println("Subscribing to interval " + intervalSubscribed.incrementAndGet());
-                                        }
-                            }
-                             )
-                            .flatMap(new Function<Long, Publisher<String>>() {
-                                @Override
-                                public Publisher<String> apply(Long t1) {
-                                        return Flowable.defer(new Supplier<Publisher<String>>() {
-                                            @Override
-                                            public Publisher<String> get() {
-                                                    return Flowable.<String>error(new TestException("Some exception"));
-                                            }
-                                        });
-                                }
-                            })
-                            .onErrorResumeNext(new Function<Throwable, Publisher<String>>() {
-                                @Override
-                                public Publisher<String> apply(Throwable t1) {
-                                        return Flowable.error(t1);
-                                }
-                            })
+                            .doOnSubscribe(_ -> System.out.println("Subscribing to interval " + intervalSubscribed.incrementAndGet())
+                            )
+                            .flatMap(_ -> Flowable.defer(() -> Flowable.<String>error(new TestException("Some exception"))))
+                            .onErrorResumeNext((Function<Throwable, Publisher<String>>) t1 -> Flowable.error(t1))
                             .publish()
                             .refCount();
 
             interval
-                    .doOnError(new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable t1) {
-                                System.out.println("Subscriber 1 onError: " + t1);
-                        }
-                    })
+                    .doOnError(t1 -> System.out.println("Subscriber 1 onError: " + t1))
                     .retry(5)
-                    .subscribe(new Consumer<String>() {
-                        @Override
-                        public void accept(String t1) {
-                                System.out.println("Subscriber 1: " + t1);
-                        }
-                    });
+                    .subscribe(t1 -> System.out.println("Subscriber 1: " + t1));
             Thread.sleep(100);
             interval
-            .doOnError(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t1) {
-                        System.out.println("Subscriber 2 onError: " + t1);
-                }
-            })
+            .doOnError(t1 -> System.out.println("Subscriber 2 onError: " + t1))
             .retry(5)
-                    .subscribe(new Consumer<String>() {
-                        @Override
-                        public void accept(String t1) {
-                                System.out.println("Subscriber 2: " + t1);
-                        }
-                    });
+                    .subscribe(t1 -> System.out.println("Subscriber 2: " + t1));
 
             Thread.sleep(1300);
 
@@ -616,12 +561,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
-        source = Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return new byte[100 * 1000 * 1000];
-            }
-        })
+        source = Flowable.fromCallable((Callable<Object>) () -> new byte[100 * 1000 * 1000])
         .replay(1)
         .refCount();
 
@@ -641,12 +581,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
-        source = Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return new byte[100 * 1000 * 1000];
-            }
-        }).concatWith(Flowable.never())
+        source = Flowable.fromCallable((Callable<Object>) () -> new byte[100 * 1000 * 1000]).concatWith(Flowable.never())
         .replay(1)
         .refCount();
 
@@ -682,11 +617,8 @@ public class FlowableRefCountTest extends RxJavaTest {
         System.gc();
         Thread.sleep(GC_SLEEP_TIME);
 
-        source = Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new ExceptionData(new byte[100 * 1000 * 1000]);
-            }
+        source = Flowable.fromCallable(() -> {
+            throw new ExceptionData(new byte[100 * 1000 * 1000]);
         })
         .publish()
         .refCount();
@@ -709,12 +641,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         long start = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
 
-        source = Flowable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return new byte[100 * 1000 * 1000];
-            }
-        }).concatWith(Flowable.never())
+        source = Flowable.fromCallable((Callable<Object>) () -> new byte[100 * 1000 * 1000]).concatWith(Flowable.never())
         .publish()
         .refCount();
 
@@ -970,20 +897,12 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         final AtomicBoolean interrupted = new AtomicBoolean();
 
-        f.switchMap(new Function<Integer, Publisher<? extends Object>>() {
-            @Override
-            public Publisher<? extends Object> apply(Integer v) throws Exception {
-                return Flowable.create(new FlowableOnSubscribe<Object>() {
-                    @Override
-                    public void subscribe(FlowableEmitter<Object> emitter) throws Exception {
-                        while (!emitter.isCancelled()) {
-                            Thread.sleep(100);
-                        }
-                        interrupted.set(true);
-                    }
-                }, BackpressureStrategy.MISSING);
+        f.switchMap(_ -> Flowable.create(emitter -> {
+            while (!emitter.isCancelled()) {
+                Thread.sleep(100);
             }
-        })
+            interrupted.set(true);
+        }, BackpressureStrategy.MISSING))
         .takeUntil(Flowable.timer(500, TimeUnit.MILLISECONDS))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -997,12 +916,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         final int[] subscriptions = { 0 };
 
         Flowable<Integer> source = Flowable.range(1, 5)
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                subscriptions[0]++;
-            }
-        })
+        .doOnSubscribe(_ -> subscriptions[0]++)
         .publish()
         .refCount(2);
 
@@ -1027,12 +941,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         Flowable<Integer> source = pp
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                subscriptions[0]++;
-            }
-        })
+        .doOnSubscribe(_ -> subscriptions[0]++)
         .publish()
         .refCount(500, TimeUnit.MILLISECONDS);
 
@@ -1070,12 +979,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
         Flowable<Integer> source = pp
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                subscriptions[0]++;
-            }
-        })
+        .doOnSubscribe(_ -> subscriptions[0]++)
         .publish()
         .refCount(1, 100, TimeUnit.MILLISECONDS);
 
@@ -1137,19 +1041,9 @@ public class FlowableRefCountTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = () -> ts1.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    source.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> source.subscribe(ts2);
 
             TestHelper.race(r1, r2, Schedulers.single());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeatTest.java
@@ -41,13 +41,9 @@ public class FlowableRepeatTest {
     public void repetition() {
         int num = 10;
         final AtomicInteger count = new AtomicInteger();
-        int value = Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super Integer> subscriber) {
-                subscriber.onNext(count.incrementAndGet());
-                subscriber.onComplete();
-            }
+        int value = Flowable.unsafeCreate((Publisher<Integer>) subscriber -> {
+            subscriber.onNext(count.incrementAndGet());
+            subscriber.onComplete();
         }).repeat().subscribeOn(Schedulers.computation())
         .take(num).blockingLast();
 
@@ -70,30 +66,21 @@ public class FlowableRepeatTest {
     public void repeatTakeWithSubscribeOn() throws InterruptedException {
 
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<Integer> oi = Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> sub) {
-                sub.onSubscribe(new BooleanSubscription());
-                counter.incrementAndGet();
-                sub.onNext(1);
-                sub.onNext(2);
-                sub.onComplete();
-            }
+        Flowable<Integer> oi = Flowable.unsafeCreate((Publisher<Integer>) sub -> {
+            sub.onSubscribe(new BooleanSubscription());
+            counter.incrementAndGet();
+            sub.onNext(1);
+            sub.onNext(2);
+            sub.onComplete();
         }).subscribeOn(Schedulers.newThread());
 
-        Object[] ys = oi.repeat().subscribeOn(Schedulers.newThread()).map(new Function<Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1) {
-                try {
-                    Thread.sleep(50);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                return t1;
+        Object[] ys = oi.repeat().subscribeOn(Schedulers.newThread()).map(t1 -> {
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
             }
-
+            return t1;
         }).take(4).toList().blockingGet().toArray();
 
         assertEquals(2, counter.get());
@@ -180,14 +167,11 @@ public class FlowableRepeatTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.just(1, 2)
         .repeat(5)
-        .concatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer x) {
-                System.out.println("testRepeatRetarget -> " + x);
-                concatBase.add(x);
-                return Flowable.<Integer>empty()
-                        .delay(200, TimeUnit.MILLISECONDS);
-            }
+        .concatMap((Function<Integer, Flowable<Integer>>) x -> {
+            System.out.println("testRepeatRetarget -> " + x);
+            concatBase.add(x);
+            return Flowable.<Integer>empty()
+                    .delay(200, TimeUnit.MILLISECONDS);
         })
         .subscribe(ts);
 
@@ -211,17 +195,11 @@ public class FlowableRepeatTest {
         ts.assertComplete();
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void repeatWhenDefaultScheduler() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
-        Flowable.just(1).repeatWhen((Function)new Function<Flowable, Flowable>() {
-            @Override
-            public Flowable apply(Flowable f) {
-                return f.take(2);
-            }
-        }).subscribe(ts);
+        Flowable.just(1).repeatWhen(f -> f.take(2)).subscribe(ts);
 
         ts.assertValues(1, 1);
         ts.assertNoErrors();
@@ -229,18 +207,12 @@ public class FlowableRepeatTest {
 
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void repeatWhenTrampolineScheduler() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.just(1).subscribeOn(Schedulers.trampoline())
-        .repeatWhen((Function)new Function<Flowable, Flowable>() {
-            @Override
-            public Flowable apply(Flowable f) {
-                return f.take(2);
-            }
-        }).subscribe(ts);
+        .repeatWhen(f -> f.take(2)).subscribe(ts);
 
         ts.assertValues(1, 1);
         ts.assertNoErrors();
@@ -250,12 +222,7 @@ public class FlowableRepeatTest {
     @Test
     public void repeatUntil() {
         Flowable.just(1)
-        .repeatUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        })
+        .repeatUntil(() -> false)
         .take(5)
         .test()
         .assertResult(1, 1, 1, 1, 1);
@@ -264,12 +231,7 @@ public class FlowableRepeatTest {
     @Test
     public void repeatUntilCancel() {
         Flowable.just(1)
-        .repeatUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return true;
-            }
-        })
+        .repeatUntil(() -> true)
         .test(2L, true)
         .assertEmpty();
     }
@@ -287,12 +249,7 @@ public class FlowableRepeatTest {
     @Test
     public void repeatUntilError() {
         Flowable.error(new TestException())
-        .repeatUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return true;
-            }
-        })
+        .repeatUntil(() -> true)
         .test()
         .assertFailure(TestException.class);
     }
@@ -300,12 +257,7 @@ public class FlowableRepeatTest {
     @Test
     public void repeatUntilFalse() {
         Flowable.just(1)
-        .repeatUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return true;
-            }
-        })
+        .repeatUntil(() -> true)
         .test()
         .assertResult(1);
     }
@@ -313,11 +265,8 @@ public class FlowableRepeatTest {
     @Test
     public void repeatUntilSupplierCrash() {
         Flowable.just(1)
-        .repeatUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                throw new TestException();
-            }
+        .repeatUntil(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class, 1);
@@ -327,17 +276,7 @@ public class FlowableRepeatTest {
     public void shouldDisposeInnerObservable() {
         final PublishProcessor<Object> processor = PublishProcessor.create();
         final Disposable disposable = Flowable.just("Leak")
-                .repeatWhen(new Function<Flowable<Object>, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Flowable<Object> completions) throws Exception {
-                        return completions.switchMap(new Function<Object, Flowable<Object>>() {
-                            @Override
-                            public Flowable<Object> apply(Object ignore) throws Exception {
-                                return processor;
-                            }
-                        });
-                    }
-                })
+                .repeatWhen((Function<Flowable<Object>, Flowable<Object>>) completions -> completions.switchMap((Function<Object, Flowable<Object>>) _ -> processor))
                 .subscribe();
 
         assertTrue(processor.hasSubscribers());
@@ -348,12 +287,7 @@ public class FlowableRepeatTest {
     @Test
     public void repeatWhen() {
         Flowable.error(new TestException())
-        .repeatWhen(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> v) throws Exception {
-                return v.delay(10, TimeUnit.SECONDS);
-            }
-        })
+        .repeatWhen((Function<Flowable<Object>, Flowable<Object>>) v -> v.delay(10, TimeUnit.SECONDS))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
@@ -361,12 +295,7 @@ public class FlowableRepeatTest {
 
     @Test
     public void whenTake() {
-        Flowable.range(1, 3).repeatWhen(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> handler) throws Exception {
-                return handler.take(2);
-            }
-        })
+        Flowable.range(1, 3).repeatWhen((Function<Flowable<Object>, Flowable<Object>>) handler -> handler.take(2))
         .test()
         .assertResult(1, 2, 3, 1, 2, 3);
     }
@@ -375,12 +304,7 @@ public class FlowableRepeatTest {
     public void noCancelPreviousRepeat() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.just(1).doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Flowable<Integer> source = Flowable.just(1).doOnCancel(() -> counter.getAndIncrement());
 
         source.repeat(5)
         .test()
@@ -393,21 +317,11 @@ public class FlowableRepeatTest {
     public void noCancelPreviousRepeatUntil() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.just(1).doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Flowable<Integer> source = Flowable.just(1).doOnCancel(() -> counter.getAndIncrement());
 
         final AtomicInteger times = new AtomicInteger();
 
-        source.repeatUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return times.getAndIncrement() == 4;
-            }
-        })
+        source.repeatUntil(() -> times.getAndIncrement() == 4)
         .test()
         .assertResult(1, 1, 1, 1, 1);
 
@@ -418,26 +332,11 @@ public class FlowableRepeatTest {
     public void noCancelPreviousRepeatWhen() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.just(1).doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Flowable<Integer> source = Flowable.just(1).doOnCancel(() -> counter.getAndIncrement());
 
         final AtomicInteger times = new AtomicInteger();
 
-        source.repeatWhen(new Function<Flowable<Object>, Flowable<?>>() {
-            @Override
-            public Flowable<?> apply(Flowable<Object> e) throws Exception {
-                return e.takeWhile(new Predicate<Object>() {
-                    @Override
-                    public boolean test(Object v) throws Exception {
-                        return times.getAndIncrement() < 4;
-                    }
-                });
-            }
-        })
+        source.repeatWhen((Function<Flowable<Object>, Flowable<?>>) e -> e.takeWhile(_ -> times.getAndIncrement() < 4))
         .test()
         .assertResult(1, 1, 1, 1, 1);
 
@@ -455,28 +354,16 @@ public class FlowableRepeatTest {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
                 TestSubscriber<Integer> ts = source.take(1)
-                .repeatWhen(new Function<Flowable<Object>, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Flowable<Object> v)
-                            throws Exception {
-                        return signaller;
-                    }
-                }).test();
+                .repeatWhen((Function<Flowable<Object>, Flowable<Integer>>) _ -> signaller).test();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                            source.onNext(1);
-                        }
+                Runnable r1 = () -> {
+                    for (int i1 = 0; i1 < TestHelper.RACE_DEFAULT_LOOPS; i1++) {
+                        source.onNext(1);
                     }
                 };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                            signaller.offer(1);
-                        }
+                Runnable r2 = () -> {
+                    for (int i2 = 0; i2 < TestHelper.RACE_DEFAULT_LOOPS; i2++) {
+                        signaller.offer(1);
                     }
                 };
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -187,23 +187,9 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void replaySelector() {
-        final Function<Integer, Integer> dbl = new Function<Integer, Integer>() {
+        final Function<Integer, Integer> dbl = t1 -> t1 * 2;
 
-            @Override
-            public Integer apply(Integer t1) {
-                return t1 * 2;
-            }
-
-        };
-
-        Function<Flowable<Integer>, Flowable<Integer>> selector = new Function<Flowable<Integer>, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> t1) {
-                return t1.map(dbl);
-            }
-
-        };
+        Function<Flowable<Integer>, Flowable<Integer>> selector = t1 -> t1.map(dbl);
 
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -249,23 +235,9 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void bufferedReplaySelector() {
 
-        final Function<Integer, Integer> dbl = new Function<Integer, Integer>() {
+        final Function<Integer, Integer> dbl = t1 -> t1 * 2;
 
-            @Override
-            public Integer apply(Integer t1) {
-                return t1 * 2;
-            }
-
-        };
-
-        Function<Flowable<Integer>, Flowable<Integer>> selector = new Function<Flowable<Integer>, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> t1) {
-                return t1.map(dbl);
-            }
-
-        };
+        Function<Flowable<Integer>, Flowable<Integer>> selector = t1 -> t1.map(dbl);
 
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -309,23 +281,9 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void windowedReplaySelector() {
 
-        final Function<Integer, Integer> dbl = new Function<Integer, Integer>() {
+        final Function<Integer, Integer> dbl = t1 -> t1 * 2;
 
-            @Override
-            public Integer apply(Integer t1) {
-                return t1 * 2;
-            }
-
-        };
-
-        Function<Flowable<Integer>, Flowable<Integer>> selector = new Function<Flowable<Integer>, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> t1) {
-                return t1.map(dbl);
-            }
-
-        };
+        Function<Flowable<Integer>, Flowable<Integer>> selector = t1 -> t1.map(dbl);
 
         TestScheduler scheduler = new TestScheduler();
 
@@ -465,45 +423,19 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void synchronousDisconnect() {
         final AtomicInteger effectCounter = new AtomicInteger();
         Flowable<Integer> source = Flowable.just(1, 2, 3, 4)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) {
-                effectCounter.incrementAndGet();
-                System.out.println("Sideeffect #" + v);
-            }
+        .doOnNext(v -> {
+            effectCounter.incrementAndGet();
+            System.out.println("Sideeffect #" + v);
         });
 
         Flowable<Integer> result = source.replay(
-        new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> f) {
-                return f.take(2);
-            }
-        });
+                (Function<Flowable<Integer>, Flowable<Integer>>) f -> f.take(2));
 
         for (int i = 1; i < 3; i++) {
             effectCounter.set(0);
             System.out.printf("- %d -%n", i);
-            result.subscribe(new Consumer<Integer>() {
-
-                @Override
-                public void accept(Integer t1) {
-                    System.out.println(t1);
-                }
-
-            }, new Consumer<Throwable>() {
-
-                @Override
-                public void accept(Throwable t1) {
-                    t1.printStackTrace();
-                }
-            },
-            new Action() {
-                @Override
-                public void run() {
-                    System.out.println("Done");
-                }
-            });
+            result.subscribe(t1 -> System.out.println(t1), t1 -> t1.printStackTrace(),
+                    () -> System.out.println("Done"));
             assertEquals(2, effectCounter.get());
         }
     }
@@ -807,12 +739,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void backpressure() {
         final AtomicLong requested = new AtomicLong();
         Flowable<Integer> source = Flowable.range(1, 1000)
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long t) {
-                        requested.addAndGet(t);
-                    }
-                });
+                .doOnRequest(t -> requested.addAndGet(t));
         ConnectableFlowable<Integer> cf = source.replay();
 
         TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>(10L);
@@ -838,12 +765,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void backpressureBounded() {
         final AtomicLong requested = new AtomicLong();
         Flowable<Integer> source = Flowable.range(1, 1000)
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long t) {
-                        requested.addAndGet(t);
-                    }
-                });
+                .doOnRequest(t -> requested.addAndGet(t));
         ConnectableFlowable<Integer> cf = source.replay(50, true);
 
         TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>(10L);
@@ -907,47 +829,31 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void cache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        counter.incrementAndGet();
-                        System.out.println("published observable being executed");
-                        subscriber.onNext("one");
-                        subscriber.onComplete();
-                    }
-                }).start();
-            }
+        Flowable<String> f = Flowable.unsafeCreate((Publisher<String>) subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            new Thread(() -> {
+                counter.incrementAndGet();
+                System.out.println("published observable being executed");
+                subscriber.onNext("one");
+                subscriber.onComplete();
+            }).start();
         }).replay().autoConnect();
 
         // we then expect the following 2 subscriptions to get that same value
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                System.out.println("v: " + v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            Assert.assertEquals("one", v);
+            System.out.println("v: " + v);
+            latch.countDown();
         });
 
         // subscribe again
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                System.out.println("v: " + v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            Assert.assertEquals("one", v);
+            System.out.println("v: " + v);
+            latch.countDown();
         });
 
         if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
@@ -1042,15 +948,12 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void noMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Flowable<Integer> firehose = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> t) {
-                t.onSubscribe(new BooleanSubscription());
-                for (int i = 0; i < m; i++) {
-                    t.onNext(i);
-                }
-                t.onComplete();
+        Flowable<Integer> firehose = Flowable.unsafeCreate(t -> {
+            t.onSubscribe(new BooleanSubscription());
+            for (int i = 0; i < m; i++) {
+                t.onNext(i);
             }
+            t.onComplete();
         });
 
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
@@ -1089,12 +992,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
 
         Flowable<Integer> source = Flowable.range(1, 100)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        })
+        .doOnNext(_ -> count.getAndIncrement())
         .replay().autoConnect();
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
@@ -1120,12 +1018,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         final List<Long> requests = new ArrayList<>();
 
         Flowable<Integer> out = source
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long t) {
-                        requests.add(t);
-                    }
-                }).replay().autoConnect();
+                .doOnRequest(t -> requests.add(t)).replay().autoConnect();
 
         TestSubscriber<Integer> ts1 = new TestSubscriber<>(5L);
         TestSubscriber<Integer> ts2 = new TestSubscriber<>(10L);
@@ -1277,12 +1170,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cf.connect();
-                }
-            };
+            Runnable r = () -> cf.connect();
 
             TestHelper.race(r, r);
         }
@@ -1296,19 +1184,9 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
             final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
             final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts1);
-                }
-            };
+            Runnable r1 = () -> cf.subscribe(ts1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> cf.subscribe(ts2);
 
             TestHelper.race(r1, r2);
         }
@@ -1324,19 +1202,9 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
             cf.subscribe(ts1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = () -> ts1.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> cf.subscribe(ts2);
 
             TestHelper.race(r1, r2);
         }
@@ -1370,11 +1238,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         .replay();
 
         try {
-            cf.connect(new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable t) throws Exception {
-                    throw new TestException();
-                }
+            cf.connect(_ -> {
+                throw new TestException();
             });
             fail("Should have thrown");
         } catch (TestException ex) {
@@ -1421,19 +1286,11 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts1);
-                }
-            };
+            Runnable r1 = () -> cf.subscribe(ts1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 1000; j++) {
-                        pp.onNext(j);
-                    }
+            Runnable r2 = () -> {
+                for (int j = 0; j < 1000; j++) {
+                    pp.onNext(j);
                 }
             };
 
@@ -1452,19 +1309,11 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
             cf.subscribe(ts1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = () -> ts1.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 1000; j++) {
-                        pp.onNext(j);
-                    }
+            Runnable r2 = () -> {
+                for (int j = 0; j < 1000; j++) {
+                    pp.onNext(j);
                 }
             };
 
@@ -1481,19 +1330,9 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
             cf.connect();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts1);
-                }
-            };
+            Runnable r1 = () -> cf.subscribe(ts1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r2 = () -> ts1.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -1714,11 +1553,8 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void multicastSelectorCallableConnectableCrash() {
-        FlowableReplay.multicastSelector(new Supplier<ConnectableFlowable<Object>>() {
-            @Override
-            public ConnectableFlowable<Object> get() throws Exception {
-                throw new TestException();
-            }
+        FlowableReplay.multicastSelector(() -> {
+            throw new TestException();
         }, Functions.<Flowable<Object>>identity())
         .test()
         .assertFailure(TestException.class);
@@ -1902,22 +1738,16 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void createBufferFactoryCrash() {
-        FlowableReplay.create(Flowable.just(1), new Supplier<ReplayBuffer<Integer>>() {
-            @Override
-            public ReplayBuffer<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        FlowableReplay.create(Flowable.just(1), () -> {
+            throw new TestException();
         })
         .connect();
     }
 
     @Test
     public void createBufferFactoryCrashOnSubscribe() {
-        FlowableReplay.create(Flowable.just(1), new Supplier<ReplayBuffer<Integer>>() {
-            @Override
-            public ReplayBuffer<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        FlowableReplay.create(Flowable.just(1), () -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -1926,24 +1756,9 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void noBoundedRetentionViaThreadLocal() throws Exception {
         Flowable<byte[]> source = Flowable.range(1, 200)
-        .map(new Function<Integer, byte[]>() {
-            @Override
-            public byte[] apply(Integer v) throws Exception {
-                return new byte[1024 * 1024];
-            }
-        })
-        .replay(new Function<Flowable<byte[]>, Publisher<byte[]>>() {
-            @Override
-            public Publisher<byte[]> apply(final Flowable<byte[]> f) throws Exception {
-                return f.take(1)
-                .concatMap(new Function<byte[], Publisher<byte[]>>() {
-                    @Override
-                    public Publisher<byte[]> apply(byte[] v) throws Exception {
-                        return f;
-                    }
-                });
-            }
-        }, 1, true)
+        .map(_ -> new byte[1024 * 1024])
+        .replay(f -> f.take(1)
+        .concatMap((Function<byte[], Publisher<byte[]>>) _ -> f), 1, true)
         .takeLast(1)
         ;
 
@@ -1963,19 +1778,16 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
         final AtomicLong after = new AtomicLong();
 
-        source.subscribe(new Consumer<byte[]>() {
-            @Override
-            public void accept(byte[] v) throws Exception {
-                System.out.println("Bounded Replay Leak check: Wait before GC 2");
-                Thread.sleep(1000);
+        source.subscribe(_ -> {
+            System.out.println("Bounded Replay Leak check: Wait before GC 2");
+            Thread.sleep(1000);
 
-                System.out.println("Bounded Replay Leak check:  GC 2");
-                System.gc();
+            System.out.println("Bounded Replay Leak check:  GC 2");
+            System.gc();
 
-                Thread.sleep(500);
+            Thread.sleep(500);
 
-                after.set(memoryMXBean.getHeapMemoryUsage().getUsed());
-            }
+            after.set(memoryMXBean.getHeapMemoryUsage().getUsed());
         });
 
         System.out.printf("Bounded Replay Leak check: After: %.3f MB%n", after.get() / 1024.0 / 1024.0);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -190,23 +190,9 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void replaySelector() {
-        final Function<Integer, Integer> dbl = new Function<Integer, Integer>() {
+        final Function<Integer, Integer> dbl = t1 -> t1 * 2;
 
-            @Override
-            public Integer apply(Integer t1) {
-                return t1 * 2;
-            }
-
-        };
-
-        Function<Flowable<Integer>, Flowable<Integer>> selector = new Function<Flowable<Integer>, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> t1) {
-                return t1.map(dbl);
-            }
-
-        };
+        Function<Flowable<Integer>, Flowable<Integer>> selector = t1 -> t1.map(dbl);
 
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -252,23 +238,9 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void bufferedReplaySelector() {
 
-        final Function<Integer, Integer> dbl = new Function<Integer, Integer>() {
+        final Function<Integer, Integer> dbl = t1 -> t1 * 2;
 
-            @Override
-            public Integer apply(Integer t1) {
-                return t1 * 2;
-            }
-
-        };
-
-        Function<Flowable<Integer>, Flowable<Integer>> selector = new Function<Flowable<Integer>, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> t1) {
-                return t1.map(dbl);
-            }
-
-        };
+        Function<Flowable<Integer>, Flowable<Integer>> selector = t1 -> t1.map(dbl);
 
         PublishProcessor<Integer> source = PublishProcessor.create();
 
@@ -312,23 +284,9 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void windowedReplaySelector() {
 
-        final Function<Integer, Integer> dbl = new Function<Integer, Integer>() {
+        final Function<Integer, Integer> dbl = t1 -> t1 * 2;
 
-            @Override
-            public Integer apply(Integer t1) {
-                return t1 * 2;
-            }
-
-        };
-
-        Function<Flowable<Integer>, Flowable<Integer>> selector = new Function<Flowable<Integer>, Flowable<Integer>>() {
-
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> t1) {
-                return t1.map(dbl);
-            }
-
-        };
+        Function<Flowable<Integer>, Flowable<Integer>> selector = t1 -> t1.map(dbl);
 
         TestScheduler scheduler = new TestScheduler();
 
@@ -468,45 +426,19 @@ public class FlowableReplayTest extends RxJavaTest {
     public void synchronousDisconnect() {
         final AtomicInteger effectCounter = new AtomicInteger();
         Flowable<Integer> source = Flowable.just(1, 2, 3, 4)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) {
-                effectCounter.incrementAndGet();
-                System.out.println("Sideeffect #" + v);
-            }
+        .doOnNext(v -> {
+            effectCounter.incrementAndGet();
+            System.out.println("Sideeffect #" + v);
         });
 
         Flowable<Integer> result = source.replay(
-        new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> f) {
-                return f.take(2);
-            }
-        });
+                (Function<Flowable<Integer>, Flowable<Integer>>) f -> f.take(2));
 
         for (int i = 1; i < 3; i++) {
             effectCounter.set(0);
             System.out.printf("- %d -%n", i);
-            result.subscribe(new Consumer<Integer>() {
-
-                @Override
-                public void accept(Integer t1) {
-                    System.out.println(t1);
-                }
-
-            }, new Consumer<Throwable>() {
-
-                @Override
-                public void accept(Throwable t1) {
-                    t1.printStackTrace();
-                }
-            },
-            new Action() {
-                @Override
-                public void run() {
-                    System.out.println("Done");
-                }
-            });
+            result.subscribe(t1 -> System.out.println(t1), t1 -> t1.printStackTrace(),
+                    () -> System.out.println("Done"));
             assertEquals(2, effectCounter.get());
         }
     }
@@ -824,12 +756,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void backpressure() {
         final AtomicLong requested = new AtomicLong();
         Flowable<Integer> source = Flowable.range(1, 1000)
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long t) {
-                        requested.addAndGet(t);
-                    }
-                });
+                .doOnRequest(t -> requested.addAndGet(t));
         ConnectableFlowable<Integer> cf = source.replay();
 
         TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>(10L);
@@ -855,12 +782,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void backpressureBounded() {
         final AtomicLong requested = new AtomicLong();
         Flowable<Integer> source = Flowable.range(1, 1000)
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long t) {
-                        requested.addAndGet(t);
-                    }
-                });
+                .doOnRequest(t -> requested.addAndGet(t));
         ConnectableFlowable<Integer> cf = source.replay(50);
 
         TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>(10L);
@@ -924,47 +846,31 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void cache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Flowable<String> f = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        counter.incrementAndGet();
-                        System.out.println("published observable being executed");
-                        subscriber.onNext("one");
-                        subscriber.onComplete();
-                    }
-                }).start();
-            }
+        Flowable<String> f = Flowable.unsafeCreate((Publisher<String>) subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            new Thread(() -> {
+                counter.incrementAndGet();
+                System.out.println("published observable being executed");
+                subscriber.onNext("one");
+                subscriber.onComplete();
+            }).start();
         }).replay().autoConnect();
 
         // we then expect the following 2 subscriptions to get that same value
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                System.out.println("v: " + v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            Assert.assertEquals("one", v);
+            System.out.println("v: " + v);
+            latch.countDown();
         });
 
         // subscribe again
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String v) {
-                assertEquals("one", v);
-                System.out.println("v: " + v);
-                latch.countDown();
-            }
+        f.subscribe(v -> {
+            Assert.assertEquals("one", v);
+            System.out.println("v: " + v);
+            latch.countDown();
         });
 
         if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
@@ -1061,15 +967,12 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void noMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Flowable<Integer> firehose = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> t) {
-                t.onSubscribe(new BooleanSubscription());
-                for (int i = 0; i < m; i++) {
-                    t.onNext(i);
-                }
-                t.onComplete();
+        Flowable<Integer> firehose = Flowable.unsafeCreate(t -> {
+            t.onSubscribe(new BooleanSubscription());
+            for (int i = 0; i < m; i++) {
+                t.onNext(i);
             }
+            t.onComplete();
         });
 
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
@@ -1108,12 +1011,7 @@ public class FlowableReplayTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
 
         Flowable<Integer> source = Flowable.range(1, 100)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        })
+        .doOnNext(_ -> count.getAndIncrement())
         .replay().autoConnect();
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
@@ -1185,12 +1083,7 @@ public class FlowableReplayTest extends RxJavaTest {
         final List<Long> requests = new ArrayList<>();
 
         Flowable<Integer> out = source
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long t) {
-                        requests.add(t);
-                    }
-                }).replay().autoConnect();
+                .doOnRequest(t -> requests.add(t)).replay().autoConnect();
 
         TestSubscriber<Integer> ts1 = new TestSubscriber<>(5L);
         TestSubscriber<Integer> ts2 = new TestSubscriber<>(10L);
@@ -1342,12 +1235,7 @@ public class FlowableReplayTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ConnectableFlowable<Integer> cf = Flowable.range(1, 3).replay();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    cf.connect();
-                }
-            };
+            Runnable r = () -> cf.connect();
 
             TestHelper.race(r, r);
         }
@@ -1361,19 +1249,9 @@ public class FlowableReplayTest extends RxJavaTest {
             final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
             final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts1);
-                }
-            };
+            Runnable r1 = () -> cf.subscribe(ts1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> cf.subscribe(ts2);
 
             TestHelper.race(r1, r2);
         }
@@ -1389,19 +1267,9 @@ public class FlowableReplayTest extends RxJavaTest {
 
             cf.subscribe(ts1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = () -> ts1.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> cf.subscribe(ts2);
 
             TestHelper.race(r1, r2);
         }
@@ -1435,11 +1303,8 @@ public class FlowableReplayTest extends RxJavaTest {
         .replay();
 
         try {
-            cf.connect(new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable t) throws Exception {
-                    throw new TestException();
-                }
+            cf.connect(_ -> {
+                throw new TestException();
             });
             fail("Should have thrown");
         } catch (TestException ex) {
@@ -1486,19 +1351,11 @@ public class FlowableReplayTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts1);
-                }
-            };
+            Runnable r1 = () -> cf.subscribe(ts1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 1000; j++) {
-                        pp.onNext(j);
-                    }
+            Runnable r2 = () -> {
+                for (int j = 0; j < 1000; j++) {
+                    pp.onNext(j);
                 }
             };
 
@@ -1517,19 +1374,11 @@ public class FlowableReplayTest extends RxJavaTest {
 
             cf.subscribe(ts1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = () -> ts1.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 1000; j++) {
-                        pp.onNext(j);
-                    }
+            Runnable r2 = () -> {
+                for (int j = 0; j < 1000; j++) {
+                    pp.onNext(j);
                 }
             };
 
@@ -1546,19 +1395,9 @@ public class FlowableReplayTest extends RxJavaTest {
 
             cf.connect();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cf.subscribe(ts1);
-                }
-            };
+            Runnable r1 = () -> cf.subscribe(ts1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r2 = () -> ts1.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -1779,11 +1618,8 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void multicastSelectorCallableConnectableCrash() {
-        FlowableReplay.multicastSelector(new Supplier<ConnectableFlowable<Object>>() {
-            @Override
-            public ConnectableFlowable<Object> get() throws Exception {
-                throw new TestException();
-            }
+        FlowableReplay.multicastSelector(() -> {
+            throw new TestException();
         }, Functions.<Flowable<Object>>identity())
         .test()
         .assertFailure(TestException.class);
@@ -1967,22 +1803,16 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void createBufferFactoryCrash() {
-        FlowableReplay.create(Flowable.just(1), new Supplier<ReplayBuffer<Integer>>() {
-            @Override
-            public ReplayBuffer<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        FlowableReplay.create(Flowable.just(1), () -> {
+            throw new TestException();
         })
         .connect();
     }
 
     @Test
     public void createBufferFactoryCrashOnSubscribe() {
-        FlowableReplay.create(Flowable.just(1), new Supplier<ReplayBuffer<Integer>>() {
-            @Override
-            public ReplayBuffer<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        FlowableReplay.create(Flowable.just(1), () -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -1991,24 +1821,9 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void noBoundedRetentionViaThreadLocal() throws Exception {
         Flowable<byte[]> source = Flowable.range(1, 200)
-        .map(new Function<Integer, byte[]>() {
-            @Override
-            public byte[] apply(Integer v) throws Exception {
-                return new byte[1024 * 1024];
-            }
-        })
-        .replay(new Function<Flowable<byte[]>, Publisher<byte[]>>() {
-            @Override
-            public Publisher<byte[]> apply(final Flowable<byte[]> f) throws Exception {
-                return f.take(1)
-                .concatMap(new Function<byte[], Publisher<byte[]>>() {
-                    @Override
-                    public Publisher<byte[]> apply(byte[] v) throws Exception {
-                        return f;
-                    }
-                });
-            }
-        }, 1)
+        .map(_ -> new byte[1024 * 1024])
+        .replay(f -> f.take(1)
+        .concatMap((Function<byte[], Publisher<byte[]>>) _ -> f), 1)
         .takeLast(1)
         ;
 
@@ -2028,19 +1843,16 @@ public class FlowableReplayTest extends RxJavaTest {
 
         final AtomicLong after = new AtomicLong();
 
-        source.subscribe(new Consumer<byte[]>() {
-            @Override
-            public void accept(byte[] v) throws Exception {
-                System.out.println("Bounded Replay Leak check: Wait before GC 2");
-                Thread.sleep(1000);
+        source.subscribe(_ -> {
+            System.out.println("Bounded Replay Leak check: Wait before GC 2");
+            Thread.sleep(1000);
 
-                System.out.println("Bounded Replay Leak check:  GC 2");
-                System.gc();
+            System.out.println("Bounded Replay Leak check:  GC 2");
+            System.gc();
 
-                Thread.sleep(500);
+            Thread.sleep(500);
 
-                after.set(memoryMXBean.getHeapMemoryUsage().getUsed());
-            }
+            after.set(memoryMXBean.getHeapMemoryUsage().getUsed());
         });
 
         System.out.printf("Bounded Replay Leak check: After: %.3f MB%n", after.get() / 1024.0 / 1024.0);
@@ -2056,12 +1868,7 @@ public class FlowableReplayTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
 
         Flowable<Integer> source = Flowable.range(1, 100)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        })
+        .doOnNext(_ -> count.getAndIncrement())
         .replay(1000).autoConnect();
 
         TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
@@ -65,32 +65,18 @@ public class FlowableRetryTest extends RxJavaTest {
 
         });
         TestSubscriber<String> ts = new TestSubscriber<>(consumer);
-        producer.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
-
-            @Override
-            public Flowable<Object> apply(Flowable<? extends Throwable> attempts) {
-                // Worker w = Schedulers.computation().createWorker();
-                return attempts
-                    .map(new Function<Throwable, Tuple>() {
-                        @Override
-                        public Tuple apply(Throwable n) {
-                            return new Tuple(1L, n);
-                        }})
-                    .scan(new BiFunction<Tuple, Tuple, Tuple>() {
-                        @Override
-                        public Tuple apply(Tuple t, Tuple n) {
-                            return new Tuple(t.count + n.count, n.n);
-                        }})
-                    .flatMap(new Function<Tuple, Flowable<Object>>() {
-                        @Override
-                        public Flowable<Object> apply(Tuple t) {
-                            System.out.println("Retry # " + t.count);
-                            return t.count > 20 ?
-                                Flowable.<Object>error(t.n) :
-                                Flowable.timer(t.count * 1L, TimeUnit.MILLISECONDS)
-                                .cast(Object.class);
-                    }});
-            }
+        producer.retryWhen((Function<Flowable<? extends Throwable>, Flowable<Object>>) attempts -> {
+            // Worker w = Schedulers.computation().createWorker();
+            return attempts
+                .map((Function<Throwable, Tuple>) n -> new Tuple(1L, n))
+                .scan((t, n) -> new Tuple(t.count + n.count, n.n))
+                .flatMap((Function<Tuple, Flowable<Object>>) t -> {
+                    System.out.println("Retry # " + t.count);
+                    return t.count > 20 ?
+                        Flowable.<Object>error(t.n) :
+                        Flowable.timer(t.count * 1L, TimeUnit.MILLISECONDS)
+                        .cast(Object.class);
+            });
         }).subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -138,23 +124,12 @@ public class FlowableRetryTest extends RxJavaTest {
         int numRetries = 2;
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
         TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
-        origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
-                return t1.observeOn(Schedulers.computation()).map(new Function<Throwable, Integer>() {
-                    @Override
-                    public Integer apply(Throwable t1) {
-                        return 1;
-                    }
-                }).startWithItem(1).cast(Object.class);
-            }
-        })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) {
-                e.printStackTrace();
-            }
-        })
+        origin.retryWhen((Function<Flowable<? extends Throwable>, Flowable<Object>>) t1 ->
+            t1.observeOn(Schedulers.computation()).map((Function<Throwable, Integer>) _ -> 1)
+            .startWithItem(1)
+            .cast(Object.class)
+        )
+        .doOnError(e -> e.printStackTrace())
         .subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -175,18 +150,8 @@ public class FlowableRetryTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         int numRetries = 2;
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-        origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
-                return t1.map(new Function<Throwable, Integer>() {
-
-                    @Override
-                    public Integer apply(Throwable t1) {
-                        return 0;
-                    }
-                }).startWithItem(0).cast(Object.class);
-            }
-        }).subscribe(subscriber);
+        origin.retryWhen((Function<Flowable<? extends Throwable>, Flowable<Object>>) t1 ->
+            t1.map((Function<Throwable, Integer>) _ -> 0).startWithItem(0).cast(Object.class)).subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         // should show 3 attempts
@@ -205,12 +170,7 @@ public class FlowableRetryTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(1));
         TestSubscriber<String> ts = new TestSubscriber<>(subscriber);
-        origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
-                return Flowable.empty();
-            }
-        }).subscribe(ts);
+        origin.retryWhen((Function<Flowable<? extends Throwable>, Flowable<Object>>) _ -> Flowable.empty()).subscribe(ts);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber).onSubscribe(notNull());
@@ -225,12 +185,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void onErrorFromNotificationHandler() {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(2));
-        origin.retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<? extends Throwable> t1) {
-                return Flowable.error(new RuntimeException());
-            }
-        }).subscribe(subscriber);
+        origin.retryWhen((Function<Flowable<? extends Throwable>, Flowable<Object>>) _ -> Flowable.error(new RuntimeException())).subscribe(subscriber);
 
         InOrder inOrder = inOrder(subscriber);
         inOrder.verify(subscriber).onSubscribe(notNull());
@@ -244,28 +199,15 @@ public class FlowableRetryTest extends RxJavaTest {
     @Test
     public void singleSubscriptionOnFirst() throws Exception {
         final AtomicInteger inc = new AtomicInteger(0);
-        Publisher<Integer> onSubscribe = new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                final int emit = inc.incrementAndGet();
-                subscriber.onNext(emit);
-                subscriber.onComplete();
-            }
+        Publisher<Integer> onSubscribe = subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            final int emit = inc.incrementAndGet();
+            subscriber.onNext(emit);
+            subscriber.onComplete();
         };
 
         int first = Flowable.unsafeCreate(onSubscribe)
-                .retryWhen(new Function<Flowable<? extends Throwable>, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Flowable<? extends Throwable> attempt) {
-                        return attempt.zipWith(Flowable.just(1), new BiFunction<Throwable, Integer, Object>() {
-                            @Override
-                            public Object apply(Throwable o, Integer integer) {
-                                return 0;
-                            }
-                        });
-                    }
-                })
+                .retryWhen(attempt -> attempt.zipWith(Flowable.just(1), (_, _) -> 0))
                 .blockingFirst();
 
         assertEquals("Observer did not receive the expected output", 1, first);
@@ -451,12 +393,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void unsubscribeFromRetry() {
         PublishProcessor<Integer> processor = PublishProcessor.create();
         final AtomicInteger count = new AtomicInteger(0);
-        Disposable sub = processor.retry().subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer n) {
-                count.incrementAndGet();
-            }
-        });
+        Disposable sub = processor.retry().subscribe(_ -> count.incrementAndGet());
         processor.onNext(1);
         sub.dispose();
         processor.onNext(2);
@@ -466,24 +403,21 @@ public class FlowableRetryTest extends RxJavaTest {
     @Test
     public void retryAllowsSubscriptionAfterAllSubscriptionsUnsubscribed() throws InterruptedException {
         final AtomicInteger subsCount = new AtomicInteger(0);
-        Publisher<String> onSubscribe = new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> s) {
-                subsCount.incrementAndGet();
-                s.onSubscribe(new Subscription() {
+        Publisher<String> onSubscribe = s -> {
+            subsCount.incrementAndGet();
+            s.onSubscribe(new Subscription() {
 
-                    @Override
-                    public void request(long n) {
+                @Override
+                public void request(long n) {
 
-                    }
+                }
 
-                    @Override
-                    public void cancel() {
-                        subsCount.decrementAndGet();
-                    }
-                });
+                @Override
+                public void cancel() {
+                    subsCount.decrementAndGet();
+                }
+            });
 
-            }
         };
         Flowable<String> stream = Flowable.unsafeCreate(onSubscribe);
         Flowable<String> streamWithRetry = stream.retry();
@@ -501,24 +435,21 @@ public class FlowableRetryTest extends RxJavaTest {
 
         final TestSubscriber<String> ts = new TestSubscriber<>();
 
-        Publisher<String> onSubscribe = new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> s) {
-                BooleanSubscription bs = new BooleanSubscription();
-                // if isUnsubscribed is true that means we have a bug such as
-                // https://github.com/ReactiveX/RxJava/issues/1024
-                if (!bs.isCancelled()) {
-                    subsCount.incrementAndGet();
-                    s.onError(new RuntimeException("failed"));
-                    // it unsubscribes the child directly
-                    // this simulates various error/completion scenarios that could occur
-                    // or just a source that proactively triggers cleanup
-                    // FIXME can't unsubscribe child
+        Publisher<String> onSubscribe = s -> {
+            BooleanSubscription bs = new BooleanSubscription();
+            // if isUnsubscribed is true that means we have a bug such as
+            // https://github.com/ReactiveX/RxJava/issues/1024
+            if (!bs.isCancelled()) {
+                subsCount.incrementAndGet();
+                s.onError(new RuntimeException("failed"));
+                // it unsubscribes the child directly
+                // this simulates various error/completion scenarios that could occur
+                // or just a source that proactively triggers cleanup
+                // FIXME can't unsubscribe child
 //                    s.unsubscribe();
-                    bs.cancel();
-                } else {
-                    s.onError(new RuntimeException());
-                }
+                bs.cancel();
+            } else {
+                s.onError(new RuntimeException());
             }
         };
 
@@ -532,13 +463,10 @@ public class FlowableRetryTest extends RxJavaTest {
 
         final TestSubscriber<String> ts = new TestSubscriber<>();
 
-        Publisher<String> onSubscribe = new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> s) {
-                s.onSubscribe(new BooleanSubscription());
-                subsCount.incrementAndGet();
-                s.onError(new RuntimeException("failed"));
-            }
+        Publisher<String> onSubscribe = s -> {
+            s.onSubscribe(new BooleanSubscription());
+            subsCount.incrementAndGet();
+            s.onError(new RuntimeException("failed"));
         };
 
         Flowable.unsafeCreate(onSubscribe).retry(1).subscribe(ts);
@@ -551,13 +479,10 @@ public class FlowableRetryTest extends RxJavaTest {
 
         final TestSubscriber<String> ts = new TestSubscriber<>();
 
-        Publisher<String> onSubscribe = new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> s) {
-                s.onSubscribe(new BooleanSubscription());
-                subsCount.incrementAndGet();
-                s.onError(new RuntimeException("failed"));
-            }
+        Publisher<String> onSubscribe = s -> {
+            s.onSubscribe(new BooleanSubscription());
+            subsCount.incrementAndGet();
+            s.onError(new RuntimeException("failed"));
         };
 
         Flowable.unsafeCreate(onSubscribe).retry(0).subscribe(ts);
@@ -758,32 +683,29 @@ public class FlowableRetryTest extends RxJavaTest {
                 final CountDownLatch cdl = new CountDownLatch(m);
                 for (int i = 0; i < m; i++) {
                     final int j = i;
-                    exec.execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            final AtomicInteger nexts = new AtomicInteger();
-                            try {
-                                Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
-                                TestSubscriberEx<String> ts = new TestSubscriberEx<>();
-                                origin.retry()
-                                .observeOn(Schedulers.computation()).subscribe(ts);
-                                ts.awaitDone(2500, TimeUnit.MILLISECONDS);
-                                List<String> onNextEvents = new ArrayList<>(ts.values());
-                                if (onNextEvents.size() != numRetries + 2) {
-                                    for (Throwable t : ts.errors()) {
-                                        onNextEvents.add(t.toString());
-                                    }
-                                    for (long err = ts.completions(); err != 0; err--) {
-                                        onNextEvents.add("onComplete");
-                                    }
-                                    data.put(j, onNextEvents);
+                    exec.execute(() -> {
+                        final AtomicInteger nexts = new AtomicInteger();
+                        try {
+                            Flowable<String> origin = Flowable.unsafeCreate(new FuncWithErrors(numRetries));
+                            TestSubscriberEx<String> ts = new TestSubscriberEx<>();
+                            origin.retry()
+                            .observeOn(Schedulers.computation()).subscribe(ts);
+                            ts.awaitDone(2500, TimeUnit.MILLISECONDS);
+                            List<String> onNextEvents = new ArrayList<>(ts.values());
+                            if (onNextEvents.size() != numRetries + 2) {
+                                for (Throwable t : ts.errors()) {
+                                    onNextEvents.add(t.toString());
                                 }
-                            } catch (Throwable t) {
-                                timeouts.incrementAndGet();
-                                System.out.println(j + " | " + cdl.getCount() + " !!! " + nexts.get());
+                                for (long err = ts.completions(); err != 0; err--) {
+                                    onNextEvents.add("onComplete");
+                                }
+                                data.put(j, onNextEvents);
                             }
-                            cdl.countDown();
+                        } catch (Throwable t) {
+                            timeouts.incrementAndGet();
+                            System.out.println(j + " | " + cdl.getCount() + " !!! " + nexts.get());
                         }
+                        cdl.countDown();
                     });
                 }
                 cdl.await();
@@ -846,26 +768,12 @@ public class FlowableRetryTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
 
         Flowable<String> origin = Flowable.range(0, NUM_MSG)
-                .map(new Function<Integer, String>() {
-                    @Override
-                    public String apply(Integer t1) {
-                        return "msg: " + count.incrementAndGet();
-                    }
-                });
+                .map(_ -> "msg: " + count.incrementAndGet());
 
         origin.retry()
-        .groupBy(new Function<String, String>() {
-            @Override
-            public String apply(String t1) {
-                return t1;
-            }
-        })
-        .flatMap(new Function<GroupedFlowable<String, String>, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(GroupedFlowable<String, String> t1) {
-                return t1.take(1);
-            }
-        }, new FlatMapConfig(NUM_MSG)) // Must request as many groups as groupBy produces to avoid MBE
+        .groupBy(t1 -> t1)
+        // Must request as many groups as groupBy produces to avoid MBE
+        .flatMap(t1 -> t1.take(1), new FlatMapConfig(NUM_MSG))
         .subscribe(new TestSubscriber<>(subscriber));
 
         InOrder inOrder = inOrder(subscriber);
@@ -886,31 +794,17 @@ public class FlowableRetryTest extends RxJavaTest {
         final int NUM_MSG = 1034;
         final AtomicInteger count = new AtomicInteger();
 
-        Flowable<String> origin = Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                for (int i = 0; i < NUM_MSG; i++) {
-                    subscriber.onNext("msg:" + count.incrementAndGet());
-                }
-                subscriber.onComplete();
+        Flowable<String> origin = Flowable.unsafeCreate(subscriber1 -> {
+            subscriber1.onSubscribe(new BooleanSubscription());
+            for (int i = 0; i < NUM_MSG; i++) {
+                subscriber1.onNext("msg:" + count.incrementAndGet());
             }
+            subscriber1.onComplete();
         });
 
         origin.retry()
-        .groupBy(new Function<String, String>() {
-            @Override
-            public String apply(String t1) {
-                return t1;
-            }
-        })
-        .flatMap(new Function<GroupedFlowable<String, String>, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(GroupedFlowable<String, String> t1) {
-                return t1.take(1);
-            }
-        })
+        .groupBy(t1 -> t1)
+        .flatMap((Function<GroupedFlowable<String, String>, Flowable<String>>) t1 -> t1.take(1))
         .subscribe(new TestSubscriber<>(subscriber));
 
         InOrder inOrder = inOrder(subscriber);
@@ -925,19 +819,13 @@ public class FlowableRetryTest extends RxJavaTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void retryWhenDefaultScheduler() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
 
         Flowable.just(1)
         .concatWith(Flowable.<Integer>error(new TestException()))
-        .retryWhen((Function)new Function<Flowable, Flowable>() {
-            @Override
-            public Flowable apply(Flowable f) {
-                return f.take(2);
-            }
-        }).subscribe(ts);
+        .retryWhen(f -> f.take(2)).subscribe(ts);
 
         ts.assertValues(1, 1);
         ts.assertNoErrors();
@@ -945,7 +833,6 @@ public class FlowableRetryTest extends RxJavaTest {
 
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void retryWhenTrampolineScheduler() {
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -953,12 +840,7 @@ public class FlowableRetryTest extends RxJavaTest {
         Flowable.just(1)
         .concatWith(Flowable.<Integer>error(new TestException()))
         .subscribeOn(Schedulers.trampoline())
-        .retryWhen((Function)new Function<Flowable, Flowable>() {
-            @Override
-            public Flowable apply(Flowable f) {
-                return f.take(2);
-            }
-        }).subscribe(ts);
+        .retryWhen(f -> f.take(2)).subscribe(ts);
 
         ts.assertValues(1, 1);
         ts.assertNoErrors();
@@ -968,12 +850,7 @@ public class FlowableRetryTest extends RxJavaTest {
     @Test
     public void retryPredicate() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
-        .retry(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable v) throws Exception {
-                return true;
-            }
-        })
+        .retry(_ -> true)
         .take(5)
         .test()
         .assertResult(1, 1, 1, 1, 1);
@@ -982,12 +859,7 @@ public class FlowableRetryTest extends RxJavaTest {
     @Test
     public void retryLongPredicateInvalid() {
         try {
-            Flowable.just(1).retry(-99, new Predicate<Throwable>() {
-                @Override
-                public boolean test(Throwable e) throws Exception {
-                    return true;
-                }
-            });
+            Flowable.just(1).retry(-99, _ -> true);
             fail("Should have thrown");
         } catch (IllegalArgumentException ex) {
             assertEquals("times >= 0 required but it was -99", ex.getMessage());
@@ -997,12 +869,7 @@ public class FlowableRetryTest extends RxJavaTest {
     @Test
     public void retryUntil() {
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
-        .retryUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        })
+        .retryUntil(() -> false)
         .take(5)
         .test()
         .assertResult(1, 1, 1, 1, 1);
@@ -1012,17 +879,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void shouldDisposeInnerFlowable() {
         final PublishProcessor<Object> processor = PublishProcessor.create();
         final Disposable disposable = Flowable.error(new RuntimeException("Leak"))
-                .retryWhen(new Function<Flowable<Throwable>, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Flowable<Throwable> errors) throws Exception {
-                        return errors.switchMap(new Function<Throwable, Flowable<Object>>() {
-                            @Override
-                            public Flowable<Object> apply(Throwable ignore) throws Exception {
-                                return processor;
-                            }
-                        });
-                    }
-                })
+                .retryWhen((Function<Flowable<Throwable>, Flowable<Object>>) errors -> errors.switchMap((Function<Throwable, Flowable<Object>>) _ -> processor))
                 .subscribe();
 
         assertTrue(processor.hasSubscribers());
@@ -1036,21 +893,13 @@ public class FlowableRetryTest extends RxJavaTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() throws Exception {
-                if (times.getAndIncrement() < 4) {
-                    return Flowable.error(new TestException());
-                }
-                return Flowable.just(1);
+        Flowable<Integer> source = Flowable.defer((Supplier<Flowable<Integer>>) () -> {
+            if (times.getAndIncrement() < 4) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(1);
         })
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        .doOnCancel(() -> counter.getAndIncrement());
 
         source.retry(5)
         .test()
@@ -1065,21 +914,13 @@ public class FlowableRetryTest extends RxJavaTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() throws Exception {
-                if (times.getAndIncrement() < 4) {
-                    return Flowable.error(new TestException());
-                }
-                return Flowable.just(1);
+        Flowable<Integer> source = Flowable.defer((Supplier<Flowable<Integer>>) () -> {
+            if (times.getAndIncrement() < 4) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(1);
         })
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        .doOnCancel(() -> counter.getAndIncrement());
 
         source.retry(5, Functions.alwaysTrue())
         .test()
@@ -1094,28 +935,15 @@ public class FlowableRetryTest extends RxJavaTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() throws Exception {
-                if (times.getAndIncrement() < 4) {
-                    return Flowable.error(new TestException());
-                }
-                return Flowable.just(1);
+        Flowable<Integer> source = Flowable.defer((Supplier<Flowable<Integer>>) () -> {
+            if (times.getAndIncrement() < 4) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(1);
         })
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        .doOnCancel(() -> counter.getAndIncrement());
 
-        source.retry(new BiPredicate<Integer, Throwable>() {
-            @Override
-            public boolean test(Integer a, Throwable b) throws Exception {
-                return a < 5;
-            }
-        })
+        source.retry((a, _) -> a < 5)
         .test()
         .assertResult(1);
 
@@ -1128,28 +956,15 @@ public class FlowableRetryTest extends RxJavaTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() throws Exception {
-                if (times.getAndIncrement() < 4) {
-                    return Flowable.error(new TestException());
-                }
-                return Flowable.just(1);
+        Flowable<Integer> source = Flowable.defer((Supplier<Flowable<Integer>>) () -> {
+            if (times.getAndIncrement() < 4) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(1);
         })
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        .doOnCancel(() -> counter.getAndIncrement());
 
-        source.retryUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        })
+        source.retryUntil(() -> false)
         .test()
         .assertResult(1);
 
@@ -1162,32 +977,14 @@ public class FlowableRetryTest extends RxJavaTest {
 
         final AtomicInteger times = new AtomicInteger();
 
-        Flowable<Integer> source = Flowable.defer(new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() throws Exception {
-                if (times.get() < 4) {
-                    return Flowable.error(new TestException());
-                }
-                return Flowable.just(1);
+        Flowable<Integer> source = Flowable.defer((Supplier<Flowable<Integer>>) () -> {
+            if (times.get() < 4) {
+                return Flowable.error(new TestException());
             }
-        }).doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+            return Flowable.just(1);
+        }).doOnCancel(() -> counter.getAndIncrement());
 
-        source.retryWhen(new Function<Flowable<Throwable>, Flowable<?>>() {
-            @Override
-            public Flowable<?> apply(Flowable<Throwable> e) throws Exception {
-                return e.takeWhile(new Predicate<Object>() {
-                    @Override
-                    public boolean test(Object v) throws Exception {
-                        return times.getAndIncrement() < 4;
-                    }
-                });
-            }
-        })
+        source.retryWhen((Function<Flowable<Throwable>, Flowable<?>>) e -> e.takeWhile((Predicate<Object>) _ -> times.getAndIncrement() < 4))
         .test()
         .assertResult(1);
 
@@ -1201,24 +998,9 @@ public class FlowableRetryTest extends RxJavaTest {
         final AtomicInteger times = new AtomicInteger();
 
         Flowable<Integer> source = Flowable.<Integer>error(new TestException())
-                .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+                .doOnCancel(() -> counter.getAndIncrement());
 
-        source.retryWhen(new Function<Flowable<Throwable>, Flowable<?>>() {
-            @Override
-            public Flowable<?> apply(Flowable<Throwable> e) throws Exception {
-                return e.takeWhile(new Predicate<Object>() {
-                    @Override
-                    public boolean test(Object v) throws Exception {
-                        return times.getAndIncrement() < 4;
-                    }
-                });
-            }
-        })
+        source.retryWhen((Function<Flowable<Throwable>, Flowable<?>>) e -> e.takeWhile((Predicate<Object>) _ -> times.getAndIncrement() < 4))
         .test()
         .assertResult();
 
@@ -1238,34 +1020,19 @@ public class FlowableRetryTest extends RxJavaTest {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
                 TestSubscriber<Integer> ts = source.take(1)
-                .map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        throw error;
-                    }
+                .map((Function<Integer, Integer>) _ -> {
+                    throw error;
                 })
-                .retryWhen(new Function<Flowable<Throwable>, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Flowable<Throwable> v)
-                            throws Exception {
-                        return signaller;
-                    }
-                }).test();
+                .retryWhen((Function<Flowable<Throwable>, Flowable<Integer>>) _ -> signaller).test();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                            source.onNext(1);
-                        }
+                Runnable r1 = () -> {
+                    for (int i1 = 0; i1 < TestHelper.RACE_DEFAULT_LOOPS; i1++) {
+                        source.onNext(1);
                     }
                 };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                            signaller.offer(1);
-                        }
+                Runnable r2 = () -> {
+                    for (int i2 = 0; i2 < TestHelper.RACE_DEFAULT_LOOPS; i2++) {
+                        signaller.offer(1);
                     }
                 };
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -38,24 +38,9 @@ import io.reactivex.rxjava4.subscribers.TestSubscriber;
 import io.reactivex.rxjava4.testsupport.*;
 
 public class FlowableRetryWithPredicateTest extends RxJavaTest {
-    BiPredicate<Integer, Throwable> retryTwice = new BiPredicate<Integer, Throwable>() {
-        @Override
-        public boolean test(Integer t1, Throwable t2) {
-            return t1 <= 2;
-        }
-    };
-    BiPredicate<Integer, Throwable> retry5 = new BiPredicate<Integer, Throwable>() {
-        @Override
-        public boolean test(Integer t1, Throwable t2) {
-            return t1 <= 5;
-        }
-    };
-    BiPredicate<Integer, Throwable> retryOnTestException = new BiPredicate<Integer, Throwable>() {
-        @Override
-        public boolean test(Integer t1, Throwable t2) {
-            return t2 instanceof IOException;
-        }
-    };
+    BiPredicate<Integer, Throwable> retryTwice = (t1, _) -> t1 <= 2;
+    BiPredicate<Integer, Throwable> retry5 = (t1, _) -> t1 <= 5;
+    BiPredicate<Integer, Throwable> retryOnTestException = (_, t2) -> t2 instanceof IOException;
     @Test
     public void withNothingToRetry() {
         Flowable<Integer> source = Flowable.range(0, 3);
@@ -110,14 +95,11 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryTwiceAndGiveUp() {
-        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> t1) {
-                t1.onSubscribe(new BooleanSubscription());
-                t1.onNext(0);
-                t1.onNext(1);
-                t1.onError(new TestException());
-            }
+        Flowable<Integer> source = Flowable.unsafeCreate(t1 -> {
+            t1.onSubscribe(new BooleanSubscription());
+            t1.onNext(0);
+            t1.onNext(1);
+            t1.onError(new TestException());
         });
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -213,12 +195,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
     public void unsubscribeFromRetry() {
         PublishProcessor<Integer> processor = PublishProcessor.create();
         final AtomicInteger count = new AtomicInteger(0);
-        Disposable sub = processor.retry(retryTwice).subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer n) {
-                count.incrementAndGet();
-            }
-        });
+        Disposable sub = processor.retry(retryTwice).subscribe(_ -> count.incrementAndGet());
         processor.onNext(1);
         sub.dispose();
         processor.onNext(2);
@@ -282,12 +259,9 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         final RuntimeException e = new RuntimeException("You shall not pass");
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1) {
-                c.incrementAndGet();
-                throw e;
-            }
+        Flowable.just(1).map((Function<Integer, Integer>) _ -> {
+            c.incrementAndGet();
+            throw e;
         }).retry(retry5).subscribe(ts);
 
         ts.assertTerminated();
@@ -298,14 +272,11 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
     @Test
     public void justAndRetry() throws Exception {
         final AtomicBoolean throwException = new AtomicBoolean(true);
-        int value = Flowable.just(1).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1) {
-                if (throwException.compareAndSet(true, false)) {
-                    throw new TestException();
-                }
-                return t1;
+        int value = Flowable.just(1).map(t1 -> {
+            if (throwException.compareAndSet(true, false)) {
+                throw new TestException();
             }
+            return t1;
         }).retry(1).blockingSingle();
 
         assertEquals(1, value);
@@ -315,27 +286,18 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
     public void issue3008RetryWithPredicate() {
         final List<Long> list = new CopyOnWriteArrayList<>();
         final AtomicBoolean isFirst = new AtomicBoolean(true);
-        Flowable.<Long> just(1L, 2L, 3L).map(new Function<Long, Long>() {
-            @Override
-            public Long apply(Long x) {
-                System.out.println("map " + x);
-                if (x == 2 && isFirst.getAndSet(false)) {
-                    throw new RuntimeException("retryable error");
-                }
-                return x;
-            }})
-        .retry(new BiPredicate<Integer, Throwable>() {
-            @Override
-            public boolean test(Integer t1, Throwable t2) {
-                return true;
-            }})
-        .forEach(new Consumer<Long>() {
-
-            @Override
-            public void accept(Long t) {
-                System.out.println(t);
-                list.add(t);
-            }});
+        Flowable.<Long> just(1L, 2L, 3L).map(x -> {
+            System.out.println("map " + x);
+            if (x == 2 && isFirst.getAndSet(false)) {
+                throw new RuntimeException("retryable error");
+            }
+            return x;
+        })
+        .retry((_, _) -> true)
+        .forEach(t -> {
+            System.out.println(t);
+            list.add(t);
+        });
         assertEquals(Arrays.asList(1L, 1L, 2L, 3L), list);
     }
 
@@ -343,23 +305,18 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
     public void issue3008RetryInfinite() {
         final List<Long> list = new CopyOnWriteArrayList<>();
         final AtomicBoolean isFirst = new AtomicBoolean(true);
-        Flowable.<Long> just(1L, 2L, 3L).map(new Function<Long, Long>() {
-            @Override
-            public Long apply(Long x) {
-                System.out.println("map " + x);
-                if (x == 2 && isFirst.getAndSet(false)) {
-                    throw new RuntimeException("retryable error");
-                }
-                return x;
-            }})
+        Flowable.<Long> just(1L, 2L, 3L).map(x -> {
+            System.out.println("map " + x);
+            if (x == 2 && isFirst.getAndSet(false)) {
+                throw new RuntimeException("retryable error");
+            }
+            return x;
+        })
         .retry()
-        .forEach(new Consumer<Long>() {
-
-            @Override
-            public void accept(Long t) {
-                System.out.println(t);
-                list.add(t);
-            }});
+        .forEach(t -> {
+            System.out.println(t);
+            list.add(t);
+        });
         assertEquals(Arrays.asList(1L, 1L, 2L, 3L), list);
     }
 
@@ -370,20 +327,12 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
         Flowable<Integer> source = Flowable
                 .just(1)
                 .concatWith(Flowable.<Integer>error(new TestException()))
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long t) {
-                        requests.add(t);
-                    }
-                });
+                .doOnRequest(t -> requests.add(t));
 
         TestSubscriber<Integer> ts = new TestSubscriber<>(3L);
         source
-        .retry(new BiPredicate<Integer, Throwable>() {
-            @Override
-            public boolean test(Integer t1, Throwable t2) {
-                return t1 < 4; // FIXME was 3 in 1.x for some reason
-            }
+        .retry((t1, _) -> {
+            return t1 < 4; // FIXME was 3 in 1.x for some reason
         }).subscribe(ts);
 
         assertEquals(Arrays.asList(3L, 2L, 1L), requests);
@@ -396,11 +345,8 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
     public void predicateThrows() {
 
         TestSubscriberEx<Object> ts = Flowable.error(new TestException("Outer"))
-        .retry(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable e) throws Exception {
-                throw new TestException("Inner");
-            }
+        .retry(_ -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
@@ -429,19 +375,9 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
                 final TestSubscriber<Integer> ts = pp.retry(Functions.alwaysTrue()).test();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ts.cancel();
-                    }
-                };
+                Runnable r2 = () -> ts.cancel();
 
                 TestHelper.race(r1, r2);
 
@@ -456,11 +392,8 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
     public void bipredicateThrows() {
 
         TestSubscriberEx<Object> ts = Flowable.error(new TestException("Outer"))
-        .retry(new BiPredicate<Integer, Throwable>() {
-            @Override
-            public boolean test(Integer n, Throwable e) throws Exception {
-                throw new TestException("Inner");
-            }
+        .retry((_, _) -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
@@ -478,28 +411,13 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                 final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-                final TestSubscriber<Integer> ts = pp.retry(new BiPredicate<Object, Object>() {
-                    @Override
-                    public boolean test(Object t1, Object t2) throws Exception {
-                        return true;
-                    }
-                }).test();
+                final TestSubscriber<Integer> ts = pp.retry((BiPredicate<Object, Object>) (_, _) -> true).test();
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ts.cancel();
-                    }
-                };
+                Runnable r2 = () -> ts.cancel();
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSampleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSampleTest.java
@@ -49,29 +49,11 @@ public class FlowableSampleTest extends RxJavaTest {
 
     @Test
     public void sample() {
-        Flowable<Long> source = Flowable.unsafeCreate(new Publisher<Long>() {
-            @Override
-            public void subscribe(final Subscriber<? super Long> subscriber1) {
-                subscriber1.onSubscribe(new BooleanSubscription());
-                innerScheduler.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        subscriber1.onNext(1L);
-                    }
-                }, 1, TimeUnit.SECONDS);
-                innerScheduler.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        subscriber1.onNext(2L);
-                    }
-                }, 2, TimeUnit.SECONDS);
-                innerScheduler.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        subscriber1.onComplete();
-                    }
-                }, 3, TimeUnit.SECONDS);
-            }
+        Flowable<Long> source = Flowable.unsafeCreate(subscriber1 -> {
+            subscriber1.onSubscribe(new BooleanSubscription());
+            innerScheduler.schedule(() -> subscriber1.onNext(1L), 1, TimeUnit.SECONDS);
+            innerScheduler.schedule(() -> subscriber1.onNext(2L), 2, TimeUnit.SECONDS);
+            innerScheduler.schedule(() -> subscriber1.onComplete(), 3, TimeUnit.SECONDS);
         });
 
         Flowable<Long> sampled = source.sample(400L, TimeUnit.MILLISECONDS, scheduler);
@@ -271,12 +253,7 @@ public class FlowableSampleTest extends RxJavaTest {
     public void sampleUnsubscribe() {
         final Subscription s = mock(Subscription.class);
         Flowable<Integer> f = Flowable.unsafeCreate(
-                new Publisher<Integer>() {
-                    @Override
-                    public void subscribe(Subscriber<? super Integer> subscriber) {
-                        subscriber.onSubscribe(s);
-                    }
-                }
+                subscriber -> subscriber.onSubscribe(s)
         );
         f.throttleLast(1, TimeUnit.MILLISECONDS).subscribe().dispose();
         verify(s).cancel();
@@ -360,19 +337,9 @@ public class FlowableSampleTest extends RxJavaTest {
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-                }
-            };
+            Runnable r2 = () -> scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
             TestHelper.race(r1, r2);
 
@@ -407,19 +374,9 @@ public class FlowableSampleTest extends RxJavaTest {
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    sampler.onNext(1);
-                }
-            };
+            Runnable r2 = () -> sampler.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -437,19 +394,9 @@ public class FlowableSampleTest extends RxJavaTest {
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    sampler.onComplete();
-                }
-            };
+            Runnable r2 = () -> sampler.onComplete();
 
             TestHelper.race(r1, r2);
 
@@ -459,21 +406,9 @@ public class FlowableSampleTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.sample(1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.sample(1, TimeUnit.SECONDS));
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.sample(PublishProcessor.create());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.sample(PublishProcessor.create()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScalarXMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScalarXMapTest.java
@@ -71,12 +71,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
     @Test
     public void tryScalarXMap() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
-        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new CallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer f) throws Exception {
-                return Flowable.just(1);
-            }
-        }));
+        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new CallablePublisher(), ts, (Function<Integer, Publisher<Integer>>) _ -> Flowable.just(1)));
 
         ts.assertFailure(TestException.class);
     }
@@ -85,12 +80,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
     public void emptyXMap() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new EmptyCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer f) throws Exception {
-                return Flowable.just(1);
-            }
-        }));
+        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new EmptyCallablePublisher(), ts, (Function<Integer, Publisher<Integer>>) _ -> Flowable.just(1)));
 
         ts.assertResult();
     }
@@ -99,11 +89,8 @@ public class FlowableScalarXMapTest extends RxJavaTest {
     public void mapperCrashes() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer f) throws Exception {
-                throw new TestException();
-            }
+        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, (Function<Integer, Publisher<Integer>>) _ -> {
+            throw new TestException();
         }));
 
         ts.assertFailure(TestException.class);
@@ -113,12 +100,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
     public void mapperToJust() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer f) throws Exception {
-                return Flowable.just(1);
-            }
-        }));
+        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, (Function<Integer, Publisher<Integer>>) _ -> Flowable.just(1)));
 
         ts.assertResult(1);
     }
@@ -127,12 +109,7 @@ public class FlowableScalarXMapTest extends RxJavaTest {
     public void mapperToEmpty() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer f) throws Exception {
-                return Flowable.empty();
-            }
-        }));
+        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, (Function<Integer, Publisher<Integer>>) _ -> Flowable.empty()));
 
         ts.assertResult();
     }
@@ -141,36 +118,21 @@ public class FlowableScalarXMapTest extends RxJavaTest {
     public void mapperToCrashingCallable() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer f) throws Exception {
-                return new CallablePublisher();
-            }
-        }));
+        assertTrue(FlowableScalarXMap.tryScalarXMapSubscribe(new OneCallablePublisher(), ts, (Function<Integer, Publisher<Integer>>) _ -> new CallablePublisher()));
 
         ts.assertFailure(TestException.class);
     }
 
     @Test
     public void scalarMapToEmpty() {
-        FlowableScalarXMap.scalarXMap(1, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.empty();
-            }
-        })
+        FlowableScalarXMap.scalarXMap(1, (Function<Integer, Publisher<Integer>>) _ -> Flowable.empty())
         .test()
         .assertResult();
     }
 
     @Test
     public void scalarMapToCrashingCallable() {
-        FlowableScalarXMap.scalarXMap(1, new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return new CallablePublisher();
-            }
-        })
+        FlowableScalarXMap.scalarXMap(1, (Function<Integer, Publisher<Integer>>) _ -> new CallablePublisher())
         .test()
         .assertFailure(TestException.class);
     }
@@ -215,19 +177,9 @@ public class FlowableScalarXMapTest extends RxJavaTest {
             final ScalarSubscription<Integer> sd = new ScalarSubscription<>(ts, 1);
             ts.onSubscribe(sd);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    sd.request(1);
-                }
-            };
+            Runnable r1 = () -> sd.request(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    sd.cancel();
-                }
-            };
+            Runnable r2 = () -> sd.cancel();
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
@@ -206,14 +206,7 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void seedFactory() {
         Single<List<Integer>> o = Flowable.range(1, 10)
-                .collect(() -> new ArrayList<>(), new BiConsumer<List<Integer>, Integer>() {
-
-                    @Override
-                    public void accept(List<Integer> list, Integer t2) {
-                        list.add(t2);
-                    }
-
-                });
+                .collect(() -> new ArrayList<>(), (list, t2) -> list.add(t2));
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingGet());
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), o.blockingGet());
@@ -291,25 +284,22 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void scanShouldNotRequestZero() {
         final AtomicReference<Subscription> producer = new AtomicReference<>();
-        Flowable<Integer> f = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> subscriber) {
+        Flowable<Integer> f = Flowable.unsafeCreate((Publisher<Integer>) subscriber -> {
 
-                var requested = new AtomicBoolean(false);
+            var requested = new AtomicBoolean(false);
 
-                var subber = new SubscriptionDelegate<Integer, AtomicBoolean>(subscriber, (sub, _, data) -> {
-                        if (data.compareAndSet(false, true)) {
-                            sub.onNext(1);
-                            sub.onComplete();
-                        }
-                    }, (_, _) -> { },
-                    requested
-                );
+            var subber = new SubscriptionDelegate<Integer, AtomicBoolean>(subscriber, (sub, _, data) -> {
+                    if (data.compareAndSet(false, true)) {
+                        sub.onNext(1);
+                        sub.onComplete();
+                    }
+                }, (_, _) -> { },
+                requested
+            );
 
-                Subscription p = spy(subber);
-                producer.set(p);
-                subscriber.onSubscribe(p);
-            }
+            Subscription p = spy(subber);
+            producer.set(p);
+            subscriber.onSubscribe(p);
         }).scan(100, (t1, t2) -> t1 + t2);
 
         f.subscribe(new TestSubscriber<Integer>(1L) {
@@ -334,12 +324,7 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.scan((a, _) -> a);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.scan((a, _) -> a));
 
         TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f ->
         f.scan(0, (a, _) -> a));
@@ -367,12 +352,9 @@ public class FlowableScanTest extends RxJavaTest {
     public void unsubscribeScan() {
 
         FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
-        .scan(new HashMap<>(), new BiFunction<HashMap<String, String>, Event, HashMap<String, String>>() {
-            @Override
-            public HashMap<String, String> apply(HashMap<String, String> accum, Event perInstanceEvent) {
-                accum.put("instance", perInstanceEvent.instanceId);
-                return accum;
-            }
+        .scan(new HashMap<>(), (BiFunction<HashMap<String, String>, Event, HashMap<String, String>>) (accum, perInstanceEvent) -> {
+            accum.put("instance", perInstanceEvent.instanceId);
+            return accum;
         })
         .take(10)
         .blockingForEach(System.out::println);
@@ -381,11 +363,7 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void scanWithSeedDoesNotEmitErrorTwiceIfScanFunctionThrows() {
         final List<Throwable> list = new CopyOnWriteArrayList<>();
-        Consumer<Throwable> errorConsumer = new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable t) throws Exception {
-                 list.add(t);
-            }};
+        Consumer<Throwable> errorConsumer = t -> list.add(t);
         try {
             RxJavaPlugins.setErrorHandler(errorConsumer);
             final RuntimeException e = new RuntimeException();
@@ -418,13 +396,10 @@ public class FlowableScanTest extends RxJavaTest {
     public void scanWithSeedDoesNotProcessOnNextAfterTerminalEventIfScanFunctionThrows() {
         final RuntimeException e = new RuntimeException();
         final AtomicInteger count = new AtomicInteger();
-        Burst.items(1, 2).create().scan(0, new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer n1, Integer n2) throws Exception {
-                count.incrementAndGet();
-                throw e;
-            }})
+        Burst.items(1, 2).create().scan(0, (_, _) -> {
+            count.incrementAndGet();
+            throw e;
+        })
         .test()
         .assertValues(0)
         .assertError(e);
@@ -461,11 +436,7 @@ public class FlowableScanTest extends RxJavaTest {
     @Test
     public void scanNoSeedDoesNotEmitErrorTwiceIfScanFunctionThrows() {
         final List<Throwable> list = new CopyOnWriteArrayList<>();
-        Consumer<Throwable> errorConsumer = new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable t) throws Exception {
-                 list.add(t);
-            }};
+        Consumer<Throwable> errorConsumer = t -> list.add(t);
         try {
             RxJavaPlugins.setErrorHandler(errorConsumer);
             final RuntimeException e = new RuntimeException();
@@ -498,13 +469,10 @@ public class FlowableScanTest extends RxJavaTest {
     public void scanNoSeedDoesNotProcessOnNextAfterTerminalEventIfScanFunctionThrows() {
         final RuntimeException e = new RuntimeException();
         final AtomicInteger count = new AtomicInteger();
-        Burst.items(1, 2, 3).create().scan(new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer n1, Integer n2) throws Exception {
-                count.incrementAndGet();
-                throw e;
-            }})
+        Burst.items(1, 2, 3).create().scan((_, _) -> {
+            count.incrementAndGet();
+            throw e;
+        })
         .test()
         .assertValue(1)
         .assertError(e);
@@ -512,28 +480,16 @@ public class FlowableScanTest extends RxJavaTest {
     }
 
     private static BiFunction<Integer, Integer, Integer> throwingBiFunction(final RuntimeException e) {
-        return new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer n1, Integer n2) throws Exception {
-                throw e;
-            }
+        return (_, _) -> {
+            throw e;
         };
     }
 
-    private static final BiFunction<Integer, Integer, Integer> SUM = new BiFunction<Integer, Integer, Integer>() {
-
-        @Override
-        public Integer apply(Integer t1, Integer t2) throws Exception {
-            return t1 + t2;
-        }
-    };
+    private static final BiFunction<Integer, Integer, Integer> SUM = (t1, t2) -> t1 + t2;
 
     private static Supplier<Integer> throwingSupplier(final RuntimeException e) {
-        return new Supplier<Integer>() {
-            @Override
-            public Integer get() throws Exception {
-                throw e;
-            }
+        return () -> {
+            throw e;
         };
     }
 
@@ -578,12 +534,7 @@ public class FlowableScanTest extends RxJavaTest {
 
         for (int b = 1; b <= n; b *= 2) {
             List<Integer> list = Flowable.range(1, n)
-            .scan(0, new BiFunction<Integer, Integer, Integer>() {
-                @Override
-                public Integer apply(Integer a, Integer b) throws Exception {
-                    return b;
-                }
-            })
+            .scan(0, (_, b1) -> b1)
             .rebatchRequests(b)
             .toList()
             .blockingGet();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -25,7 +25,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -115,11 +114,8 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
     public void withEqualityErrorFlowable() {
         Flowable<Boolean> flowable = Flowable.sequenceEqual(
                 Flowable.just("one"), Flowable.just("one"),
-                new BiPredicate<String, String>() {
-                    @Override
-                    public boolean test(String t1, String t2) {
-                        throw new TestException();
-                    }
+                (_, _) -> {
+                    throw new TestException();
                 }).toFlowable();
         verifyError(flowable);
     }
@@ -203,11 +199,8 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
     public void withEqualityError() {
         Single<Boolean> single = Flowable.sequenceEqual(
                 Flowable.just("one"), Flowable.just("one"),
-                new BiPredicate<String, String>() {
-                    @Override
-                    public boolean test(String t1, String t2) {
-                        throw new TestException();
-                    }
+                (_, _) -> {
+                    throw new TestException();
                 });
         verifyError(single);
     }
@@ -286,19 +279,9 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
             final TestObserver<Boolean> to = Flowable.sequenceEqual(Flowable.never(), pp).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> to.dispose();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r2 = () -> pp.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -313,19 +296,9 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
             final TestSubscriber<Boolean> ts = Flowable.sequenceEqual(Flowable.never(), pp).toFlowable().test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> ts.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r2 = () -> pp.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -359,10 +332,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void syncFusedCrashFlowable() {
-        Flowable<Integer> source = Flowable.range(1, 10).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception { throw new TestException(); }
-        });
+        Flowable<Integer> source = Flowable.range(1, 10).map(_ -> { throw new TestException(); });
 
         Flowable.sequenceEqual(source, Flowable.range(1, 10).hide())
         .toFlowable()
@@ -394,19 +364,9 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
             .toFlowable()
             .subscribe(ts);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -464,10 +424,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void syncFusedCrash() {
-        Flowable<Integer> source = Flowable.range(1, 10).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception { throw new TestException(); }
-        });
+        Flowable<Integer> source = Flowable.range(1, 10).map(_ -> { throw new TestException(); });
 
         Flowable.sequenceEqual(source, Flowable.range(1, 10).hide())
         .test()
@@ -496,19 +453,9 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
             Flowable.sequenceEqual(swap ? pp : neverNever, swap ? neverNever : pp)
             .subscribe(to);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = () -> to.dispose();
 
             TestHelper.race(r1, r2);
 
@@ -554,42 +501,24 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Single<Boolean>>() {
-            @Override
-            public Single<Boolean> apply(Flowable<Integer> upstream) {
-                return Flowable.sequenceEqual(Flowable.just(1).hide(), upstream);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Single<Boolean>>) upstream -> Flowable.sequenceEqual(Flowable.just(1).hide(), upstream));
     }
 
     @Test
     public void undeliverableUponCancelAsFlowable() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Boolean>>() {
-            @Override
-            public Flowable<Boolean> apply(Flowable<Integer> upstream) {
-                return Flowable.sequenceEqual(Flowable.just(1).hide(), upstream).toFlowable();
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Boolean>>) upstream ->
+            Flowable.sequenceEqual(Flowable.just(1).hide(), upstream).toFlowable());
     }
 
     @Test
     public void undeliverableUponCancel2() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Single<Boolean>>() {
-            @Override
-            public Single<Boolean> apply(Flowable<Integer> upstream) {
-                return Flowable.sequenceEqual(upstream, Flowable.just(1).hide());
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Single<Boolean>>) upstream -> Flowable.sequenceEqual(upstream, Flowable.just(1).hide()));
     }
 
     @Test
     public void undeliverableUponCancelAsFlowable2() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Boolean>>() {
-            @Override
-            public Flowable<Boolean> apply(Flowable<Integer> upstream) {
-                return Flowable.sequenceEqual(upstream, Flowable.just(1).hide()).toFlowable();
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Boolean>>) upstream ->
+            Flowable.sequenceEqual(upstream, Flowable.just(1).hide()).toFlowable());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingleTest.java
@@ -77,12 +77,7 @@ public class FlowableSingleTest extends RxJavaTest {
         final List<Long> requests = new ArrayList<>();
         Flowable.just(1)
         //
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long n) {
-                        requests.add(n);
-                    }
-                })
+                .doOnRequest(n -> requests.add(n))
                 //
                 .singleElement()
                 //
@@ -118,12 +113,7 @@ public class FlowableSingleTest extends RxJavaTest {
         final List<Long> requests = new ArrayList<>();
         Flowable.just(1)
         //
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long n) {
-                        requests.add(n);
-                    }
-                })
+                .doOnRequest(n -> requests.add(n))
                 //
                 .singleElement()
                 //
@@ -158,12 +148,7 @@ public class FlowableSingleTest extends RxJavaTest {
         final List<Long> requests = new ArrayList<>();
         Flowable.just(1)
         //
-                .doOnRequest(new LongConsumer() {
-                    @Override
-                    public void accept(long n) {
-                        requests.add(n);
-                    }
-                })
+                .doOnRequest(n -> requests.add(n))
                 //
                 .singleElement()
                 //
@@ -197,13 +182,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleWithPredicateFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2)
                 .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                        t1 -> t1 % 2 == 0)
                 .singleElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -219,13 +198,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleWithPredicateAndTooManyElementsFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4)
                 .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                        t1 -> t1 % 2 == 0)
                 .singleElement().toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -241,13 +214,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleWithPredicateAndEmptyFlowable() {
         Flowable<Integer> flowable = Flowable.just(1)
                 .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                        t1 -> t1 % 2 == 0)
                 .singleElement().toFlowable();
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
         flowable.subscribe(subscriber);
@@ -301,12 +268,7 @@ public class FlowableSingleTest extends RxJavaTest {
     @Test
     public void singleOrDefaultWithPredicateFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .single(4).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -321,12 +283,7 @@ public class FlowableSingleTest extends RxJavaTest {
     @Test
     public void singleOrDefaultWithPredicateAndTooManyElementsFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .single(6).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -341,12 +298,7 @@ public class FlowableSingleTest extends RxJavaTest {
     @Test
     public void singleOrDefaultWithPredicateAndEmptyFlowable() {
         Flowable<Integer> flowable = Flowable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .single(2).toFlowable();
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -432,12 +384,7 @@ public class FlowableSingleTest extends RxJavaTest {
     @Test
     public void singleDoesNotRequestMoreThanItNeedsToEmitItem() {
         final AtomicLong request = new AtomicLong();
-        Flowable.just(1).doOnRequest(new LongConsumer() {
-            @Override
-            public void accept(long n) {
-                request.addAndGet(n);
-            }
-        }).blockingSingle();
+        Flowable.just(1).doOnRequest(n -> request.addAndGet(n)).blockingSingle();
         // FIXME single now triggers fast-path
         assertEquals(Long.MAX_VALUE, request.get());
     }
@@ -446,12 +393,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleDoesNotRequestMoreThanItNeedsToEmitErrorFromEmpty() {
         final AtomicLong request = new AtomicLong();
         try {
-            Flowable.empty().doOnRequest(new LongConsumer() {
-                @Override
-                public void accept(long n) {
-                    request.addAndGet(n);
-                }
-            }).blockingSingle();
+            Flowable.empty().doOnRequest(n -> request.addAndGet(n)).blockingSingle();
         } catch (NoSuchElementException e) {
             // FIXME single now triggers fast-path
             assertEquals(Long.MAX_VALUE, request.get());
@@ -462,12 +404,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleDoesNotRequestMoreThanItNeedsToEmitErrorFromMoreThanOne() {
         final AtomicLong request = new AtomicLong();
         try {
-            Flowable.just(1, 2).doOnRequest(new LongConsumer() {
-                @Override
-                public void accept(long n) {
-                    request.addAndGet(n);
-                }
-            }).blockingSingle();
+            Flowable.just(1, 2).doOnRequest(n -> request.addAndGet(n)).blockingSingle();
         } catch (IllegalArgumentException e) {
             // FIXME single now triggers fast-path
             assertEquals(Long.MAX_VALUE, request.get());
@@ -478,13 +415,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleWithPredicate() {
         Maybe<Integer> maybe = Flowable.just(1, 2)
                 .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                        t1 -> t1 % 2 == 0)
                 .singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
@@ -499,13 +430,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleWithPredicateAndTooManyElements() {
         Maybe<Integer> maybe = Flowable.just(1, 2, 3, 4)
                 .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                        t1 -> t1 % 2 == 0)
                 .singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
@@ -521,13 +446,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleWithPredicateAndEmpty() {
         Maybe<Integer> maybe = Flowable.just(1)
                 .filter(
-                new Predicate<Integer>() {
-
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                        t1 -> t1 % 2 == 0)
                 .singleElement();
 
         MaybeObserver<Integer> observer = TestHelper.mockMaybeObserver();
@@ -580,12 +499,7 @@ public class FlowableSingleTest extends RxJavaTest {
     @Test
     public void singleOrDefaultWithPredicate() {
         Single<Integer> single = Flowable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .single(4);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
@@ -599,12 +513,7 @@ public class FlowableSingleTest extends RxJavaTest {
     @Test
     public void singleOrDefaultWithPredicateAndTooManyElements() {
         Single<Integer> single = Flowable.just(1, 2, 3, 4)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .single(6);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
@@ -619,12 +528,7 @@ public class FlowableSingleTest extends RxJavaTest {
     @Test
     public void singleOrDefaultWithPredicateAndEmpty() {
         Single<Integer> single = Flowable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .single(2);
 
         SingleObserver<Integer> observer = TestHelper.mockSingleObserver();
@@ -639,12 +543,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void issue1527() throws InterruptedException {
         //https://github.com/ReactiveX/RxJava/pull/1527
         Flowable<Integer> source = Flowable.just(1, 2, 3, 4, 5, 6);
-        Maybe<Integer> reduced = source.reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer i1, Integer i2) {
-                return i1 + i2;
-            }
-        });
+        Maybe<Integer> reduced = source.reduce((i1, i2) -> i1 + i2);
 
         Integer r = reduced.blockingGet();
         assertEquals(21, r.intValue());
@@ -691,12 +590,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void issue1527Flowable() throws InterruptedException {
         //https://github.com/ReactiveX/RxJava/pull/1527
         Flowable<Integer> source = Flowable.just(1, 2, 3, 4, 5, 6);
-        Flowable<Integer> reduced = source.reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer i1, Integer i2) {
-                return i1 + i2;
-            }
-        }).toFlowable();
+        Flowable<Integer> reduced = source.reduce((i1, i2) -> i1 + i2).toFlowable();
 
         Integer r = reduced.blockingFirst();
         assertEquals(21, r.intValue());
@@ -708,17 +602,11 @@ public class FlowableSingleTest extends RxJavaTest {
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
         try {
-            RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-                @Override public void accept(final Throwable throwable) throws Exception {
-                    error.set(throwable);
-                }
-            });
+            RxJavaPlugins.setErrorHandler(throwable -> error.set(throwable));
 
-            Flowable.unsafeCreate(new Publisher<Integer>() {
-                @Override public void subscribe(final Subscriber<? super Integer> subscriber) {
-                    subscriber.onComplete();
-                    subscriber.onError(exception);
-                }
+            Flowable.unsafeCreate((Publisher<Integer>) subscriber -> {
+                subscriber.onComplete();
+                subscriber.onError(exception);
             }).singleElement().test().assertComplete();
 
             assertSame(exception, error.get().getCause());
@@ -729,57 +617,22 @@ public class FlowableSingleTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> f) throws Exception {
-                return f.singleOrError();
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable((Function<Flowable<Object>, Object>) f -> f.singleOrError(), false, 1, 1, 1);
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> f) throws Exception {
-                return f.singleElement();
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable((Function<Flowable<Object>, Object>) f -> f.singleElement(), false, 1, 1, 1);
 
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> f) throws Exception {
-                return f.singleOrError().toFlowable();
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable((Function<Flowable<Object>, Object>) f -> f.singleOrError().toFlowable(), false, 1, 1, 1);
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Flowable<Object> f) throws Exception {
-                return f.singleOrError();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle(f -> f.singleOrError());
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.singleOrError().toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.singleOrError().toFlowable());
 
-        TestHelper.checkDoubleOnSubscribeFlowableToMaybe(new Function<Flowable<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Flowable<Object> f) throws Exception {
-                return f.singleElement();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToMaybe(f -> f.singleElement());
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.singleElement().toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.singleElement().toFlowable());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLastTimedTest.java
@@ -186,12 +186,7 @@ public class FlowableSkipLastTimedTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.skipLast(1, TimeUnit.DAYS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.skipLast(1, TimeUnit.DAYS));
     }
 
     @Test
@@ -202,19 +197,9 @@ public class FlowableSkipLastTimedTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = pp.skipLast(1, TimeUnit.DAYS, scheduler).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipWhileTest.java
@@ -31,14 +31,11 @@ public class FlowableSkipWhileTest extends RxJavaTest {
 
     Subscriber<Integer> w = TestHelper.mockSubscriber();
 
-    private static final Predicate<Integer> LESS_THAN_FIVE = new Predicate<Integer>() {
-        @Override
-        public boolean test(Integer v) {
-            if (v == 42) {
-                throw new RuntimeException("that's not the answer to everything!");
-            }
-            return v < 5;
+    private static final Predicate<Integer> LESS_THAN_FIVE = v -> {
+        if (v == 42) {
+            throw new RuntimeException("that's not the answer to everything!");
         }
+        return v < 5;
     };
 
     private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<Integer>() {
@@ -142,12 +139,7 @@ public class FlowableSkipWhileTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.skipWhile(Functions.alwaysFalse());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.skipWhile(Functions.alwaysFalse()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -45,26 +45,22 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable
-        .unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(
-                    final Subscriber<? super Integer> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                scheduled.countDown();
+        .unsafeCreate((Publisher<Integer>) subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            scheduled.countDown();
+            try {
                 try {
-                    try {
-                        latch.await();
-                    } catch (InterruptedException e) {
-                        // this means we were unsubscribed (Scheduler shut down and interrupts)
-                        // ... but we'll pretend we are like many Flowables that ignore interrupts
-                    }
-
-                    subscriber.onComplete();
-                } catch (Throwable e) {
-                    subscriber.onError(e);
-                } finally {
-                    doneLatch.countDown();
+                    latch.await();
+                } catch (InterruptedException e) {
+                    // this means we were unsubscribed (Scheduler shut down and interrupts)
+                    // ... but we'll pretend we are like many Flowables that ignore interrupts
                 }
+
+                subscriber.onComplete();
+            } catch (Throwable e) {
+                subscriber.onError(e);
+            } finally {
+                doneLatch.countDown();
             }
         }).subscribeOn(Schedulers.computation()).subscribe(ts);
 
@@ -81,14 +77,9 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
     @Test
     public void onError() {
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
-        Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> s) {
-                s.onSubscribe(new BooleanSubscription());
-                s.onError(new RuntimeException("fail"));
-            }
-
+        Flowable.unsafeCreate((Publisher<String>) s -> {
+            s.onSubscribe(new BooleanSubscription());
+            s.onError(new RuntimeException("fail"));
         }).subscribeOn(Schedulers.computation()).subscribe(ts);
         ts.awaitDone(1000, TimeUnit.MILLISECONDS);
         ts.assertTerminated();
@@ -155,18 +146,13 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
     public void unsubscribeInfiniteStream() throws InterruptedException {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         final AtomicInteger count = new AtomicInteger();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> sub) {
-                BooleanSubscription bs = new BooleanSubscription();
-                sub.onSubscribe(bs);
-                for (int i = 1; !bs.isCancelled(); i++) {
-                    count.incrementAndGet();
-                    sub.onNext(i);
-                }
+        Flowable.unsafeCreate((Publisher<Integer>) sub -> {
+            BooleanSubscription bs = new BooleanSubscription();
+            sub.onSubscribe(bs);
+            for (int i = 1; !bs.isCancelled(); i++) {
+                count.incrementAndGet();
+                sub.onNext(i);
             }
-
         }).subscribeOn(Schedulers.newThread()).take(10).subscribe(ts);
 
         ts.awaitDone(1000, TimeUnit.MILLISECONDS);
@@ -210,49 +196,44 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
     @Test
     public void setProducerSynchronousRequest() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
-        Flowable.just(1, 2, 3).lift(new FlowableOperator<Integer, Integer>() {
+        Flowable.just(1, 2, 3).lift((FlowableOperator<Integer, Integer>) child -> {
+            final AtomicLong requested = new AtomicLong();
+            child.onSubscribe(new Subscription() {
 
-            @Override
-            public Subscriber<? super Integer> apply(final Subscriber<? super Integer> child) {
-                final AtomicLong requested = new AtomicLong();
-                child.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        if (!requested.compareAndSet(0, n)) {
-                            child.onError(new RuntimeException("Expected to receive request before onNext but didn't"));
-                        }
+                @Override
+                public void request(long n) {
+                    if (!requested.compareAndSet(0, n)) {
+                        child.onError(new RuntimeException("Expected to receive request before onNext but didn't"));
                     }
+                }
 
-                    @Override
-                    public void cancel() {
+                @Override
+                public void cancel() {
 
+                }
+
+            });
+            Subscriber<Integer> parent = new DefaultSubscriber<Integer>() {
+
+                @Override
+                public void onComplete() {
+                    child.onComplete();
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    child.onError(e);
+                }
+
+                @Override
+                public void onNext(Integer t) {
+                    if (requested.compareAndSet(0, -99)) {
+                        child.onError(new RuntimeException("Got values before requested"));
                     }
+                }
+            };
 
-                });
-                Subscriber<Integer> parent = new DefaultSubscriber<Integer>() {
-
-                    @Override
-                    public void onComplete() {
-                        child.onComplete();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        child.onError(e);
-                    }
-
-                    @Override
-                    public void onNext(Integer t) {
-                        if (requested.compareAndSet(0, -99)) {
-                            child.onError(new RuntimeException("Got values before requested"));
-                        }
-                    }
-                };
-
-                return parent;
-            }
-
+            return parent;
         }).subscribeOn(Schedulers.newThread()).subscribe(ts);
         ts.awaitDone(20, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -294,19 +275,9 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
             final BooleanSubscription bs = new BooleanSubscription();
 
             try {
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        so.onSubscribe(bs);
-                    }
-                };
+                Runnable r1 = () -> so.onSubscribe(bs);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        so.request(1);
-                    }
-                };
+                Runnable r2 = () -> so.request(1);
 
                 TestHelper.race(r1, r2);
             } finally {
@@ -317,15 +288,12 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void nonScheduledRequests() {
-        TestSubscriber<Object> ts = Flowable.create(new FlowableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(FlowableEmitter<Object> s) throws Exception {
-                for (int i = 1; i < 1001; i++) {
-                    s.onNext(i);
-                    Thread.sleep(1);
-                }
-                s.onComplete();
+        TestSubscriber<Object> ts = Flowable.create(s -> {
+            for (int i = 1; i < 1001; i++) {
+                s.onNext(i);
+                Thread.sleep(1);
             }
+            s.onComplete();
         }, BackpressureStrategy.DROP)
         .subscribeOn(Schedulers.single())
         .observeOn(Schedulers.computation())
@@ -341,15 +309,12 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void scheduledRequests() {
-        Flowable.create(new FlowableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(FlowableEmitter<Object> s) throws Exception {
-                for (int i = 1; i < 1001; i++) {
-                    s.onNext(i);
-                    Thread.sleep(1);
-                }
-                s.onComplete();
+        Flowable.create(s -> {
+            for (int i = 1; i < 1001; i++) {
+                s.onNext(i);
+                Thread.sleep(1);
             }
+            s.onComplete();
         }, BackpressureStrategy.DROP)
         .map(Functions.identity())
         .subscribeOn(Schedulers.single())
@@ -363,15 +328,12 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void nonScheduledRequestsNotSubsequentSubscribeOn() {
-        TestSubscriber<Object> ts = Flowable.create(new FlowableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(FlowableEmitter<Object> s) throws Exception {
-                for (int i = 1; i < 1001; i++) {
-                    s.onNext(i);
-                    Thread.sleep(1);
-                }
-                s.onComplete();
+        TestSubscriber<Object> ts = Flowable.create(s -> {
+            for (int i = 1; i < 1001; i++) {
+                s.onNext(i);
+                Thread.sleep(1);
             }
+            s.onComplete();
         }, BackpressureStrategy.DROP)
         .map(Functions.identity())
         .subscribeOn(Schedulers.single(), false)
@@ -388,15 +350,12 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
 
     @Test
     public void scheduledRequestsNotSubsequentSubscribeOn() {
-        Flowable.create(new FlowableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(FlowableEmitter<Object> s) throws Exception {
-                for (int i = 1; i < 1001; i++) {
-                    s.onNext(i);
-                    Thread.sleep(1);
-                }
-                s.onComplete();
+        Flowable.create(s -> {
+            for (int i = 1; i < 1001; i++) {
+                s.onNext(i);
+                Thread.sleep(1);
             }
+            s.onComplete();
         }, BackpressureStrategy.DROP)
         .map(Functions.identity())
         .subscribeOn(Schedulers.single(), true)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.*;
@@ -35,12 +34,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
         final AtomicBoolean subscribed = new AtomicBoolean(false);
         final Flowable<Integer> flowable = Flowable.just(4)
                 .switchIfEmpty(Flowable.just(2)
-                .doOnSubscribe(new Consumer<Subscription>() {
-                    @Override
-                    public void accept(Subscription s) {
-                        subscribed.set(true);
-                    }
-                }));
+                .doOnSubscribe(_ -> subscribed.set(true)));
 
         assertEquals(4, flowable.blockingSingle().intValue());
         assertFalse(subscribed.get());
@@ -57,26 +51,21 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
     @Test
     public void switchWithProducer() throws Exception {
         final AtomicBoolean emitted = new AtomicBoolean(false);
-        Flowable<Long> withProducer = Flowable.unsafeCreate(new Publisher<Long>() {
+        Flowable<Long> withProducer = Flowable.unsafeCreate(subscriber -> subscriber.onSubscribe(new Subscription() {
             @Override
-            public void subscribe(final Subscriber<? super Long> subscriber) {
-                subscriber.onSubscribe(new Subscription() {
-                    @Override
-                    public void request(long n) {
-                        if (n > 0 && emitted.compareAndSet(false, true)) {
-                            emitted.set(true);
-                            subscriber.onNext(42L);
-                            subscriber.onComplete();
-                        }
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
+            public void request(long n) {
+                if (n > 0 && emitted.compareAndSet(false, true)) {
+                    emitted.set(true);
+                    subscriber.onNext(42L);
+                    subscriber.onComplete();
+                }
             }
-        });
+
+            @Override
+            public void cancel() {
+
+            }
+        }));
 
         final Flowable<Long> flowable = Flowable.<Long>empty().switchIfEmpty(withProducer);
         assertEquals(42, flowable.blockingSingle().intValue());
@@ -87,20 +76,14 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
 
         final BooleanSubscription bs = new BooleanSubscription();
 
-        Flowable<Long> withProducer = Flowable.unsafeCreate(new Publisher<Long>() {
-            @Override
-            public void subscribe(final Subscriber<? super Long> subscriber) {
-                subscriber.onSubscribe(bs);
-                subscriber.onNext(42L);
-            }
+        Flowable<Long> withProducer = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(bs);
+            subscriber.onNext(42L);
         });
 
         Flowable.<Long>empty()
                 .switchIfEmpty(withProducer)
-                .lift(new FlowableOperator<Long, Long>() {
-            @Override
-            public Subscriber<? super Long> apply(final Subscriber<? super Long> child) {
-                return new DefaultSubscriber<Long>() {
+                .lift((FlowableOperator<Long, Long>) _ -> new DefaultSubscriber<Long>() {
                     @Override
                     public void onComplete() {
 
@@ -116,9 +99,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
                         cancel();
                     }
 
-                };
-            }
-        }).subscribe();
+                }).subscribe();
 
         assertTrue(bs.isCancelled());
         // FIXME no longer assertable
@@ -129,12 +110,9 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
     public void switchShouldNotTriggerUnsubscribe() {
         final BooleanSubscription bs = new BooleanSubscription();
 
-        Flowable.unsafeCreate(new Publisher<Long>() {
-            @Override
-            public void subscribe(final Subscriber<? super Long> subscriber) {
-                subscriber.onSubscribe(bs);
-                subscriber.onComplete();
-            }
+        Flowable.unsafeCreate((Publisher<Long>) subscriber -> {
+            subscriber.onSubscribe(bs);
+            subscriber.onComplete();
         }).switchIfEmpty(Flowable.<Long>never()).subscribe();
         assertFalse(bs.isCancelled());
     }
@@ -174,29 +152,20 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
     @Test
     public void requestsNotLost() throws InterruptedException {
         final TestSubscriber<Long> ts = new TestSubscriber<>(0L);
-        Flowable.unsafeCreate(new Publisher<Long>() {
+        Flowable.unsafeCreate((Publisher<Long>) subscriber -> subscriber.onSubscribe(new Subscription() {
+            final AtomicBoolean completed = new AtomicBoolean(false);
+            @Override
+            public void request(long n) {
+                if (n > 0 && completed.compareAndSet(false, true)) {
+                    Schedulers.cached().createWorker().schedule(() -> subscriber.onComplete(), 100, TimeUnit.MILLISECONDS);
+                }
+            }
 
             @Override
-            public void subscribe(final Subscriber<? super Long> subscriber) {
-                subscriber.onSubscribe(new Subscription() {
-                    final AtomicBoolean completed = new AtomicBoolean(false);
-                    @Override
-                    public void request(long n) {
-                        if (n > 0 && completed.compareAndSet(false, true)) {
-                            Schedulers.cached().createWorker().schedule(new Runnable() {
-                                @Override
-                                public void run() {
-                                    subscriber.onComplete();
-                                }}, 100, TimeUnit.MILLISECONDS);
-                        }
-                    }
+            public void cancel() {
 
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
-            }})
+            }
+        }))
         .switchIfEmpty(Flowable.fromIterable(Arrays.asList(1L, 2L, 3L)))
         .subscribeOn(Schedulers.computation())
         .subscribe(ts);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
@@ -36,12 +36,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     public void takeEmpty() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.empty().takeUntil(new Predicate<Object>() {
-            @Override
-            public boolean test(Object v) {
-                return true;
-            }
-        }).subscribe(subscriber);
+        Flowable.empty().takeUntil(_ -> true).subscribe(subscriber);
 
         verify(subscriber, never()).onNext(any());
         verify(subscriber, never()).onError(any(Throwable.class));
@@ -52,12 +47,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     public void takeAll() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.just(1, 2).takeUntil(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return false;
-            }
-        }).subscribe(subscriber);
+        Flowable.just(1, 2).takeUntil(_ -> false).subscribe(subscriber);
 
         verify(subscriber).onNext(1);
         verify(subscriber).onNext(2);
@@ -69,12 +59,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     public void takeFirst() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.just(1, 2).takeUntil(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        }).subscribe(subscriber);
+        Flowable.just(1, 2).takeUntil(_ -> true).subscribe(subscriber);
 
         verify(subscriber).onNext(1);
         verify(subscriber, never()).onNext(2);
@@ -86,12 +71,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     public void takeSome() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Flowable.just(1, 2, 3).takeUntil(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 == 2;
-            }
-        })
+        Flowable.just(1, 2, 3).takeUntil(t1 -> t1 == 2)
         .subscribe(subscriber);
 
         verify(subscriber).onNext(1);
@@ -105,11 +85,8 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     public void functionThrows() {
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
-        Predicate<Integer> predicate = new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                    throw new TestException("Forced failure");
-            }
+        Predicate<Integer> predicate = _ -> {
+                throw new TestException("Forced failure");
         };
         Flowable.just(1, 2, 3).takeUntil(predicate).subscribe(subscriber);
 
@@ -127,12 +104,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
         Flowable.just(1)
         .concatWith(Flowable.<Integer>error(new TestException()))
         .concatWith(Flowable.just(2))
-        .takeUntil(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return false;
-            }
-        }).subscribe(subscriber);
+        .takeUntil(_ -> false).subscribe(subscriber);
 
         verify(subscriber).onNext(1);
         verify(subscriber, never()).onNext(2);
@@ -144,12 +116,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     public void backpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(5L);
 
-        Flowable.range(1, 1000).takeUntil(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return false;
-            }
-        }).subscribe(ts);
+        Flowable.range(1, 1000).takeUntil(_ -> false).subscribe(ts);
 
         ts.assertNoErrors();
         ts.assertValues(1, 2, 3, 4, 5);
@@ -160,11 +127,8 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     public void errorIncludesLastValueAsCause() {
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
         final TestException e = new TestException("Forced failure");
-        Predicate<String> predicate = new Predicate<String>() {
-            @Override
-            public boolean test(String t) {
-                    throw e;
-            }
+        Predicate<String> predicate = _ -> {
+                throw e;
         };
         Flowable.just("abc").takeUntil(predicate).subscribe(ts);
 
@@ -182,12 +146,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.takeUntil(Functions.alwaysFalse());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.takeUntil(Functions.alwaysFalse()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeUntilTest.java
@@ -290,12 +290,7 @@ public class FlowableTakeUntilTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> c) throws Exception {
-                return c.takeUntil(Flowable.never());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Integer>, Flowable<Integer>>) c -> c.takeUntil(Flowable.never()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimestampTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimestampTest.java
@@ -23,7 +23,6 @@ import org.mockito.InOrder;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.schedulers.*;
@@ -89,22 +88,12 @@ public class FlowableTimestampTest extends RxJavaTest {
     public void timeIntervalDefault() {
         final TestScheduler scheduler = new TestScheduler();
 
-        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler v) throws Exception {
-                return scheduler;
-            }
-        });
+        RxJavaPlugins.setComputationSchedulerHandler(_ -> scheduler);
 
         try {
             Flowable.range(1, 5)
             .timestamp()
-            .map(new Function<Timed<Integer>, Long>() {
-                @Override
-                public Long apply(Timed<Integer> v) throws Exception {
-                    return v.time();
-                }
-            })
+            .map(v -> v.time())
             .test()
             .assertResult(0L, 0L, 0L, 0L, 0L);
         } finally {
@@ -116,22 +105,12 @@ public class FlowableTimestampTest extends RxJavaTest {
     public void timeIntervalDefaultSchedulerCustomUnit() {
         final TestScheduler scheduler = new TestScheduler();
 
-        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler v) throws Exception {
-                return scheduler;
-            }
-        });
+        RxJavaPlugins.setComputationSchedulerHandler(_ -> scheduler);
 
         try {
             Flowable.range(1, 5)
             .timestamp(TimeUnit.SECONDS)
-            .map(new Function<Timed<Integer>, Long>() {
-                @Override
-                public Long apply(Timed<Integer> v) throws Exception {
-                    return v.time();
-                }
-            })
+            .map(v -> v.time())
             .test()
             .assertResult(0L, 0L, 0L, 0L, 0L);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToFutureTest.java
@@ -165,11 +165,8 @@ public class FlowableToFutureTest extends RxJavaTest {
     public void backpressure() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(0);
 
-        FutureTask<Integer> f = new FutureTask<>(new Runnable() {
-            @Override
-            public void run() {
+        FutureTask<Integer> f = new FutureTask<>(() -> {
 
-            }
         }, 1);
 
         f.run();
@@ -187,11 +184,8 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void withTimeoutNoTimeout() {
-        FutureTask<Integer> task = new FutureTask<>(new Runnable() {
-            @Override
-            public void run() {
+        FutureTask<Integer> task = new FutureTask<>(() -> {
 
-            }
         }, 1);
 
         task.run();
@@ -207,11 +201,8 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void withTimeoutTimeout() {
-        FutureTask<Integer> task = new FutureTask<>(new Runnable() {
-            @Override
-            public void run() {
+        FutureTask<Integer> task = new FutureTask<>(() -> {
 
-            }
         }, 1);
 
         TestSubscriber<Integer> ts = TestSubscriber.create();
@@ -225,11 +216,8 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void withTimeoutNoTimeoutScheduler() {
-        FutureTask<Integer> task = new FutureTask<>(new Runnable() {
-            @Override
-            public void run() {
+        FutureTask<Integer> task = new FutureTask<>(() -> {
 
-            }
         }, 1);
 
         TestSubscriber<Integer> ts = TestSubscriber.create();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipCompletionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipCompletionTest.java
@@ -41,12 +41,7 @@ public class FlowableZipCompletionTest extends RxJavaTest {
 
     @Before
     public void setUp() {
-        concat2Strings = new BiFunction<String, String, String>() {
-            @Override
-            public String apply(String t1, String t2) {
-                return t1 + "-" + t2;
-            }
-        };
+        concat2Strings = (t1, t2) -> t1 + "-" + t2;
 
         s1 = PublishProcessor.create();
         s2 = PublishProcessor.create();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayOtherTest.java
@@ -205,12 +205,7 @@ public class MaybeDelayOtherTest extends RxJavaTest {
 
     @Test
     public void withCompletableDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeCompletableToMaybe(new Function<Completable, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Completable c) throws Exception {
-                return c.andThen(Maybe.just(1));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletableToMaybe(c -> c.andThen(Maybe.just(1)));
     }
 
     @Test
@@ -220,12 +215,7 @@ public class MaybeDelayOtherTest extends RxJavaTest {
 
     @Test
     public void withOtherPublisherDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Maybe<Integer> c) throws Exception {
-                return c.delay(Flowable.never());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, MaybeSource<Integer>>) c -> c.delay(Flowable.never()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmptySingleTest.java
@@ -71,12 +71,7 @@ public class MaybeSwitchIfEmptySingleTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Integer>, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Maybe<Integer> f) throws Exception {
-                return f.switchIfEmpty(Single.just(2));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle((Function<Maybe<Integer>, Single<Integer>>) f -> f.switchIfEmpty(Single.just(2)));
     }
 
     @Test
@@ -86,19 +81,9 @@ public class MaybeSwitchIfEmptySingleTest extends RxJavaTest {
 
             final TestObserver<Integer> to = pp.singleElement().switchIfEmpty(Single.just(2)).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = () -> to.dispose();
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmptyTest.java
@@ -86,12 +86,7 @@ public class MaybeSwitchIfEmptyTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Maybe<Integer> f) throws Exception {
-                return f.switchIfEmpty(Maybe.just(2));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, Maybe<Integer>>) f -> f.switchIfEmpty(Maybe.just(2)));
     }
 
     @Test
@@ -101,19 +96,9 @@ public class MaybeSwitchIfEmptyTest extends RxJavaTest {
 
             final TestObserver<Integer> to = pp.singleElement().switchIfEmpty(Maybe.just(2)).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = () -> to.dispose();
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUnsubscribeOnTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -37,12 +36,9 @@ public class MaybeUnsubscribeOnTest extends RxJavaTest {
 
         final CountDownLatch cdl = new CountDownLatch(1);
 
-        pp.doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                name[0] = Thread.currentThread().getName();
-                cdl.countDown();
-            }
+        pp.doOnCancel(() -> {
+            name[0] = Thread.currentThread().getName();
+            cdl.countDown();
         })
         .singleElement()
         .unsubscribeOn(Schedulers.single())
@@ -94,12 +90,7 @@ public class MaybeUnsubscribeOnTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> v) throws Exception {
-                return v.unsubscribeOn(Schedulers.single());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(v -> v.unsubscribeOn(Schedulers.single()));
     }
 
     @Test
@@ -131,12 +122,7 @@ public class MaybeUnsubscribeOnTest extends RxJavaTest {
                 }
             });
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    ds[0].dispose();
-                }
-            };
+            Runnable r = () -> ds[0].dispose();
 
             TestHelper.race(r, r);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletableTest.java
@@ -352,42 +352,20 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream -> upstream.concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Throwable {
-                return Completable.complete().hide();
-            }
-        }));
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            upstream.concatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return upstream.concatMapCompletableDelayError(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                }, false, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            upstream.concatMapCompletableDelayError((Function<Integer, Completable>) _ -> Completable.complete().hide(), false, 2));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return upstream.concatMapCompletableDelayError(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            upstream.concatMapCompletableDelayError((Function<Integer, Completable>) _ -> Completable.complete().hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -42,13 +42,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void simple() {
         Flowable.range(1, 5)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v))
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -76,13 +70,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void backpressure() {
         TestSubscriber<Integer> ts = Flowable.range(1, 1024)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        }, 32)
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v), 32)
         .test(0);
 
         for (int i = 1; i <= 1024; i++) {
@@ -100,13 +88,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void empty() {
         Flowable.range(1, 10)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.empty();
-            }
-        })
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty())
         .test()
         .assertResult();
     }
@@ -114,15 +96,11 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void mixed() {
         Flowable.range(1, 10)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                if (v % 2 == 0) {
-                    return Maybe.just(v);
-                }
-                return Maybe.empty();
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v % 2 == 0) {
+                return Maybe.just(v);
             }
+            return Maybe.empty();
         })
         .test()
         .assertResult(2, 4, 6, 8, 10);
@@ -131,15 +109,11 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void mixedLong() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 1024)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                if (v % 2 == 0) {
-                    return Maybe.just(v).subscribeOn(Schedulers.computation());
-                }
-                return Maybe.<Integer>empty().subscribeOn(Schedulers.computation());
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v % 2 == 0) {
+                return Maybe.just(v).subscribeOn(Schedulers.computation());
             }
+            return Maybe.<Integer>empty().subscribeOn(Schedulers.computation());
         })
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -220,14 +194,8 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(
-                new Function<Flowable<Object>, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Flowable<Object> f)
-                            throws Exception {
-                        return f.concatMapMaybeDelayError(
-                                Functions.justFunction(Maybe.empty()));
-                    }
-                }
+                (Function<Flowable<Object>, Flowable<Object>>) f -> f.concatMapMaybeDelayError(
+                        Functions.justFunction(Maybe.empty()))
         );
     }
 
@@ -260,13 +228,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void limit() {
         Flowable.range(1, 5)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .concatMapMaybe(Maybe::just)
         .take(3)
         .test()
         .assertResult(1, 2, 3);
@@ -275,13 +237,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void cancel() {
         Flowable.range(1, 5)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v))
         .test(3)
         .assertValues(1, 2, 3)
         .assertNoErrors()
@@ -298,19 +254,13 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
             final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = pp.concatMapMaybe(
-                    new Function<Integer, MaybeSource<Integer>>() {
-                        @Override
-                        public MaybeSource<Integer> apply(Integer v)
-                                throws Exception {
-                            return new Maybe<Integer>() {
-                                    @Override
-                                    protected void subscribeActual(
-                                            MaybeObserver<? super Integer> observer) {
-                                        observer.onSubscribe(Disposable.empty());
-                                        obs.set(observer);
-                                    }
-                            };
-                        }
+                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() {
+                            @Override
+                            protected void subscribeActual(
+                                    MaybeObserver<? super Integer> observer) {
+                                observer.onSubscribe(Disposable.empty());
+                                obs.set(observer);
+                            }
                     }
             ).to(TestHelper.<Integer>testConsumer());
 
@@ -330,13 +280,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void delayAllErrors() {
         TestSubscriberEx<Object> ts = Flowable.range(1, 5)
-        .concatMapMaybeDelayError(new Function<Integer, MaybeSource<? extends Object>>() {
-            @Override
-            public MaybeSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Maybe.error(new TestException());
-            }
-        })
+        .concatMapMaybeDelayError(_ -> Maybe.error(new TestException()))
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class)
         ;
@@ -350,13 +294,9 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Object> ts = pp
-        .concatMapMaybe(new Function<Integer, MaybeSource<? extends Object>>() {
-            @Override
-            public MaybeSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                        throw new TestException();
-                    }
-        })
+        .concatMapMaybe(_ -> {
+                    throw new TestException();
+                })
         .test();
 
         ts.assertEmpty();
@@ -405,18 +345,8 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
                     .concatMapMaybe(Functions.justFunction(ms))
                     .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ms.onSuccess(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> ms.onSuccess(1);
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -426,47 +356,20 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                }, false, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMapMaybeDelayError((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), false, 2));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMapMaybeDelayError((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -40,13 +40,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void simple() {
         Flowable.range(1, 5)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        })
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v))
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -74,13 +68,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void backpressure() {
         TestSubscriber<Integer> ts = Flowable.range(1, 1024)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        }, 32)
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v), 32)
         .test(0);
 
         for (int i = 1; i <= 1024; i++) {
@@ -138,14 +126,8 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeFlowable(
-                new Function<Flowable<Object>, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Flowable<Object> f)
-                            throws Exception {
-                        return f.concatMapSingleDelayError(
-                                Functions.justFunction(Single.just((Object)1)));
-                    }
-                }
+                (Function<Flowable<Object>, Flowable<Object>>) f -> f.concatMapSingleDelayError(
+                        Functions.justFunction(Single.just((Object)1)))
         );
     }
 
@@ -178,13 +160,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void limit() {
         Flowable.range(1, 5)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        })
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v))
         .take(3)
         .test()
         .assertResult(1, 2, 3);
@@ -193,13 +169,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void cancel() {
         Flowable.range(1, 5)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        })
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v))
         .test(3)
         .assertValues(1, 2, 3)
         .assertNoErrors()
@@ -216,19 +186,13 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
             final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = pp.concatMapSingle(
-                    new Function<Integer, SingleSource<Integer>>() {
-                        @Override
-                        public SingleSource<Integer> apply(Integer v)
-                                throws Exception {
-                            return new Single<Integer>() {
-                                    @Override
-                                    protected void subscribeActual(
-                                            SingleObserver<? super Integer> observer) {
-                                        observer.onSubscribe(Disposable.empty());
-                                        obs.set(observer);
-                                    }
-                            };
-                        }
+                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
+                            @Override
+                            protected void subscribeActual(
+                                    SingleObserver<? super Integer> observer) {
+                                observer.onSubscribe(Disposable.empty());
+                                obs.set(observer);
+                            }
                     }
             ).to(TestHelper.<Integer>testConsumer());
 
@@ -248,13 +212,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void delayAllErrors() {
         TestSubscriberEx<Object> ts = Flowable.range(1, 5)
-        .concatMapSingleDelayError(new Function<Integer, SingleSource<? extends Object>>() {
-            @Override
-            public SingleSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Single.error(new TestException());
-            }
-        })
+        .concatMapSingleDelayError(_ -> Single.error(new TestException()))
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class)
         ;
@@ -268,13 +226,9 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Object> ts = pp
-        .concatMapSingle(new Function<Integer, SingleSource<? extends Object>>() {
-            @Override
-            public SingleSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                        throw new TestException();
-                    }
-        })
+        .concatMapSingle(_ -> {
+                    throw new TestException();
+                })
         .test();
 
         ts.assertEmpty();
@@ -323,18 +277,8 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
                     .concatMapSingle(Functions.justFunction(ss))
                     .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ss.onSuccess(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> ss.onSuccess(1);
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -344,47 +288,20 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapSingle(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapSingleDelayError(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                }, false, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMapSingleDelayError((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), false, 2));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.concatMapSingleDelayError(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.concatMapSingleDelayError((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
@@ -36,12 +36,7 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
     @Test
     public void normal() {
         Flowable.range(1, 10)
-        .switchMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        .switchMapCompletable(_ -> Completable.complete())
         .test()
         .assertResult();
     }
@@ -49,12 +44,7 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
     @Test
     public void mainError() {
         Flowable.<Integer>error(new TestException())
-        .switchMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        .switchMapCompletable(_ -> Completable.complete())
         .test()
         .assertFailure(TestException.class);
     }
@@ -93,12 +83,7 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Void> to = pp.switchMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return css[v];
-            }
-        })
+        TestObserver<Void> to = pp.switchMapCompletable(v -> css[v])
         .test();
 
         to.assertEmpty();
@@ -152,21 +137,13 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
     @Test
     public void checkBadSource() {
-        TestHelper.checkDoubleOnSubscribeFlowableToCompletable(new Function<Flowable<Object>, Completable>() {
-            @Override
-            public Completable apply(Flowable<Object> f) throws Exception {
-                return f.switchMapCompletable(Functions.justFunction(Completable.never()));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowableToCompletable(f -> f.switchMapCompletable(Functions.justFunction(Completable.never())));
     }
 
     @Test
     public void mapperCrash() {
-        Flowable.range(1, 5).switchMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer f) throws Exception {
-                throw new TestException();
-            }
+        Flowable.range(1, 5).switchMapCompletable(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -176,12 +153,9 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
     public void mapperCancels() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Flowable.range(1, 5).switchMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer f) throws Exception {
-                to.dispose();
-                return Completable.complete();
-            }
+        Flowable.range(1, 5).switchMapCompletable(_ -> {
+            to.dispose();
+            return Completable.complete();
         })
         .subscribe(to);
 
@@ -198,19 +172,9 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(2);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(2);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cs.onComplete();
-                }
-            };
+            Runnable r2 = () -> cs.onComplete();
 
             TestHelper.race(r1, r2);
 
@@ -231,28 +195,13 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
                 pp.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onNext(2);
-                    }
-                };
+                Runnable r1 = () -> pp.onNext(2);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        cs.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> cs.onError(ex);
 
                 TestHelper.race(r1, r2);
 
-                to.assertError(new Predicate<Throwable>() {
-                    @Override
-                    public boolean test(Throwable e) throws Exception {
-                        return e instanceof TestException || e instanceof CompositeException;
-                    }
-                });
+                to.assertError(e -> e instanceof TestException || e instanceof CompositeException);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -277,28 +226,13 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
                 pp.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onError(ex0);
-                    }
-                };
+                Runnable r1 = () -> pp.onError(ex0);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        cs.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> cs.onError(ex);
 
                 TestHelper.race(r1, r2);
 
-                to.assertError(new Predicate<Throwable>() {
-                    @Override
-                    public boolean test(Throwable e) throws Exception {
-                        return e instanceof TestException || e instanceof CompositeException;
-                    }
-                });
+                to.assertError(e -> e instanceof TestException || e instanceof CompositeException);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -390,31 +324,13 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return upstream.switchMapCompletable(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            upstream.switchMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Flowable<Integer> upstream) {
-                return upstream.switchMapCompletableDelayError(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
+            upstream.switchMapCompletableDelayError((Function<Integer, Completable>) _ -> Completable.complete().hide()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDematerializeTest.java
@@ -49,11 +49,8 @@ public class ObservableDematerializeTest extends RxJavaTest {
     public void selectorCrash() {
         Observable.just(1, 2)
         .materialize()
-        .dematerialize(new Function<Notification<Integer>, Notification<Object>>() {
-            @Override
-            public Notification<Object> apply(Notification<Integer> v) throws Exception {
-                throw new TestException();
-            }
+        .dematerialize(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -63,12 +60,7 @@ public class ObservableDematerializeTest extends RxJavaTest {
     public void selectorNull() {
         Observable.just(1, 2)
         .materialize()
-        .dematerialize(new Function<Notification<Integer>, Notification<Object>>() {
-            @Override
-            public Notification<Object> apply(Notification<Integer> v) throws Exception {
-                return null;
-            }
-        })
+        .dematerialize(_ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -187,12 +179,8 @@ public class ObservableDematerializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Notification<Object>>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Notification<Object>> o) throws Exception {
-                return o.dematerialize(Functions.<Notification<Object>>identity());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable((Function<Observable<Notification<Object>>, ObservableSource<Object>>) o ->
+            o.dematerialize(Functions.<Notification<Object>>identity()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleToFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleToFlowableTest.java
@@ -14,10 +14,7 @@
 package io.reactivex.rxjava4.internal.operators.single;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.subjects.PublishSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -30,11 +27,6 @@ public class SingleToFlowableTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToFlowable(new Function<Single<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Single<Object> s) throws Exception {
-                return s.toFlowable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToFlowable(s -> s.toFlowable());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleToObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleToObservableTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.operators.single;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.subjects.PublishSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -29,11 +28,6 @@ public class SingleToObservableTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToObservable(new Function<Single<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Single<Object> s) throws Exception {
-                return s.toObservable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToObservable(s -> s.toObservable());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/util/TestingHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/TestingHelper.java
@@ -24,32 +24,16 @@ public final class TestingHelper {
     }
 
     public static <T> Consumer<T> addToList(final List<T> list) {
-        return new Consumer<T>() {
-
-            @Override
-            public void accept(T t) {
-                list.add(t);
-            }
-        };
+        return t -> list.add(t);
     }
 
     public static <T> Supplier<List<T>> supplierListCreator() {
-        return new Supplier<List<T>>() {
-
-            @Override
-            public List<T> get() {
-                return new ArrayList<>();
-            }
-        };
+        return () -> new ArrayList<>();
     }
 
     public static BiConsumer<Object, Object> biConsumerThrows(final RuntimeException e) {
-        return new BiConsumer<Object, Object>() {
-
-            @Override
-            public void accept(Object t1, Object t2) {
-                throw e;
-            }
+        return (_, _) -> {
+            throw e;
         };
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/schedulers/NewThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/NewThreadSchedulerTest.java
@@ -42,12 +42,7 @@ public class NewThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
     public void shutdownRejects() {
         final int[] calls = { 0 };
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                calls[0]++;
-            }
-        };
+        Runnable r = () -> calls[0]++;
 
         Scheduler s = getScheduler();
         Worker w = s.createWorker();
@@ -84,10 +79,7 @@ public class NewThreadSchedulerTest extends AbstractSchedulerConcurrencyTests {
         w.dispose();
 
         //This method used to throw a NPE when the worker has been disposed and the parent is null
-        w.scheduleActual(new Runnable() {
-            @Override
-            public void run() {
-            }
+        w.scheduleActual(() -> {
         }, 0, TimeUnit.MILLISECONDS, null);
 
     }

--- a/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
@@ -45,15 +45,12 @@ public class TestSchedulerTest extends RxJavaTest {
         final Scheduler.Worker inner = scheduler.createWorker();
 
         try {
-            inner.schedulePeriodically(new Runnable() {
-                @Override
-                public void run() {
-                    System.out.println(scheduler.now(TimeUnit.MILLISECONDS));
-                    try {
-                        calledOp.apply(scheduler.now(TimeUnit.MILLISECONDS));
-                    } catch (Throwable ex) {
-                        ExceptionHelper.wrapOrThrow(ex);
-                    }
+            inner.schedulePeriodically(() -> {
+                System.out.println(scheduler.now(TimeUnit.MILLISECONDS));
+                try {
+                    calledOp.apply(scheduler.now(TimeUnit.MILLISECONDS));
+                } catch (Throwable ex) {
+                    ExceptionHelper.wrapOrThrow(ex);
                 }
             }, 1, 2, TimeUnit.SECONDS);
 
@@ -95,15 +92,12 @@ public class TestSchedulerTest extends RxJavaTest {
         final Scheduler.Worker inner = scheduler.createWorker();
 
         try {
-            final Disposable subscription = inner.schedulePeriodically(new Runnable() {
-                @Override
-                public void run() {
-                    System.out.println(scheduler.now(TimeUnit.MILLISECONDS));
-                    try {
-                        calledOp.apply(scheduler.now(TimeUnit.MILLISECONDS));
-                    } catch (Throwable ex) {
-                        ExceptionHelper.wrapOrThrow(ex);
-                    }
+            final Disposable subscription = inner.schedulePeriodically(() -> {
+                System.out.println(scheduler.now(TimeUnit.MILLISECONDS));
+                try {
+                    calledOp.apply(scheduler.now(TimeUnit.MILLISECONDS));
+                } catch (Throwable ex) {
+                    ExceptionHelper.wrapOrThrow(ex);
                 }
             }, 1, 2, TimeUnit.SECONDS);
 

--- a/src/test/java/io/reactivex/rxjava4/schedulers/VirtualThreadSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/VirtualThreadSchedulerTest.java
@@ -22,7 +22,6 @@ import org.junit.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.disposables.Disposable;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.schedulers.DeferredExecutorScheduler;
 import io.reactivex.rxjava4.testsupport.SuppressUndeliverable;
 
@@ -41,22 +40,12 @@ public class VirtualThreadSchedulerTest extends AbstractSchedulerConcurrencyTest
 
         Flowable<Integer> f1 = Flowable.just(1, 2, 3, 4, 5);
         Flowable<Integer> f2 = Flowable.just(6, 7, 8, 9, 10);
-        Flowable<String> f = Flowable.merge(f1, f2).map(new Function<Integer, String>() {
-
-            @Override
-            public String apply(Integer t) {
-                assertTrue(Thread.currentThread().isVirtual());
-                return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
-            }
+        Flowable<String> f = Flowable.merge(f1, f2).map(t -> {
+            assertTrue(Thread.currentThread().isVirtual());
+            return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
         });
 
-        f.subscribeOn(Schedulers.virtual()).blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String t) {
-                System.out.println("t: " + t);
-            }
-        });
+        f.subscribeOn(Schedulers.virtual()).blockingForEach(t -> System.out.println("t: " + t));
     }
 
     @Test
@@ -97,12 +86,7 @@ public class VirtualThreadSchedulerTest extends AbstractSchedulerConcurrencyTest
     public void shutdownRejects() {
         final int[] calls = { 0 };
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                calls[0]++;
-            }
-        };
+        Runnable r = () -> calls[0]++;
 
         DeferredExecutorScheduler s = new DeferredExecutorScheduler(Executors::newVirtualThreadPerTaskExecutor, true, true);
         s.shutdown();

--- a/src/test/java/io/reactivex/rxjava4/tck/FromSupplierTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/FromSupplierTckTest.java
@@ -18,7 +18,6 @@ import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Supplier;
 
 @Test
 public class FromSupplierTckTest extends BaseTck<Long> {
@@ -26,12 +25,7 @@ public class FromSupplierTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFlowPublisher(final long elements) {
         return
-                Flowable.fromSupplier(new Supplier<Long>() {
-                    @Override
-                    public Long get() throws Throwable {
-                        return 1L;
-                    }
-                }
+                Flowable.fromSupplier(() -> 1L
                 )
             ;
     }
@@ -39,11 +33,8 @@ public class FromSupplierTckTest extends BaseTck<Long> {
     @Override
     public Publisher<Long> createFailedFlowPublisher() {
         return
-                Flowable.fromSupplier(new Supplier<Long>() {
-                    @Override
-                    public Long get() throws Throwable {
-                        throw new TestException();
-                    }
+                Flowable.fromSupplier(() -> {
+                    throw new TestException();
                 }
                 )
             ;

--- a/src/test/java/io/reactivex/rxjava4/tck/WithLatestFromTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/WithLatestFromTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.BiFunction;
 
 @Test
 public class WithLatestFromTckTest extends BaseTck<Integer> {
@@ -26,12 +25,7 @@ public class WithLatestFromTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
                 Flowable.range(0, (int)elements)
-                .withLatestFrom(Flowable.just(1), new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                })
+                .withLatestFrom(Flowable.just(1), (a, b) -> a + b)
         ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/ZipIterableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ZipIterableTckTest.java
@@ -19,7 +19,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.Function;
 
 @Test
 public class ZipIterableTckTest extends BaseTck<Long> {
@@ -31,12 +30,7 @@ public class ZipIterableTckTest extends BaseTck<Long> {
                     Flowable.fromIterable(iterate(elements)),
                     Flowable.fromIterable(iterate(elements))
                 ),
-                new Function<Object[], Long>() {
-                    @Override
-                    public Long apply(Object[] a) throws Exception {
-                        return (Long)a[0] + (Long)a[1];
-                    }
-                }
+                    a -> (Long)a[0] + (Long)a[1]
             )
         ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/ZipTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ZipTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.BiFunction;
 
 @Test
 public class ZipTckTest extends BaseTck<Long> {
@@ -28,12 +27,7 @@ public class ZipTckTest extends BaseTck<Long> {
             Flowable.zip(
                     Flowable.fromIterable(iterate(elements)),
                     Flowable.fromIterable(iterate(elements)),
-                    new BiFunction<Long, Long, Long>() {
-                        @Override
-                        public Long apply(Long a, Long b) throws Exception {
-                            return a + b;
-                        }
-                    }
+                    (a, b) -> a + b
             )
         ;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/ZipWithIterableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ZipWithIterableTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.BiFunction;
 
 @Test
 public class ZipWithIterableTckTest extends BaseTck<Integer> {
@@ -26,12 +25,7 @@ public class ZipWithIterableTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
                 Flowable.range(0, (int)elements)
-                .zipWith(iterate(elements), new BiFunction<Integer, Long, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Long b) throws Exception {
-                        return a + b.intValue();
-                    }
-                })
+                .zipWith(iterate(elements), (a, b) -> a + b.intValue())
         ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/ZipWithTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ZipWithTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.BiFunction;
 
 @Test
 public class ZipWithTckTest extends BaseTck<Integer> {
@@ -26,12 +25,7 @@ public class ZipWithTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
                 Flowable.range(0, (int)elements)
-                .zipWith(Flowable.range((int)elements, (int)elements), new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                })
+                .zipWith(Flowable.range((int)elements, (int)elements), (a, b) -> a + b)
         ;
     }
 }


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

IntelliJ: Inspect -> *RedundantCast*, Inspect -> *Anonymous type can be replaced by lambda*
Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080